### PR TITLE
feat: 添加 CLAUDE.md 符号链接并适配 Claude Code / Codex 本地指令

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ assets/
 # ghcr.io/superduck-ai/e2b-local image.  Docker daemon needs host-accessible
 # envd to bind-mount into sandbox containers.
 envd-bin/
+
+# AI agent 个人本地覆盖文件（不提交）
+# Claude Code 读 CLAUDE.local.md；Codex 读 AGENTS.override.md（覆盖同级 AGENTS.md）。
+# Codex 全局个人偏好放 ~/.codex/AGENTS.override.md，不在此处。
+CLAUDE.local.md
+AGENTS.override.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Close #26

## 变更内容

同时适配 Claude Code 与 Codex 两种 AI 协作工具，保持 `AGENTS.md` 为单一信息源。

### 1. `CLAUDE.md` — 符号链接到 `AGENTS.md`

Claude Code 只读取 `CLAUDE.md` 而不自动读取 `AGENTS.md`。按照[官方文档](https://code.claude.com/docs/en/memory)的推荐，在无 Claude 专属内容时用 symlink，避免重复维护：

```
CLAUDE.md -> AGENTS.md
```

Codex 继续直接读 `AGENTS.md`，两者共享同一份团队指令。

### 2. `.gitignore` 加入个人本地覆盖文件

| 文件 | 工具 | 用途 |
|------|------|------|
| `CLAUDE.local.md` | Claude Code | 个人本地偏好（沙箱地址、测试数据等） |
| `AGENTS.override.md` | Codex | 项目内个人/临时覆盖（发现顺序优先于 `AGENTS.md`） |

Codex 全局个人偏好应放 `~/.codex/AGENTS.override.md`，不在此仓库管理。

## 验收

- ✅ `CLAUDE.md` 是 symlink（git 记录为 `mode 120000`）
- ✅ `.gitignore` 包含 `CLAUDE.local.md` 和 `AGENTS.override.md`

## 各工具指令发现对照

| 工具 | 读取文件 | 个人本地覆盖 |
|------|---------|-------------|
| Claude Code | `CLAUDE.md` → `AGENTS.md` | `CLAUDE.local.md` |
| Codex | `AGENTS.md` | `AGENTS.override.md`（项目）/ `~/.codex/AGENTS.override.md`（全局） |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore rules to keep personal AI-agent override files out of version control.
  * Added a reference file that points to the main agent guidance document for easier local setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->