### PR TITLE
[Readiness Fix] Add duplicate code detection

### DIFF
--- a/.github/workflows/duplicate-code.yml
+++ b/.github/workflows/duplicate-code.yml
@@ -1,0 +1,55 @@
+name: Duplicate code
+
+on:
+  pull_request:
+    paths:
+      - "**/*.go"
+      - "web/src/**/*.ts"
+      - "web/src/**/*.tsx"
+      - ".jscpd.json"
+      - "web/.jscpd.json"
+      - "web/package.json"
+      - "web/bun.lock"
+      - "scripts/check-duplicates.sh"
+      - ".github/workflows/duplicate-code.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - "web/src/**/*.ts"
+      - "web/src/**/*.tsx"
+      - ".jscpd.json"
+      - "web/.jscpd.json"
+      - "web/package.json"
+      - "web/bun.lock"
+      - "scripts/check-duplicates.sh"
+      - ".github/workflows/duplicate-code.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: duplicate-code-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  duplicate-code:
+    name: Go and TypeScript duplication
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install duplicate-code detector
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Check duplicate-code budgets
+        run: ./scripts/check-duplicates.sh

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,9 @@
+{
+  "minTokens": 70,
+  "minLines": 12,
+  "mode": "strict",
+  "format": ["go"],
+  "ignore": ["**/*_test.go"],
+  "reporters": ["threshold"],
+  "threshold": 3.75
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-minimum_pre_commit_version: '4.6.0'
+minimum_pre_commit_version: "4.6.0"
 fail_fast: false
 exclude: ^web/src/features/managed-agents/quickstart/platformQuickstartOfficialRequest\.generated\.ts$
 
@@ -53,6 +53,14 @@ repos:
         entry: scripts/check-go-file-lines.sh
         language: script
         files: ^(?:.*\.go|scripts/(?:check-go-file-lines\.sh|go-file-line-budgets\.txt|tests/check-go-file-lines_test\.sh))$
+        pass_filenames: false
+        require_serial: true
+
+      - id: duplicate-code
+        name: Enforce Go and TypeScript duplicate-code budgets
+        entry: scripts/check-duplicates.sh
+        language: script
+        files: ^(?:.*\.go|web/src/.*\.tsx?|\.jscpd\.json|web/\.jscpd\.json|web/(?:package\.json|bun\.lock)|scripts/check-duplicates\.sh)$
         pass_filenames: false
         require_serial: true
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 ## 提交前质量门禁
 
 - 首次 clone 仓库或发现 hook 尚未安装时运行 `just hooks-install`，为当前 Git 仓库安装受管的 pre-commit hook；同一 clone 下的 worktree 共用该 hook。缺少 `pre-commit` 时，脚本会优先通过 `uv` 安装固定版本。
-- hook 对暂存文件执行通用文件卫生检查，对 Go 文件执行 `gofmt`、对应 package 的 golangci-lint、不可达声明检测、文件行数、函数长度和生产代码复杂度检查，并用项目固定版本的 Prettier 格式化前端文件，同时检查 TypeScript 命名、文件行数、函数长度与复杂度。
+- hook 对暂存文件执行通用文件卫生检查，对 Go 文件执行 `gofmt`、对应 package 的 golangci-lint、不可达声明检测、重复代码检测、文件行数、函数长度和生产代码复杂度检查，并用项目固定版本的 Prettier 格式化前端文件，同时检查 TypeScript 重复代码、命名、文件行数、函数长度与复杂度。
 - 使用 `just hooks-run` 对全部跟踪文件复跑相同检查；不要使用 `SKIP` 绕过失败项，除非用户明确批准并记录原因。
 - 使用 `just large-files` 通过仓库固定版本的 `check-added-large-files --enforce-all` 检查全部受跟踪文件，统一上限为 1 MiB。嵌入式目录快照 `internal/platformapi/directory_servers.json` 必须保存为紧凑 JSON。不要通过改名、忽略路径或提高预算绕过失败；有意引入大二进制文件时，应单独评审 Git LFS 策略。
 
@@ -24,6 +24,12 @@
 
 - 修改 Go 代码后运行 `just dead-code`。`.golangci-dead-code.yml` 使用 `unused` 分析器检查生产代码和测试中的不可达包级函数、方法、变量、常量与类型。
 - pre-commit 和 `.github/workflows/dead-code.yml` 使用同一配置；不要通过 `nolint`、全局排除、伪造引用或保留无调用路径的兼容包装来绕过失败。确认不再可达的声明及其专属辅助链应直接删除。
+
+## 重复代码预算
+
+- 修改 Go 或 TypeScript/TSX 生产代码后运行 `just duplicates`。项目固定的 jscpd 以 strict token 模式检测至少 12 行且至少 70 token 的复制代码；Go 与前端分别执行，避免一个应用较低的比例掩盖另一个应用的增长。
+- `.jscpd.json` 将 Go 生产代码重复率限制为 3.75%，`web/.jscpd.json` 将前端生产代码重复率限制为 1.1%。测试、suite 和生成文件不计入生产预算；不要通过扩大 ignore、提高百分比、提高最小行数/token 数或拆成近似副本绕过门禁。
+- pre-commit 和 `.github/workflows/duplicate-code.yml` 使用 `scripts/check-duplicates.sh` 执行相同门禁。预算失败时优先抽取领域辅助函数、共享数据映射或展示组件；只有确实共享同一语义与演进方向的代码才应合并。
 
 ## 复杂度预算
 

--- a/docs/design/development-quality-gates.md
+++ b/docs/design/development-quality-gates.md
@@ -8,7 +8,7 @@
 
 - `.pre-commit-config.yaml` 固定通用 hook 版本，并排除由上游流程生成的 quickstart 请求文件。
 - 通用 hook 检查尾随空白、文件结尾、合并冲突标记、YAML/JSON 语法、私钥、大文件和混合换行符。
-- 暂存 Go 文件先由 `gofmt` 格式化，再对其所属 package 执行仓库 `.golangci.yml` 规则；独立的 `unused` 门禁随后分析全部 Go package 和测试，阻止不可达的包级声明进入提交。
+- 暂存 Go 文件先由 `gofmt` 格式化，再对其所属 package 执行仓库 `.golangci.yml` 规则；独立的 `unused` 门禁随后分析全部 Go package 和测试，阻止不可达的包级声明进入提交。jscpd 再对 Go 和 TypeScript/TSX 生产代码执行独立的复制代码预算。
 - 暂存前端代码、配置、样式和 Markdown 由 `web` 中固定版本的 Prettier 格式化，并遵循 `web/.prettierignore`。
 - 官方 `check-added-large-files` hook 使用 `--enforce-all`，因此新增和修改的文件都执行统一的 1 MiB 上限。由服务嵌入的 `internal/platformapi/directory_servers.json` 保存为紧凑 JSON，避免为生成数据引入长期阈值例外。
 - `just hooks-install` 为当前 Git clone 安装 hook，同一 clone 下的 worktree 共用该 hook。若机器尚未安装 `pre-commit`，`scripts/pre-commit.sh` 会通过 `uv` 安装固定版本 `4.6.0`；`just hooks-run` 可对全部跟踪文件复跑门禁。
@@ -20,10 +20,12 @@
 - `.golangci-dead-code.yml` 单独启用 golangci-lint 的 `unused` 分析器并覆盖测试代码；`just dead-code` 通过 `scripts/go-dead-code.sh` 枚举当前 Go module 的仓库 package，避免本地前端依赖中的第三方 Go 示例污染结果。
 - `.github/workflows/lint.yml` 在 Pull Request 和 `main` 分支推送时运行固定版本的 `golangci-lint`。
 - `.github/workflows/dead-code.yml` 在 Go 代码或死代码配置变化时运行固定版本的 `unused` 分析，pre-commit 使用相同脚本阻止不可达函数、方法、变量、常量和类型进入提交。
+- `.jscpd.json` 与 `web/.jscpd.json` 固定 strict token 检测规则：复制块至少 12 行且至少 70 token；Go 生产代码上限为 3.75%，TypeScript/TSX 生产代码上限为 1.1%。两个应用分别执行，避免合并百分比掩盖单侧增长；测试、suite 和生成文件不计入生产预算。
+- `.github/workflows/duplicate-code.yml` 和 pre-commit 都调用 `scripts/check-duplicates.sh`。本地通过 `just duplicates` 运行同一门禁，超限时输出 clone 文件与行号供重构定位。
 - `.github/workflows/large-files.yml` 在每个 Pull Request 和 `main` 分支推送时通过固定版本的 `uv` 和 `pre-commit` 对全部受跟踪文件运行同一个官方 hook，确保本地与 CI 共用一套实现和阈值。
 - 门禁启用 `govet`、`ineffassign`，以及覆盖时间计算、日志参数、切片初始化、序列化标签、nil 错误、变量重赋值、数据库 rows/资源关闭和 tracing span 的专项分析器，同时用 `gofmt` 检查格式。
 
-规则变更应先在本地通过 `just lint` 和 `just dead-code`，再提交配置与必要的代码修复；不要通过全局排除、`nolint`、伪造引用或跳过标记隐藏既有问题。
+规则变更应先在本地通过 `just lint`、`just dead-code` 和 `just duplicates`，再提交配置与必要的代码修复；不要通过全局排除、提高重复率预算、`nolint`、伪造引用或跳过标记隐藏既有问题。
 
 ## 验收
 
@@ -33,5 +35,6 @@ just hooks-run
 just large-files
 just lint
 just dead-code
+just duplicates
 go test ./... -count=1
 ```

--- a/justfile
+++ b/justfile
@@ -36,6 +36,9 @@ lint:
 dead-code:
   ./scripts/go-dead-code.sh
 
+duplicates:
+  ./scripts/check-duplicates.sh
+
 complexity: go-file-lines go-complexity web-complexity
 
 go-file-lines:

--- a/scripts/check-duplicates.sh
+++ b/scripts/check-duplicates.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+jscpd="$repo_root/web/node_modules/.bin/jscpd"
+
+if [[ ! -x "$jscpd" ]]; then
+  echo "jscpd is not installed; run 'cd web && bun install --frozen-lockfile'" >&2
+  exit 1
+fi
+
+check_duplicates() {
+  local label="$1"
+  local config="$2"
+  shift 2
+
+  if "$jscpd" --config "$config" --no-tips "$@"; then
+    echo "$label duplicate-code budget passed"
+    return
+  fi
+
+  echo "$label duplicate-code budget exceeded; reporting detected clones:" >&2
+  "$jscpd" --config "$config" --reporters ai --no-tips "$@" || true
+  return 1
+}
+
+check_duplicates \
+  "Go production code" \
+  "$repo_root/.jscpd.json" \
+  "$repo_root/main.go" \
+  "$repo_root/cmd" \
+  "$repo_root/internal"
+
+check_duplicates \
+  "TypeScript production code" \
+  "$repo_root/web/.jscpd.json" \
+  "$repo_root/web/src"

--- a/web/.jscpd.json
+++ b/web/.jscpd.json
@@ -1,0 +1,9 @@
+{
+  "minTokens": 70,
+  "minLines": 12,
+  "mode": "strict",
+  "format": ["typescript", "tsx"],
+  "ignore": ["**/*.test.ts", "**/*.test.tsx", "**/*.suite.ts", "**/*.suite.tsx", "**/*.gen.ts"],
+  "reporters": ["threshold"],
+  "threshold": 1.1
+}

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -17,6 +17,7 @@
   - `bun run build`
   - `bun test`
   - `bun run lint:complexity`
+  - `bun run lint:duplicates`
   - `bun run lint:naming`
   - `bun run format`
   - `bun run format:check`
@@ -197,6 +198,11 @@
 - 修改生产 TypeScript/TSX 后运行 `bun run lint:complexity`。新文件和未列入历史预算的文件最多 500 个有效行，单函数最多 200 个有效行，并采用 modified cyclomatic complexity 上限 20；空行和纯注释不计入行数。
 - `eslint.complexity.config.js` 中的历史文件、函数长度和复杂度预算是只能下降的 ratchet，不是目标值；不得为了通过检查提高预算或扩大匹配范围。
 - 复杂函数优先拆成领域判断、数据归一化、事件处理和展示组件。保持 API 请求、状态流、路由语义、文案与样式不变，并用对应功能测试和 `bun run build` 验证机械拆分。
+
+## 重复代码预算
+
+- 修改生产 TypeScript/TSX 后运行 `bun run lint:duplicates`，或从仓库根目录运行 `just duplicates` 同时检查 Go 和前端。jscpd 以 strict token 模式检测至少 12 行且至少 70 token 的复制代码，前端生产代码重复率上限为 1.1%。
+- 测试、suite 和生成文件不计入生产重复率。不要通过扩大 ignore、提高阈值或机械改名绕过检查；只有共享业务语义与演进方向一致时才抽取共享实现。
 
 ## 本地开发
 

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -54,6 +54,7 @@
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.6.0",
         "happy-dom": "^20.10.5",
+        "jscpd": "5.0.12",
         "prettier": "3.9.5",
         "tailwindcss": "^4.3.1",
         "typescript": "^6.0.3",
@@ -588,6 +589,20 @@
     "jiti": ["jiti@2.7.0", "https://registry.npmmirror.com/jiti/-/jiti-2.7.0.tgz", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jscpd": ["jscpd@5.0.12", "https://registry.npmmirror.com/jscpd/-/jscpd-5.0.12.tgz", { "optionalDependencies": { "jscpd-darwin-arm64": "5.0.12", "jscpd-darwin-x64": "5.0.12", "jscpd-linux-arm64-gnu": "5.0.12", "jscpd-linux-x64-gnu": "5.0.12", "jscpd-linux-x64-musl": "5.0.12", "jscpd-windows-x64-msvc": "5.0.12" }, "bin": { "jscpd": "run-jscpd.js" } }, "sha512-87dC+akj2mCywlt8p3xnRlDg0B55u4GDbfE9cuwOOeIxbEuWuIoNqGoYi65A0516aJ4EzAjGwBj1Qb/Ahc8WAQ=="],
+
+    "jscpd-darwin-arm64": ["jscpd-darwin-arm64@5.0.12", "https://registry.npmmirror.com/jscpd-darwin-arm64/-/jscpd-darwin-arm64-5.0.12.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-CQCDYhQY9yOGGeauzkRGYW/QtXurPCjfDkEhUoM/M5UdmpzxfG3i9mnNsaheJ0RdFRf73mL7JaLVRP8U2l5/kA=="],
+
+    "jscpd-darwin-x64": ["jscpd-darwin-x64@5.0.12", "https://registry.npmmirror.com/jscpd-darwin-x64/-/jscpd-darwin-x64-5.0.12.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-7XNCDfChP9fPkIWLepd0zGnTov7/5mR7rJ5Utc1MdWFdgkN//qz6FAJ1FhQA0E/qjFedy9XTucfUCgLybSBsjw=="],
+
+    "jscpd-linux-arm64-gnu": ["jscpd-linux-arm64-gnu@5.0.12", "https://registry.npmmirror.com/jscpd-linux-arm64-gnu/-/jscpd-linux-arm64-gnu-5.0.12.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-i/usHD0/8twzb2Qo4vFWcnuAD4IDLS6K/mTXwYy1CiJZDw4gmjfH45jtjdKUyoutTAiNs+ZWZgx1gIRljUbFuA=="],
+
+    "jscpd-linux-x64-gnu": ["jscpd-linux-x64-gnu@5.0.12", "https://registry.npmmirror.com/jscpd-linux-x64-gnu/-/jscpd-linux-x64-gnu-5.0.12.tgz", { "os": "linux", "cpu": "x64" }, "sha512-TqaeSTaGawcqyXSrQvYJFtLRn4aQeHgphGGsq2ZtVAg+lPeuMmh81c3bl0yi2dL3gDX1RGBQKBVul1XQknOuoA=="],
+
+    "jscpd-linux-x64-musl": ["jscpd-linux-x64-musl@5.0.12", "https://registry.npmmirror.com/jscpd-linux-x64-musl/-/jscpd-linux-x64-musl-5.0.12.tgz", { "os": "linux", "cpu": "x64" }, "sha512-WelugY1/rdoo0Y0sqJ2XQOIvyIZTfRe+vP3MJe4XvEUwPF0v+9SQoS34FnfblRhsddVixyNkgl7x/sHid9UMJw=="],
+
+    "jscpd-windows-x64-msvc": ["jscpd-windows-x64-msvc@5.0.12", "https://registry.npmmirror.com/jscpd-windows-x64-msvc/-/jscpd-windows-x64-msvc-5.0.12.tgz", { "os": "win32", "cpu": "x64" }, "sha512-01x1klKjvfzI6Of5tI9u72x7TIQZQLLG6kMdsEPJKl/BXbskdknrfCepeTXRBbdFPKs25jfcd0klZ4OdDvww5w=="],
 
     "jsesc": ["jsesc@3.1.0", "https://registry.npmmirror.com/jsesc/-/jsesc-3.1.0.tgz", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "test": "bun test",
     "lint": "eslint .",
     "lint:complexity": "eslint --config eslint.complexity.config.js src",
+    "lint:duplicates": "jscpd --config .jscpd.json --no-tips src",
     "lint:naming": "eslint --config eslint.naming.config.js src",
     "format": "prettier . --write",
     "format:check": "prettier . --check"
@@ -64,6 +65,7 @@
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.6.0",
     "happy-dom": "^20.10.5",
+    "jscpd": "5.0.12",
     "prettier": "3.9.5",
     "tailwindcss": "^4.3.1",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Summary
- pin jscpd 5.0.12 and configure independent Go and TypeScript/TSX production-code duplication budgets
- add a shared local runner with actionable clone reporting, plus `just duplicates` and a frontend package script
- enforce the same gate in pre-commit and a path-filtered GitHub Actions workflow
- document thresholds, exclusions, local commands, and refactoring expectations

## Verification
- `just duplicates`
- temporary duplicate probes for Go and TypeScript (both rejected, then removed)
- `./scripts/pre-commit.sh run duplicate-code --all-files`
- `just hooks-run`
- `cd web && bun install --frozen-lockfile`
- `cd web && bun run lint:duplicates`
- `cd web && bun run format:check`
- `cd web && bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated duplicate-code checks for Go and TypeScript/TSX production code.
  * Added commands for running duplication checks locally.
  * Added configurable duplication budgets with clear reporting when limits are exceeded.

* **Documentation**
  * Updated development and contribution guidance with duplicate-code thresholds, workflows, and acceptance checks.

* **Chores**
  * Integrated duplicate-code validation into pre-commit checks and continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->