### PR TITLE
[codex] Fix managed agent detail navigation flicker

### DIFF
--- a/web/src/features/managed-agents/ManagedAgentsPage.agents.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.agents.suite.tsx
@@ -166,6 +166,30 @@ export function registerManagedAgentsAgentsTests() {
     expect(screen.queryByRole('dialog', { name: 'Create agent' })).toBeNull();
   });
 
+  test('uses client-side navigation for agent detail links', async () => {
+    resetTestDom('https://oma.duck.ai/workspaces/default/agents');
+    mockAgentsApi([serverAgent]);
+    let popstateCount = 0;
+    const handlePopstate = () => {
+      popstateCount += 1;
+    };
+    window.addEventListener('popstate', handlePopstate);
+
+    try {
+      render(<ManagedAgentsPage section="agents" />);
+
+      const agentLink = await screen.findByRole('link', { name: 'Server agent' });
+      expect(agentLink.getAttribute('href')).toBe('/workspaces/default/agents/agent_server123456');
+
+      fireEvent.click(agentLink);
+
+      expect(window.location.pathname).toBe('/workspaces/default/agents/agent_server123456');
+      expect(popstateCount).toBe(1);
+    } finally {
+      window.removeEventListener('popstate', handlePopstate);
+    }
+  });
+
   test('validates and generates create-agent config before navigating to the created agent', async () => {
     resetTestDom('https://oma.duck.ai/workspaces/default/agents');
     const api = mockAgentsApi([], {

--- a/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
@@ -61,6 +61,27 @@ export function registerManagedAgentsResourceTests() {
     expect(api.requests.some((request) => request.url.startsWith('/v1/memory_stores?') && request.method === 'GET')).toBe(true);
   });
 
+  test('uses client-side navigation for managed resource detail links', async () => {
+    resetTestDom('https://oma.duck.ai/workspaces/default/sessions');
+    mockManagedResourceApi();
+    const popstateHandler = mock(() => undefined);
+    window.addEventListener('popstate', popstateHandler);
+
+    try {
+      renderManagedAgentsPage('sessions');
+
+      const sessionLink = await screen.findByRole('link', { name: 'Session one' });
+      expect(sessionLink.getAttribute('href')).toBe('/workspaces/default/sessions/sesn_one123456');
+
+      fireEvent.click(sessionLink);
+
+      expect(window.location.pathname).toBe('/workspaces/default/sessions/sesn_one123456');
+      expect(popstateHandler).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener('popstate', popstateHandler);
+    }
+  });
+
   test('uses shared alerts for managed resource list failures', async () => {
     resetTestDom('https://oma.duck.ai/workspaces/default/environments');
     mockManagedResourceApi();

--- a/web/src/features/managed-agents/agents/AgentsResourcePage.tsx
+++ b/web/src/features/managed-agents/agents/AgentsResourcePage.tsx
@@ -31,7 +31,7 @@ import {
 } from '../components/common';
 import { createdFilterLabel, createdFilterOptionsFor, managedColumnLabel, resourceCreateLabel, resourceDescription, resourceEmptyAction, resourceSearchPlaceholder, resourceTitle, statusFilterLabel, statusFilterOptionsFor } from '../labels';
 import { type AgentApiResponse, type AgentCreatedFilter, type AgentFilterMenu, type AgentLoadMode, type AgentStatusFilter, type CreateAgentInput, type PageCursor, type ResourceConfig } from '../types';
-import { agentDetailHref, errorMessage } from '../utils';
+import { agentDetailHref, errorMessage, handleInternalLinkClick } from '../utils';
 import { CreateAgentDialog } from './create-dialog';
 import {
   agentMatchesClientFilters,
@@ -548,13 +548,21 @@ export function AgentsResourcePage({ config, routeWorkspaceId }: { config: Resou
                           ariaLabel={msg('managedAgents.common.copyIdValue', 'Copy {id}', { id: agent.id })}
                           className="gap-1.5"
                         >
-                          <a href={detailHref} className="truncate font-mono text-[13px] text-foreground underline-offset-4 hover:underline">
+                          <a
+                            href={detailHref}
+                            className="truncate font-mono text-[13px] text-foreground underline-offset-4 hover:underline"
+                            onClick={(event) => handleInternalLinkClick(event, detailHref)}
+                          >
                             {compactAgentId(agent.id)}
                           </a>
                         </CopyIdCell>
                       </DataTableCell>
                       <DataTableCell className="truncate text-foreground">
-                        <a href={detailHref} className="underline-offset-4 hover:underline">
+                        <a
+                          href={detailHref}
+                          className="underline-offset-4 hover:underline"
+                          onClick={(event) => handleInternalLinkClick(event, detailHref)}
+                        >
                           {agent.name || msg('managedAgents.agents.untitled', 'Untitled agent')}
                         </a>
                       </DataTableCell>

--- a/web/src/features/managed-agents/components/breadcrumbs.tsx
+++ b/web/src/features/managed-agents/components/breadcrumbs.tsx
@@ -2,6 +2,7 @@ import { useI18n } from '../../../shared/i18n';
 import { cn } from '../../../shared/lib/utils';
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '../../../shared/ui/breadcrumb';
 import { type ReactNode } from 'react';
+import { handleInternalLinkClick } from '../utils';
 
 export function ManagedDetailBreadcrumb({
   listHref,
@@ -22,7 +23,9 @@ export function ManagedDetailBreadcrumb({
     <Breadcrumb aria-label={msg('navigation.breadcrumb', 'Breadcrumb')} className={className}>
       <BreadcrumbList className="min-w-0">
         <BreadcrumbItem>
-          <BreadcrumbLink href={listHref}>{listLabel}</BreadcrumbLink>
+          <BreadcrumbLink href={listHref} onClick={(event) => handleInternalLinkClick(event, listHref)}>
+            {listLabel}
+          </BreadcrumbLink>
         </BreadcrumbItem>
         {currentLabel ? (
           <>

--- a/web/src/features/managed-agents/resources/entities.tsx
+++ b/web/src/features/managed-agents/resources/entities.tsx
@@ -21,7 +21,7 @@ import { archiveManagedEntity, createManagedEntity, deleteManagedEntity, listAge
 import { AgentFilterDropdown, AgentSelectionCheckbox, ConfirmEntityDialog, EmptyState, ManagedErrorAlert, ManagedSearchField } from '../components/common';
 import { entityActionLabel, entityKindLabel, managedColumnLabel, managedMessage, managedToastMessage, resourceCreateLabel, resourceDescription, resourceSearchPlaceholder, resourceTitle } from '../labels';
 import { type AgentDetailCreatedFilter, type AgentDetailStatusFilter, type AgentStatusFilter, type DeploymentApiResponse, type EntityOption, type ManagedEntityApiResponse, type ManagedEntityFormValues, type ManagedEntityListFilters, type ManagedEntitySection, type PageCursor, type ResourceConfig, type SessionApiResponse } from '../types';
-import { compactEntityId, copyText, errorMessage, managedEntityDetailHref } from '../utils';
+import { compactEntityId, copyText, errorMessage, handleInternalLinkClick, managedEntityDetailHref } from '../utils';
 import { ManagedEntityDialog } from './dialogs';
 import { cellsForEntity, columnWidth, entityAgentId, entityAgentLabel, entityDisplayName, entityStatusLabel } from './model';
 
@@ -816,6 +816,7 @@ export function ManagedEntityRow({
   const busy = Boolean(busyAction?.endsWith(`:${entity.id}`));
   const deployment = config.section === 'deployments' ? (entity as DeploymentApiResponse) : null;
   const paused = deployment?.status === 'paused';
+  const detailHref = managedEntityDetailHref(workspaceId, config.section, entity.id);
 
   return (
     <DataTableRow selected={selected}>
@@ -830,8 +831,9 @@ export function ManagedEntityRow({
           ) :
           column === 'Name' ? (
             <a
-              href={managedEntityDetailHref(workspaceId, config.section, entity.id)}
+              href={detailHref}
               className="truncate text-foreground underline-offset-4 hover:underline"
+              onClick={(event) => handleInternalLinkClick(event, detailHref)}
             >
               {cells[column]}
             </a>

--- a/web/src/features/managed-agents/resources/model.tsx
+++ b/web/src/features/managed-agents/resources/model.tsx
@@ -4,7 +4,9 @@ import { relativeTime } from '../agents/AgentsResourcePage';
 import { localTimezone } from '../api';
 import { CompactChip, StatusPill } from '../components/common';
 import { type CredentialFormValues, type DeploymentApiResponse, type DeploymentRunApiResponse, type EnvironmentApiResponse, type EnvironmentEditValues, type EnvironmentPackageRow, type ManagedEntityApiResponse, type ManagedEntityFormValues, type ManagedEntitySection, type MemoryApiResponse, type MemoryBranchState, type MemoryTreeNode, type PageResponse, type SessionApiResponse, type VaultApiResponse, type VaultCredentialApiResponse } from '../types';
-import { formatBytes, objectRecord, titleCase } from '../utils';
+import { formatBytes, objectRecord, sectionPathSegment, titleCase } from '../utils';
+
+export { sectionPathSegment };
 
 export function initialSelectedMemoryId() {
   if (typeof window === 'undefined') {
@@ -466,17 +468,6 @@ export function deploymentRunStatus(run: DeploymentRunApiResponse) {
     return 'Succeeded';
   }
   return 'Running';
-}
-
-export function sectionPathSegment(section: ManagedEntitySection) {
-  switch (section) {
-    case 'credential-vaults':
-      return 'vaults';
-    case 'memory-stores':
-      return 'memory-stores';
-    default:
-      return section;
-  }
 }
 
 export function environmentEditValues(entity: EnvironmentApiResponse): EnvironmentEditValues {

--- a/web/src/features/managed-agents/utils.ts
+++ b/web/src/features/managed-agents/utils.ts
@@ -1,6 +1,6 @@
 import { type ApiError } from '../../shared/api/client';
 import { copyText } from '../../shared/lib/clipboard';
-import { sectionPathSegment } from './resources/ManagedResources';
+import { type MouseEvent } from 'react';
 import { type ManagedEntitySection } from './types';
 
 export { copyText };
@@ -111,6 +111,17 @@ export function managedEntityDetailHref(workspaceId: string, section: ManagedEnt
   return `${managedEntityListHref(workspaceId, section)}/${encodeURIComponent(entityId)}`;
 }
 
+export function sectionPathSegment(section: ManagedEntitySection) {
+  switch (section) {
+    case 'credential-vaults':
+      return 'vaults';
+    case 'memory-stores':
+      return 'memory-stores';
+    default:
+      return section;
+  }
+}
+
 export function agentDetailHref(workspaceId: string, agentId: string) {
   return `/workspaces/${encodeURIComponent(workspaceId || 'default')}/agents/${encodeURIComponent(agentId)}`;
 }
@@ -120,8 +131,39 @@ export function navigateToAgentConfig(workspaceId: string, agentId: string) {
     return;
   }
   const href = `${agentDetailHref(workspaceId, agentId)}?tab=config`;
+  navigateToInternalHref(href);
+}
+
+export function handleInternalLinkClick(event: MouseEvent<HTMLAnchorElement>, href: string) {
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.currentTarget.target ||
+    event.metaKey ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    typeof window === 'undefined'
+  ) {
+    return;
+  }
+
+  const targetUrl = new URL(href, window.location.href);
+  if (targetUrl.origin !== window.location.origin) {
+    return;
+  }
+
+  event.preventDefault();
+  navigateToInternalHref(`${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`);
+}
+
+export function navigateToInternalHref(href: string) {
+  if (typeof window === 'undefined') {
+    return;
+  }
   window.history.pushState(null, '', href);
-  const event = typeof PopStateEvent === 'function' ? new PopStateEvent('popstate') : new Event('popstate');
+  const event =
+    typeof window.PopStateEvent === 'function' ? new window.PopStateEvent('popstate') : new window.Event('popstate');
   window.dispatchEvent(event);
 }
 


### PR DESCRIPTION
Fixes Managed Agents list-to-detail navigation by intercepting same-origin left-clicks on internal links and dispatching client-side history updates while preserving href behavior for new tabs and copied links.

Applies this to agent/resource rows and detail breadcrumbs, and moves section path mapping into the shared managed-agents utils to avoid route helpers depending on page modules.

This prevents full-page reload flicker when opening sessions or agents from lists.

Validated with `bun test`, `bun test ./web/src/features/managed-agents/ManagedAgentsPage.test.tsx`, and `bun run build`.
