### PR TITLE
Configure Go linting and CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go-lint:
+    name: Go static analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          args: --config=.golangci.yml --timeout=5m ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  default: none
+  enable:
+    - durationcheck
+    - govet
+    - ineffassign
+    - loggercheck
+    - makezero
+    - musttag
+    - nilnesserr
+    - reassign
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+
+formatters:
+  enable:
+    - gofmt
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@
 ## 测试要求
 
 - 测试组织顺序应先写失败场景，再写成功场景。
+- 修改 Go 代码后，运行 `just lint`；该命令使用仓库根目录的 `.golangci.yml` 执行与 CI 相同的静态分析和格式检查。
 - 修改 schema 或 handler 后，运行 `go test ./... -count=1`。
 - 做真实 E2E 时，先用 `ADDR=127.0.0.1:18080 go run .` 启动本地服务，再以 `TEST_API_BASE_URL=http://127.0.0.1:18080` 和 `sk-ant-local-default` 运行 SDK 测试。
 - 自定义 SDK E2E 覆盖：

--- a/docs/design/development-quality-gates.md
+++ b/docs/design/development-quality-gates.md
@@ -1,0 +1,21 @@
+# 开发质量门禁
+
+## 目标
+
+Go 后端使用统一、可复现的静态分析门禁，使本地开发与 Pull Request CI 对可疑代码、无效赋值、资源生命周期、日志参数、序列化约束和格式保持相同判断。
+
+## 配置与执行
+
+- `.golangci.yml` 是唯一的 Go lint 规则来源。
+- `just lint` 在本地对所有 Go package（包括测试）运行相同配置。
+- `.github/workflows/lint.yml` 在 Pull Request 和 `main` 分支推送时运行固定版本的 `golangci-lint`。
+- 门禁启用 `govet`、`ineffassign`，以及覆盖时间计算、日志参数、切片初始化、序列化标签、nil 错误、变量重赋值、数据库 rows/资源关闭和 tracing span 的专项分析器，同时用 `gofmt` 检查格式。
+
+规则变更应先在本地通过 `just lint`，再提交配置与必要的代码修复；不要通过全局排除或跳过标记隐藏既有问题。
+
+## 验收
+
+```bash
+just lint
+go test ./... -count=1
+```

--- a/internal/codesessions/tool_permissions.go
+++ b/internal/codesessions/tool_permissions.go
@@ -235,7 +235,7 @@ func (s *Service) queueControlResponseForToolConfirmation(ctx context.Context, c
 	if err != nil {
 		return false, err
 	}
-	behavior := resolvedToolPermissionAsk
+	var behavior resolvedToolPermission
 	switch stringField(payload, "result") {
 	case "allow":
 		behavior = resolvedToolPermissionAllow

--- a/internal/files/platform.go
+++ b/internal/files/platform.go
@@ -175,14 +175,13 @@ func (h *Handler) uploadBase64(w http.ResponseWriter, r *http.Request) {
 	thumbnailWidth, thumbnailHeight := imageWidth, imageHeight
 	if hasThumbnail {
 		thumbnailKey := platformThumbnailKey(record)
-		if thumbnailKey == "" {
-			hasThumbnail = false
-		} else if err := h.store.Put(r.Context(), thumbnailKey, bytes.NewReader(thumbnail.Content), int64(len(thumbnail.Content)), thumbnail.ContentType); err != nil {
-			hasThumbnail = false
-			log.Printf("put platform thumbnail object file_uuid=%s key=%s: %v", record.UUID, thumbnailKey, err)
-		} else {
-			thumbnailWidth = thumbnail.Width
-			thumbnailHeight = thumbnail.Height
+		if thumbnailKey != "" {
+			if err := h.store.Put(r.Context(), thumbnailKey, bytes.NewReader(thumbnail.Content), int64(len(thumbnail.Content)), thumbnail.ContentType); err != nil {
+				log.Printf("put platform thumbnail object file_uuid=%s key=%s: %v", record.UUID, thumbnailKey, err)
+			} else {
+				thumbnailWidth = thumbnail.Width
+				thumbnailHeight = thumbnail.Height
+			}
 		}
 	}
 

--- a/internal/memory/handler.go
+++ b/internal/memory/handler.go
@@ -751,7 +751,6 @@ func (h *Handler) updateMemory(w http.ResponseWriter, r *http.Request, storeID, 
 			}
 			targetContent = copied
 			targetContentKnown = true
-			targetSHA = record.ContentSHA256
 		}
 		versionID, err := ids.New("memver_")
 		if err != nil {

--- a/justfile
+++ b/justfile
@@ -29,6 +29,10 @@ restart-web:
 test:
   go test ./... -count=1
 
+# Run the repository's configured Go static-analysis and formatting checks.
+lint:
+  golangci-lint run --config .golangci.yml ./...
+
 web-build:
   cd web && bun run build
 


### PR DESCRIPTION
## Summary

- add a repository-wide golangci-lint v2 configuration with 11 bug-focused analyzers and gofmt
- expose the same check locally through `just lint` and run it on pull requests and main
- remove four ineffectual assignments surfaced during baseline adoption
- document the quality gate and agent validation command

## Why

The Go backend had no configured linter or static-analysis gate, leaving the Agent Readiness linter signal at 1/2. This change establishes a full-repository check without exclusions or skip directives.

## Impact

Backend changes now receive consistent static analysis locally and in GitHub Actions. The cleanup is behavior-preserving: it removes values that were always overwritten or never read.

## Validation

- `golangci-lint config verify --config .golangci.yml`
- `just lint` — 0 issues
- `go test ./internal/codesessions ./internal/files ./internal/memory -count=1`
- `go test ./... -count=1` — all packages passed except the pre-existing `TestFilesAPI/routing_group_auth_applies_only_to_v1` assertion (expected 401, current main behavior returns 404); the failure reproduces in isolation and this PR does not modify routing/authentication
