### PR TITLE
Remove legacy WebSocket ingress and harden worker event delivery

### DIFF
--- a/docs/design/be/ccrv2/ccr-v2-epoch-design.md
+++ b/docs/design/be/ccrv2/ccr-v2-epoch-design.md
@@ -268,12 +268,24 @@ lease 过期本身不修改 epoch。UI 或观测状态用 `worker_lease_expires_
 
 ## 11. Legacy 兼容边界
 
-以下入口保留 token-only 行为，用于兼容旧 session ingress 客户端，不属于 CCR v2 worker epoch 所有权面：
+legacy WebSocket transport 已移除，包括：
 
-- `/v1/session_ingress/*`
-- `/v2/session_ingress/*`
-- WebSocket ingress
+- `/v1/session_ingress/ws/{code_session_id}`
+- `/v2/session_ingress/ws/{code_session_id}`
+- `/v1/code/sessions/{code_session_id}` 的 WebSocket upgrade 行为
+
+前两个显式 WebSocket 路径不存在，canonical code session 路径收到 WebSocket upgrade 请求时返回 `404`；不带 upgrade 的 `GET` 仍保持 HTTP poll 兼容语义。
+
+CCR v2 worker 使用持久化 inbound event 队列和带 epoch 的
+`/v1/code/sessions/{code_session_id}/worker/events/stream`，不依赖进程内 WebSocket worker 连接。
+
+以下 legacy HTTP 入口仍保留 token-only 行为，用于兼容旧 session ingress 客户端，不属于 CCR v2 worker epoch 所有权面：
+
+- `/v1/session_ingress/session/{code_session_id}`
+- `/v2/session_ingress/session/{code_session_id}`
+- 上述路径的 `/events`、`/diag_logs` 子资源
 - `/v1/code/sessions/{code_session_id}` HTTP poll / persistence 兼容入口
+- `/v2/sessions/{code_session_id}` session context 兼容入口
 
 这些入口仍可写 worker event，但不提供“旧 worker 被新 register 抢占后必然 409”的语义。要让它们进入 CCR v2 所有权保证，需要先定义对应客户端 register/epoch 传递契约，再改成 `AppendWorkerEventForEpoch()`。
 

--- a/docs/design/be/ccrv2/ccr-v2-worker-events-delivery-backend-design.md
+++ b/docs/design/be/ccrv2/ccr-v2-worker-events-delivery-backend-design.md
@@ -433,7 +433,7 @@ and processed_at is null
 - 不要求修改 Claude Code TS 客户端。
 - `processed` 可直接从 `sent/received` 跳过 `processing`，因为 TS 里部分路径会直接上报 completed。
 - `replBridgeTransport` 当前可能在收到 SSE 后立即上报 `received + processed`，后端按终态幂等处理。
-- 旧 WebSocket / HTTP poll 路径可保持现有“写出即 sent”行为；可靠 delivery/replay 只约束 CCR v2 SSE worker stream。
+- legacy WebSocket transport 已移除；旧 HTTP poll 路径仍保持现有“写出即 sent”行为，可靠 delivery/replay 只约束 CCR v2 SSE worker stream。
 - delivery ACK 不作为 lease 续租信号；worker 活性仍以 heartbeat/lease 为准。
 - 当前还没有专门的 ignored ACK metric；如需运营可观测性，后续应加安全截断 event id 的日志或指标。
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/anthropics/anthropic-sdk-go v1.50.1
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/joho/godotenv v1.5.1
 	github.com/minio/minio-go/v7 v7.2.0

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+
 github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
-github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 h1:HWRh5R2+9EifMyIHV7ZV+MIZqgz+PMpZ14Jynv3O2Zs=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0/go.mod h1:JfhWUomR1baixubs02l85lZYYOm7LV6om4ceouMv45c=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=

--- a/internal/batches/worker.go
+++ b/internal/batches/worker.go
@@ -231,14 +231,40 @@ func pollHeartbeat(errCh <-chan error) error {
 
 func uploadResults(ctx context.Context, store storage.ObjectStore, database *db.DB, batch db.MessageBatch) (bucket, key string, size int64, shaHex string, err error) {
 	key = fmt.Sprintf("workspaces/%s/message_batches/%s/results.jsonl", batch.WorkspaceUUID, batch.UUID)
+	// producer 和对象存储通过无缓冲 pipe 传输结果。uploadResults 持有读取端，
+	// 因此必须保证所有返回路径都会关闭读取端。
 	pr, pw := io.Pipe()
+	defer pr.Close()
+
+	// 使用子 context，使 Put 提前返回时可以中断数据库读取；如果 producer
+	// 已经阻塞在 Write，后续关闭 pipe 会负责解除阻塞。
+	producerCtx, cancelProducer := context.WithCancel(ctx)
+	defer cancelProducer()
+	// 使用带缓冲的结果通道，避免 Put 返回期间 producer 因上报结果而再次阻塞。
+	producerDone := make(chan error, 1)
 	go func() {
-		err := writeResultsJSONL(ctx, database, batch.ID, pw)
-		_ = pw.CloseWithError(err)
+		producerErr := writeResultsJSONL(producerCtx, database, batch.ID, pw)
+		_ = pw.CloseWithError(producerErr)
+		producerDone <- producerErr
 	}()
 	reader := newCountingHashReader(pr)
-	if err := store.Put(ctx, key, reader, -1, "application/x-jsonl"); err != nil {
-		return "", "", 0, "", err
+	putErr := store.Put(ctx, key, reader, -1, "application/x-jsonl")
+	// Put 可能在未消费完 body 时失败。等待 producer 前必须先关闭读取端，
+	// 让阻塞在 PipeWriter.Write 的 producer 能够退出。
+	cancelProducer()
+	if putErr != nil {
+		_ = pr.CloseWithError(putErr)
+	} else {
+		_ = pr.Close()
+	}
+	producerErr := <-producerDone
+	if putErr != nil {
+		// 优先保留真实的存储错误；producer 错误通常只是上述取消操作或
+		// CloseWithError 派生出的后续错误。
+		return "", "", 0, "", putErr
+	}
+	if producerErr != nil {
+		return "", "", 0, "", producerErr
 	}
 	return store.Bucket(), key, reader.Size(), reader.SHA256Hex(), nil
 }

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
-	"github.com/gorilla/websocket"
 )
 
 const (
@@ -32,10 +31,6 @@ const (
 	codeSessionWorkerLeaseGrace = 10 * time.Second
 	internalEventsPageSize      = 500
 )
-
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
-}
 
 type BridgeAuthenticator func(r *http.Request, codeSessionID string) (auth.Principal, *httpapi.Error)
 
@@ -62,10 +57,8 @@ func (s *Service) RegisterRoutes(router chi.Router) {
 	router.Post("/v1/code/sessions/{code_session_id}/worker/heartbeat", s.handleCodeSessionWorkerHeartbeat)
 	router.Post("/v1/code/sessions/{code_session_id}/worker/otlp/metrics", s.handleCodeSessionWorkerOTLP)
 	router.Post("/v1/code/sessions/{code_session_id}/worker/otlp/logs", s.handleCodeSessionWorkerOTLP)
-	// Legacy session_ingress routes remain token-only for compatibility. CCR v2
-	// ownership is enforced on the /worker/* surface.
-	router.Get("/v1/session_ingress/ws/{code_session_id}", s.handleWebSocket)
-	router.Get("/v2/session_ingress/ws/{code_session_id}", s.handleWebSocket)
+	// Legacy HTTP session_ingress routes remain token-only for compatibility.
+	// CCR v2 ownership is enforced on the /worker/* surface.
 	router.Get("/v1/session_ingress/session/{code_session_id}", s.handleSessionIngressPersistence)
 	router.Post("/v1/session_ingress/session/{code_session_id}", s.handleSessionIngressPersistence)
 	router.Put("/v1/session_ingress/session/{code_session_id}", s.handleSessionIngressPersistence)
@@ -80,11 +73,13 @@ func (s *Service) RegisterRoutes(router chi.Router) {
 }
 
 func (s *Service) handleCodeSession(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodGet && websocket.IsWebSocketUpgrade(r) {
-		s.handleWebSocket(w, r)
-		return
-	}
 	if r.Method == http.MethodGet {
+		// legacy WebSocket ingress 已移除。必须在请求进入旧的 30 秒 HTTP poll
+		// 之前拒绝 WebSocket upgrade，避免退化成长轮询请求。
+		if strings.EqualFold(strings.TrimSpace(r.Header.Get("Upgrade")), "websocket") {
+			httpapi.WriteError(w, r, httpapi.NewError(http.StatusNotFound, "not_found_error", "Not found"))
+			return
+		}
 		s.handleCodeSessionHTTPPoll(w, r)
 		return
 	}
@@ -601,70 +596,6 @@ func (s *Service) handleCodeSessionWorkerOTLP(w http.ResponseWriter, r *http.Req
 	}
 	s.recordCodeSessionWorkerOTLP(r, codeSessionID, body, true, epochSource, epochValue)
 	writeOTLPSuccess(w, r)
-}
-
-func (s *Service) handleWebSocket(w http.ResponseWriter, r *http.Request) {
-	codeSessionID := chi.URLParam(r, "code_session_id")
-	if !s.authorizeIngress(w, r, codeSessionID) {
-		return
-	}
-	if _, err := s.db.GetCodeSession(r.Context(), codeSessionID); err != nil {
-		writeIngressLoadError(w, r, err)
-		return
-	}
-	conn, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		return
-	}
-	client := &workerClient{codeSessionID: codeSessionID, conn: conn}
-	s.replaceWorker(codeSessionID, client)
-	if err := s.db.MarkCodeSessionWorkerConnected(r.Context(), codeSessionID); err != nil && !errors.Is(err, db.ErrNotFound) {
-		log.Printf("mark code session worker connected code_session_id=%s: %v", codeSessionID, err)
-	}
-	defer func() {
-		s.clearWorker(codeSessionID, client)
-		if err := s.db.MarkCodeSessionWorkerDisconnected(r.Context(), codeSessionID); err != nil && !errors.Is(err, db.ErrNotFound) {
-			log.Printf("mark code session worker disconnected code_session_id=%s: %v", codeSessionID, err)
-		}
-	}()
-	s.flushQueuedInboundEvents(r.Context(), codeSessionID, client)
-	conn.SetReadLimit(maxIngressBodySize)
-	for {
-		messageType, message, err := conn.ReadMessage()
-		if err != nil {
-			return
-		}
-		if messageType != websocket.TextMessage && messageType != websocket.BinaryMessage {
-			continue
-		}
-		payloads, err := splitWorkerFrame(message)
-		if err != nil {
-			log.Printf("decode code session websocket frame code_session_id=%s: %v", codeSessionID, err)
-			continue
-		}
-		for _, payload := range payloads {
-			if err := s.AppendWorkerEvent(r.Context(), codeSessionID, payload, "websocket"); err != nil {
-				log.Printf("append code session websocket event code_session_id=%s: %v", codeSessionID, err)
-			}
-		}
-	}
-}
-
-func (s *Service) flushQueuedInboundEvents(ctx context.Context, codeSessionID string, client *workerClient) {
-	events, err := s.db.ListQueuedCodeSessionInboundEvents(ctx, codeSessionID)
-	if err != nil {
-		log.Printf("list queued code session inbound events code_session_id=%s: %v", codeSessionID, err)
-		return
-	}
-	for _, event := range events {
-		if err := client.send(event.Payload); err != nil {
-			log.Printf("send queued code session inbound event code_session_id=%s event_id=%s: %v", codeSessionID, event.ExternalID, err)
-			return
-		}
-		if err := s.db.MarkCodeSessionInboundEventSent(ctx, event.ExternalID); err != nil && !errors.Is(err, db.ErrNotFound) {
-			log.Printf("mark queued code session inbound event sent code_session_id=%s event_id=%s: %v", codeSessionID, event.ExternalID, err)
-		}
-	}
 }
 
 func (s *Service) handleSessionIngressEvents(w http.ResponseWriter, r *http.Request) {
@@ -1368,29 +1299,6 @@ func parseWorkerEpochString(value string) (int64, error) {
 		return 0, errors.New("worker_epoch must be a positive integer")
 	}
 	return epoch, nil
-}
-
-func splitWorkerFrame(frame []byte) ([]json.RawMessage, error) {
-	frame = bytes.TrimSpace(frame)
-	if len(frame) == 0 {
-		return nil, nil
-	}
-	decoder := json.NewDecoder(bytes.NewReader(frame))
-	decoder.UseNumber()
-	var payloads []json.RawMessage
-	for {
-		var raw json.RawMessage
-		if err := decoder.Decode(&raw); err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return nil, err
-		}
-		if len(bytes.TrimSpace(raw)) > 0 {
-			payloads = append(payloads, raw)
-		}
-	}
-	return payloads, nil
 }
 
 func decodeIngressEventsBody(w http.ResponseWriter, r *http.Request) ([]json.RawMessage, error) {

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -1,7 +1,6 @@
 package codesessions
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -18,7 +17,6 @@ import (
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 
 	"github.com/google/uuid"
-	"github.com/gorilla/websocket"
 )
 
 type PublicEventSink interface {
@@ -30,9 +28,8 @@ type Service struct {
 	db                  *db.DB
 	bridgeAuthenticator BridgeAuthenticator
 
-	mu      sync.Mutex
-	sink    PublicEventSink
-	workers map[string]*workerClient
+	mu   sync.Mutex
+	sink PublicEventSink
 
 	otlpLogMu sync.Mutex
 }
@@ -60,18 +57,10 @@ type workerOutputEvent struct {
 	Ephemeral bool
 }
 
-type workerClient struct {
-	codeSessionID string
-	conn          *websocket.Conn
-	mu            sync.Mutex
-	closed        bool
-}
-
 func NewService(cfg config.Config, database *db.DB) *Service {
 	return &Service{
-		cfg:     cfg,
-		db:      database,
-		workers: map[string]*workerClient{},
+		cfg: cfg,
+		db:  database,
 	}
 }
 
@@ -197,15 +186,16 @@ func (s *Service) QueueRawPublicSessionEvents(ctx context.Context, codeSession d
 	if s == nil || len(payloads) == 0 {
 		return nil
 	}
+	// 持久化队列是事件投递边界：CCR v2 SSE 和保留的 HTTP poll 都从
+	// 持久化入站队列消费事件。
 	for _, payload := range payloads {
-		event, duplicate, err := s.appendInboundPayload(ctx, codeSession.ExternalID, payload, "public-session")
+		_, duplicate, err := s.appendInboundPayload(ctx, codeSession.ExternalID, payload, "public-session")
 		if err != nil {
 			return err
 		}
 		if duplicate {
 			continue
 		}
-		s.pushInboundEvent(ctx, event)
 	}
 	return nil
 }
@@ -218,15 +208,16 @@ func (s *Service) QueueRawCodeSessionEvents(ctx context.Context, codeSession db.
 	if source == "" {
 		source = "code-session-api"
 	}
+	// 不得通过进程内 push 绕过持久化队列。CCR v2 投递必须校验 epoch，
+	// 并且在 worker 被替换后仍可重放。
 	for _, payload := range payloads {
-		event, duplicate, err := s.appendInboundPayload(ctx, codeSession.ExternalID, payload, source)
+		_, duplicate, err := s.appendInboundPayload(ctx, codeSession.ExternalID, payload, source)
 		if err != nil {
 			return err
 		}
 		if duplicate {
 			continue
 		}
-		s.pushInboundEvent(ctx, event)
 	}
 	return nil
 }
@@ -547,73 +538,6 @@ func (s *Service) subagentThreadMappings(ctx context.Context, codeSession db.Cod
 		}
 	}
 	return threadByAgent, nil
-}
-
-func (s *Service) pushInboundEvent(ctx context.Context, event db.CodeSessionEvent) {
-	client := s.workerFor(event.CodeSessionExternalID)
-	if client == nil {
-		return
-	}
-	if err := client.send(event.Payload); err != nil {
-		log.Printf("send code session inbound event code_session_id=%s event_id=%s: %v", event.CodeSessionExternalID, event.ExternalID, err)
-		s.clearWorker(event.CodeSessionExternalID, client)
-		return
-	}
-	if err := s.db.MarkCodeSessionInboundEventSent(ctx, event.ExternalID); err != nil && !errors.Is(err, db.ErrNotFound) {
-		log.Printf("mark code session inbound event sent code_session_id=%s event_id=%s: %v", event.CodeSessionExternalID, event.ExternalID, err)
-	}
-}
-
-func (s *Service) workerFor(codeSessionID string) *workerClient {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.workers[codeSessionID]
-}
-
-func (s *Service) replaceWorker(codeSessionID string, next *workerClient) {
-	s.mu.Lock()
-	old := s.workers[codeSessionID]
-	s.workers[codeSessionID] = next
-	s.mu.Unlock()
-	if old != nil {
-		old.close()
-	}
-}
-
-func (s *Service) clearWorker(codeSessionID string, client *workerClient) {
-	s.mu.Lock()
-	if s.workers[codeSessionID] == client {
-		delete(s.workers, codeSessionID)
-	}
-	s.mu.Unlock()
-	if client != nil {
-		client.close()
-	}
-}
-
-func (c *workerClient) send(payload json.RawMessage) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.closed {
-		return websocket.ErrCloseSent
-	}
-	line := bytes.TrimSpace(payload)
-	if len(line) == 0 {
-		return nil
-	}
-	line = append(append([]byte(nil), line...), '\n')
-	_ = c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
-	return c.conn.WriteMessage(websocket.TextMessage, line)
-}
-
-func (c *workerClient) close() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.closed {
-		return
-	}
-	c.closed = true
-	_ = c.conn.Close()
 }
 
 func forwardPublicEventToWorker(eventType string) bool {

--- a/internal/codesessions/tool_permissions.go
+++ b/internal/codesessions/tool_permissions.go
@@ -328,11 +328,12 @@ func (s *Service) respondToToolPermissionRequest(ctx context.Context, codeSessio
 	if err != nil {
 		return err
 	}
-	event, duplicate, err := s.appendInboundPayload(ctx, codeSessionID, payload, source)
+	// 持久化入站队列是唯一投递路径；当前 CCR v2 worker 通过按 epoch
+	// 隔离的事件流接收该响应。
+	_, duplicate, err := s.appendInboundPayload(ctx, codeSessionID, payload, source)
 	if err != nil || duplicate {
 		return err
 	}
-	s.pushInboundEvent(ctx, event)
 	return nil
 }
 

--- a/tests/message_batches_api_test.go
+++ b/tests/message_batches_api_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -66,6 +67,39 @@ func TestMessageBatchesAPI(t *testing.T) {
 		decodeJSON(t, resp.Body, &batch)
 		if batch.Type != "message_batch" || batch.ProcessingStatus != "in_progress" {
 			t.Fatalf("unexpected fixture batch: %+v", batch)
+		}
+	})
+
+	t.Run("failure results upload closes producer pipe", func(t *testing.T) {
+		uploadErr := errors.New("result upload failed")
+		failingStore := &earlyFailBatchStore{
+			fakeStore: newFakeStore("early-fail-bucket"),
+			putErr:    uploadErr,
+		}
+		failingApp := newTestAppWithStore(t, &cfg, failingStore)
+		defer failingApp.close()
+
+		created := createBatch(t, failingApp, defaultTestKey, minimalBatchBody("upload-failure-1"))
+		defer cleanupBatchRows(t, failingApp.db, created.ID)
+		prioritizeBatchJob(t, failingApp.db, created.ID)
+
+		err := batches.RunBatchOnce(context.Background(), failingApp.db, failingStore, failingApp.cfg, &fakeBatchUpstream{}, "batch-worker-upload-failure-test")
+		if !errors.Is(err, uploadErr) {
+			t.Fatalf("run batch worker error = %v, want %v", err, uploadErr)
+		}
+		if failingStore.body == nil || failingStore.bytesRead != 1 || failingStore.readErr != nil {
+			t.Fatalf("early failing store read = (%d, %v), want (1, nil)", failingStore.bytesRead, failingStore.readErr)
+		}
+
+		// 上传失败后，保留下来的读取端必须已经关闭。没有修复时，此处会读到
+		// producer 剩余的 JSONL，并通过继续消费数据意外解除其阻塞。
+		probe := make([]byte, 1)
+		n, readErr := failingStore.body.Read(probe)
+		if n != 0 || !errors.Is(readErr, io.ErrClosedPipe) {
+			if readErr == nil {
+				_, _ = io.Copy(io.Discard, failingStore.body)
+			}
+			t.Fatalf("pipe read after failed upload = (%d bytes, %v), want (0 bytes, %v)", n, readErr, io.ErrClosedPipe)
 		}
 	})
 
@@ -141,6 +175,25 @@ func TestMessageBatchesAPI(t *testing.T) {
 
 type fakeBatchUpstream struct {
 	calls []db.MessageBatchRequest
+}
+
+type earlyFailBatchStore struct {
+	*fakeStore
+	putErr    error
+	body      io.Reader
+	bytesRead int
+	readErr   error
+}
+
+func (s *earlyFailBatchStore) Put(_ context.Context, _ string, body io.Reader, _ int64, _ string) error {
+	s.body = body
+	// 失败前只消费一个字节，确保 producer 稳定阻塞在同一次无缓冲 pipe 写入中，
+	// 且该次写入仍有剩余数据尚未被读取。
+	s.bytesRead, s.readErr = body.Read(make([]byte, 1))
+	if s.readErr != nil {
+		return s.readErr
+	}
+	return s.putErr
 }
 
 func (u *fakeBatchUpstream) Send(_ context.Context, batch db.MessageBatch, req db.MessageBatchRequest) (batches.UpstreamResult, error) {

--- a/tests/sessions_api_test.go
+++ b/tests/sessions_api_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/google/uuid"
-	"github.com/gorilla/websocket"
 )
 
 type sessionAPIResponse struct {
@@ -899,69 +898,27 @@ func TestSessionThreadsDefaultPageSupportsOfficialPollingAndLegacyPrimary(t *tes
 	}
 }
 
-func TestCodeSessionWebSocketReceivesQueuedAndLiveUserEvents(t *testing.T) {
-	app := newTestAppWithStore(t, nil, newFakeStore("sessions-code-ws-bucket"))
+func TestLegacyCodeSessionWebSocketRoutesAreRemoved(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("sessions-code-ws-removed-bucket"))
 	defer app.close()
 
-	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"sessions-code-ws-agent"}`)
-	defer cleanupAgentRows(t, app.db, agent.ID)
-	env := createEnvironment(t, app, `{"name":"sessions-code-ws-env"}`)
-	defer cleanupEnvironmentRows(t, app.db, env.ID)
-	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
-	sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"queued message"}]}]}`, defaultTestKey)
-	codeSessionID := launchLocalCodeSession(t, app, session.ID)
-	assertCodeSessionHTTPPersistence(t, app, codeSessionID)
-
-	wsURL := "ws" + strings.TrimPrefix(app.baseURL, "http") + "/v1/code/sessions/" + codeSessionID
-	headers := http.Header{"Authorization": []string{"Bearer " + codeSessionID}}
-	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, headers)
-	if err != nil {
-		status := 0
-		if resp != nil {
-			status = resp.StatusCode
+	for _, path := range []string{
+		"/v1/session_ingress/ws/cse_retired",
+		"/v2/session_ingress/ws/cse_retired",
+	} {
+		req, err := http.NewRequest(http.MethodGet, app.baseURL+path, nil)
+		if err != nil {
+			t.Fatalf("new retired websocket route request %s: %v", path, err)
 		}
-		t.Fatalf("dial code session websocket status=%d: %v", status, err)
-	}
-	defer conn.Close()
-
-	initialize := readWebSocketJSON(t, conn)
-	request := initialize["request"].(map[string]any)
-	if initialize["type"] != "control_request" || request["subtype"] != "initialize" {
-		t.Fatalf("unexpected initialize frame: %#v", initialize)
-	}
-	queued := readWebSocketJSON(t, conn)
-	message := queued["message"].(map[string]any)
-	if queued["type"] != "user" || message["content"] != "queued message" {
-		t.Fatalf("unexpected queued user frame: %#v", queued)
-	}
-	_ = conn.Close()
-	conn, resp, err = websocket.DefaultDialer.Dial(wsURL, headers)
-	if err != nil {
-		status := 0
-		if resp != nil {
-			status = resp.StatusCode
+		resp, err := app.client.Do(req)
+		if err != nil {
+			t.Fatalf("request retired websocket route %s: %v", path, err)
 		}
-		t.Fatalf("redial code session websocket status=%d: %v", status, err)
-	}
-	defer conn.Close()
-	expectNoWebSocketMessage(t, conn, 150*time.Millisecond)
-	_ = conn.Close()
-
-	conn, resp, err = websocket.DefaultDialer.Dial(wsURL, headers)
-	if err != nil {
-		status := 0
-		if resp != nil {
-			status = resp.StatusCode
+		body := readAll(t, resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("retired websocket route %s status = %d, want %d: %s", path, resp.StatusCode, http.StatusNotFound, body)
 		}
-		t.Fatalf("third dial code session websocket status=%d: %v", status, err)
-	}
-	defer conn.Close()
-
-	sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"live message"}]}]}`, defaultTestKey)
-	live := readWebSocketJSON(t, conn)
-	liveMessage := live["message"].(map[string]any)
-	if live["type"] != "user" || liveMessage["content"] != "live message" {
-		t.Fatalf("unexpected live user frame: %#v", live)
 	}
 }
 
@@ -996,6 +953,27 @@ func TestCodeSessionHTTPPollReceivesQueuedUserEvents(t *testing.T) {
 	decodeJSON(t, resp.Body, &polled)
 	if len(polled.Events) < 2 || !eventPageContains(sessionEventPageAPIResponse{Data: polled.Events}, "queued over http poll") {
 		t.Fatalf("unexpected polled events: %s", polled.Events)
+	}
+
+	// The canonical path remains an HTTP poll endpoint, but WebSocket upgrade
+	// requests on it are retired. Queue an event first so a regression that
+	// accidentally falls through to polling cannot wait for its 30-second empty
+	// response timeout.
+	sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"queued for upgrade-shaped poll"}]}]}`, defaultTestKey)
+	upgradeReq, err := http.NewRequest(http.MethodGet, app.baseURL+"/v1/code/sessions/"+codeSessionID, nil)
+	if err != nil {
+		t.Fatalf("new upgrade-shaped code session poll request: %v", err)
+	}
+	upgradeReq.Header.Set("Authorization", "Bearer "+codeSessionID)
+	upgradeReq.Header.Set("Connection", "Upgrade")
+	upgradeReq.Header.Set("Upgrade", "websocket")
+	upgradeResp, err := app.client.Do(upgradeReq)
+	if err != nil {
+		t.Fatalf("upgrade-shaped code session poll: %v", err)
+	}
+	defer upgradeResp.Body.Close()
+	if upgradeResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("retired canonical websocket upgrade status = %d, want 404: %s", upgradeResp.StatusCode, readAll(t, upgradeResp.Body))
 	}
 }
 
@@ -2550,7 +2528,7 @@ func TestCodeSessionBridgeBumpsWorkerEpoch(t *testing.T) {
 	assertCodeSessionWorkerHeartbeat(t, app, codeSessionID, second.WorkerEpoch)
 }
 
-func TestCodeSessionWorkerEventsStreamReceivesQueuedUserEvents(t *testing.T) {
+func TestCodeSessionWorkerEventsStreamReceivesQueuedAndLiveUserEvents(t *testing.T) {
 	app := newTestAppWithStore(t, nil, newFakeStore("sessions-code-worker-stream-bucket"))
 	defer app.close()
 
@@ -2561,15 +2539,35 @@ func TestCodeSessionWorkerEventsStreamReceivesQueuedUserEvents(t *testing.T) {
 	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
 	sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"queued over worker sse"}]}]}`, defaultTestKey)
 	codeSessionID := launchLocalCodeSession(t, app, session.ID)
+	workerEpoch := registerCodeSessionWorker(t, app, codeSessionID)
 
-	frames := readCodeSessionWorkerSSEFrames(t, app, codeSessionID, "queued over worker sse")
-	if len(frames) < 2 {
-		t.Fatalf("worker SSE frames len = %d, want at least 2: %#v", len(frames), frames)
+	frames := readCodeSessionWorkerSSEFramesAfterConnect(
+		t,
+		app,
+		codeSessionID,
+		"events/stream?worker_epoch="+url.QueryEscape(workerEpoch),
+		"live over worker sse",
+		func() {
+			sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"live over worker sse"}]}]}`, defaultTestKey)
+		},
+	)
+	if len(frames) < 3 {
+		t.Fatalf("worker SSE frames len = %d, want at least 3: %#v", len(frames), frames)
 	}
 	if !strings.Contains(frames[0], "event: client_event") || !strings.Contains(frames[0], `"event_type":"control_request"`) {
 		t.Fatalf("unexpected first worker SSE frame: %s", frames[0])
 	}
-	if !strings.Contains(frames[len(frames)-1], "event: client_event") || !strings.Contains(frames[len(frames)-1], `"payload"`) {
+	queuedSeen := false
+	for _, frame := range frames {
+		if strings.Contains(frame, "queued over worker sse") {
+			queuedSeen = true
+			break
+		}
+	}
+	if !queuedSeen {
+		t.Fatalf("worker SSE frames missing queued event: %#v", frames)
+	}
+	if !strings.Contains(frames[len(frames)-1], "event: client_event") || !strings.Contains(frames[len(frames)-1], "live over worker sse") {
 		t.Fatalf("unexpected user worker SSE frame: %s", frames[len(frames)-1])
 	}
 	frameData := decodeWorkerSSEFrameData(t, frames[len(frames)-1])
@@ -4036,12 +4034,12 @@ func readJSONLObjectsForTest(t *testing.T, path string) []map[string]any {
 	return result
 }
 
-func readCodeSessionWorkerSSEFrames(t *testing.T, app *testApp, codeSessionID string, waitFor string) []string {
+func readCodeSessionWorkerSSEFramesFromSuffix(t *testing.T, app *testApp, codeSessionID string, suffix string, waitFor string) []string {
 	t.Helper()
-	return readCodeSessionWorkerSSEFramesFromSuffix(t, app, codeSessionID, "events/stream", waitFor)
+	return readCodeSessionWorkerSSEFramesAfterConnect(t, app, codeSessionID, suffix, waitFor, nil)
 }
 
-func readCodeSessionWorkerSSEFramesFromSuffix(t *testing.T, app *testApp, codeSessionID string, suffix string, waitFor string) []string {
+func readCodeSessionWorkerSSEFramesAfterConnect(t *testing.T, app *testApp, codeSessionID string, suffix string, waitFor string, afterConnect func()) []string {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -4058,6 +4056,9 @@ func readCodeSessionWorkerSSEFramesFromSuffix(t *testing.T, app *testApp, codeSe
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("worker events stream status = %d, want 200: %s", resp.StatusCode, readAll(t, resp.Body))
+	}
+	if afterConnect != nil {
+		afterConnect()
 	}
 	reader := bufio.NewReader(resp.Body)
 	frames := []string{}
@@ -4118,34 +4119,6 @@ func assertCodeSessionHTTPPersistence(t *testing.T, app *testApp, codeSessionID 
 			t.Fatalf("%s code session persistence status = %d, want 200: %s", method, resp.StatusCode, body)
 		}
 	}
-}
-
-func readWebSocketJSON(t *testing.T, conn *websocket.Conn) map[string]any {
-	t.Helper()
-	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	_, data, err := conn.ReadMessage()
-	if err != nil {
-		t.Fatalf("read websocket message: %v", err)
-	}
-	var payload map[string]any
-	if err := json.Unmarshal(data, &payload); err != nil {
-		t.Fatalf("decode websocket message: %v: %s", err, data)
-	}
-	return payload
-}
-
-func expectNoWebSocketMessage(t *testing.T, conn *websocket.Conn, wait time.Duration) {
-	t.Helper()
-	_ = conn.SetReadDeadline(time.Now().Add(wait))
-	_, data, err := conn.ReadMessage()
-	if err == nil {
-		t.Fatalf("unexpected websocket message after reconnect: %s", data)
-	}
-	if netErr, ok := err.(interface{ Timeout() bool }); ok && netErr.Timeout() {
-		_ = conn.SetReadDeadline(time.Time{})
-		return
-	}
-	t.Fatalf("unexpected websocket read error: %v", err)
 }
 
 func listSessionThreads(t *testing.T, app *testApp, sessionID, key string) sessionThreadPageAPIResponse {


### PR DESCRIPTION
## Summary
- Remove legacy code session WebSocket ingress routes and retire WebSocket upgrade handling on the canonical code session path
- Keep the remaining HTTP poll and session ingress compatibility endpoints intact for token-only legacy clients
- Switch worker event delivery to the persisted inbound queue path and drop in-process worker push logic
- Harden batch result uploads so producer pipes are always closed on failure
- Update design docs and tests to reflect the new delivery and compatibility boundaries

## Testing
- Added coverage for retired WebSocket routes returning 404
- Added coverage for canonical code session upgrade requests being rejected while HTTP poll remains available
- Added coverage for worker SSE delivery with both queued and live events
- Added a regression test for batch result upload failure to ensure the producer pipe is closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed legacy WebSocket session-ingress endpoints; WebSocket upgrade requests now return `404`.
  - Legacy compatibility remains available through supported HTTP polling and persistence endpoints.

- **Improvements**
  - Session events are reliably delivered through the event stream, including queued and newly published events.
  - Improved batch result uploads to handle storage failures cleanly and prevent stalled transfers.

- **Documentation**
  - Updated design documentation to clarify transport compatibility, event delivery, and epoch ownership behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->