### PR TITLE
[codex] Polish managed agents shadcn controls

### DIFF
--- a/web/src/features/managed-agents/ManagedAgentsPage.agents.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.agents.suite.tsx
@@ -602,7 +602,7 @@ export function registerManagedAgentsAgentsTests() {
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
     const dialog = screen.getByRole('dialog', { name: 'Edit agent' });
-    expect(within(dialog).getByRole('combobox', { name: 'YAML' })).toBeTruthy();
+    expect(within(dialog).getByRole('combobox', { name: 'Code format' })).toBeTruthy();
     expect(within(dialog).getByRole('button', { name: 'Close' })).toBeTruthy();
     expect(within(dialog).getByRole('button', { name: 'Copy code' })).toBeTruthy();
     expect(within(dialog).getByRole('button', { name: 'Save new version' })).toBeTruthy();
@@ -613,7 +613,7 @@ export function registerManagedAgentsAgentsTests() {
     expect(configCard?.className).toContain('bg-card');
     expect(configCard?.className).not.toContain('bg-muted');
     expect(dialog.textContent).toContain('name: Editable agent');
-    fireEvent.click(within(dialog).getByRole('combobox', { name: 'YAML' }));
+    fireEvent.click(within(dialog).getByRole('combobox', { name: 'Code format' }));
     expect(screen.getByRole('option', { name: 'YAML' }).getAttribute('aria-selected')).toBe('true');
 
     fireEvent.keyDown(document, { key: 'Escape' });
@@ -664,8 +664,8 @@ export function registerManagedAgentsAgentsTests() {
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
     const dialog = screen.getByRole('dialog', { name: 'Edit agent' });
-    await selectManagedComboboxOption(dialog, 'YAML', 'JSON');
-    await waitFor(() => expect(within(dialog).getByRole('combobox', { name: 'JSON' })).toBeTruthy());
+    await selectManagedComboboxOption(dialog, 'Code format', 'JSON');
+    await waitFor(() => expect(within(dialog).getByRole('combobox', { name: 'Code format' }).textContent).toContain('JSON'));
 
     setAgentConfigEditorValue(dialog, '{', 'Agent configuration');
 

--- a/web/src/features/managed-agents/ManagedAgentsPage.agents.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.agents.suite.tsx
@@ -602,7 +602,7 @@ export function registerManagedAgentsAgentsTests() {
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
     const dialog = screen.getByRole('dialog', { name: 'Edit agent' });
-    expect(within(dialog).getByRole('button', { name: 'YAML' })).toBeTruthy();
+    expect(within(dialog).getByRole('combobox', { name: 'YAML' })).toBeTruthy();
     expect(within(dialog).getByRole('button', { name: 'Close' })).toBeTruthy();
     expect(within(dialog).getByRole('button', { name: 'Copy code' })).toBeTruthy();
     expect(within(dialog).getByRole('button', { name: 'Save new version' })).toBeTruthy();
@@ -613,8 +613,8 @@ export function registerManagedAgentsAgentsTests() {
     expect(configCard?.className).toContain('bg-card');
     expect(configCard?.className).not.toContain('bg-muted');
     expect(dialog.textContent).toContain('name: Editable agent');
-    fireEvent.click(within(dialog).getByRole('button', { name: 'YAML' }));
-    expect(screen.getByRole('menuitemradio', { name: 'YAML' }).getAttribute('aria-checked')).toBe('true');
+    fireEvent.click(within(dialog).getByRole('combobox', { name: 'YAML' }));
+    expect(screen.getByRole('option', { name: 'YAML' }).getAttribute('aria-selected')).toBe('true');
 
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByRole('dialog', { name: 'Edit agent' })).toBeNull();
@@ -664,8 +664,8 @@ export function registerManagedAgentsAgentsTests() {
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
     const dialog = screen.getByRole('dialog', { name: 'Edit agent' });
-    fireEvent.click(within(dialog).getByRole('button', { name: 'YAML' }));
-    fireEvent.click(screen.getByRole('menuitemradio', { name: 'JSON' }));
+    await selectManagedComboboxOption(dialog, 'YAML', 'JSON');
+    await waitFor(() => expect(within(dialog).getByRole('combobox', { name: 'JSON' })).toBeTruthy());
 
     setAgentConfigEditorValue(dialog, '{', 'Agent configuration');
 

--- a/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
@@ -18,6 +18,7 @@ import {
   renderManagedAgentsPage,
   resetTestDom,
   screen,
+  selectManagedComboboxOption,
   serverAgent,
   sessionStatusValuesFromUrl,
   setAgentConfigEditorValue,
@@ -157,7 +158,7 @@ export function registerManagedAgentsQuickstartTests() {
     fireEvent.click(screen.getByRole('button', { name: /Structured extractor/i }));
 
     expect(screen.getByRole('button', { name: 'Back to templates' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'YAML' })).toBeTruthy();
+    expect(screen.getByRole('combobox', { name: 'YAML' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy code' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Use template' })).toBeTruthy();
     expect(screen.getByText(/name:/)).toBeTruthy();
@@ -466,10 +467,8 @@ export function registerManagedAgentsQuickstartTests() {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /Structured extractor/i }));
-    fireEvent.click(screen.getByRole('button', { name: 'YAML' }));
-    fireEvent.click(screen.getByRole('menuitemradio', { name: 'JSON' }));
-
-    expect(screen.getByRole('button', { name: 'JSON' })).toBeTruthy();
+    await selectManagedComboboxOption(document.body, 'YAML', 'JSON');
+    await waitFor(() => expect(screen.getByRole('combobox', { name: 'JSON' })).toBeTruthy());
     expectPageTextToContain('"metadata":');
     const templateJsonBlock = codeBlockContaining('"metadata":');
     expect(templateJsonBlock?.querySelector('code.language-json')).toBeTruthy();
@@ -498,7 +497,7 @@ export function registerManagedAgentsQuickstartTests() {
     await waitFor(() =>
       expect(api.requests.some((request) => request.url === '/api/organizations/org_test/proxy/v1/messages')).toBe(true)
     );
-    expect(screen.getByRole('button', { name: 'Test run' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Test run' }).hasAttribute('disabled')).toBe(true);
     expect(await screen.findByText("Let's configure the environment.")).toBeTruthy();
     const panelTabs = screen.getByRole('tablist', { name: 'Agent panel views' });
     const agentPanel = panelTabs.closest('aside') as HTMLElement | null;
@@ -1270,7 +1269,7 @@ export function registerManagedAgentsQuickstartTests() {
     expect((integrationMessage as HTMLElement).querySelector('[data-slot="message-avatar"]')).toBeTruthy();
     expect(screen.getAllByText(/agent_created123456/).length).toBeGreaterThan(0);
     expect(screen.queryAllByText(/agent_model_wrong123456/)).toHaveLength(0);
-    fireEvent.click(screen.getByRole('button', { name: 'Python' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Python' }));
     expectPageTextToContain('from anthropic import Anthropic');
     expectPageTextToContain('client.beta.sessions.events.stream');
     const pythonCodeBlock = codeBlockContaining('from anthropic import Anthropic');

--- a/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
@@ -158,7 +158,7 @@ export function registerManagedAgentsQuickstartTests() {
     fireEvent.click(screen.getByRole('button', { name: /Structured extractor/i }));
 
     expect(screen.getByRole('button', { name: 'Back to templates' })).toBeTruthy();
-    expect(screen.getByRole('combobox', { name: 'YAML' })).toBeTruthy();
+    expect(screen.getByRole('combobox', { name: 'Code format' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy code' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Use template' })).toBeTruthy();
     expect(screen.getByText(/name:/)).toBeTruthy();
@@ -467,8 +467,8 @@ export function registerManagedAgentsQuickstartTests() {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /Structured extractor/i }));
-    await selectManagedComboboxOption(document.body, 'YAML', 'JSON');
-    await waitFor(() => expect(screen.getByRole('combobox', { name: 'JSON' })).toBeTruthy());
+    await selectManagedComboboxOption(document.body, 'Code format', 'JSON');
+    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Code format' }).textContent).toContain('JSON'));
     expectPageTextToContain('"metadata":');
     const templateJsonBlock = codeBlockContaining('"metadata":');
     expect(templateJsonBlock?.querySelector('code.language-json')).toBeTruthy();

--- a/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
@@ -186,6 +186,7 @@ export function registerManagedAgentsResourceTests() {
     expect(screen.getByRole('tab', { name: 'reporter' }).dataset.slot).toBe('tabs-trigger');
     expect(screen.getByRole('tab', { name: 'reporter' }).getAttribute('title')).toBeNull();
     expect(screen.getByRole('button', { name: '+1 archived' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '+1 archived' }).dataset.slot).toBe('toggle');
     expect(screen.queryByRole('tab', { name: 'archived' })).toBeNull();
     expect(screen.queryByRole('tab', { name: /sthr_orp/ })).toBeNull();
     expect(screen.queryByText('(Bash completed with no output)')).toBeNull();
@@ -291,7 +292,7 @@ export function registerManagedAgentsResourceTests() {
     expect(screen.queryByText('Reporter is summarizing order cohorts.')).toBeNull();
     expect(screen.queryByText('{"command":"unzip /mnt/session/uploads/orders.zip -d /workspace/data/"}')).toBeNull();
     const resultPreview = screen.getByText(/^Verification with/);
-    const resultRow = resultPreview.closest('[data-slot="button"]');
+    const resultRow = resultPreview.closest('[data-slot="toggle"]');
     expect(resultRow?.className).toContain('h-9');
     expect(resultPreview.className).toContain('truncate');
     const resultBadge = within(resultRow as HTMLElement).getByText('Result').parentElement;
@@ -391,6 +392,7 @@ export function registerManagedAgentsResourceTests() {
     fireEvent.click(screen.getByRole('tab', { name: 'Transcript' }));
     await waitFor(() => expect(screen.getAllByText('Reporter is summarizing order cohorts.').length).toBeGreaterThan(0));
     const selectedReporterRow = document.querySelector('[data-event-id^="evt_reporter-"][data-entry-kind="message"]') as HTMLElement;
+    expect(selectedReporterRow.querySelector('[data-transcript-header]')?.getAttribute('data-slot')).toBe('toggle');
     expect(selectedReporterRow.querySelector('[data-transcript-header]')?.getAttribute('aria-pressed')).toBe('true');
     expect(new URL(window.location.href).searchParams.get('event')).toBe('evt_reporter');
     fireEvent.click(screen.getByRole('tab', { name: 'Debug' }));

--- a/web/src/features/managed-agents/components/CodeBlocks.tsx
+++ b/web/src/features/managed-agents/components/CodeBlocks.tsx
@@ -156,6 +156,7 @@ export function FormatSelect({
   buttonClassName?: string;
   menuClassName?: string;
 }) {
+  const { msg } = useI18n();
   const items: Array<{ value: CodeFormat; label: CodeFormat }> = [
     { value: 'YAML', label: 'YAML' },
     { value: 'JSON', label: 'JSON' }
@@ -172,10 +173,10 @@ export function FormatSelect({
       }}
     >
       <SelectTrigger
-        aria-label={value}
+        aria-label={msg('managedAgents.codeBlocks.codeFormat', 'Code format')}
         size="sm"
         className={clsx(
-          'h-7 w-auto min-w-[4.5rem] border-transparent bg-transparent px-2 text-sm text-foreground shadow-none hover:bg-accent focus-visible:ring-0',
+          'h-7 w-auto min-w-[4.5rem] border-transparent bg-transparent px-2 text-sm text-foreground shadow-none hover:bg-accent',
           compact ? 'rounded-md px-2' : 'px-2.5',
           buttonClassName
         )}

--- a/web/src/features/managed-agents/components/CodeBlocks.tsx
+++ b/web/src/features/managed-agents/components/CodeBlocks.tsx
@@ -1,6 +1,6 @@
 import { useI18n } from '../../../shared/i18n';
 import { Button } from '../../../shared/ui/button';
-import { DropdownMenu, DropdownMenuContent, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuTrigger } from '../../../shared/ui/dropdown-menu';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../../shared/ui/select';
 import clsx from 'clsx';
 import hljs from 'highlight.js/lib/core';
 import bash from 'highlight.js/lib/languages/bash';
@@ -9,7 +9,7 @@ import json from 'highlight.js/lib/languages/json';
 import python from 'highlight.js/lib/languages/python';
 import typescript from 'highlight.js/lib/languages/typescript';
 import yamlLanguage from 'highlight.js/lib/languages/yaml';
-import { Check, ChevronDown, Copy } from 'lucide-react';
+import { Check, Copy } from 'lucide-react';
 import { useState } from 'react';
 import { templateBody, templateTitle } from '../labels';
 import { looksLikeJson } from '../sessions/SessionDetailPage';
@@ -156,39 +156,45 @@ export function FormatSelect({
   buttonClassName?: string;
   menuClassName?: string;
 }) {
+  const items: Array<{ value: CodeFormat; label: CodeFormat }> = [
+    { value: 'YAML', label: 'YAML' },
+    { value: 'JSON', label: 'JSON' }
+  ];
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className={clsx(
-              'gap-1.5 text-sm text-foreground hover:bg-accent',
-              compact ? 'px-2' : 'px-2.5',
-              buttonClassName
-            )}
-          />
+    <Select<CodeFormat>
+      value={value}
+      items={items}
+      onValueChange={(nextValue) => {
+        if (nextValue !== null) {
+          onChange(nextValue);
         }
+      }}
+    >
+      <SelectTrigger
+        aria-label={value}
+        size="sm"
+        className={clsx(
+          'h-7 w-auto min-w-[4.5rem] border-transparent bg-transparent px-2 text-sm text-foreground shadow-none hover:bg-accent focus-visible:ring-0',
+          compact ? 'rounded-md px-2' : 'px-2.5',
+          buttonClassName
+        )}
       >
-        {value}
-        <ChevronDown className="size-4 text-muted-foreground" aria-hidden />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
+        <SelectValue>{value}</SelectValue>
+      </SelectTrigger>
+      <SelectContent
         align={align === 'left' ? 'start' : 'end'}
+        alignItemWithTrigger={false}
         sideOffset={6}
         className={clsx('w-28 min-w-[7rem]', menuClassName)}
       >
-        <DropdownMenuRadioGroup value={value} onValueChange={(nextValue) => onChange(nextValue as CodeFormat)}>
-          {(['YAML', 'JSON'] as const).map((item) => (
-            <DropdownMenuRadioItem key={item} value={item} className="h-8 px-2 text-sm">
-              {item}
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        {items.map((item) => (
+          <SelectItem key={item.value} value={item.value} label={item.label}>
+            {item.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }
 

--- a/web/src/features/managed-agents/quickstart/AgentQuickstartPage.tsx
+++ b/web/src/features/managed-agents/quickstart/AgentQuickstartPage.tsx
@@ -1005,7 +1005,9 @@ export function AgentQuickstartPage() {
         {createdTemplate && createdAgent ? (
           <Button
             type="button"
-            className="absolute right-0 top-0 h-8 gap-2 bg-foreground px-3 text-sm font-semibold text-background hover:bg-muted"
+            size="sm"
+            disabled={!selectedEnvironment}
+            className="absolute right-0 top-0 gap-2"
             onClick={() => {
               if (session && !testRunStopped) {
                 void stopTestRun();

--- a/web/src/features/managed-agents/quickstart/components.tsx
+++ b/web/src/features/managed-agents/quickstart/components.tsx
@@ -1661,7 +1661,7 @@ export function IntegrationExitsCard({
               </div>
               <div className="flex min-w-0 items-center gap-1">
                 <TabsList
-                  aria-label={msg('managedAgents.quickstart.sampleCode', 'Sample code')}
+                  aria-label={msg('managedAgents.quickstart.selectLanguage', 'Select language')}
                   className="subtle-scrollbar h-7 max-w-[238px] gap-0.5 overflow-x-auto bg-secondary p-0.5"
                 >
                   {integrationSnippetLanguages.map((item) => (

--- a/web/src/features/managed-agents/quickstart/components.tsx
+++ b/web/src/features/managed-agents/quickstart/components.tsx
@@ -1254,14 +1254,12 @@ export function QuickstartApiCallCard({ method, path, code, maxLines }: { method
         </span>
         <span className="font-mono text-[13px] text-foreground">{path}</span>
         <div className="ml-auto flex items-center gap-1">
-          <Button
-            type="button"
-            variant="ghost"
-            className="gap-1 px-2 text-foreground hover:bg-accent"
+          <Badge
+            variant="outline"
+            className="h-7 rounded-md px-2 text-[11px] font-semibold uppercase tracking-[0.02em] text-muted-foreground"
           >
             CLI
-            <ChevronDown className="size-4 text-muted-foreground" aria-hidden />
-          </Button>
+          </Badge>
           <CopyButton value={code} label={msg('managedAgents.quickstart.copyCode', 'Copy code')} />
         </div>
       </div>
@@ -1643,33 +1641,37 @@ export function IntegrationExitsCard({
   return (
     <QuickstartAssistantTurn>
       <div className="flex flex-col gap-4">
-        <div className="overflow-hidden rounded-lg border border-border bg-popover">
-          <div className="flex min-h-11 items-center justify-between gap-3 border-b border-border px-3 py-1.5">
-            <div className="text-sm font-medium text-foreground">
-              {msg('managedAgents.quickstart.sampleCode', 'Sample code')}
-            </div>
-            <div className="flex min-w-0 items-center gap-1">
-              <div className="subtle-scrollbar flex max-w-[238px] items-center gap-1 overflow-x-auto rounded-md bg-secondary p-0.5">
-                {integrationSnippetLanguages.map((item) => (
-                  <Button
-                    key={item}
-                    type="button"
-                    variant="ghost"
-                    className={clsx(
-                      'h-7 rounded px-2 text-xs font-medium',
-                      item === language ? 'bg-accent text-foreground' : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-                    )}
-                    onClick={() => setLanguage(item)}
-                  >
-                    {integrationLanguageLabels[item]}
-                  </Button>
-                ))}
+        <Tabs value={language} onValueChange={(nextValue) => setLanguage(nextValue as IntegrationSnippetLanguage)} className="gap-0">
+          <div className="overflow-hidden rounded-lg border border-border bg-popover">
+            <div className="flex min-h-11 items-center justify-between gap-3 border-b border-border px-3 py-1.5">
+              <div className="text-sm font-medium text-foreground">
+                {msg('managedAgents.quickstart.sampleCode', 'Sample code')}
               </div>
-              <CopyButton value={sampleCode} label={msg('managedAgents.quickstart.copyCode', 'Copy code')} />
+              <div className="flex min-w-0 items-center gap-1">
+                <TabsList
+                  aria-label={msg('managedAgents.quickstart.sampleCode', 'Sample code')}
+                  className="subtle-scrollbar h-7 max-w-[238px] gap-0.5 overflow-x-auto bg-secondary p-0.5"
+                >
+                  {integrationSnippetLanguages.map((item) => (
+                    <TabsTrigger
+                      key={item}
+                      value={item}
+                      className="h-6 shrink-0 px-2 text-xs font-medium"
+                    >
+                      {integrationLanguageLabels[item]}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
+                <CopyButton value={sampleCode} label={msg('managedAgents.quickstart.copyCode', 'Copy code')} />
+              </div>
             </div>
+            {integrationSnippetLanguages.map((item) => (
+              <TabsContent key={item} value={item} className="mt-0">
+                <ScrollableCodeBlock code={snippets[item]} language={integrationHighlightLanguage[item]} />
+              </TabsContent>
+            ))}
           </div>
-          <ScrollableCodeBlock code={sampleCode} language={integrationHighlightLanguage[language]} />
-        </div>
+        </Tabs>
         <div className="flex flex-wrap items-center gap-2">
           {call.status === 'awaiting_user' ? (
             <>

--- a/web/src/features/managed-agents/quickstart/components.tsx
+++ b/web/src/features/managed-agents/quickstart/components.tsx
@@ -1478,6 +1478,10 @@ export function nextStepButtonLabel(call: QuickstartToolCall, msg?: I18nMsg) {
 
 export const integrationSnippetLanguages: IntegrationSnippetLanguage[] = ['cli', 'python', 'typescript', 'curl'];
 
+export function isIntegrationSnippetLanguage(value: unknown): value is IntegrationSnippetLanguage {
+  return integrationSnippetLanguages.some((item) => item === value);
+}
+
 export const integrationLanguageLabels: Record<IntegrationSnippetLanguage, string> = {
   cli: 'CLI',
   python: 'Python',
@@ -1641,7 +1645,15 @@ export function IntegrationExitsCard({
   return (
     <QuickstartAssistantTurn>
       <div className="flex flex-col gap-4">
-        <Tabs value={language} onValueChange={(nextValue) => setLanguage(nextValue as IntegrationSnippetLanguage)} className="gap-0">
+        <Tabs
+          value={language}
+          onValueChange={(nextValue) => {
+            if (isIntegrationSnippetLanguage(nextValue)) {
+              setLanguage(nextValue);
+            }
+          }}
+          className="gap-0"
+        >
           <div className="overflow-hidden rounded-lg border border-border bg-popover">
             <div className="flex min-h-11 items-center justify-between gap-3 border-b border-border px-3 py-1.5">
               <div className="text-sm font-medium text-foreground">
@@ -1667,7 +1679,9 @@ export function IntegrationExitsCard({
             </div>
             {integrationSnippetLanguages.map((item) => (
               <TabsContent key={item} value={item} className="mt-0">
-                <ScrollableCodeBlock code={snippets[item]} language={integrationHighlightLanguage[item]} />
+                {item === language ? (
+                  <ScrollableCodeBlock code={snippets[item]} language={integrationHighlightLanguage[item]} />
+                ) : null}
               </TabsContent>
             ))}
           </div>

--- a/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
+++ b/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
@@ -580,7 +580,7 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
             timelineVisibleIds={timelineVisibleIds}
             threadNameById={threadNameById}
             onDetailTabChange={setSelectedDetailTab}
-            onToggleArchivedLanes={setShowArchivedLanes}
+            onToggleArchivedLanes={(nextPressed) => setShowArchivedLanes(nextPressed)}
             view={view}
           />
         </SessionDetailDeltaFramesContext.Provider>

--- a/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
+++ b/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
@@ -580,7 +580,7 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
             timelineVisibleIds={timelineVisibleIds}
             threadNameById={threadNameById}
             onDetailTabChange={setSelectedDetailTab}
-            onToggleArchivedLanes={() => setShowArchivedLanes(!showArchivedLanes)}
+            onToggleArchivedLanes={setShowArchivedLanes}
             view={view}
           />
         </SessionDetailDeltaFramesContext.Provider>

--- a/web/src/features/managed-agents/sessions/sessionTimeline.tsx
+++ b/web/src/features/managed-agents/sessions/sessionTimeline.tsx
@@ -957,7 +957,7 @@ export function LaneTabStrip({
             type="button"
             size="sm"
             className={clsx(
-              'shrink-0 rounded-md text-sm font-medium shadow-none hover:bg-accent hover:text-foreground aria-pressed:bg-accent aria-pressed:text-foreground aria-pressed:hover:bg-accent',
+              'shrink-0 rounded-md text-sm font-medium shadow-none',
               !showArchivedLanes && 'text-muted-foreground'
             )}
             pressed={showArchivedLanes}
@@ -1057,7 +1057,7 @@ export function HeaderRow({
       data-transcript-header
       pressed={isSelected}
       className={clsx(
-        'flex h-9 w-[calc(100%+2rem)] cursor-pointer justify-start rounded-none border-0 bg-transparent px-4 text-left font-normal active:translate-y-0 hover:bg-accent hover:text-foreground aria-pressed:bg-accent aria-pressed:text-foreground aria-pressed:hover:bg-accent',
+        'flex h-9 w-[calc(100%+2rem)] cursor-pointer justify-start rounded-none border-0 bg-transparent px-4 text-left font-normal active:translate-y-0',
         '-mx-4',
         isSelected && '[[data-panel-focused=true]_&]:bg-accent'
       )}

--- a/web/src/features/managed-agents/sessions/sessionTimeline.tsx
+++ b/web/src/features/managed-agents/sessions/sessionTimeline.tsx
@@ -2,6 +2,7 @@ import { useFormatters, useI18n } from '../../../shared/i18n';
 import { Badge } from '../../../shared/ui/badge';
 import { Button } from '../../../shared/ui/button';
 import { Tabs, TabsList, TabsTrigger } from '../../../shared/ui/tabs';
+import { Toggle } from '../../../shared/ui/toggle';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../shared/ui/tooltip';
 import { type DisplayEventType, type IconComponent, type LaneTabGroup, type SessionDetailLane, type SessionEventUsage, type SessionTimelineLane, type SessionTimelineTick, type TimelinePickOptions, type ToolLifecycle } from '../types';
 import clsx from 'clsx';
@@ -835,7 +836,7 @@ export function LaneTabStrip({
   showArchivedLanes: boolean;
   timeline: SessionTimelineLane[];
   timelineVisibleIds?: Set<string>;
-  onToggleArchivedLanes: () => void;
+  onToggleArchivedLanes: (nextPressed: boolean) => void;
   onChange: (laneId: string, targetEntryId?: string | null) => void;
 }) {
   const { msg } = useI18n();
@@ -952,18 +953,18 @@ export function LaneTabStrip({
           </TabsList>
         </Tabs>
         {archivedLaneCount > 0 ? (
-          <Button
+          <Toggle
             type="button"
-            variant="ghost"
+            size="sm"
             className={clsx(
-              'h-8 shrink-0 rounded-md px-2 text-sm font-medium',
-              showArchivedLanes ? 'bg-accent text-foreground hover:bg-accent' : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+              'shrink-0 rounded-md text-sm font-medium shadow-none hover:bg-accent hover:text-foreground aria-pressed:bg-accent aria-pressed:text-foreground aria-pressed:hover:bg-accent',
+              !showArchivedLanes && 'text-muted-foreground'
             )}
-            aria-pressed={showArchivedLanes}
-            onClick={onToggleArchivedLanes}
+            pressed={showArchivedLanes}
+            onPressedChange={onToggleArchivedLanes}
           >
             {msg('managedAgents.sessions.detail.archivedLanes', '+{count} archived', { count: archivedLaneCount })}
-          </Button>
+          </Toggle>
         ) : null}
       </div>
       {scrollState.canScroll ? (
@@ -1050,21 +1051,20 @@ export function HeaderRow({
   onSelect: () => void;
 }) {
   return (
-    <Button
+    <Toggle
       render={<div />}
       nativeButton={false}
-      variant="ghost"
       data-transcript-header
-      aria-pressed={isSelected}
+      pressed={isSelected}
       className={clsx(
-        'flex h-9 w-[calc(100%+2rem)] cursor-pointer justify-start rounded-none border-0 bg-transparent px-4 text-left font-normal active:translate-y-0',
+        'flex h-9 w-[calc(100%+2rem)] cursor-pointer justify-start rounded-none border-0 bg-transparent px-4 text-left font-normal active:translate-y-0 hover:bg-accent hover:text-foreground aria-pressed:bg-accent aria-pressed:text-foreground aria-pressed:hover:bg-accent',
         '-mx-4',
-        isSelected ? 'bg-accent [[data-panel-focused=true]_&]:bg-accent' : 'hover:bg-accent'
+        isSelected && '[[data-panel-focused=true]_&]:bg-accent'
       )}
-      onClick={onSelect}
+      onPressedChange={() => onSelect()}
     >
       {children}
-    </Button>
+    </Toggle>
   );
 }
 

--- a/web/src/features/managed-agents/types.ts
+++ b/web/src/features/managed-agents/types.ts
@@ -715,7 +715,7 @@ export type EventsTabProps = {
   onThreadClick: (threadId: string, processedAtMs: number, eventType: string) => void;
   onSelectedTypesChange: (types: string[]) => void;
   onTimelineSeek: (entryId: string | null) => void;
-  onToggleArchivedLanes: () => void;
+  onToggleArchivedLanes: (nextPressed: boolean) => void;
   onViewChange: (view: SessionTraceView) => void;
   query: string;
   scrollerRef: RefObject<HTMLDivElement | null>;

--- a/web/src/shared/i18n/messages/en.json
+++ b/web/src/shared/i18n/messages/en.json
@@ -599,6 +599,7 @@
   "managedAgents.quickstart.scrollMoreTemplates": "Scroll to see more templates",
   "managedAgents.quickstart.searchTemplates": "Search templates",
   "managedAgents.quickstart.selectEnvironment": "Select an environment",
+  "managedAgents.quickstart.selectLanguage": "Select language",
   "managedAgents.quickstart.selected": "Selected",
   "managedAgents.quickstart.selectingEnvironment": "Selecting environment",
   "managedAgents.quickstart.sendMessage": "Send message",

--- a/web/src/shared/i18n/messages/zh-CN.json
+++ b/web/src/shared/i18n/messages/zh-CN.json
@@ -599,6 +599,7 @@
   "managedAgents.quickstart.scrollMoreTemplates": "滚动查看更多模板",
   "managedAgents.quickstart.searchTemplates": "搜索模板",
   "managedAgents.quickstart.selectEnvironment": "选择环境",
+  "managedAgents.quickstart.selectLanguage": "选择语言",
   "managedAgents.quickstart.selected": "已选择",
   "managedAgents.quickstart.selectingEnvironment": "正在选择环境",
   "managedAgents.quickstart.sendMessage": "发送消息",

--- a/web/src/shared/ui/toggle.tsx
+++ b/web/src/shared/ui/toggle.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/shared/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[background-color,color,box-shadow] outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-pressed:bg-accent aria-pressed:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground aria-pressed:bg-accent aria-pressed:text-accent-foreground dark:bg-input/30 dark:hover:bg-input/50",
+      },
+      size: {
+        default: "h-9 min-w-9 px-2.5",
+        sm: "h-8 min-w-8 px-2",
+        lg: "h-10 min-w-10 px-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }


### PR DESCRIPTION
## Summary
- replace the remaining Managed Agents quickstart format and language switches with shared shadcn `Select` and `Tabs`
- add a shared `Toggle` primitive and migrate the session archived-lanes control plus transcript row pressed-state chrome onto it
- update the managed-agents suites to assert the new combobox, tab, and toggle semantics

## Why
Managed Agents still had a few feature-local controls and pseudo-button pressed states after the shadcn/base-ui migration. That left parts of quickstart and sessions with inconsistent new-york semantics and DOM roles compared with the rest of the console.

## Impact
The Managed Agents surfaces now use shared shadcn/base-ui primitives more consistently across quickstart, agent edit flows, and session detail interactions. This is a frontend-only semantics and usability pass; it does not change API contracts, routing, permissions, or backend state handling.

## Root cause
The earlier migration covered most menus and tabs, but a handful of quickstart and session controls still used custom button wrappers or dropdown patterns instead of the shared component layer.

## Validation
- `bun test ./src/features/managed-agents/ManagedAgentsPage.test.tsx`
- `bun run build`
- SuperDuck verification across:
  - `agent-quickstart`
  - agents list and detail
  - sessions list and detail, including a real multi-lane session
  - deployments, environments, credential vaults, and memory stores

## Notes
- design docs were not updated because this change does not alter API behavior, state machines, permissions, or cross-surface contracts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated managed-agent UI with clearer toggle controls for archived lanes and selected transcript rows.
  * Reworked YAML/JSON code-format selection to a cleaner picker experience.
  * Improved quickstart/integration screens: sample code now uses tabbed language views and the CLI control is shown as a labeled badge.
* **Bug Fixes**
  * Session “Test run”/stop controls now disable appropriately when no environment is selected.
  * Archived-lane preferences now persist more reliably when toggled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->