### PR TITLE
tests: add e2e build tags to Go SDK tests

### DIFF
--- a/tests/sdk_go_deployments_e2e_test.go
+++ b/tests/sdk_go_deployments_e2e_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 package tests
 
 import (

--- a/tests/sdk_go_quickstart_demo_test.go
+++ b/tests/sdk_go_quickstart_demo_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 package tests
 
 import (


### PR DESCRIPTION
Add //go:build e2e tags to sdk_go_deployments_e2e_test.go and sdk_go_quickstart_demo_test.go to control when these E2E tests are compiled.

These build tags allow the tests to be conditionally compiled based on the e2e build constraint, following Go build tag conventions. Both the new //go:build format and legacy // +build format are included for compatibility.