### PR TITLE
Configure polyglot monorepo tooling

### DIFF
--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/monorepo.yml
+++ b/.github/workflows/monorepo.yml
@@ -1,0 +1,74 @@
+name: Monorepo
+
+on:
+  pull_request:
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "moon.yml"
+      - ".moon/**"
+      - "web/**"
+      - "tests/js-test/**"
+      - "scripts/moon.sh"
+      - "scripts/check-monorepo.sh"
+      - "scripts/go-lint.sh"
+      - ".github/workflows/monorepo.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "moon.yml"
+      - ".moon/**"
+      - "web/**"
+      - "tests/js-test/**"
+      - "scripts/moon.sh"
+      - "scripts/check-monorepo.sh"
+      - "scripts/go-lint.sh"
+      - ".github/workflows/monorepo.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: monorepo-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  project-graph:
+    name: Project graph and builds
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      MOON_TOOLCHAIN_FORCE_GLOBALS: "true"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install frontend dependencies and moon
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Install JavaScript SDK test dependencies
+        working-directory: tests/js-test
+        run: bun install --frozen-lockfile
+
+      - name: Validate project graph and task boundaries
+        run: ./scripts/check-monorepo.sh
+
+      - name: Build applications and type-check SDK test tool
+        run: ./scripts/moon.sh run backend:build web:build agent-sdk-test:typecheck --summary

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,11 @@ test-results/
 web/test-results/
 *.tsbuildinfo
 
+# moon workspace artifacts
+.moon/cache/
+.moon/docker/
+web/.moon/cache/
+
 # Local databases and object storage scratch data
 *.db
 *.sqlite

--- a/.moon/toolchains.yml
+++ b/.moon/toolchains.yml
@@ -1,0 +1,8 @@
+javascript:
+  packageManager: "bun"
+
+bun:
+  version: "1.3.11"
+
+go:
+  version: "1.26.2"

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,0 +1,11 @@
+projects:
+  backend: "."
+  web: "web"
+  agent-sdk-test: "tests/js-test"
+
+constraints:
+  enforceLayerRelationships: true
+
+vcs:
+  defaultBranch: "main"
+  provider: "github"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,14 @@ repos:
         pass_filenames: false
         require_serial: true
 
+      - id: monorepo-graph
+        name: Validate monorepo project graph and tasks
+        entry: scripts/check-monorepo.sh
+        language: script
+        files: ^(?:\.moon/.*|moon\.yml|web/moon\.yml|tests/js-test/moon\.yml|web/(?:package\.json|bun\.lock)|scripts/(?:moon|check-monorepo|go-lint)\.sh)$
+        pass_filenames: false
+        require_serial: true
+
       - id: duplicate-code
         name: Enforce Go and TypeScript duplicate-code budgets
         entry: scripts/check-duplicates.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,13 @@
 - `.jscpd.json` 将 Go 生产代码重复率限制为 3.75%，`web/.jscpd.json` 将前端生产代码重复率限制为 1.1%。测试、suite 和生成文件不计入生产预算；不要通过扩大 ignore、提高百分比、提高最小行数/token 数或拆成近似副本绕过门禁。
 - pre-commit 和 `.github/workflows/duplicate-code.yml` 使用 `scripts/check-duplicates.sh` 执行相同门禁。预算失败时优先抽取领域辅助函数、共享数据映射或展示组件；只有确实共享同一语义与演进方向的代码才应合并。
 
+## Monorepo 工作区
+
+- `.moon/workspace.yml` 将仓库显式划分为 `backend`、`web` 和 `agent-sdk-test` 三个项目，并通过 `moon.yml`、`web/moon.yml` 与 `tests/js-test/moon.yml` 固定各项目的语言、层级、输入、输出和任务边界。
+- moon CLI 固定在 `web` 的 Bun lockfile 中；统一通过 `scripts/moon.sh` 调用，避免与系统中其他名为 `moon` 的命令冲突。首次使用前运行 `cd web && bun install --frozen-lockfile`。
+- 使用 `just workspace-projects` 查看项目图，使用 `just workspace-build` 构建 Go 服务与前端，使用 `just workspace-test` 运行项目测试和 SDK test typecheck，使用 `just workspace-check` 运行当前强制执行的跨项目静态检查（Go lint、前端命名/复杂度/格式与 SDK typecheck）。完整但尚未清零历史基线的前端 `bun run lint` 仍保留为显式的 `web:lint` 任务。moon 根据声明的 inputs/outputs 进行增量执行和本地缓存；后端 lint 通过 `scripts/go-lint.sh` 只分析仓库 Go package，不扫描 `web/node_modules` 中的第三方示例源码。
+- 修改 `.moon/`、任一项目的 `moon.yml` 或 moon 包版本后，运行 `scripts/check-monorepo.sh`。pre-commit 和 `.github/workflows/monorepo.yml` 会验证三个项目及关键任务均存在，并在 CI 中实际构建两个应用和 typecheck SDK 测试工具。
+
 ## 复杂度预算
 
 - 修改 Go 或 TypeScript/TSX 生产代码后运行 `just complexity`。Go 使用 `cyclop`，单函数最大圈复杂度为 30；`funlen` 以当前最长函数作为 ratchet，限制函数最多 163 行且最多 100 条语句；测试文件不计入生产函数指标。

--- a/docs/design/development-monorepo-tooling.md
+++ b/docs/design/development-monorepo-tooling.md
@@ -32,4 +32,4 @@
 3. 通过同一个 moon action graph 构建 Go API 与 Web 控制台；
 4. typecheck JavaScript SDK 测试工具。
 
-CI 使用官方 setup actions 提供已经固定版本的 Go 与 Bun，并通过 `MOON_TOOLCHAIN_FORCE_GLOBALS=true` 复用这些二进制；开发机未设置该变量时，moon 可按 `.moon/toolchains.yml` 准备匹配版本。
+CI checkout 保留完整 Git 历史，使 moon 能解析 `main` 与当前提交的 merge base；官方 setup actions 提供已经固定版本的 Go 与 Bun，并通过 `MOON_TOOLCHAIN_FORCE_GLOBALS=true` 复用这些二进制。开发机未设置该变量时，moon 可按 `.moon/toolchains.yml` 准备匹配版本。

--- a/docs/design/development-monorepo-tooling.md
+++ b/docs/design/development-monorepo-tooling.md
@@ -1,0 +1,35 @@
+# Monorepo 工具链
+
+## 目标
+
+仓库由三个可独立理解和执行的项目组成：根目录的 Go API、`web/` 中的浏览器控制台，以及 `tests/js-test/` 中的 JavaScript SDK 测试工具。moon 为这些异构项目提供统一项目图、任务入口、输入/输出声明和增量缓存，同时保留 Go module 与两个 Bun package 各自已有的依赖边界。
+
+## 项目边界
+
+| 项目             | 路径             | 语言/层级                       | 主要任务                                                                  |
+| ---------------- | ---------------- | ------------------------------- | ------------------------------------------------------------------------- |
+| `backend`        | `/`              | Go backend application          | `build`、`test`、`lint`                                                   |
+| `web`            | `web/`           | TypeScript frontend application | `build`、`test`、`lint`、`lint-naming`、`lint-complexity`、`format-check` |
+| `agent-sdk-test` | `tests/js-test/` | TypeScript backend automation   | `typecheck`                                                               |
+
+`agent-sdk-test` 以 development scope 依赖 `backend`，表达它验证后端 API 的关系；应用项目之间没有伪造编译依赖。workspace 启用 layer relationship 校验，使后续新增依赖必须符合 automation、application、tool、library 等层级方向。
+
+## 工具链与执行
+
+- `.moon/toolchains.yml` 固定 Go 1.26.2 与 Bun 1.3.11，并为 JavaScript 项目选择 Bun package manager。
+- `@moonrepo/cli` 固定在 `web/bun.lock`；`scripts/moon.sh` 始终调用仓库内版本，避免开发机 PATH 中同名命令造成结果漂移。
+- 每个 task 只声明与自身项目相关的 inputs。Go 根项目不会把嵌套的前端文件当作后端输入；`scripts/go-lint.sh` 从 `go list` 结果中排除 `web/node_modules` 的第三方 Go 示例。前端 build 的 `dist/` 与 Go build 的 `bin/open-managed-agents` 声明为可恢复输出。
+- `just workspace-build`、`just workspace-test` 与 `just workspace-check` 是开发者的跨项目入口。`workspace-check` 聚合仓库当前已强制执行的 Go lint、前端命名/复杂度/格式检查与 SDK typecheck；完整前端 ESLint 仍可通过 `web:lint` 单独运行，在既有错误基线清零前不伪装成全绿门禁。单项目调试仍可使用现有 Go、Bun 与 Just 命令。
+
+## 验证与 CI
+
+`scripts/check-monorepo.sh` 解析项目图，并确认三个项目和十个关键 task 均能由 moon 加载。pre-commit 在 workspace 配置或固定 CLI 发生变化时运行该验证。
+
+`.github/workflows/monorepo.yml` 使用仓库固定的 Go、Bun 和 moon 版本，在干净 runner 中：
+
+1. 安装两个 Bun package 的冻结依赖；
+2. 验证项目图与 task 定义；
+3. 通过同一个 moon action graph 构建 Go API 与 Web 控制台；
+4. typecheck JavaScript SDK 测试工具。
+
+CI 使用官方 setup actions 提供已经固定版本的 Go 与 Bun，并通过 `MOON_TOOLCHAIN_FORCE_GLOBALS=true` 复用这些二进制；开发机未设置该变量时，moon 可按 `.moon/toolchains.yml` 准备匹配版本。

--- a/docs/design/development-quality-gates.md
+++ b/docs/design/development-quality-gates.md
@@ -16,12 +16,13 @@
 ## 配置与执行
 
 - `.golangci.yml` 是常规 Go lint 规则来源；复杂度和死代码等需要不同扫描范围的专项门禁使用独立的固定配置。
-- `just lint` 在本地对所有 Go package（包括测试）运行相同配置。
+- `just lint` 通过 `scripts/go-lint.sh` 对所有仓库 Go package（包括测试）运行相同配置，并排除 `web/node_modules` 中不属于后端项目的第三方 Go 示例。
 - `.golangci-dead-code.yml` 单独启用 golangci-lint 的 `unused` 分析器并覆盖测试代码；`just dead-code` 通过 `scripts/go-dead-code.sh` 枚举当前 Go module 的仓库 package，避免本地前端依赖中的第三方 Go 示例污染结果。
 - `.github/workflows/lint.yml` 在 Pull Request 和 `main` 分支推送时运行固定版本的 `golangci-lint`。
 - `.github/workflows/dead-code.yml` 在 Go 代码或死代码配置变化时运行固定版本的 `unused` 分析，pre-commit 使用相同脚本阻止不可达函数、方法、变量、常量和类型进入提交。
 - `.jscpd.json` 与 `web/.jscpd.json` 固定 strict token 检测规则：复制块至少 12 行且至少 70 token；Go 生产代码上限为 3.75%，TypeScript/TSX 生产代码上限为 1.1%。两个应用分别执行，避免合并百分比掩盖单侧增长；测试、suite 和生成文件不计入生产预算。
 - `.github/workflows/duplicate-code.yml` 和 pre-commit 都调用 `scripts/check-duplicates.sh`。本地通过 `just duplicates` 运行同一门禁，超限时输出 clone 文件与行号供重构定位。
+- `.moon/workspace.yml` 显式注册 Go 后端、Web 控制台和 JavaScript SDK 测试工具；各项目的 `moon.yml` 声明缓存输入、构建输出和可执行任务。`scripts/check-monorepo.sh` 在 pre-commit 中验证项目图与关键任务，`.github/workflows/monorepo.yml` 则在干净环境中运行实际构建与 typecheck。
 - `.github/workflows/large-files.yml` 在每个 Pull Request 和 `main` 分支推送时通过固定版本的 `uv` 和 `pre-commit` 对全部受跟踪文件运行同一个官方 hook，确保本地与 CI 共用一套实现和阈值。
 - 门禁启用 `govet`、`ineffassign`，以及覆盖时间计算、日志参数、切片初始化、序列化标签、nil 错误、变量重赋值、数据库 rows/资源关闭和 tracing span 的专项分析器，同时用 `gofmt` 检查格式。
 

--- a/justfile
+++ b/justfile
@@ -31,13 +31,25 @@ test:
 
 # Run the repository's configured Go static-analysis and formatting checks.
 lint:
-  golangci-lint run --config .golangci.yml ./...
+  ./scripts/go-lint.sh
 
 dead-code:
   ./scripts/go-dead-code.sh
 
 duplicates:
   ./scripts/check-duplicates.sh
+
+workspace-projects:
+  ./scripts/moon.sh projects
+
+workspace-build:
+  ./scripts/moon.sh run backend:build web:build
+
+workspace-test:
+  ./scripts/moon.sh run backend:test web:test agent-sdk-test:typecheck
+
+workspace-check:
+  ./scripts/moon.sh run backend:lint web:lint-naming web:lint-complexity web:format-check agent-sdk-test:typecheck
 
 complexity: go-file-lines go-complexity web-complexity
 

--- a/moon.yml
+++ b/moon.yml
@@ -1,0 +1,46 @@
+language: "go"
+stack: "backend"
+layer: "application"
+
+project:
+  title: "Open Managed Agents API"
+  description: "Go API server, persistence layer, runtime orchestration, and backend tests."
+
+toolchains:
+  default: "go"
+
+fileGroups:
+  sources:
+    - "main.go"
+    - "cmd/**/*.go"
+    - "internal/**/*"
+    - "go.mod"
+    - "go.sum"
+  tests:
+    - "**/*_test.go"
+    - "tests/**/*.go"
+
+tasks:
+  build:
+    command: "go build -o bin/open-managed-agents ."
+    inputs:
+      - "@group(sources)"
+    outputs:
+      - "bin/open-managed-agents"
+
+  test:
+    command: "go test"
+    args:
+      - "./..."
+      - "-count=1"
+    inputs:
+      - "@group(sources)"
+      - "@group(tests)"
+
+  lint:
+    command: "./scripts/go-lint.sh"
+    inputs:
+      - "@group(sources)"
+      - "@group(tests)"
+      - ".golangci.yml"
+      - "scripts/go-lint.sh"

--- a/scripts/check-monorepo.sh
+++ b/scripts/check-monorepo.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+moon="$repo_root/scripts/moon.sh"
+
+for project in backend web agent-sdk-test; do
+  "$moon" project "$project" --json >/dev/null
+done
+
+for target in \
+  backend:build \
+  backend:test \
+  backend:lint \
+  web:build \
+  web:test \
+  web:lint \
+  web:lint-naming \
+  web:lint-complexity \
+  web:format-check \
+  agent-sdk-test:typecheck; do
+  "$moon" task "$target" --json >/dev/null
+done
+
+echo "moon project graph and task boundaries are valid"

--- a/scripts/go-lint.sh
+++ b/scripts/go-lint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v golangci-lint >/dev/null 2>&1; then
+  echo "golangci-lint is required for Go lint checks. Install the version used by .github/workflows/lint.yml." >&2
+  exit 1
+fi
+
+packages=()
+while IFS= read -r directory; do
+  [[ "$directory" == "$repo_root/web/node_modules/"* ]] && continue
+
+  if [[ "$directory" == "$repo_root" ]]; then
+    packages+=(.)
+  else
+    packages+=("./${directory#"$repo_root/"}")
+  fi
+done < <(go list -f '{{.Dir}}' ./...)
+
+exec golangci-lint run --config .golangci.yml "${packages[@]}"

--- a/scripts/moon.sh
+++ b/scripts/moon.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+moon="$repo_root/web/node_modules/.bin/moon"
+
+if [[ ! -x "$moon" ]]; then
+  echo "moon is not installed; run 'cd web && bun install --frozen-lockfile'" >&2
+  exit 1
+fi
+
+cd "$repo_root"
+exec "$moon" "$@"

--- a/tests/js-test/moon.yml
+++ b/tests/js-test/moon.yml
@@ -1,0 +1,31 @@
+dependsOn:
+  - id: "backend"
+    scope: "development"
+
+language: "typescript"
+stack: "backend"
+layer: "automation"
+
+project:
+  title: "JavaScript SDK agent test"
+  description: "Type-checked Bun runner for exercising the managed-agent API through the JavaScript SDK."
+
+toolchains:
+  default:
+    - "javascript"
+    - "bun"
+
+fileGroups:
+  sources:
+    - "src/**/*.ts"
+  configs:
+    - "package.json"
+    - "bun.lock"
+    - "tsconfig.json"
+
+tasks:
+  typecheck:
+    command: "bun run typecheck"
+    inputs:
+      - "@group(sources)"
+      - "@group(configs)"

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -21,6 +21,7 @@
   - `bun run lint:naming`
   - `bun run format`
   - `bun run format:check`
+- 仓库级构建与检查由 moon 工作区编排；在仓库根目录使用 `just workspace-projects` 查看边界，使用 `just workspace-build` 或 `just workspace-check` 运行跨项目任务。不要直接调用 PATH 中不确定来源的 `moon`，统一使用 `scripts/moon.sh`。
 - 修改 `web/` 下的前端代码后，在使用浏览器或 SuperDuck 验证前，需要先在仓库根目录运行 `./restart-web.sh` 重启前端开发服务器。
 - 生产环境产物应为 `web/dist` 下的静态文件，由 Nginx 或其他静态服务器提供服务。
 - 除非用户明确调整架构，否则不要引入 Next.js、Remix、Node 服务或 Bun HTTP 服务。

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -42,6 +42,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@moonrepo/cli": "2.4.2",
         "@tailwindcss/vite": "^4.3.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -199,6 +200,22 @@
     "@lezer/yaml": ["@lezer/yaml@1.0.4", "https://registry.npmmirror.com/@lezer/yaml/-/yaml-1.0.4.tgz", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.4.0" } }, "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw=="],
 
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.3", "https://registry.npmmirror.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz", {}, "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA=="],
+
+    "@moonrepo/cli": ["@moonrepo/cli@2.4.2", "https://registry.npmmirror.com/@moonrepo/cli/-/cli-2.4.2.tgz", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@moonrepo/core-linux-arm64-gnu": "2.4.2", "@moonrepo/core-linux-arm64-musl": "2.4.2", "@moonrepo/core-linux-x64-gnu": "2.4.2", "@moonrepo/core-linux-x64-musl": "2.4.2", "@moonrepo/core-macos-arm64": "2.4.2", "@moonrepo/core-macos-x64": "2.4.2", "@moonrepo/core-windows-x64-msvc": "2.4.2" }, "bin": { "moon": "moon.js", "moonx": "moonx.js" } }, "sha512-/Ga7i9yzGzmUKy/n8pCeFEpFJnQs02+CEmQYOv/9ngI5G7zMhI+rB5zBVfJZFnKIKGKPrS3Nl73cLa7b8kDtVw=="],
+
+    "@moonrepo/core-linux-arm64-gnu": ["@moonrepo/core-linux-arm64-gnu@2.4.2", "https://registry.npmmirror.com/@moonrepo/core-linux-arm64-gnu/-/core-linux-arm64-gnu-2.4.2.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-6xdS2MF6NYjky+3PgIo17L9DF3nDurUYultUqGwue8u5lyHvredBQY8SPfoBNqVCWpmlGG1zTszB4NXxCz32Wg=="],
+
+    "@moonrepo/core-linux-arm64-musl": ["@moonrepo/core-linux-arm64-musl@2.4.2", "https://registry.npmmirror.com/@moonrepo/core-linux-arm64-musl/-/core-linux-arm64-musl-2.4.2.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-fzVvZn4HzWmdWNyZzhhjPAFFRO+2MsIFWXC4CZVS9uvnpjooxOP/XcccS5dD3Q5Vi89Eib4K0SLuos+UTzRTfw=="],
+
+    "@moonrepo/core-linux-x64-gnu": ["@moonrepo/core-linux-x64-gnu@2.4.2", "https://registry.npmmirror.com/@moonrepo/core-linux-x64-gnu/-/core-linux-x64-gnu-2.4.2.tgz", { "os": "linux", "cpu": "x64" }, "sha512-Uw+mV/AAubnL8wVCv7rMkvtoU5XKnuJ5tZDpLwUiR3djKVGEg3ZbhX8KNuo6ANhxE1BsIzH5PXmlWPYakqLgTg=="],
+
+    "@moonrepo/core-linux-x64-musl": ["@moonrepo/core-linux-x64-musl@2.4.2", "https://registry.npmmirror.com/@moonrepo/core-linux-x64-musl/-/core-linux-x64-musl-2.4.2.tgz", { "os": "linux", "cpu": "x64" }, "sha512-BcBymmcLcaDY0QXx0+wsEzBL2CXcodkGJs2752gsbLkdeMeopyJMZeafd4EeJ+RTLmR4ov+Kz7QMpdVhCAPMNA=="],
+
+    "@moonrepo/core-macos-arm64": ["@moonrepo/core-macos-arm64@2.4.2", "https://registry.npmmirror.com/@moonrepo/core-macos-arm64/-/core-macos-arm64-2.4.2.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-V0O+punkt6VjdH2Dg6Jt4hN4m+M7ugwheapYlVL2QfPITttXn8SjFY2h7hyVEgBJqRGpCxXGaubhtztZReGnjQ=="],
+
+    "@moonrepo/core-macos-x64": ["@moonrepo/core-macos-x64@2.4.2", "https://registry.npmmirror.com/@moonrepo/core-macos-x64/-/core-macos-x64-2.4.2.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-Etb4WY/Xb5nD9IZbsgTscn9F7akGkCFRjcMqhepomx917VgjrZ5gLKrBbw9YNBlIEAo9xzalzV5tbxHzrm8pvQ=="],
+
+    "@moonrepo/core-windows-x64-msvc": ["@moonrepo/core-windows-x64-msvc@2.4.2", "https://registry.npmmirror.com/@moonrepo/core-windows-x64-msvc/-/core-windows-x64-msvc-2.4.2.tgz", { "os": "win32", "cpu": "x64" }, "sha512-oE7NLmAQrxZjBk364nA68NKdP+1M5GMIkQNwEV7Aht6DeVxfCyTcVDxcAo7jzR66sET/Nm2r/wojVN8CjxMIjA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "https://registry.npmmirror.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
 

--- a/web/moon.yml
+++ b/web/moon.yml
@@ -1,0 +1,63 @@
+language: 'typescript'
+stack: 'frontend'
+layer: 'application'
+
+project:
+  title: 'Open Managed Agents Console'
+  description: 'React and TypeScript browser console built with Vite and Bun.'
+
+toolchains:
+  default:
+    - 'javascript'
+    - 'bun'
+
+fileGroups:
+  sources:
+    - 'src/**/*'
+    - 'index.html'
+  configs:
+    - 'package.json'
+    - 'bun.lock'
+    - 'tsconfig*.json'
+    - '*.config.*'
+
+tasks:
+  build:
+    command: 'bun run build'
+    inputs:
+      - '@group(sources)'
+      - '@group(configs)'
+    outputs:
+      - 'dist'
+
+  test:
+    command: 'bun test'
+    inputs:
+      - '@group(sources)'
+      - '@group(configs)'
+
+  lint:
+    command: 'bun run lint'
+    inputs:
+      - '@group(sources)'
+      - '@group(configs)'
+
+  lint-naming:
+    command: 'bun run lint:naming'
+    inputs:
+      - '@group(sources)'
+      - '@group(configs)'
+
+  lint-complexity:
+    command: 'bun run lint:complexity'
+    inputs:
+      - '@group(sources)'
+      - '@group(configs)'
+
+  format-check:
+    command: 'bun run format:check'
+    inputs:
+      - '@group(sources)'
+      - '@group(configs)'
+      - '.prettierrc.json'
+      - '.prettierignore'

--- a/web/package.json
+++ b/web/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@moonrepo/cli": "2.4.2",
     "@tailwindcss/vite": "^4.3.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
## Summary

- configure a pinned moon workspace with explicit backend, web, and JavaScript SDK test project boundaries
- add cached build, test, lint, format, and type-check tasks with Just, pre-commit, and CI entry points
- keep Go lint inside the backend boundary so frontend dependency examples are not analyzed as repository packages
- document project relationships, local commands, toolchain pinning, and CI behavior

## Verification

- `just hooks-run`
- `MOON_TOOLCHAIN_FORCE_GLOBALS=true just workspace-check`
- `MOON_TOOLCHAIN_FORCE_GLOBALS=true just workspace-build` (repeated to verify cache hits)
- `bun install --frozen-lockfile` in `web/` and `tests/js-test/`
- `just lint`
- `just web-format-check`

`MOON_TOOLCHAIN_FORCE_GLOBALS=true just workspace-test` runs all three project test tasks, but the existing Go test `TestFilesAPI/routing_group_auth_applies_only_to_v1` still fails with status 404 instead of the expected 401. Web tests and the SDK type-check complete successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coordinated workspace commands for building, testing, linting, formatting, and type-checking backend, web, and SDK test projects.
  - Added automated project-boundary validation through pre-commit checks and CI.
  - Standardized pinned Go and Bun toolchain versions.

- **Documentation**
  - Added guidance for monorepo development, workspace commands, tooling, and quality gates.

- **Bug Fixes**
  - Improved Go lint coverage while excluding unrelated third-party examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->