### PR TITLE
[codex] Refine shared UI borders and spacing

### DIFF
--- a/web/src/shared/ui/alert-dialog.tsx
+++ b/web/src/shared/ui/alert-dialog.tsx
@@ -85,7 +85,7 @@ function AlertDialogFooter({
     <div
       data-slot="alert-dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
         className
       )}
       {...props}

--- a/web/src/shared/ui/card.tsx
+++ b/web/src/shared/ui/card.tsx
@@ -84,7 +84,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-footer"
       className={cn(
-        "flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)",
+        "flex items-center p-(--card-spacing)",
         className
       )}
       {...props}

--- a/web/src/shared/ui/command.tsx
+++ b/web/src/shared/ui/command.tsx
@@ -68,7 +68,7 @@ function CommandInput({
   return (
     <div
       data-slot="command-input-wrapper"
-      className="flex h-9 items-center gap-2 border-b px-3"
+      className="flex h-9 items-center gap-2 border-b border-border px-3"
     >
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input

--- a/web/src/shared/ui/dialog.tsx
+++ b/web/src/shared/ui/dialog.tsx
@@ -100,7 +100,7 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
         className
       )}
       {...props}

--- a/web/src/shared/ui/sheet.tsx
+++ b/web/src/shared/ui/sheet.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/shared/lib/utils"
 import { Button } from "@/shared/ui/button"
 
 const sheetVariants = cva(
-  "fixed z-50 flex flex-col gap-4 bg-background text-foreground shadow-lg ring-1 ring-foreground/10 outline-none duration-150 data-open:animate-in data-closed:animate-out",
+  "fixed z-50 flex flex-col gap-4 border-border bg-background text-foreground shadow-lg ring-1 ring-foreground/10 outline-none duration-150 data-open:animate-in data-closed:animate-out",
   {
     variants: {
       side: {

--- a/web/src/shared/ui/sidebar.tsx
+++ b/web/src/shared/ui/sidebar.tsx
@@ -214,7 +214,7 @@ function Sidebar({
           'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex',
           variant === 'floating' || variant === 'inset'
             ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
+            : 'border-sidebar-border group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
           className
         )}
         {...props}

--- a/web/src/shared/ui/table.tsx
+++ b/web/src/shared/ui/table.tsx
@@ -21,7 +21,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   return (
     <thead
       data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
+      className={cn("[&_tr]:border-b [&_tr]:border-border", className)}
       {...props}
     />
   )
@@ -42,7 +42,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
     <tfoot
       data-slot="table-footer"
       className={cn(
-        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        "border-t border-border bg-muted/50 font-medium [&>tr]:last:border-b-0",
         className
       )}
       {...props}
@@ -55,7 +55,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        "border-b border-border transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Remove default dialog and alert-dialog footer trays so API key modals match shadcn footer spacing without bright separators.
- Remove default card-footer separator chrome and bind shared table, command, sheet, and sidebar borders to semantic border tokens.
- Keep API/data behavior unchanged; this is a shared UI styling cleanup.

## Root Cause
Dialog-style footers and several shared surfaces used default or unbound border classes. In dark mode those could render as bright separator lines instead of the lower-contrast shadcn tokenized borders.

## Validation
- `bun run build`
- `bun test`
- Browser QA on the local API keys page: create-key, created-key, and delete confirmation dialogs all render footer `border-top: 0px`; temporary test key was deleted afterward.