### PR TITLE
fix: align quickstart composer submit shortcuts

### DIFF
--- a/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
@@ -328,12 +328,14 @@ export function registerManagedAgentsQuickstartTests() {
     const chatStream = screen.getByTestId('quickstart-chat-stream');
     const chatContent = screen.getByTestId('quickstart-chat-content');
     expect(chatStream.getAttribute('data-slot')).toBe('message-scroller-viewport');
+    expect(chatStream.className).toContain('subtle-scrollbar-auto');
     expect(chatContent.getAttribute('data-slot')).toBe('message-scroller-content');
     expect(chatContent.className).toContain('w-full');
     expect(chatContent.className).toContain('px-4');
     expect(chatContent.className).not.toContain('w-[432px]');
     expect(chatContent.className).not.toContain('max-w-');
     expect(chatContent.className).not.toContain('px-6');
+    expect(codeBlockContaining('ant beta:agents create')?.className).toContain('subtle-scrollbar-auto');
 
     const userMessage = within(chatContent)
       .getByText('Parses unstructured text into a typed JSON schema.')

--- a/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
@@ -210,6 +210,70 @@ export function registerManagedAgentsQuickstartTests() {
     expect(promptInput.className).toContain('overflow-y-auto');
   });
 
+  test('keeps Enter for newlines in the initial quickstart composer and submits on Cmd/Ctrl+Enter', async () => {
+    resetTestDom('https://oma.duck.ai/workspaces/default/agent-quickstart');
+    const api = mockAgentsApi([], {
+      quickstartStream: () => quickstartToolStream('build_agent_config', {
+        name: 'Invoice tracker',
+        description: 'Tracks invoices and keeps the team updated.',
+        model: 'claude-sonnet-4-6',
+        system: 'Track invoice intake and summarize status.',
+        mcp_servers: [],
+        tools: [],
+        skills: [],
+        metadata: { template: 'blank-agent', source: 'description' }
+      })
+    });
+    renderManagedAgentsPage('quickstart');
+
+    const promptInput = screen.getByLabelText('Describe your agent') as HTMLTextAreaElement;
+
+    fireEvent.change(promptInput, { target: { value: 'Build an invoice tracker.' } });
+    fireEvent.keyDown(promptInput, { key: 'Enter' });
+    expect(api.requests.filter((request) => request.url === '/api/organizations/org_test/proxy/v1/messages').length).toBe(0);
+
+    fireEvent.keyDown(promptInput, { key: 'Enter', ctrlKey: true });
+
+    await waitFor(() => expect(api.requests.filter((request) => request.url === '/api/organizations/org_test/proxy/v1/messages').length).toBe(1));
+    expect(await screen.findByRole('button', { name: 'Create this agent' })).toBeTruthy();
+  });
+
+  test('sends quickstart chat replies on Enter and keeps Shift+Enter for newlines', async () => {
+    resetTestDom('https://oma.duck.ai/workspaces/default/agent-quickstart');
+    let proxyCalls = 0;
+    const api = mockAgentsApi([], {
+      quickstartStream: () => {
+        proxyCalls += 1;
+        if (proxyCalls === 1) {
+          return quickstartTextStream('Ready for the next step.');
+        }
+        return quickstartTextStream("Thanks, I'll continue from there.");
+      }
+    });
+    renderManagedAgentsPage('quickstart');
+
+    const promptInput = screen.getByLabelText('Describe your agent') as HTMLTextAreaElement;
+    fireEvent.change(promptInput, { target: { value: 'Build an invoice tracker.' } });
+    fireEvent.keyDown(promptInput, { key: 'Enter', ctrlKey: true });
+
+    expect(await screen.findByText('Ready for the next step.')).toBeTruthy();
+    const reply = screen.getByLabelText('Reply…') as HTMLTextAreaElement;
+
+    fireEvent.change(reply, { target: { value: 'Use limited networking.' } });
+    const initialRequestCount = api.requests.filter((request) => request.url === '/api/organizations/org_test/proxy/v1/messages').length;
+
+    fireEvent.keyDown(reply, { key: 'Enter', shiftKey: true });
+    expect(api.requests.filter((request) => request.url === '/api/organizations/org_test/proxy/v1/messages').length).toBe(initialRequestCount);
+
+    fireEvent.keyDown(reply, { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(api.requests.filter((request) => request.url === '/api/organizations/org_test/proxy/v1/messages').length).toBe(initialRequestCount + 1)
+    );
+    const latestProxyRequest = api.requests.filter((request) => request.url === '/api/organizations/org_test/proxy/v1/messages').at(-1);
+    expect(JSON.stringify(latestProxyRequest?.body?.messages)).toContain('Use limited networking.');
+  });
+
   test('anchors the initial quickstart composer inside a full-height primary pane', () => {
     resetTestDom('https://oma.duck.ai/workspaces/default/agent-quickstart');
     render(<ManagedAgentsPage section="quickstart" />);
@@ -1047,6 +1111,8 @@ export function registerManagedAgentsQuickstartTests() {
     const reply = screen.getByLabelText('Reply…') as HTMLTextAreaElement;
     expect(reply.className).toContain('focus-visible:ring-0');
     expect(reply.parentElement?.dataset.slot).toBe('input-group');
+    expect(reply.closest('form')?.className).toContain('p-3');
+    expect(reply.closest('form')?.className).toContain('pt-0');
     fireEvent.change(reply, { target: { value: 'Keep the current setup and continue.' } });
     fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
 

--- a/web/src/features/managed-agents/components/CodeBlocks.tsx
+++ b/web/src/features/managed-agents/components/CodeBlocks.tsx
@@ -236,7 +236,7 @@ export function MiniCodeBlock({ code, maxLines }: { code: string; maxLines: numb
 
   return (
     <pre
-      className="subtle-scrollbar overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-[12px] leading-[18px] text-foreground"
+      className="subtle-scrollbar-auto overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-[12px] leading-[18px] text-foreground"
       style={{ maxHeight }}
     >
       <HighlightedCode code={code} language="bash-yaml" />
@@ -246,7 +246,7 @@ export function MiniCodeBlock({ code, maxLines }: { code: string; maxLines: numb
 
 export function ScrollableCodeBlock({ code, language }: { code: string; language: HighlightLanguage }) {
   return (
-    <pre className="subtle-scrollbar max-h-80 overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-[12px] leading-[18px] text-foreground">
+    <pre className="subtle-scrollbar-auto max-h-80 overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-[12px] leading-[18px] text-foreground">
       <HighlightedCode code={code} language={language} />
     </pre>
   );

--- a/web/src/features/managed-agents/quickstart/components.tsx
+++ b/web/src/features/managed-agents/quickstart/components.tsx
@@ -23,7 +23,7 @@ import { RadioGroup, RadioGroupItem } from '../../../shared/ui/radio-group';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../../shared/ui/tabs';
 import clsx from 'clsx';
 import { AlertCircle, ArrowUp, ArrowUpRight, CalendarClock, Check, ChevronDown, ChevronLeft, ChevronRight, Cloud, Copy, FileText, Loader2, LockKeyhole, Pencil, Play, Plus, Search, Sparkles, Terminal, TriangleAlert, UserRound } from 'lucide-react';
-import { type Dispatch, type ReactNode, type RefObject, type SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
+import { type Dispatch, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, type RefObject, type SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
 import { codeForTemplate, createDialogAgentConfig, displayAgentConfig, yamlStringify } from '../agentConfig';
 import { quickstartComposerFrameClassName, quickstartComposerSendButtonClassName, quickstartComposerTextareaClassName } from '../components/composerStyles';
 import { listSessionEvents, quickstartEnvironmentRequestBody, streamQuickstartSessionEvents } from '../api';
@@ -35,6 +35,8 @@ import { copyText, errorMessage, managedEntityDetailHref, titleCase, toRecord } 
 
 export const quickstartEnvironmentSearchQuery =
   "An environment is a reusable template for the container where your agent's tools execute — things like networking policy and package access. Let me check what environments you already have.";
+
+type PromptComposerSubmitShortcut = 'enter' | 'mod-enter';
 
 export function InitialPromptPane({
   prompt,
@@ -65,6 +67,7 @@ export function InitialPromptPane({
         label={msg('managedAgents.quickstart.initial.inputLabel', 'Describe your agent')}
         placeholder={msg('managedAgents.quickstart.initial.placeholder', 'Describe your agent…')}
         isBusy={isCreating}
+        submitShortcut="mod-enter"
         onChange={onPromptChange}
         onSubmit={onSubmit}
       />
@@ -245,9 +248,10 @@ export function QuickstartChatPane({
         label={msg('managedAgents.quickstart.reply.label', 'Reply…')}
         placeholder={msg('managedAgents.quickstart.reply.placeholder', 'Reply…')}
         isBusy={isStreaming}
+        submitShortcut="enter"
         onChange={onReplyChange}
         onSubmit={onSubmitReply}
-        formClassName="shrink-0"
+        formClassName="shrink-0 p-3 pt-0"
       />
     </div>
   );
@@ -1976,6 +1980,7 @@ export function PromptComposer({
   label,
   placeholder,
   isBusy = false,
+  submitShortcut,
   formClassName = 'absolute inset-x-0 bottom-0 p-3 pt-0',
   onChange,
   onSubmit
@@ -1984,6 +1989,7 @@ export function PromptComposer({
   label: string;
   placeholder: string;
   isBusy?: boolean;
+  submitShortcut?: PromptComposerSubmitShortcut;
   formClassName?: string;
   onChange: (value: string) => void;
   onSubmit?: () => void;
@@ -1991,6 +1997,7 @@ export function PromptComposer({
   const { msg } = useI18n();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const promptId = `${label.toLowerCase().replace(/\s+/g, '-')}-prompt`;
+  const canSubmit = !isBusy && value.trim().length > 0;
 
   useEffect(() => {
     const textarea = textareaRef.current;
@@ -2001,14 +2008,41 @@ export function PromptComposer({
     textarea.style.height = `${textarea.scrollHeight}px`;
   }, [value]);
 
+  const submitPrompt = () => {
+    if (canSubmit) {
+      onSubmit?.();
+    }
+  };
+
+  const handleTextareaKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    if (!submitShortcut || event.key !== 'Enter') {
+      return;
+    }
+    const nativeEvent = event.nativeEvent as KeyboardEvent;
+    // Respect IME composition so Enter confirms text instead of sending.
+    if (nativeEvent.isComposing || nativeEvent.keyCode === 229) {
+      return;
+    }
+    if (submitShortcut === 'enter') {
+      if (event.shiftKey || isBusy) {
+        return;
+      }
+    } else if ((!event.metaKey && !event.ctrlKey) || isBusy) {
+      return;
+    }
+    event.preventDefault();
+    if (event.repeat) {
+      return;
+    }
+    submitPrompt();
+  };
+
   return (
     <form
       className={formClassName}
       onSubmit={(event) => {
         event.preventDefault();
-        if (!isBusy && value.trim()) {
-          onSubmit?.();
-        }
+        submitPrompt();
       }}
     >
       <label htmlFor={promptId} className="sr-only">
@@ -2025,6 +2059,7 @@ export function PromptComposer({
           placeholder={placeholder}
           className={clsx(quickstartComposerTextareaClassName, 'subtle-scrollbar block max-h-52 overflow-y-auto px-4 pb-2 pt-4 text-[15px] leading-6')}
           onChange={(event) => onChange(event.target.value)}
+          onKeyDown={handleTextareaKeyDown}
         />
         <InputGroupAddon align="block-end" className="justify-end px-3 pb-3 pt-0">
           <InputGroupButton
@@ -2032,7 +2067,7 @@ export function PromptComposer({
             variant="ghost"
             size="icon-sm"
             aria-label={msg('managedAgents.quickstart.sendMessage', 'Send message')}
-            disabled={!value.trim() || isBusy}
+            disabled={!canSubmit}
             className={quickstartComposerSendButtonClassName}
           >
             {isBusy ? <Loader2 className="size-4 animate-spin" aria-hidden /> : <ArrowUp className="size-4" aria-hidden />}

--- a/web/src/features/managed-agents/quickstart/components.tsx
+++ b/web/src/features/managed-agents/quickstart/components.tsx
@@ -155,7 +155,7 @@ export function QuickstartChatPane({
     <div className="relative flex h-full min-w-0 flex-col overflow-hidden">
       <MessageScrollerProvider autoScroll defaultScrollPosition="end">
         <MessageScroller className="min-h-0 flex-1">
-          <MessageScrollerViewport data-testid="quickstart-chat-stream" className="pb-6">
+          <MessageScrollerViewport data-testid="quickstart-chat-stream" className="subtle-scrollbar-auto pb-6">
             <MessageScrollerContent data-testid="quickstart-chat-content" className="mt-8 w-full gap-0 px-4">
               {streamItems.map((item, index) => {
                 if (item.type === 'message') {
@@ -1666,7 +1666,7 @@ export function IntegrationExitsCard({
               <div className="flex min-w-0 items-center gap-1">
                 <TabsList
                   aria-label={msg('managedAgents.quickstart.selectLanguage', 'Select language')}
-                  className="subtle-scrollbar h-7 max-w-[238px] gap-0.5 overflow-x-auto bg-secondary p-0.5"
+                  className="subtle-scrollbar-auto h-7 max-w-[238px] gap-0.5 overflow-x-auto bg-secondary p-0.5"
                 >
                   {integrationSnippetLanguages.map((item) => (
                     <TabsTrigger
@@ -2057,7 +2057,7 @@ export function PromptComposer({
           value={value}
           rows={1}
           placeholder={placeholder}
-          className={clsx(quickstartComposerTextareaClassName, 'subtle-scrollbar block max-h-52 overflow-y-auto px-4 pb-2 pt-4 text-[15px] leading-6')}
+          className={clsx(quickstartComposerTextareaClassName, 'subtle-scrollbar-auto block max-h-52 overflow-y-auto px-4 pb-2 pt-4 text-[15px] leading-6')}
           onChange={(event) => onChange(event.target.value)}
           onKeyDown={handleTextareaKeyDown}
         />
@@ -2154,14 +2154,14 @@ export function BrowseTemplatesPanel({
         {visibleTemplates.length > 0 ? (
           <div
             ref={listRef}
-            className="subtle-scrollbar mt-4 grid min-h-0 flex-1 auto-rows-[136px] content-start items-stretch grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-3 overflow-y-auto pr-1"
+            className="subtle-scrollbar-auto mt-4 grid min-h-0 flex-1 auto-rows-[136px] content-start items-stretch grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-3 overflow-y-auto pr-1"
           >
             {visibleTemplates.map((template) => (
               <TemplateCard key={template.id} template={template} onClick={() => onTemplateClick(template)} />
             ))}
           </div>
         ) : (
-          <div ref={listRef} className="subtle-scrollbar mt-4 min-h-0 flex-1 overflow-y-auto pr-1">
+          <div ref={listRef} className="subtle-scrollbar-auto mt-4 min-h-0 flex-1 overflow-y-auto pr-1">
             <Card size="sm" className="py-0">
               <CardContent className="grid min-h-[240px] place-items-center px-4 py-12 text-center">
                 <div>
@@ -2244,7 +2244,7 @@ export function TemplateDetailPanel({
             {isUsing ? msg('common.creating', 'Creating...') : msg('managedAgents.quickstart.useTemplate', 'Use template')}
           </Button>
         </div>
-        <div className="subtle-scrollbar min-h-0 flex-1 overflow-auto px-5 py-4">
+        <div className="subtle-scrollbar-auto min-h-0 flex-1 overflow-auto px-5 py-4">
           <NumberedCodeBlock code={code} format={format} />
         </div>
       </CardContent>
@@ -2328,7 +2328,7 @@ export function CreatedAgentConfigPanel({
           ) : null}
         </div>
 
-        <TabsContent value="config" className="subtle-scrollbar min-h-0 overflow-auto px-5 py-4">
+        <TabsContent value="config" className="subtle-scrollbar-auto min-h-0 overflow-auto px-5 py-4">
           <NumberedCodeBlock code={code} format={format} />
         </TabsContent>
         <TabsContent value="preview" className="min-h-0">
@@ -2587,7 +2587,7 @@ export function PreviewEnvironmentPanel({
         )}
       </div>
       {environment ? (
-        <div className="subtle-scrollbar flex-1 overflow-auto p-4">
+        <div className="subtle-scrollbar-auto flex-1 overflow-auto p-4">
           <div className="rounded-lg border border-border bg-secondary p-4">
             <div className="flex items-start justify-between gap-4">
               <div>

--- a/web/src/styles/utilities.css
+++ b/web/src/styles/utilities.css
@@ -53,6 +53,37 @@
   background: color-mix(in srgb, var(--muted-foreground) 42%, transparent);
 }
 
+.subtle-scrollbar-auto {
+  scrollbar-color: transparent transparent;
+  scrollbar-width: thin;
+}
+
+.subtle-scrollbar-auto::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.subtle-scrollbar-auto::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.subtle-scrollbar-auto::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 999px;
+}
+
+.subtle-scrollbar-auto:is(:hover, :focus-within, :active) {
+  scrollbar-color: color-mix(in srgb, var(--muted-foreground) 36%, transparent) transparent;
+}
+
+.subtle-scrollbar-auto:is(:hover, :focus-within, :active)::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--muted-foreground) 28%, transparent);
+}
+
+.subtle-scrollbar-auto:is(:hover, :focus-within, :active)::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--muted-foreground) 42%, transparent);
+}
+
 .sidebar-scroll-area {
   scrollbar-width: none;
 }


### PR DESCRIPTION
This PR improves keyboard shortcuts in the quickstart flow to match user expectations:

- The initial prompt composer now uses Enter for newlines and Cmd/Ctrl+Enter to submit (preventing accidental submission when typing multi-line descriptions)
- Chat replies use Enter to submit and Shift+Enter for newlines (faster chat flow)
- Adds proper padding classes to the reply composer form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quickstart composers now support different submit shortcuts depending on the step, improving keyboard flow for creating and replying to agents.
  * The initial composer submits with **Cmd/Ctrl+Enter**, while reply composers submit with **Enter**.

* **Bug Fixes**
  * Improved multiline entry handling so **Enter** inserts a new line instead of submitting when appropriate.
  * Prevented duplicate submissions during keyboard input and IME composition.
  * Refined composer spacing for a cleaner reply layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->