### PR TITLE
docs: add Cursor Cloud dev environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,3 +133,37 @@
   - TypeScript SDK：`./node_modules/.bin/jest tests/api-resources/beta/files.test.ts --runInBand`
   - Python SDK：`.venv/bin/pytest tests/api_resources/beta/test_files.py -q`
 - 结束前停止所有为 E2E 启动的本地服务。
+
+## Cursor Cloud specific instructions
+
+这些是为 Cursor Cloud 环境准备的补充说明。系统依赖（Go 1.26.2、Bun、`just`、`golangci-lint` v2.12.2、`uv`、PostgreSQL 16、Redis、MinIO/`mc`）已经安装在 VM 快照中，启动脚本（update script）只负责刷新 `go mod download` 和 `web` 的 `bun install`，不会启动任何服务。
+
+### 每次会话开始时先启动基础设施
+
+后端启动时会 **自动建库、自动迁移（dev 默认 `DB_AUTO_MIGRATE=true`）、自动 seed API key、自动创建 MinIO bucket**，所以只要把三项基础设施拉起来即可，无需手动建 `claude_api` 库或 `claude-files` bucket。这三项 **不会** 在 VM 启动时自动运行，需要手动启动一次（都写好了默认连接串，见 `internal/config/config.go`）：
+
+```bash
+sudo pg_ctlcluster 16 main start || true          # PostgreSQL :5432
+sudo redis-server --daemonize yes --port 6379 --dir /var/lib/redis
+# MinIO 前台进程，建议放到 tmux/后台：
+MINIO_ROOT_USER=minioadmin MINIO_ROOT_PASSWORD=minioadmin \
+  minio server /home/ubuntu/minio-data --address :9000 --console-address :9001
+```
+
+- PostgreSQL 的 `pg_hba.conf` 已改为对 `127.0.0.1/32` 和 `::1/128` 使用 `trust`，因此 `postgres` 管理连接（`POSTGRES_ADMIN_URL`）和 `claude:123456` 业务连接都能免密/按默认串直接连上。
+- 起服务用现成的 `just restart-server`（后端 `127.0.0.1:38080`）和 `just restart-web`（前端 `127.0.0.1:5173`，`/api` 与 `/v1` 反代到后端）。两者都是前台阻塞命令，在 Cloud 环境里请放进 tmux 或后台运行。
+
+### 控制台登录（本地 magic-link）
+
+- 本地登录是 dev 版 magic-link：登录页输入任意邮箱（如 `demo@example.com`）+ 任意 6 位验证码（如 `000000`）即可，后端 `verify_magic_link` 会直接创建用户并下发 session cookie。
+- 已知的前端遗留问题：点击 “Verify email” 完成登录跳转的一瞬间，前端可能报 `Maximum update depth exceeded` 并白屏（后端此时已返回 200 且 cookie 已写入）。**刷新一次页面即可进入已登录的控制台**，属于既有前端行为，与环境配置无关。
+
+### Lint 的 node_modules 误报
+
+- 执行过 `web` 的 `bun install` 后，`just lint`（即 `golangci-lint run ./...`）会对 `web/node_modules/flatted/golang/...` 里一个自带的 `.go` 文件报 `govet` 误报。CI 的 Go lint job 不安装前端依赖，所以不受影响。
+- 想在本地复现 CI 的 Go lint 结果，把范围限定到仓库自身的 Go 源码目录即可：`golangci-lint run --config .golangci.yml ./ ./cmd/... ./internal/... ./tests/...`（`go test`/`go list` 本身会忽略 `node_modules`，不受影响）。
+
+### 其它注意点
+
+- Files API 需要带 header `anthropic-beta: files-api-2025-04-14`，否则返回 400（`?beta=true` 单独不够）。
+- 已知既有失败用例：`go test ./... -count=1` 中 `TestFilesAPI/routing_group_auth_applies_only_to_v1` 会失败（未鉴权访问 `/v1/unknown` 期望 401，实际返回 404）。这是当前 base 分支上与环境无关的既有行为，其余用例通过。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景

为 Cursor Cloud 环境搭建完整的开发环境，并把非显而易见的启动/运行注意点沉淀到 `AGENTS.md`，方便后续 Cloud Agent 直接使用。

本 PR 只新增文档（`AGENTS.md` 追加 `## Cursor Cloud specific instructions`），不改动任何生产代码。系统依赖的自动刷新通过 update script 完成（`go mod download` + `bun install --cwd web`）。

## 环境搭建内容

- 系统依赖：Go 1.26.2、Bun、`just`、`golangci-lint` v2.12.2、`uv`、PostgreSQL 16、Redis、MinIO/`mc`。
- 基础设施：PostgreSQL（`127.0.0.1:5432`，`pg_hba` 改为本地 `trust`）、Redis（`:6379`）、MinIO（`:9000/:9001`，creds `minioadmin/minioadmin`）。
- 后端 `just restart-server`（`127.0.0.1:38080`）启动时自动建库、自动迁移、seed API key、创建 `claude-files` bucket。
- 前端 `just restart-web`（`127.0.0.1:5173`，`/api`、`/v1` 反代到后端）。

## 验证

| 服务 | 命令 | 结果 |
| --- | --- | --- |
| Backend | `ADDR=127.0.0.1:38080 go run .` → `curl /healthz` | ✅ `{"status":"ok"}` |
| Backend Lint | `golangci-lint run --config .golangci.yml ./ ./cmd/... ./internal/... ./tests/...` | ✅ 0 issues |
| Backend Test | `go test ./... -count=1` | ⚠️ 全部通过，仅 `TestFilesAPI/routing_group_auth_applies_only_to_v1` 为既有失败（未鉴权 `/v1/unknown` 期望 401 实际 404，与环境无关） |
| Frontend | `just restart-web` → Vite `:5173` | ✅ 加载正常，`/api` 代理可用 |
| Hello-world (API) | 上传/列出文件（带 `anthropic-beta: files-api-2025-04-14`） | ✅ 落库 + 落 MinIO |
| Hello-world (UI) | 控制台登录 + 创建 Agent | ✅ Agent 落库 |

### 控制台演示

<a href="https://cursor.com/agents/bc-03a3144e-e445-4e7a-bff6-3384a08526c4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_create_agent_clean_demo.mp4"><img src="https://cursor.com/artifacts/c/art-efe6fd8e-7a2f-4b9e-9d29-96537ff7a716" alt="console_create_agent_clean_demo.mp4" /></a>

![Console dashboard](https://cursor.com/artifacts/c/art-5412f26f-8eed-4c4b-a0b6-714a45f929b7)
![Agents list after creating a new agent](https://cursor.com/artifacts/c/art-2b512aec-601d-4d65-8c7d-9e2006c2b6f7)

## AGENTS.md 追加要点

- 每次会话开始需手动启动 Postgres/Redis/MinIO（update script 不启动服务），并给出具体命令。
- 控制台 dev magic-link 登录：任意邮箱 + `000000`；已知登录跳转时的前端 `Maximum update depth exceeded` 白屏，刷新一次即进入（后端已 200，属既有前端行为）。
- `just lint` 在 `bun install` 之后会对 `web/node_modules` 里的自带 `.go` 文件误报；给出复现 CI Go lint 的范围限定命令。
- Files API 需带 `anthropic-beta` header；记录既有失败用例。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03a3144e-e445-4e7a-bff6-3384a08526c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03a3144e-e445-4e7a-bff6-3384a08526c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

