### PR TITLE
Refactor console workspace switcher into the sidebar menu

### DIFF
--- a/web/src/app/layout/ConsoleLayout.test.tsx
+++ b/web/src/app/layout/ConsoleLayout.test.tsx
@@ -27,8 +27,7 @@ describe('ConsoleShell', () => {
       </ConsoleShell>
     );
 
-    expect(screen.getByText('Open Managed Agents')).toBeTruthy();
-    expect(screen.getByRole('combobox', { name: /Default/i })).toBeTruthy();
+    expect(getWorkspaceMenuButton(/Default/i)).toBeTruthy();
     expect(screen.getByText('Dashboard')).toBeTruthy();
     expect(screen.getByText('API keys')).toBeTruthy();
     expect(screen.getByText('Build')).toBeTruthy();
@@ -65,13 +64,13 @@ describe('ConsoleShell', () => {
       </ConsoleShell>
     );
 
-    expect(screen.getByRole('combobox', { name: /Default/i }).closest('[data-sidebar-scroll-area="true"]')).toBeNull();
+    expect(getWorkspaceMenuButton(/Default/i).closest('[data-sidebar-scroll-area="true"]')).toBeNull();
     const scrollArea = screen.getByRole('navigation', { name: /Console navigation/i }).closest('[data-sidebar-scroll-area="true"]');
     expect(scrollArea).toBeTruthy();
     expect(scrollArea?.classList.contains('sidebar-scroll-area')).toBe(true);
   });
 
-  test('collapses and expands the desktop sidebar from the header button', () => {
+  test('collapses and expands the desktop sidebar from the sidebar rail', () => {
     resetTestDom('https://oma.duck.ai/dashboard');
     renderWithWorkspaces(
       <ConsoleShell
@@ -90,15 +89,16 @@ describe('ConsoleShell', () => {
     expect(sidebar?.getAttribute('data-collapsible')).toBe('');
     expect(main?.getAttribute('data-slot')).toBe('sidebar-inset');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Collapse' }));
+    const sidebarRail = screen.getByRole('button', { name: 'Toggle Sidebar' });
+
+    fireEvent.click(sidebarRail);
 
     expect(sidebar?.getAttribute('data-state')).toBe('collapsed');
     expect(sidebar?.getAttribute('data-collapsible')).toBe('icon');
-    expect(screen.getByRole('button', { name: 'Expand' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Build' }).getAttribute('aria-expanded')).toBe('false');
     expect(screen.queryByRole('link', { name: 'Files' })).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Expand' }));
+    fireEvent.click(sidebarRail);
 
     expect(sidebar?.getAttribute('data-state')).toBe('expanded');
     expect(sidebar?.getAttribute('data-collapsible')).toBe('');
@@ -262,7 +262,7 @@ describe('ConsoleShell', () => {
     expect(screen.getByText('Dashboard')).toBeTruthy();
   });
 
-  test('opens the workspace selector with disabled all workspaces and selectable workspaces', async () => {
+  test('opens the workspace selector with labeled workspace items and create action', async () => {
     resetTestDom('https://oma.duck.ai/dashboard');
 
     renderWithWorkspaces(
@@ -276,14 +276,13 @@ describe('ConsoleShell', () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('combobox', { name: /Default/i }));
+      fireEvent.click(getWorkspaceMenuButton(/Default/i));
     });
 
-    expect(screen.getByText('All workspaces')).toBeTruthy();
-    expect(screen.getByText('Only available on Cost and Logs')).toBeTruthy();
-    expect(screen.getByRole('option', { name: /Default/i }).getAttribute('aria-selected')).toBe('true');
-    expect(screen.getByRole('option', { name: /foo/i })).toBeTruthy();
-    expect(screen.getByText('Create workspace')).toBeTruthy();
+    expect(screen.getByText('Workspaces')).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: /Default/i }).getAttribute('aria-current')).toBe('true');
+    expect(screen.getByRole('menuitem', { name: /foo/i })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Create workspace' })).toBeTruthy();
   });
 
   test('closes the workspace selector when clicking outside', async () => {
@@ -299,13 +298,13 @@ describe('ConsoleShell', () => {
       </ConsoleShell>
     );
 
-    fireEvent.click(screen.getByRole('combobox', { name: /Default/i }));
-    expect(screen.getByRole('listbox')).toBeTruthy();
+    fireEvent.click(getWorkspaceMenuButton(/Default/i));
+    expect(screen.getAllByRole('menu').length).toBeGreaterThan(0);
 
     fireEvent.mouseDown(document.body);
     fireEvent.click(document.body);
 
-    await waitFor(() => expect(screen.queryByRole('listbox')).toBeNull());
+    await waitFor(() => expect(screen.queryByRole('menuitem', { name: /Default/i })).toBeNull());
   });
 
   test('selects a workspace and updates the account subtitle', async () => {
@@ -322,13 +321,13 @@ describe('ConsoleShell', () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByRole('combobox', { name: /Default/i }));
+      fireEvent.click(getWorkspaceMenuButton(/Default/i));
     });
-    await waitFor(() => expect(screen.getByRole('option', { name: /foo/i })).toBeTruthy());
+    await waitFor(() => expect(screen.getByRole('menuitem', { name: /foo/i })).toBeTruthy());
     await act(async () => {
-      fireEvent.click(screen.getByRole('option', { name: /foo/i }));
+      fireEvent.click(screen.getByRole('menuitem', { name: /foo/i }));
     });
-    expect(screen.getByRole('combobox', { name: /foo/i })).toBeTruthy();
+    expect(getWorkspaceMenuButton(/foo/i)).toBeTruthy();
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /test/i }));
@@ -351,11 +350,11 @@ describe('ConsoleShell', () => {
       </ConsoleShell>
     );
 
-    fireEvent.click(screen.getByRole('combobox', { name: /Default/i }));
-    fireEvent.click(screen.getByRole('option', { name: /foo/i }));
+    fireEvent.click(getWorkspaceMenuButton(/Default/i));
+    fireEvent.click(screen.getByRole('menuitem', { name: /foo/i }));
 
     await waitFor(() => expect(navigate).toHaveBeenCalledWith('/workspaces/wrkspc_foo/agents'));
-    expect(screen.getByRole('combobox', { name: /foo/i })).toBeTruthy();
+    expect(getWorkspaceMenuButton(/foo/i)).toBeTruthy();
   });
 
   test('syncs the workspace selector from workspace-scoped routes', async () => {
@@ -371,7 +370,7 @@ describe('ConsoleShell', () => {
       </ConsoleShell>
     );
 
-    await waitFor(() => expect(screen.getByRole('combobox', { name: /foo/i })).toBeTruthy());
+    await waitFor(() => expect(getWorkspaceMenuButton(/foo/i)).toBeTruthy());
   });
 
   test('creates a workspace with color and US residency', async () => {
@@ -396,8 +395,8 @@ describe('ConsoleShell', () => {
       { createWorkspace }
     );
 
-    fireEvent.click(screen.getByRole('combobox', { name: /Default/i }));
-    fireEvent.click(screen.getByText('Create workspace'));
+    fireEvent.click(getWorkspaceMenuButton(/Default/i));
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Create workspace' }));
 
     expect(screen.getByRole('button', { name: 'Create' }).hasAttribute('disabled')).toBe(true);
 
@@ -413,9 +412,25 @@ describe('ConsoleShell', () => {
         workspace_geo: 'us'
       }
     });
-    expect(screen.getByRole('combobox', { name: /bar/i })).toBeTruthy();
+    expect(getWorkspaceMenuButton(/bar/i)).toBeTruthy();
   });
 });
+
+function getWorkspaceMenuButton(name: RegExp | string) {
+  const matches = screen.getAllByRole('button', { name });
+  const match = matches.find((button) => matchesName(button.getAttribute('aria-label'), name));
+  if (!match) {
+    throw new Error(`Workspace menu button ${String(name)} was not found.`);
+  }
+  return match;
+}
+
+function matchesName(value: string | null, expected: RegExp | string) {
+  if (!value) {
+    return false;
+  }
+  return typeof expected === 'string' ? value === expected : expected.test(value);
+}
 
 function renderWithWorkspaces(
   children: ReactNode,

--- a/web/src/app/layout/ConsoleLayout.tsx
+++ b/web/src/app/layout/ConsoleLayout.tsx
@@ -3,9 +3,9 @@ import {
   BookOpen,
   Box,
   Building2,
-  Check,
   ChevronDown,
   ChevronRight,
+  ChevronsUpDown,
   CircleHelp,
   Gauge,
   Globe2,
@@ -53,7 +53,6 @@ import {
   SidebarMenuSubItem,
   SidebarProvider,
   SidebarRail,
-  SidebarSeparator,
   useSidebar
 } from '@/shared/ui/sidebar';
 import {
@@ -65,12 +64,12 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger
 } from '@/shared/ui/dropdown-menu';
-import { Popover, PopoverContent, PopoverTrigger } from '@/shared/ui/popover';
 import { useAuth } from '../../shared/auth/context';
 import type { AuthAccount } from '../../shared/auth/api';
 import { useWorkspace } from '../../shared/workspaces/context';
@@ -79,7 +78,6 @@ import { CreateWorkspaceDialog } from '../../shared/workspaces/CreateWorkspaceDi
 import {
   buildCreateWorkspaceInput,
   workspaceApiKeysPath,
-  workspaceColor,
   workspaceIdFromPath,
   workspaceWebhooksPath
 } from '../../shared/workspaces/presentation';
@@ -256,11 +254,7 @@ function ConsoleSidebar({
       className="border-r border-sidebar-border"
       data-sidebar-state={collapsed ? 'collapsed' : 'expanded'}
     >
-      <ShellSidebarHeader collapsed={collapsed} onNavigate={onNavigate} />
-      <div className="shrink-0 px-2 py-2">
-        <WorkspaceSwitcher currentPath={currentPath} onNavigate={onNavigate} />
-      </div>
-      <SidebarSeparator />
+      <ShellSidebarHeader currentPath={currentPath} onNavigate={onNavigate} />
       <AppSidebarContent
         className="sidebar-scroll-area px-2 py-2"
         data-sidebar-scroll-area="true"
@@ -290,12 +284,12 @@ function ConsoleSidebar({
                     <SidebarMenuItem key={item.label} className="pt-1">
                       <SidebarMenuButton
                         type="button"
-                      isActive={groupActive}
-                      tooltip={msg(item.labelId, item.label)}
-                      className={interactiveMotionClass}
-                      aria-label={collapsed ? msg(item.labelId, item.label) : undefined}
-                      aria-expanded={collapsed ? false : isOpen}
-                      onClick={() => {
+                        isActive={groupActive}
+                        tooltip={msg(item.labelId, item.label)}
+                        className={interactiveMotionClass}
+                        aria-label={collapsed ? msg(item.labelId, item.label) : undefined}
+                        aria-expanded={collapsed ? false : isOpen}
+                        onClick={() => {
                           if (collapsed) {
                             setOpen(true);
                             setExpanded((value) => ({ ...value, [item.label]: true }));
@@ -349,7 +343,6 @@ function ConsoleSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
       </AppSidebarContent>
-      <SidebarSeparator />
       <SidebarFooter account={account} collapsed={collapsed} onLogout={onLogout} onNavigate={onNavigate} />
       <SidebarRail />
     </AppSidebar>
@@ -372,7 +365,7 @@ function SettingsSidebar({
       className="border-r border-sidebar-border"
       data-sidebar-state={collapsed ? 'collapsed' : 'expanded'}
     >
-      <ShellSidebarHeader collapsed={collapsed} onNavigate={onNavigate} />
+      <ShellSidebarHeader currentPath={currentPath} onNavigate={onNavigate} />
       <AppSidebarContent className="sidebar-scroll-area px-2 py-2" data-sidebar-scroll-area="true">
         <SidebarGroup className="p-0">
           <SidebarGroupContent>
@@ -402,12 +395,12 @@ function SettingsSidebar({
                 {settingsNavigation.map((item) => (
                   <SidebarMenuItem key={item.href}>
                     <SidebarMenuButton
-                    render={<ShellLink href={item.href} onNavigate={onNavigate} />}
-                    isActive={isActivePath(currentPath, item.href)}
-                    tooltip={msg(item.labelId, item.label)}
-                    className={interactiveMotionClass}
-                    aria-label={collapsed ? msg(item.labelId, item.label) : undefined}
-                  >
+                      render={<ShellLink href={item.href} onNavigate={onNavigate} />}
+                      isActive={isActivePath(currentPath, item.href)}
+                      tooltip={msg(item.labelId, item.label)}
+                      className={interactiveMotionClass}
+                      aria-label={collapsed ? msg(item.labelId, item.label) : undefined}
+                    >
                       <SettingsNavigationIcon href={item.href} />
                       {collapsed ? null : <span className="truncate">{msg(item.labelId, item.label)}</span>}
                     </SidebarMenuButton>
@@ -418,7 +411,6 @@ function SettingsSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
       </AppSidebarContent>
-      <SidebarSeparator />
       <SidebarFooter account={account} collapsed={collapsed} onLogout={onLogout} onNavigate={onNavigate} />
       <SidebarRail />
     </AppSidebar>
@@ -468,39 +460,15 @@ function ShellMobileBar({
 }
 
 function ShellSidebarHeader({
-  collapsed,
+  currentPath,
   onNavigate
 }: {
-  collapsed?: boolean;
+  currentPath: string;
   onNavigate?: NavigateHandler;
 }) {
-  const { msg } = useI18n();
-  const { toggleSidebar } = useSidebar();
-
   return (
-    <AppSidebarHeader className="gap-0 border-b px-2 py-2">
-      <div className={clsx('flex min-h-10 items-center gap-2', collapsed ? 'justify-center' : 'justify-between')}>
-        {collapsed ? null : (
-          <ShellLink
-            href="/dashboard"
-            onNavigate={onNavigate}
-            className="min-w-0 truncate px-2 text-base font-semibold tracking-[-0.01em] text-sidebar-foreground"
-          >
-            {msg('app.productName', 'Open Managed Agents')}
-          </ShellLink>
-        )}
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          className="text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-          aria-label={collapsed ? msg('common.expand', 'Expand') : msg('common.collapse', 'Collapse')}
-          aria-pressed={collapsed}
-          onClick={toggleSidebar}
-        >
-          <ListTree className="size-4" aria-hidden />
-        </Button>
-      </div>
+    <AppSidebarHeader>
+      <WorkspaceSwitcher currentPath={currentPath} onNavigate={onNavigate} />
     </AppSidebarHeader>
   );
 }
@@ -513,10 +481,10 @@ function WorkspaceSwitcher({
   onNavigate?: NavigateHandler;
 }) {
   const { msg } = useI18n();
-  const { state } = useSidebar();
-  const collapsed = state === 'collapsed';
   const [open, setOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const { isMobile, state } = useSidebar();
+  const collapsed = state === 'collapsed';
   const { workspaces, activeWorkspace, activeWorkspaceId, selectWorkspace, isLoading, createWorkspace } =
     useWorkspace();
 
@@ -534,98 +502,89 @@ function WorkspaceSwitcher({
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger
-          render={
-            <SidebarMenuButton
-              type="button"
-              size="lg"
-              role="combobox"
-              aria-label={activeWorkspace.name}
-              aria-expanded={open}
-              aria-controls="workspace-switcher-listbox"
-              className={clsx(
-                'h-10 text-sidebar-foreground aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground',
-                interactiveMotionClass,
-                collapsed ? 'justify-center' : 'justify-between'
-              )}
-            />
-          }
-        >
-          <span className="flex min-w-0 items-center gap-2">
-            <Box className="size-4 shrink-0" style={{ color: workspaceColor(activeWorkspace) }} aria-hidden />
-            {collapsed ? null : <span className="truncate">{activeWorkspace.name}</span>}
-          </span>
-          {collapsed ? null : <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden />}
-        </PopoverTrigger>
-        <PopoverContent
-          id="workspace-switcher-listbox"
-          role="listbox"
-          align="start"
-          side={collapsed ? 'right' : 'bottom'}
-          sideOffset={8}
-          className="w-[calc(var(--anchor-width)+2rem)] min-w-[264px] max-w-[calc(100vw-2rem)] gap-0 p-2"
-        >
-          <div className="subtle-scrollbar max-h-[264px] overflow-y-auto pr-0.5">
-            <Button
-              type="button"
-              role="option"
-              aria-disabled="true"
-              disabled
-              variant="ghost"
-              className="h-auto w-full items-start justify-start gap-3 rounded-md px-3 py-2 text-left text-sm font-normal text-muted-foreground/70"
-            >
-              <Box className="mt-0.5 size-4 shrink-0" aria-hidden />
-              <span>
-                <span className="block text-muted-foreground">{msg('workspace.all', 'All workspaces')}</span>
-                <span className="mt-0.5 block text-xs text-muted-foreground/70">
-                  {msg('workspace.onlyCostLogs', 'Only available on Cost and Logs')}
-                </span>
-              </span>
-            </Button>
-
-            {workspaces.map((workspace) => {
-              const selected = workspace.id === activeWorkspaceId;
-              return (
-                <Button
-                  key={workspace.id}
-                  type="button"
-                  role="option"
-                  aria-selected={selected}
-                  variant="ghost"
-                  className="mt-1 h-9 w-full justify-start gap-3 rounded-md px-3 text-left text-sm font-normal text-foreground hover:bg-accent"
-                  onClick={() => handleSelect(workspace)}
-                >
-                  <Box className="size-4 shrink-0" style={{ color: workspaceColor(workspace) }} aria-hidden />
-                  <span className="min-w-0 flex-1 truncate">{workspace.name}</span>
-                  {selected ? <Check className="size-4 text-primary" aria-hidden /> : null}
-                </Button>
-              );
-            })}
-          </div>
-
-          <div className="mx-3 my-2 h-px bg-border" />
-
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-9 w-full justify-start gap-3 rounded-md px-3 text-left text-sm font-normal text-foreground hover:bg-accent"
-            onClick={() => {
-              setOpen(false);
-              setCreateOpen(true);
-            }}
+        <DropdownMenu open={open} onOpenChange={setOpen}>
+          <DropdownMenuTrigger
+            render={
+              <SidebarMenuButton
+                type="button"
+                size="lg"
+                tooltip={msg('workspace.switcher', 'Switch workspace')}
+                className={clsx(
+                  'text-sidebar-foreground data-[popup-open]:bg-sidebar-accent data-[popup-open]:text-sidebar-accent-foreground',
+                  interactiveMotionClass,
+                  collapsed ? 'justify-center' : 'justify-start'
+                )}
+                aria-label={activeWorkspace.name}
+              />
+            }
           >
-            <Plus className="size-4" aria-hidden />
-            {msg('workspace.create.title', 'Create workspace')}
-          </Button>
+            <span className="grid aspect-square size-8 shrink-0 place-items-center rounded-lg border border-sidebar-border bg-sidebar-accent text-sidebar-accent-foreground">
+              <Box className="size-4" aria-hidden />
+            </span>
+            {collapsed ? null : (
+              <>
+                <span className="grid min-w-0 flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-semibold">{activeWorkspace.name}</span>
+                  <span className="truncate text-xs text-sidebar-foreground/70">
+                    {msg('settings.workspaces.workspace', 'Workspace')}
+                  </span>
+                </span>
+                <ChevronsUpDown className="ml-auto size-4 shrink-0 text-sidebar-foreground/70" aria-hidden />
+              </>
+            )}
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            side={isMobile ? 'bottom' : 'right'}
+            sideOffset={4}
+            className="w-(--anchor-width) min-w-56 max-w-[calc(100vw-2rem)] rounded-lg p-1"
+          >
+            <DropdownMenuGroup>
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                {msg('nav.workspaces', 'Workspaces')}
+              </DropdownMenuLabel>
+              <div className="subtle-scrollbar max-h-[240px] overflow-y-auto pr-0.5">
+                {workspaces.map((workspace, index) => (
+                  <DropdownMenuItem
+                    key={workspace.id}
+                    aria-current={workspace.id === activeWorkspaceId ? 'true' : undefined}
+                    className="gap-2 p-2"
+                    onClick={() => handleSelect(workspace)}
+                  >
+                    <span className="grid size-6 shrink-0 place-items-center rounded-md border bg-background text-muted-foreground">
+                      <Box className="size-4" aria-hidden />
+                    </span>
+                    <span className="min-w-0 flex-1 truncate">{workspace.name}</span>
+                    <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
+                  </DropdownMenuItem>
+                ))}
+              </div>
+            </DropdownMenuGroup>
+
+            <DropdownMenuSeparator />
+
+            <DropdownMenuItem
+              className="gap-2 p-2"
+              onClick={() => {
+                setOpen(false);
+                setCreateOpen(true);
+              }}
+            >
+              <span className="grid size-6 shrink-0 place-items-center rounded-md border bg-background">
+                <Plus className="size-4" aria-hidden />
+              </span>
+              <span className="min-w-0 flex-1 truncate font-medium text-muted-foreground">
+                {msg('workspace.create.title', 'Create workspace')}
+              </span>
+            </DropdownMenuItem>
 
             {isLoading ? (
               <div className="px-3 pt-2 text-xs text-muted-foreground">
                 {msg('workspace.loading', 'Loading workspaces...')}
               </div>
             ) : null}
-          </PopoverContent>
-      </Popover>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </SidebarMenuItem>
 
       <CreateWorkspaceDialog open={createOpen} onOpenChange={setCreateOpen} onCreate={handleCreate} />

--- a/web/src/features/settings/OrganizationMembersPage.test.tsx
+++ b/web/src/features/settings/OrganizationMembersPage.test.tsx
@@ -41,7 +41,11 @@ describe('Organization members settings', () => {
       </OrganizationMembersHarness>
     );
 
-    expect(screen.getByText('Open Managed Agents')).toBeTruthy();
+    expect(
+      screen
+        .getAllByRole('button', { name: /Default/i })
+        .some((button) => button.getAttribute('aria-label') === 'Default')
+    ).toBe(true);
     expect(screen.getByText('Organization settings')).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'Members 3' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Invite' })).toBeTruthy();

--- a/web/src/features/settings/OrganizationSettingsPage.test.tsx
+++ b/web/src/features/settings/OrganizationSettingsPage.test.tsx
@@ -51,7 +51,11 @@ describe('Organization settings', () => {
       </OrganizationSettingsHarness>
     );
 
-    expect(screen.getByText('Open Managed Agents')).toBeTruthy();
+    expect(
+      screen
+        .getAllByRole('button', { name: /Default/i })
+        .some((button) => button.getAttribute('aria-label') === 'Default')
+    ).toBe(true);
     expect(screen.getByText('Back to app')).toBeTruthy();
     expect(screen.getByText('Organization settings')).toBeTruthy();
     expect(screen.getByText('Workload identity')).toBeTruthy();

--- a/web/src/features/settings/WorkspaceApiKeysPage.test.tsx
+++ b/web/src/features/settings/WorkspaceApiKeysPage.test.tsx
@@ -23,7 +23,7 @@ afterEach(() => {
 });
 
 describe('Workspace API keys page', () => {
-  test('renders the wide workspace-scoped API keys shell with Open Managed Agents branding', async () => {
+  test('renders the wide workspace-scoped API keys shell with the workspace switcher', async () => {
     resetTestDom('https://oma.duck.ai/settings/workspaces/default/keys');
     mockWorkspaceApiKeys([activeKey, archivedKey]);
 
@@ -39,8 +39,11 @@ describe('Workspace API keys page', () => {
       </WorkspaceApiKeysHarness>
     );
 
-    expect(screen.getByText('Open Managed Agents')).toBeTruthy();
-    expect(screen.getByRole('combobox', { name: /Default/i })).toBeTruthy();
+    expect(
+      screen
+        .getAllByRole('button', { name: /Default/i })
+        .some((button) => button.getAttribute('aria-label') === 'Default')
+    ).toBe(true);
     expect(screen.getByRole('heading', { name: 'API keys' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Create key' })).toBeTruthy();
     expect(screen.getByText(/API keys are owned by workspaces/i)).toBeTruthy();

--- a/web/src/features/settings/WorkspaceWebhooksPage.test.tsx
+++ b/web/src/features/settings/WorkspaceWebhooksPage.test.tsx
@@ -37,7 +37,11 @@ describe('Workspace webhooks page', () => {
       </WorkspaceWebhooksHarness>
     );
 
-    expect(screen.getByText('Open Managed Agents')).toBeTruthy();
+    expect(
+      screen
+        .getAllByRole('button', { name: /Default/i })
+        .some((button) => button.getAttribute('aria-label') === 'Default')
+    ).toBe(true);
     expect(screen.getByRole('heading', { name: 'Webhooks' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Add webhook endpoint' })).toBeTruthy();
     expect(screen.getByText('Webhook endpoints receive event notifications when things happen in your workspace.')).toBeTruthy();

--- a/web/src/shared/i18n/messages/en.json
+++ b/web/src/shared/i18n/messages/en.json
@@ -1092,5 +1092,6 @@
   "workspace.geo": "Workspace geo",
   "workspace.geoHelp": "Control where your workspace data, including files, conversation history, and workspace artifacts, is stored. This can't be changed after creation.",
   "workspace.loading": "Loading workspaces...",
-  "workspace.onlyCostLogs": "Only available on Cost and Logs"
+  "workspace.onlyCostLogs": "Only available on Cost and Logs",
+  "workspace.switcher": "Switch workspace"
 }

--- a/web/src/shared/i18n/messages/zh-CN.json
+++ b/web/src/shared/i18n/messages/zh-CN.json
@@ -1092,5 +1092,6 @@
   "workspace.geo": "工作区地域",
   "workspace.geoHelp": "控制工作区数据的存储位置，包括文件、对话历史和工作区产物。创建后无法更改。",
   "workspace.loading": "正在加载工作区...",
-  "workspace.onlyCostLogs": "仅适用于 Cost 和 Logs"
+  "workspace.onlyCostLogs": "仅适用于 Cost 和 Logs",
+  "workspace.switcher": "切换工作区"
 }


### PR DESCRIPTION
## Summary
- Move the workspace selector into the console sidebar header and convert it from a combobox-style popover to a dropdown menu.
- Update sidebar collapse behavior to use the sidebar rail, and simplify the header layout across console and settings shells.
- Refresh affected tests and add localized copy for the new workspace switcher label.

## Testing
- Updated unit tests to cover the new sidebar workspace menu behavior, collapse interaction, and settings page rendering.
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the console sidebar workspace switcher to a new menu-based experience, making workspace selection easier to access.
  * Added keyboard shortcuts for quickly switching between workspaces.
  * Added localized “Switch workspace” text for supported languages.

* **Bug Fixes**
  * Improved sidebar collapse/expand behavior and navigation state handling.
  * Kept the workspace selector outside the sidebar scroll area for better usability.
  * Refined settings page checks to match the updated workspace button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->