### PR TITLE
Enforce consistent code naming

### DIFF
--- a/.github/workflows/web-naming.yml
+++ b/.github/workflows/web-naming.yml
@@ -1,0 +1,43 @@
+name: Web Naming
+
+on:
+  pull_request:
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-naming.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-naming.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: web-naming-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  naming:
+    name: TypeScript naming conventions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check naming conventions
+        run: bun run lint:naming

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,9 +15,14 @@ linters:
     - musttag
     - nilnesserr
     - reassign
+    - revive
     - rowserrcheck
     - spancheck
     - sqlclosecheck
+  settings:
+    revive:
+      rules:
+        - name: var-naming
 
 formatters:
   enable:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,11 @@ repos:
         language: script
         files: ^web/.*\.(?:[cm]?[jt]sx?|json|css|md|ya?ml)$
         require_serial: true
+
+      - id: typescript-naming
+        name: Enforce TypeScript naming conventions
+        entry: bash -c 'cd web && bun run lint:naming'
+        language: system
+        files: ^web/(?:src/.*\.tsx?|eslint\.naming\.config\.js|package\.json)$
+        pass_filenames: false
+        require_serial: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,13 @@
 - hook 对暂存文件执行通用文件卫生检查，对 Go 文件执行 `gofmt` 和对应 package 的 golangci-lint，并用项目固定版本的 Prettier 格式化前端文件。
 - 使用 `just hooks-run` 对全部跟踪文件复跑相同检查；不要使用 `SKIP` 绕过失败项，除非用户明确批准并记录原因。
 
+## 命名规范
+
+- Go package 名使用简短的小写单词；导出类型、函数和方法使用 PascalCase，未导出标识符使用 mixedCaps。缩写保持 Go 惯例并在同一标识符中一致，例如 `API`、`HTTP`、`ID`、`URL`、`UUID`；接收器名应简短且在同一类型的方法中一致。
+- TypeScript/React 的类型、接口、类和组件使用 PascalCase；普通变量、函数和参数使用 camelCase；模块级常量可使用 UPPER_CASE；泛型类型参数使用 PascalCase。以 PascalCase 命名的函数参数只用于组件或构造器引用等可调用类型。
+- Anthropic/API、数据库和第三方 payload 的字段名属于外部合同，可在边界 DTO、对象属性和解构中保留 `snake_case`；进入内部变量或业务模型后应映射为上述语言惯例，不要把例外扩散到业务标识符。
+- Go 命名由 `.golangci.yml` 中 `revive/var-naming` 强制；前端命名由 `bun run lint:naming` 强制，并在 pre-commit 与 `.github/workflows/web-naming.yml` 中执行。
+
 ## 前端设计方向
 
 - 前端实现细节位于 `web/AGENTS.md`。

--- a/docs/design/development-naming-conventions.md
+++ b/docs/design/development-naming-conventions.md
@@ -1,0 +1,33 @@
+# 命名一致性门禁
+
+## 目标
+
+仓库通过语言原生惯例、独立 lint 命令、pre-commit 和 CI 对标识符命名进行确定性检查，使新代码在不依赖人工评审记忆的情况下保持一致。外部 API 和数据库字段仍按兼容合同命名，但例外被限制在边界层。
+
+## Go
+
+- package 使用简短小写名；导出标识符使用 PascalCase，未导出标识符使用 mixedCaps。
+- 常见缩写保持一致的大写形式，例如 `API`、`HTTP`、`ID`、`URL` 和 `UUID`。
+- `.golangci.yml` 启用 `revive` 的 `var-naming` 规则；现有 `just lint`、pre-commit Go package 检查和 GitHub `Lint` workflow 共用该配置。
+
+## TypeScript 与 React
+
+`web/eslint.naming.config.js` 只承载命名规则，使命名门禁不会被其他 ESLint 基线问题掩盖：
+
+- 变量使用 camelCase；React 组件引用和其他构造器值允许 PascalCase；真正的模块常量允许 UPPER_CASE。
+- 函数使用 camelCase，React 函数组件允许 PascalCase。
+- 类型、接口、类和泛型类型参数使用 PascalCase。
+- 普通参数使用 camelCase；组件或构造器引用参数允许 PascalCase。
+- 类属性和方法使用 camelCase。
+
+对象属性、类型属性和解构名称不强制改写，因为这些位置承载 Anthropic/API、数据库或第三方合同中的 `snake_case`。内部业务标识符不在此例外内。
+
+`bun run lint:naming` 是独立入口；`just web-lint-naming`、pre-commit 的 `typescript-naming` hook 和 `.github/workflows/web-naming.yml` 调用同一命令。
+
+## 验收
+
+```bash
+just lint
+just web-lint-naming
+just hooks-run
+```

--- a/justfile
+++ b/justfile
@@ -42,6 +42,9 @@ web-test:
 web-lint:
   cd web && bun run lint
 
+web-lint-naming:
+  cd web && bun run lint:naming
+
 web-format:
   cd web && bun run format
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -16,6 +16,7 @@
   - `bun run dev`
   - `bun run build`
   - `bun test`
+  - `bun run lint:naming`
   - `bun run format`
   - `bun run format:check`
 - 修改 `web/` 下的前端代码后，在使用浏览器或 SuperDuck 验证前，需要先在仓库根目录运行 `./restart-web.sh` 重启前端开发服务器。
@@ -182,6 +183,13 @@
   - `bun test`
   - `bun run build`
 - 如果 UI 变更涉及层级、响应式行为或交互保真度，需要打开浏览器验证。
+
+## 标识符命名
+
+- React 组件、类型、接口和类使用 PascalCase；普通函数、变量和参数使用 camelCase；模块级常量允许 UPPER_CASE；泛型类型参数使用 PascalCase。
+- 组件或构造器引用作为参数传递时允许 PascalCase（例如 `Icon`）；普通值参数仍使用 camelCase。
+- API/数据库 payload 的 `snake_case` 仅保留在边界属性和解构位置，内部标识符应转换为 camelCase。
+- 修改 TypeScript/TSX 标识符或命名配置后运行 `bun run lint:naming`。
 
 ## 本地开发
 

--- a/web/eslint.naming.config.js
+++ b/web/eslint.naming.config.js
@@ -1,0 +1,66 @@
+import reactHooks from 'eslint-plugin-react-hooks';
+import tseslint from 'typescript-eslint';
+
+const namingConvention = [
+  {
+    selector: 'variable',
+    modifiers: ['destructured'],
+    format: null,
+  },
+  {
+    selector: 'variable',
+    format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+    leadingUnderscore: 'allow',
+    trailingUnderscore: 'allow',
+  },
+  {
+    selector: 'function',
+    format: ['camelCase', 'PascalCase'],
+    leadingUnderscore: 'allow',
+  },
+  {
+    selector: 'parameter',
+    modifiers: ['destructured'],
+    format: null,
+  },
+  {
+    selector: 'parameter',
+    format: ['camelCase', 'PascalCase'],
+    leadingUnderscore: 'allow',
+  },
+  {
+    selector: 'typeLike',
+    format: ['PascalCase'],
+  },
+  {
+    selector: 'typeParameter',
+    format: ['PascalCase'],
+  },
+  {
+    selector: ['classMethod', 'classProperty'],
+    format: ['camelCase'],
+    leadingUnderscore: 'allow',
+  },
+];
+
+export default tseslint.config(
+  {
+    ignores: ['dist', 'src/features/managed-agents/quickstart/platformQuickstartOfficialRequest.generated.ts'],
+  },
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    linterOptions: {
+      reportUnusedDisableDirectives: 'off',
+    },
+    languageOptions: {
+      parser: tseslint.parser,
+    },
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      '@typescript-eslint/naming-convention': ['error', ...namingConvention],
+    },
+  },
+);

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview --host 127.0.0.1",
     "test": "bun test",
     "lint": "eslint .",
+    "lint:naming": "eslint --config eslint.naming.config.js src",
     "format": "prettier . --write",
     "format:check": "prettier . --check"
   },


### PR DESCRIPTION
## Summary

- enforce Go identifier conventions with `revive/var-naming` through the existing golangci-lint configuration
- add a dedicated TypeScript naming-convention ESLint command with explicit external API/database boundary exceptions
- run the TypeScript naming check in pre-commit and GitHub Actions, and document the conventions for contributors and agents

## Why

The repository documented no deterministic naming rules and neither application enforced them. This change gives Go and TypeScript code repeatable naming checks while preserving `snake_case` fields required by Anthropic APIs, database payloads, and third-party contracts at boundary objects.

## Verification

- `golangci-lint config verify`
- repository Go packages linted with `.golangci.yml`: 0 issues
- `bun run lint:naming`
- `just hooks-run`
- `bun test`: 323 passed
- `bun run build`
- `bun run format:check`

## Developer impact

New TypeScript identifiers are checked locally and in CI. Go naming is enforced by the existing lint workflow and Go pre-commit package lint. The conventions and allowed external-contract exceptions are recorded in `AGENTS.md`, `web/AGENTS.md`, and the development design document.
