### PR TITLE
Set up Cursor Cloud dev environment + document setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,3 +133,31 @@
   - TypeScript SDK：`./node_modules/.bin/jest tests/api-resources/beta/files.test.ts --runInBand`
   - Python SDK：`.venv/bin/pytest tests/api_resources/beta/test_files.py -q`
 - 结束前停止所有为 E2E 启动的本地服务。
+
+## Cursor Cloud specific instructions
+
+工具链与基础设施（Go 1.26.2 toolchain、`bun`、`just`、`uv`、`golangci-lint` v2.12.2、PostgreSQL 17、Redis、MinIO）已经装进 VM 快照。依赖刷新由启动时的 update script（`go mod download` + `web` 目录 `bun install`）负责，无需手动安装。
+
+### 启动依赖服务（每个会话必做，不会自动拉起）
+
+本 VM 用 `tini` 作为 init，没有 systemd，所以 Postgres / Redis / MinIO 不会自动启动。运行后端或测试前先手动拉起：
+
+- PostgreSQL：`sudo pg_ctlcluster 17 main start`
+- Redis：`sudo redis-server --daemonize yes`
+- MinIO：在后台运行 `MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin minio server /home/ubuntu/minio-data --console-address ":9001"`（例如放进 tmux 会话）
+
+`pg_hba.conf` 已配置为对本地连接 `trust`，因此后端/测试首次连接时会用默认 `POSTGRES_ADMIN_URL` 自动创建 `claude` 角色与 `claude_api` 数据库，无需手工 createdb。
+
+### 运行服务
+
+后端、前端的标准命令见 README.cn.md 与 `justfile`（`just restart-server` → `127.0.0.1:38080`，`just restart-web` → `127.0.0.1:5173`，Vite 代理 `/api`、`/v1` 到后端）。控制台本地登录是无密码 magic-link：任意邮箱 + 任意 6 位验证码即可登录（后端忽略验证码，仅用邮箱 find-or-create 用户/组织）。
+
+E2B 沙箱（真实 agent 代码执行）在本环境未配置，需要 host 网络的 Docker + 外部镜像；agent/文件/元数据等非沙箱流程无需它即可工作。
+
+### 测试与 lint 的注意事项
+
+- `go test ./...` 里的集成测试用 `config.Load()` 默认值直连本地 **Postgres + MinIO**（会 migrate + seed 到同一个开发库 `claude_api`，共用 `claude-files` bucket），会话用内存 store，所以测试**不需要 Redis 但需要 Postgres + MinIO 已启动**。
+- `just lint`（`golangci-lint ... ./...`）在跑过 `bun install` 后会把 `web/node_modules/flatted/*.go` 也纳入，产生 2 个 govet 误报；CI 不装 node_modules 所以不受影响。只想 lint 项目代码时用：`golangci-lint run --config .golangci.yml . ./cmd/... ./internal/... ./tests/...`。
+- `golangci-lint` 必须用 go ≥ 1.26 构建（仓库 target 1.26.2），否则会报 "Go language version ... lower than the targeted Go version" 而拒绝运行。
+- 已知既有失败（与本环境无关，clean tree 上稳定复现）：`go test ./tests` 中 `TestFilesAPI/routing_group_auth_applies_only_to_v1`（`GET /v1/unknown` 无 key 期望 401，实际 404）。
+- `just web-lint`（eslint）在当前提交上有既有报错；CI 实际门禁是 `just web-format-check`（Prettier）和 `just web-lint-naming`，二者可通过。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

搭建并验证了本仓库在 Cursor Cloud VM 中的开发环境，并把非显而易见的启动/测试注意事项写入 `AGENTS.md` 的 `## Cursor Cloud specific instructions`。本 PR 仅新增文档，未改动任何产品代码。

## 环境搭建（已装入 VM 快照）

- 工具链：Go 1.26.2 toolchain、`bun`、`just`、`uv`、`golangci-lint` v2.12.2（用 go 1.26.2 构建）。
- 基础设施（原生安装，非 Docker）：PostgreSQL 17、Redis、MinIO；`pg_hba` 配为本地 `trust`，后端首启时自动创建 `claude` 角色与 `claude_api` 库。
- 依赖刷新（update script）：`go mod download` + `web` 目录 `bun install`。

## 验证结果

| 服务 | 命令 | 结果 |
| --- | --- | --- |
| 后端 API | `just restart-server` → `curl /healthz` | ✅ `{"status":"ok"}`，`/v1/models` 与文件上传（→ Postgres + MinIO）均正常 |
| 前端控制台 | `just restart-web` | ✅ Vite 起于 `:5173`，登录后创建 agent 成功落库 |
| Go lint | `golangci-lint ... . ./cmd/... ./internal/... ./tests/...` | ✅ 0 issues |
| Go 测试 | `just test` | ⚠️ 仅 1 个既有失败 `TestFilesAPI/routing_group_auth_applies_only_to_v1`（404 vs 401，clean tree 稳定复现，与环境无关） |
| Web 测试 | `just web-test` | ✅ 344 passed |
| Web 构建 | `just web-build` | ✅ built |
| Web 门禁 | `just web-format-check` / `just web-lint-naming` | ✅ 通过 |

Hello-world：通过控制台以无密码 magic-link 登录后创建了 "Hello World Agent"，并确认写入 Postgres。

<a href="https://cursor.com/agents/bc-c4e1934c-3ef1-42a6-afce-5ae51e01da00/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_create_agent_demo.mp4"><img src="https://cursor.com/artifacts/c/art-0fe60f58-d8ce-4388-a17d-3304722d83c0" alt="console_create_agent_demo.mp4" /></a>

![Agents list showing the created agent](https://cursor.com/artifacts/c/art-b143fe84-d6c1-494b-adf2-632920786c07)

## 变更

- `AGENTS.md`：新增 `## Cursor Cloud specific instructions`（服务启动方式、测试对 Postgres+MinIO 的依赖、lint 的 node_modules 误报、既有失败测试等）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4e1934c-3ef1-42a6-afce-5ae51e01da00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4e1934c-3ef1-42a6-afce-5ae51e01da00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

