### PR TITLE
docs: replace manual docker run commands with docker compose section in README.cn.md

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -35,6 +35,18 @@ Open Managed Agents 是一个用 Go 实现的本地优先 Managed Agents API 服
 
 核心依赖方向大致是：`internal/api` 负责服务组装和路由，资源包负责 HTTP handler 与业务编排，`internal/db` 只做持久化边界，不能反向依赖 API 或 handler 包。
 
+## Docker Compose 一键部署
+
+项目支持通过 `docker compose up -d` 一条命令启动完整环境（PostgreSQL、Redis、MinIO、e2b-local 沙箱网关、oma-server 以及前端 Caddy 反代）。详见 `docs/design/docker-compose-deployment.md`。
+
+```bash
+docker compose up -d
+```
+
+启动后前端访问 `http://localhost:28080`（端口可通过 `CADDY_HOST_PORT` 环境变量配置），API 访问 `http://localhost:38080`。
+
+> **平台要求**：仅支持 Linux Docker Engine 20.10+ 或 OrbStack（macOS）。
+
 ## 本地依赖
 
 需要先准备：
@@ -44,26 +56,6 @@ Open Managed Agents 是一个用 Go 实现的本地优先 Managed Agents API 服
 - PostgreSQL，默认连接串是 `postgresql://claude:123456@localhost:5432/claude_api?sslmode=disable`。
 - Redis，默认 `redis://localhost:6379`。
 - MinIO 或其他 S3 兼容存储，默认 `http://localhost:9000`、bucket `claude-files`、账号密码 `minioadmin/minioadmin`。
-
-如果你没有现成服务，可以用 Docker 快速起一组本地依赖：
-
-```bash
-docker run --name oma-postgres -d \
-  -p 5432:5432 \
-  -e POSTGRES_USER=postgres \
-  -e POSTGRES_HOST_AUTH_METHOD=trust \
-  postgres:17
-
-docker run --name oma-redis -d \
-  -p 6379:6379 \
-  redis:8
-
-docker run --name oma-minio -d \
-  -p 9000:9000 -p 9001:9001 \
-  -e MINIO_ROOT_USER=minioadmin \
-  -e MINIO_ROOT_PASSWORD=minioadmin \
-  minio/minio server /data --console-address ":9001"
-```
 
 服务启动时会尝试用 `POSTGRES_ADMIN_URL` 创建默认数据库和角色；如果你的本地 PostgreSQL 不允许默认的 `postgres` 用户免密连接，请在 `.env` 中显式配置可用的管理连接串。
 

--- a/docs/design/docker-compose-deployment.md
+++ b/docs/design/docker-compose-deployment.md
@@ -143,7 +143,7 @@ PR: https://github.com/superduck-ai/open-managed-agents/pull/6
    ANTHROPIC_UPSTREAM_API_KEY=sk-ant-...
    ```
 
-> **平台要求**：`e2b-local` 使用 `network_mode: host`，仅支持 Linux Docker Engine。Docker Desktop（macOS/Windows）不支持 host 网络模式。
+> **平台要求**：`e2b-local` 使用 `network_mode: host`，支持 Linux Docker Engine 20.10+ 和 OrbStack（macOS）。Docker Desktop for Mac/Windows 不支持 host 网络模式。
 
 ## 7. 启动
 


### PR DESCRIPTION
## 变更内容

Close #10

在 README.cn.md 中用 **Docker Compose 一键部署** 章节替代旧的手动 `docker run` 命令，包含：
- 一条 `docker compose up -d` 启动说明
- 默认访问地址（前端 28080，API 38080）
- 平台要求说明（Linux Docker Engine 20.10+ 或 OrbStack）
- 指向详细设计文档的链接

同时更新 `docs/design/docker-compose-deployment.md` 第 6 节的平台要求描述，使其与 README 和第 4.2 节兼容性表格一致（补充 OrbStack 支持）。

其余所有改进（Vite proxy 路由、Caddy 端口配置、host.docker.internal 兼容性文档、镜像迁移至 ghcr.io/superduck-ai）已在 PR #13 合并时进入 main。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a one-click Docker Compose deployment guide with startup commands, configurable frontend/API access addresses and ports, and platform requirements.
  * Clarified supported environments for host network mode, including Linux Docker Engine 20.10+ and OrbStack on macOS, and noted that Docker Desktop for Mac/Windows does not support host networking.
  * Removed a specific container-based quick-start example and kept the note about automatic default database and role creation during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->