### PR TITLE
Make quickstart composer submit on Enter

### DIFF
--- a/docs/design/fe/managed-agent-quickstart-composer.md
+++ b/docs/design/fe/managed-agent-quickstart-composer.md
@@ -1,0 +1,23 @@
+# Managed Agent Quickstart Composer 键盘交互
+
+## 范围
+
+本文定义 `/workspaces/{workspace_id}/agent-quickstart` 中首次描述输入框和后续回复输入框的键盘行为。两种输入框共享一致的发送语义，避免用户在 quickstart 的不同阶段切换操作习惯。
+
+## 交互契约
+
+| 操作 | 首次描述输入框 | 后续回复输入框 |
+| --- | --- | --- |
+| `Enter` | 发送当前内容 | 发送当前内容 |
+| `Shift+Enter` | 插入换行 | 插入换行 |
+
+补充约束：
+
+- 输入为空或正在发送时不重复提交。
+- 按键处于 IME composition 状态时，`Enter` 只用于确认输入法文本，不发送消息。
+- 长按产生的 repeat 事件不得触发重复发送。
+- 点击发送按钮与按 `Enter` 使用同一提交路径。
+
+## 实现与验收
+
+首次描述和后续回复都通过 `PromptComposer` 的 `enter` 提交模式实现。回归测试必须分别覆盖 `Shift+Enter` 不提交和 `Enter` 只提交一次，并在修改交互后对真实浏览器键盘事件进行验证。

--- a/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.quickstart.suite.tsx
@@ -214,7 +214,7 @@ export function registerManagedAgentsQuickstartTests() {
     expect(promptInput.className).toContain('overflow-y-auto');
   });
 
-  test('keeps Enter for newlines in the initial quickstart composer and submits on Cmd/Ctrl+Enter', async () => {
+  test('sends the initial quickstart prompt on Enter and keeps Shift+Enter for newlines', async () => {
     resetTestDom('https://oma.duck.ai/workspaces/default/agent-quickstart');
     const api = mockAgentsApi([], {
       quickstartStream: () =>
@@ -234,12 +234,12 @@ export function registerManagedAgentsQuickstartTests() {
     const promptInput = screen.getByLabelText('Describe your agent') as HTMLTextAreaElement;
 
     fireEvent.change(promptInput, { target: { value: 'Build an invoice tracker.' } });
-    fireEvent.keyDown(promptInput, { key: 'Enter' });
+    fireEvent.keyDown(promptInput, { key: 'Enter', shiftKey: true });
     expect(
       api.requests.filter((request) => request.url === '/api/organizations/org_test/proxy/v1/messages').length,
     ).toBe(0);
 
-    fireEvent.keyDown(promptInput, { key: 'Enter', ctrlKey: true });
+    fireEvent.keyDown(promptInput, { key: 'Enter' });
 
     await waitFor(() =>
       expect(
@@ -265,7 +265,7 @@ export function registerManagedAgentsQuickstartTests() {
 
     const promptInput = screen.getByLabelText('Describe your agent') as HTMLTextAreaElement;
     fireEvent.change(promptInput, { target: { value: 'Build an invoice tracker.' } });
-    fireEvent.keyDown(promptInput, { key: 'Enter', ctrlKey: true });
+    fireEvent.keyDown(promptInput, { key: 'Enter' });
 
     expect(await screen.findByText('Ready for the next step.')).toBeTruthy();
     const reply = screen.getByLabelText('Reply…') as HTMLTextAreaElement;

--- a/web/src/features/managed-agents/quickstart/components.tsx
+++ b/web/src/features/managed-agents/quickstart/components.tsx
@@ -127,7 +127,7 @@ export function InitialPromptPane({
         label={msg('managedAgents.quickstart.initial.inputLabel', 'Describe your agent')}
         placeholder={msg('managedAgents.quickstart.initial.placeholder', 'Describe your agent…')}
         isBusy={isCreating}
-        submitShortcut="mod-enter"
+        submitShortcut="enter"
         onChange={onPromptChange}
         onSubmit={onSubmit}
       />


### PR DESCRIPTION
## Summary
- Change the managed agent quickstart composer to submit on `Enter` and keep `Shift+Enter` for newlines.
- Align initial prompt and follow-up reply composers on the same keyboard contract.
- Update the design doc to record the keyboard interaction rules and validation expectations.
- Refresh the quickstart suite to cover the new submit behavior and prevent regressions.

## Testing
- Updated and reviewed the quickstart interaction tests for initial prompt and reply submission.
- Not run (not requested).