### PR TITLE
Tighten managed agents quickstart layout

### DIFF
--- a/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
@@ -1526,10 +1526,12 @@ export function registerManagedAgentsQuickstartTests() {
 
     const emptyState = screen.getByText('No templates found');
     const emptyStateCard = emptyState.closest('[data-slot="card"]') as HTMLElement | null;
+    const emptyStateContainer = emptyStateCard?.parentElement as HTMLElement | null;
     expect(emptyState).toBeTruthy();
     expect(screen.getByText('Try a different search.')).toBeTruthy();
-    expect(emptyStateCard?.className).toContain('col-span-full');
-    expect(emptyStateCard?.className).toContain('row-span-2');
+    expect(emptyStateCard?.className).not.toContain('row-span-2');
+    expect(emptyStateContainer?.className).not.toContain('auto-rows-[136px]');
+    expect(emptyStateContainer?.className).toContain('overflow-y-auto');
   });
 
   test('renders overflow template tags as a visible count badge', () => {
@@ -1556,7 +1558,7 @@ export function registerManagedAgentsQuickstartTests() {
     expect(within(templateCard).getByTitle('sentry')).toBeTruthy();
     expect(within(templateCard).getByTitle('linear')).toBeTruthy();
     expect(within(templateCard).queryByTitle('github')).toBeNull();
-    expect(within(templateCard).getByTitle('1 more tags')).toBeTruthy();
+    expect(within(templateCard).getByTitle('1 more tag')).toBeTruthy();
     expect(within(templateCard).getByText('+1')).toBeTruthy();
     expect(templateCard.getAttribute('aria-label')).toContain('github');
   });

--- a/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
@@ -147,12 +147,12 @@ export function registerManagedAgentsQuickstartTests() {
     const fieldMonitorTemplate = screen.getByRole('button', { name: /Field monitor/i });
     const templateGrid = fieldMonitorTemplate.parentElement as HTMLElement | null;
     const fieldMonitorDescription = within(fieldMonitorTemplate).getByText(/Scans software blogs for a topic/i);
-    expect(fieldMonitorTemplate.className).toContain('min-h-[118px]');
-    expect(fieldMonitorTemplate.className).toContain('h-auto');
-    expect(fieldMonitorTemplate.className).toContain('self-start');
+    expect(fieldMonitorTemplate.className).toContain('h-full');
+    expect(fieldMonitorTemplate.className).toContain('min-h-0');
     expect(fieldMonitorTemplate.className).toContain('overflow-hidden');
-    expect(templateGrid?.className).toContain('items-start');
-    expect(fieldMonitorDescription.className).toContain('min-h-[54px]');
+    expect(templateGrid?.className).toContain('auto-rows-[136px]');
+    expect(templateGrid?.className).toContain('items-stretch');
+    expect(fieldMonitorDescription.className).toContain('line-clamp-2');
     expect(fieldMonitorTemplate.querySelector('[title="notion"]')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: /Structured extractor/i }));
@@ -234,7 +234,7 @@ export function registerManagedAgentsQuickstartTests() {
     expect(screen.getByTestId('quickstart-resizable-panels')).toBeTruthy();
     expect(divider.getAttribute('data-slot')).toBe('resizable-handle');
     expect(divider.getAttribute('aria-orientation')).toBe('vertical');
-    expect(divider.querySelector('svg')).toBeTruthy();
+    expect(divider.querySelector('svg')).toBeNull();
   });
 
   test('clamps quickstart inspector widths against the container bounds', () => {

--- a/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
@@ -1,4 +1,7 @@
 import { expect, test } from 'bun:test';
+import { I18nProvider } from '../../shared/i18n';
+import { templateTags } from './agentConfig';
+import { TemplateCard } from './components/CodeBlocks';
 import { clampQuickstartInspectorPaneWidth } from './quickstart/AgentQuickstartPage';
 import {
   ManagedAgentsPage,
@@ -1518,6 +1521,44 @@ export function registerManagedAgentsQuickstartTests() {
 
     expect(screen.getByRole('button', { name: /Incident commander/i })).toBeTruthy();
     expect(screen.queryByRole('button', { name: /Data analyst/i })).toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText('Search templates'), { target: { value: 'no-match-template' } });
+
+    const emptyState = screen.getByText('No templates found');
+    const emptyStateCard = emptyState.closest('[data-slot="card"]') as HTMLElement | null;
+    expect(emptyState).toBeTruthy();
+    expect(screen.getByText('Try a different search.')).toBeTruthy();
+    expect(emptyStateCard?.className).toContain('col-span-full');
+    expect(emptyStateCard?.className).toContain('row-span-2');
+  });
+
+  test('renders overflow template tags as a visible count badge', () => {
+    resetTestDom('https://oma.duck.ai/workspaces/default/agent-quickstart');
+    render(
+      <I18nProvider initialLocale="en">
+        <TemplateCard
+          template={{
+            id: 'tag-overflow',
+            slug: 'tag-overflow',
+            title: 'Tag overflow',
+            body: 'Template body.',
+            prompt: 'Create an agent.',
+            tags: [templateTags.notion, templateTags.slack, templateTags.sentry, templateTags.linear, templateTags.github]
+          }}
+          onClick={() => {}}
+        />
+      </I18nProvider>
+    );
+
+    const templateCard = screen.getByRole('button', { name: /Tag overflow/i });
+    expect(within(templateCard).getByTitle('notion')).toBeTruthy();
+    expect(within(templateCard).getByTitle('slack')).toBeTruthy();
+    expect(within(templateCard).getByTitle('sentry')).toBeTruthy();
+    expect(within(templateCard).getByTitle('linear')).toBeTruthy();
+    expect(within(templateCard).queryByTitle('github')).toBeNull();
+    expect(within(templateCard).getByTitle('1 more tags')).toBeTruthy();
+    expect(within(templateCard).getByText('+1')).toBeTruthy();
+    expect(templateCard.getAttribute('aria-label')).toContain('github');
   });
 
 }

--- a/web/src/features/managed-agents/components/CodeBlocks.tsx
+++ b/web/src/features/managed-agents/components/CodeBlocks.tsx
@@ -268,6 +268,7 @@ export function TemplateCard({
   const tags = template.tags ?? [];
   const visibleTags = tags.slice(0, maxVisibleTemplateTags);
   const hiddenTagCount = tags.length - visibleTags.length;
+  const hiddenTagTitle = `${hiddenTagCount} more ${hiddenTagCount === 1 ? 'tag' : 'tags'}`;
   return (
     <Button
       type="button"
@@ -295,7 +296,7 @@ export function TemplateCard({
           {hiddenTagCount > 0 ? (
             <span
               className="grid h-5 min-w-5 place-items-center rounded-full border border-border bg-secondary px-1.5 text-[10px] font-medium leading-none text-secondary-foreground"
-              title={`${hiddenTagCount} more tags`}
+              title={hiddenTagTitle}
             >
               +{hiddenTagCount}
             </span>

--- a/web/src/features/managed-agents/components/CodeBlocks.tsx
+++ b/web/src/features/managed-agents/components/CodeBlocks.tsx
@@ -268,13 +268,13 @@ export function TemplateCard({
       type="button"
       variant="ghost"
       aria-label={label}
-      className="h-auto min-h-[118px] w-full self-start flex-col items-start justify-start gap-0 overflow-hidden whitespace-normal rounded-xl border border-border bg-card p-3 text-left shadow-sm transition-colors hover:border-border hover:bg-card"
+      className="h-full min-h-0 w-full flex-col items-start justify-start gap-0 overflow-hidden whitespace-normal rounded-lg border border-border bg-card p-3 text-left shadow-sm transition-colors hover:border-border hover:bg-card"
       onClick={onClick}
     >
-      <div className="w-full min-w-0 text-[15px] font-medium leading-5 text-foreground">{title}</div>
-      <p className="mt-1 min-h-[54px] w-full min-w-0 line-clamp-3 text-[13px] leading-[18px] text-muted-foreground">{body}</p>
+      <div className="line-clamp-2 w-full min-w-0 text-[15px] font-medium leading-5 text-foreground">{title}</div>
+      <p className="mt-1 w-full min-w-0 line-clamp-2 text-[13px] leading-[18px] text-muted-foreground">{body}</p>
       {template.tags?.length ? (
-        <div className="mt-auto flex flex-wrap gap-1.5 pt-3">
+        <div className="mt-auto flex max-w-full flex-nowrap gap-1.5 overflow-hidden pt-3">
           {template.tags.map((tag) => {
             const Icon = tag.icon;
             return (

--- a/web/src/features/managed-agents/components/CodeBlocks.tsx
+++ b/web/src/features/managed-agents/components/CodeBlocks.tsx
@@ -252,6 +252,8 @@ export function ScrollableCodeBlock({ code, language }: { code: string; language
   );
 }
 
+const maxVisibleTemplateTags = 4;
+
 export function TemplateCard({
   template,
   onClick
@@ -263,6 +265,9 @@ export function TemplateCard({
   const title = templateTitle(template, msg);
   const body = templateBody(template, msg);
   const label = [title, body, ...(template.tags?.map((tag) => tag.label) ?? [])].join(' ');
+  const tags = template.tags ?? [];
+  const visibleTags = tags.slice(0, maxVisibleTemplateTags);
+  const hiddenTagCount = tags.length - visibleTags.length;
   return (
     <Button
       type="button"
@@ -273,9 +278,9 @@ export function TemplateCard({
     >
       <div className="line-clamp-2 w-full min-w-0 text-[15px] font-medium leading-5 text-foreground">{title}</div>
       <p className="mt-1 w-full min-w-0 line-clamp-2 text-[13px] leading-[18px] text-muted-foreground">{body}</p>
-      {template.tags?.length ? (
+      {tags.length ? (
         <div className="mt-auto flex max-w-full flex-nowrap gap-1.5 overflow-hidden pt-3">
-          {template.tags.map((tag) => {
+          {visibleTags.map((tag) => {
             const Icon = tag.icon;
             return (
               <span
@@ -287,6 +292,14 @@ export function TemplateCard({
               </span>
             );
           })}
+          {hiddenTagCount > 0 ? (
+            <span
+              className="grid h-5 min-w-5 place-items-center rounded-full border border-border bg-secondary px-1.5 text-[10px] font-medium leading-none text-secondary-foreground"
+              title={`${hiddenTagCount} more tags`}
+            >
+              +{hiddenTagCount}
+            </span>
+          ) : null}
         </div>
       ) : null}
     </Button>

--- a/web/src/features/managed-agents/quickstart/AgentQuickstartPage.tsx
+++ b/web/src/features/managed-agents/quickstart/AgentQuickstartPage.tsx
@@ -1093,7 +1093,6 @@ export function AgentQuickstartPage() {
           </ResizablePanel>
 
           <ResizableHandle
-            withHandle
             aria-label={msg('managedAgents.quickstart.resizePanels', 'Resize quickstart panels')}
           />
 

--- a/web/src/features/managed-agents/quickstart/components.tsx
+++ b/web/src/features/managed-agents/quickstart/components.tsx
@@ -2125,7 +2125,7 @@ export function BrowseTemplatesPanel({
           ))}
 
           {visibleTemplates.length === 0 ? (
-            <Card size="sm" className="col-span-2 py-0">
+            <Card size="sm" className="col-span-full row-span-2 py-0">
               <CardContent className="grid min-h-[240px] place-items-center px-4 py-12 text-center">
                 <div>
                   <Search className="mx-auto mb-3 size-6 text-muted-foreground/70" aria-hidden />

--- a/web/src/features/managed-agents/quickstart/components.tsx
+++ b/web/src/features/managed-agents/quickstart/components.tsx
@@ -2116,16 +2116,18 @@ export function BrowseTemplatesPanel({
           />
         </label>
 
-        <div
-          ref={listRef}
-          className="subtle-scrollbar mt-4 grid min-h-0 flex-1 auto-rows-[136px] content-start items-stretch grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-3 overflow-y-auto pr-1"
-        >
-          {visibleTemplates.map((template) => (
-            <TemplateCard key={template.id} template={template} onClick={() => onTemplateClick(template)} />
-          ))}
-
-          {visibleTemplates.length === 0 ? (
-            <Card size="sm" className="col-span-full row-span-2 py-0">
+        {visibleTemplates.length > 0 ? (
+          <div
+            ref={listRef}
+            className="subtle-scrollbar mt-4 grid min-h-0 flex-1 auto-rows-[136px] content-start items-stretch grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-3 overflow-y-auto pr-1"
+          >
+            {visibleTemplates.map((template) => (
+              <TemplateCard key={template.id} template={template} onClick={() => onTemplateClick(template)} />
+            ))}
+          </div>
+        ) : (
+          <div ref={listRef} className="subtle-scrollbar mt-4 min-h-0 flex-1 overflow-y-auto pr-1">
+            <Card size="sm" className="py-0">
               <CardContent className="grid min-h-[240px] place-items-center px-4 py-12 text-center">
                 <div>
                   <Search className="mx-auto mb-3 size-6 text-muted-foreground/70" aria-hidden />
@@ -2138,8 +2140,8 @@ export function BrowseTemplatesPanel({
                 </div>
               </CardContent>
             </Card>
-          ) : null}
-        </div>
+          </div>
+        )}
 
         {showScrollCue ? (
           <Button

--- a/web/src/features/managed-agents/quickstart/components.tsx
+++ b/web/src/features/managed-agents/quickstart/components.tsx
@@ -2118,7 +2118,7 @@ export function BrowseTemplatesPanel({
 
         <div
           ref={listRef}
-          className="subtle-scrollbar mt-4 grid min-h-0 flex-1 content-start items-start grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-3 overflow-y-auto pr-1"
+          className="subtle-scrollbar mt-4 grid min-h-0 flex-1 auto-rows-[136px] content-start items-stretch grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-3 overflow-y-auto pr-1"
         >
           {visibleTemplates.map((template) => (
             <TemplateCard key={template.id} template={template} onClick={() => onTemplateClick(template)} />


### PR DESCRIPTION
## Summary
- Make quickstart template cards stretch to uniform grid rows with tighter content clamping
- Remove the resizable handle icon to match the updated divider presentation
- Update quickstart tests to reflect the new layout and handle behavior

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quickstart template cards and layout consistency (button/grid/description sizing and line clamping).
  * Refined template panel rendering, including the “no templates found” empty state when there are no matches.
  * Updated quickstart panel divider handle behavior to match the current UI.

* **New Features**
  * Template tags on cards are now capped (max 4) with an overflow “+N” badge for hidden tags.

* **Style**
  * Adjusted spacing, alignment, and overflow handling for a more uniform, space-efficient presentation.

* **Tests**
  * Updated and extended quickstart UI tests to reflect the new layouts and tag overflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->