### PR TITLE
[Prefactor] 提取 Environment Config 规范化边界

### DIFF
--- a/internal/environments/config.go
+++ b/internal/environments/config.go
@@ -1,0 +1,332 @@
+package environments
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strings"
+)
+
+var allowedHostPattern = regexp.MustCompile(`^(\*\.)?[A-Za-z0-9.-]+(:[0-9]{1,5})?$`)
+
+// normalizeEnvironmentConfigForCreate applies the Environment Config creation
+// contract and returns the canonical representation stored for an Environment.
+func normalizeEnvironmentConfigForCreate(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 || isJSONNull(raw) {
+		return defaultCloudEnvironmentConfig(), nil
+	}
+	return normalizeFullEnvironmentConfig(raw)
+}
+
+// normalizeEnvironmentConfigForUpdate applies an Environment Config patch to
+// the current canonical representation.
+func normalizeEnvironmentConfigForUpdate(current json.RawMessage, raw json.RawMessage) (json.RawMessage, error) {
+	if isJSONNull(raw) {
+		return defaultCloudEnvironmentConfig(), nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, errors.New("config must be an object")
+	}
+	configType := rawStringOrEmpty(fields["type"])
+	if configType == "" {
+		configType = rawConfigType(current)
+	}
+	if configType == "self_hosted" {
+		return marshalRaw(map[string]any{"type": "self_hosted"})
+	}
+	if configType != "cloud" {
+		return nil, errors.New("config.type must be cloud or self_hosted")
+	}
+	base := normalizedCloudValue(defaultCloudEnvironmentConfig())
+	if rawConfigType(current) == "cloud" {
+		base = normalizedCloudValue(current)
+	}
+	if rawPackages, ok := fields["packages"]; ok {
+		packages, err := normalizePackages(rawPackages)
+		if err != nil {
+			return nil, err
+		}
+		base["packages"] = packages
+	}
+	if rawNetworking, ok := fields["networking"]; ok {
+		networking, err := normalizeNetworking(rawNetworking)
+		if err != nil {
+			return nil, err
+		}
+		base["networking"] = networking
+	}
+	return marshalRaw(base)
+}
+
+// environmentConfigForResponse expands a stored Environment Config to the
+// compatibility shape exposed by the Environment API.
+func environmentConfigForResponse(raw json.RawMessage) json.RawMessage {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return defaultCloudEnvironmentConfigForResponse()
+	}
+	configType := rawStringOrEmpty(fields["type"])
+	switch configType {
+	case "self_hosted":
+		out, _ := marshalRaw(map[string]any{"type": "self_hosted"})
+		return out
+	case "", "cloud":
+		out, _ := marshalRaw(map[string]any{
+			"type":        "cloud",
+			"packages":    packagesForResponse(fields["packages"]),
+			"networking":  networkingForResponse(fields["networking"]),
+			"init_script": rawStringOrEmpty(fields["init_script"]),
+			"environment": platformObjectForResponse(fields["environment"]),
+		})
+		return out
+	default:
+		return raw
+	}
+}
+
+// defaultCloudEnvironmentConfig returns the canonical storage representation
+// used when a Cloud Environment Config is omitted or reset.
+func defaultCloudEnvironmentConfig() json.RawMessage {
+	raw, _ := marshalRaw(map[string]any{
+		"type":       "cloud",
+		"packages":   emptyPackages(),
+		"networking": map[string]any{"type": "unrestricted"},
+	})
+	return raw
+}
+
+func normalizeFullEnvironmentConfig(raw json.RawMessage) (json.RawMessage, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, errors.New("config must be an object")
+	}
+	configType := rawStringOrEmpty(fields["type"])
+	if configType == "" {
+		configType = "cloud"
+	}
+	switch configType {
+	case "self_hosted":
+		return marshalRaw(map[string]any{"type": "self_hosted"})
+	case "cloud":
+		packages, err := normalizePackages(fields["packages"])
+		if err != nil {
+			return nil, err
+		}
+		networking, err := normalizeNetworking(fields["networking"])
+		if err != nil {
+			return nil, err
+		}
+		return marshalRaw(map[string]any{"type": "cloud", "packages": packages, "networking": networking})
+	default:
+		return nil, errors.New("config.type must be cloud or self_hosted")
+	}
+}
+
+func defaultCloudEnvironmentConfigForResponse() json.RawMessage {
+	out, _ := marshalRaw(map[string]any{
+		"type":        "cloud",
+		"packages":    packagesForResponse(nil),
+		"networking":  networkingForResponse(nil),
+		"init_script": "",
+		"environment": map[string]any{},
+	})
+	return out
+}
+
+func normalizedCloudValue(raw json.RawMessage) map[string]any {
+	var value map[string]any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		value = map[string]any{}
+	}
+	if _, ok := value["packages"]; !ok {
+		value["packages"] = emptyPackages()
+	}
+	if _, ok := value["networking"]; !ok {
+		value["networking"] = map[string]any{"type": "unrestricted"}
+	}
+	value["type"] = "cloud"
+	return value
+}
+
+func emptyPackages() map[string]any {
+	return map[string]any{
+		"type":  "packages",
+		"apt":   []string{},
+		"cargo": []string{},
+		"gem":   []string{},
+		"go":    []string{},
+		"npm":   []string{},
+		"pip":   []string{},
+	}
+}
+
+func normalizePackages(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 || isJSONNull(raw) {
+		return emptyPackages(), nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, errors.New("config.packages must be an object or null")
+	}
+	out := emptyPackages()
+	for _, manager := range []string{"apt", "cargo", "gem", "go", "npm", "pip"} {
+		rawList, ok := fields[manager]
+		if !ok || isJSONNull(rawList) {
+			continue
+		}
+		values, err := configStringArray(rawList, "config.packages."+manager)
+		if err != nil {
+			return nil, err
+		}
+		out[manager] = values
+	}
+	return out, nil
+}
+
+func normalizeNetworking(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 || isJSONNull(raw) {
+		return map[string]any{"type": "unrestricted"}, nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, errors.New("config.networking must be an object or null")
+	}
+	networkType := rawStringOrEmpty(fields["type"])
+	if networkType == "" {
+		networkType = "unrestricted"
+	}
+	switch networkType {
+	case "unrestricted":
+		return map[string]any{"type": "unrestricted"}, nil
+	case "limited":
+		hosts := []string{}
+		if rawHosts, ok := fields["allowed_hosts"]; ok && !isJSONNull(rawHosts) {
+			values, err := configStringArray(rawHosts, "config.networking.allowed_hosts")
+			if err != nil {
+				return nil, err
+			}
+			for _, host := range values {
+				if err := validateAllowedHost(host); err != nil {
+					return nil, err
+				}
+			}
+			hosts = values
+		}
+		allowMCP, err := optionalConfigBool(fields["allow_mcp_servers"], false, "config.networking.allow_mcp_servers")
+		if err != nil {
+			return nil, err
+		}
+		allowPackages, err := optionalConfigBool(fields["allow_package_managers"], false, "config.networking.allow_package_managers")
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"type":                   "limited",
+			"allowed_hosts":          hosts,
+			"allow_mcp_servers":      allowMCP,
+			"allow_package_managers": allowPackages,
+		}, nil
+	default:
+		return nil, errors.New("config.networking.type must be unrestricted or limited")
+	}
+}
+
+func validateAllowedHost(host string) error {
+	if strings.Contains(host, "://") || strings.Contains(host, "/") || !allowedHostPattern.MatchString(host) {
+		return errors.New("config.networking.allowed_hosts entries must be hostnames without URL schemes")
+	}
+	if len(host) > 253 {
+		return errors.New("config.networking.allowed_hosts entries must be at most 253 characters")
+	}
+	return nil
+}
+
+func packagesForResponse(raw json.RawMessage) map[string]any {
+	var fields map[string]json.RawMessage
+	if len(raw) > 0 && !isJSONNull(raw) {
+		_ = json.Unmarshal(raw, &fields)
+	}
+	out := emptyPackages()
+	for _, manager := range []string{"apt", "cargo", "gem", "go", "npm", "pip"} {
+		out[manager] = stringArrayForResponse(fields[manager])
+	}
+	return out
+}
+
+func networkingForResponse(raw json.RawMessage) map[string]any {
+	var fields map[string]json.RawMessage
+	if len(raw) > 0 && !isJSONNull(raw) {
+		_ = json.Unmarshal(raw, &fields)
+	}
+	networkType := rawStringOrEmpty(fields["type"])
+	if networkType == "" {
+		networkType = "limited"
+	}
+	return map[string]any{
+		"type":                   networkType,
+		"allow_mcp_servers":      boolForResponse(fields["allow_mcp_servers"]),
+		"allow_package_managers": boolForResponse(fields["allow_package_managers"]),
+		"allowed_hosts":          stringArrayForResponse(fields["allowed_hosts"]),
+	}
+}
+
+func stringArrayForResponse(raw json.RawMessage) []string {
+	var values []string
+	if len(raw) == 0 || isJSONNull(raw) {
+		return []string{}
+	}
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return []string{}
+	}
+	if values == nil {
+		return []string{}
+	}
+	return values
+}
+
+func boolForResponse(raw json.RawMessage) bool {
+	var value bool
+	if len(raw) == 0 || isJSONNull(raw) {
+		return false
+	}
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false
+	}
+	return value
+}
+
+func configStringArray(raw json.RawMessage, name string) ([]string, error) {
+	var values []string
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, errors.New(name + " must be an array of strings")
+	}
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return nil, errors.New(name + " entries must be non-empty strings")
+		}
+		if len(value) > 255 {
+			return nil, errors.New(name + " entries must be at most 255 characters")
+		}
+	}
+	return values, nil
+}
+
+func optionalConfigBool(raw json.RawMessage, fallback bool, name string) (bool, error) {
+	if len(raw) == 0 || isJSONNull(raw) {
+		return fallback, nil
+	}
+	var value bool
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return false, errors.New(name + " must be a boolean")
+	}
+	return value, nil
+}
+
+func rawConfigType(raw json.RawMessage) string {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return ""
+	}
+	return rawStringOrEmpty(fields["type"])
+}

--- a/internal/environments/config_test.go
+++ b/internal/environments/config_test.go
@@ -1,0 +1,189 @@
+package environments
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeEnvironmentConfigForCreateRejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "non-object config", raw: `[]`, want: "config must be an object"},
+		{name: "unknown config type", raw: `{"type":"local"}`, want: "config.type must be cloud or self_hosted"},
+		{name: "non-object packages", raw: `{"packages":[]}`, want: "config.packages must be an object or null"},
+		{name: "invalid package list", raw: `{"packages":{"pip":"numpy"}}`, want: "config.packages.pip must be an array of strings"},
+		{name: "unknown network type", raw: `{"networking":{"type":"private"}}`, want: "config.networking.type must be unrestricted or limited"},
+		{name: "host URL", raw: `{"networking":{"type":"limited","allowed_hosts":["https://example.com"]}}`, want: "config.networking.allowed_hosts entries must be hostnames without URL schemes"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := normalizeEnvironmentConfigForCreate(json.RawMessage(test.raw))
+			if err == nil || err.Error() != test.want {
+				t.Fatalf("NormalizeEnvironmentConfigForCreate() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeEnvironmentConfigForCreatePreservesCurrentContract(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  json.RawMessage
+		want string
+	}{
+		{
+			name: "omitted config uses unrestricted cloud defaults",
+			want: `{
+				"type":"cloud",
+				"packages":{"type":"packages","apt":[],"cargo":[],"gem":[],"go":[],"npm":[],"pip":[]},
+				"networking":{"type":"unrestricted"}
+			}`,
+		},
+		{
+			name: "cloud config normalizes packages and limited networking",
+			raw: json.RawMessage(`{
+				"packages":{"pip":["numpy"],"npm":["typescript"]},
+				"networking":{"type":"limited","allowed_hosts":["*.example.com"],"allow_package_managers":true}
+			}`),
+			want: `{
+				"type":"cloud",
+				"packages":{"type":"packages","apt":[],"cargo":[],"gem":[],"go":[],"npm":["typescript"],"pip":["numpy"]},
+				"networking":{"type":"limited","allowed_hosts":["*.example.com"],"allow_mcp_servers":false,"allow_package_managers":true}
+			}`,
+		},
+		{
+			name: "self-hosted config drops unrelated fields",
+			raw:  json.RawMessage(`{"type":"self_hosted","packages":{"pip":["numpy"]}}`),
+			want: `{"type":"self_hosted"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := normalizeEnvironmentConfigForCreate(test.raw)
+			if err != nil {
+				t.Fatalf("NormalizeEnvironmentConfigForCreate() error = %v", err)
+			}
+			assertJSONEqual(t, got, test.want)
+		})
+	}
+}
+
+func TestNormalizeEnvironmentConfigForUpdatePreservesPatchContract(t *testing.T) {
+	current := json.RawMessage(`{
+		"type":"cloud",
+		"packages":{"type":"packages","pip":["numpy"]},
+		"networking":{"type":"limited","allowed_hosts":["example.com"],"allow_mcp_servers":true,"allow_package_managers":false},
+		"init_script":"legacy setup",
+		"environment":{"LEGACY":"value"}
+	}`)
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "null resets to cloud defaults",
+			raw:  `null`,
+			want: `{"type":"cloud","packages":{"type":"packages","apt":[],"cargo":[],"gem":[],"go":[],"npm":[],"pip":[]},"networking":{"type":"unrestricted"}}`,
+		},
+		{
+			name: "package patch retains networking and legacy response fields",
+			raw:  `{"packages":{"apt":["git"]}}`,
+			want: `{
+				"type":"cloud",
+				"packages":{"type":"packages","apt":["git"],"cargo":[],"gem":[],"go":[],"npm":[],"pip":[]},
+				"networking":{"type":"limited","allowed_hosts":["example.com"],"allow_mcp_servers":true,"allow_package_managers":false},
+				"init_script":"legacy setup",
+				"environment":{"LEGACY":"value"}
+			}`,
+		},
+		{
+			name: "networking null resets only networking",
+			raw:  `{"type":"cloud","networking":null}`,
+			want: `{
+				"type":"cloud",
+				"packages":{"type":"packages","pip":["numpy"]},
+				"networking":{"type":"unrestricted"},
+				"init_script":"legacy setup",
+				"environment":{"LEGACY":"value"}
+			}`,
+		},
+		{
+			name: "type switch replaces config",
+			raw:  `{"type":"self_hosted"}`,
+			want: `{"type":"self_hosted"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := normalizeEnvironmentConfigForUpdate(current, json.RawMessage(test.raw))
+			if err != nil {
+				t.Fatalf("NormalizeEnvironmentConfigForUpdate() error = %v", err)
+			}
+			assertJSONEqual(t, got, test.want)
+		})
+	}
+}
+
+func TestEnvironmentConfigForResponsePreservesPlatformShape(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "invalid stored config uses limited response defaults",
+			raw:  `{`,
+			want: `{
+				"type":"cloud",
+				"packages":{"type":"packages","apt":[],"cargo":[],"gem":[],"go":[],"npm":[],"pip":[]},
+				"networking":{"type":"limited","allowed_hosts":[],"allow_mcp_servers":false,"allow_package_managers":false},
+				"init_script":"",
+				"environment":{}
+			}`,
+		},
+		{
+			name: "stored cloud config gets compatibility fields",
+			raw:  `{"type":"cloud","packages":{"pip":["numpy"]},"networking":{"type":"unrestricted"}}`,
+			want: `{
+				"type":"cloud",
+				"packages":{"type":"packages","apt":[],"cargo":[],"gem":[],"go":[],"npm":[],"pip":["numpy"]},
+				"networking":{"type":"unrestricted","allowed_hosts":[],"allow_mcp_servers":false,"allow_package_managers":false},
+				"init_script":"",
+				"environment":{}
+			}`,
+		},
+		{name: "self-hosted response remains minimal", raw: `{"type":"self_hosted","unexpected":true}`, want: `{"type":"self_hosted"}`},
+		{name: "unknown config type passes through", raw: `{"type":"future","value":1}`, want: `{"type":"future","value":1}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertJSONEqual(t, environmentConfigForResponse(json.RawMessage(test.raw)), test.want)
+		})
+	}
+}
+
+func assertJSONEqual(t *testing.T, got json.RawMessage, want string) {
+	t.Helper()
+	var gotValue any
+	if err := json.Unmarshal(got, &gotValue); err != nil {
+		t.Fatalf("unmarshal actual JSON %q: %v", got, err)
+	}
+	var wantValue any
+	if err := json.Unmarshal([]byte(want), &wantValue); err != nil {
+		t.Fatalf("unmarshal expected JSON %q: %v", want, err)
+	}
+	gotCanonical, _ := json.Marshal(gotValue)
+	wantCanonical, _ := json.Marshal(wantValue)
+	if string(gotCanonical) != string(wantCanonical) {
+		t.Fatalf("JSON = %s, want %s", gotCanonical, wantCanonical)
+	}
+}

--- a/internal/environments/handler.go
+++ b/internal/environments/handler.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -25,8 +24,6 @@ import (
 )
 
 const maxEnvironmentBodySize = 4 << 20
-
-var allowedHostPattern = regexp.MustCompile(`^(\*\.)?[A-Za-z0-9.-]+(:[0-9]{1,5})?$`)
 
 type Handler struct {
 	cfg    config.Config
@@ -164,7 +161,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
 		writeBadRequest(w, r, err)
 		return
 	}
-	configRaw, err := normalizeConfigForCreate(fields["config"])
+	configRaw, err := normalizeEnvironmentConfigForCreate(fields["config"])
 	if err != nil {
 		writeBadRequest(w, r, err)
 		return
@@ -337,7 +334,7 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, environmentID s
 		}
 	}
 	if raw, ok := fields["config"]; ok {
-		next.Config, err = normalizeConfigForUpdate(current.Config, raw)
+		next.Config, err = normalizeEnvironmentConfigForUpdate(current.Config, raw)
 		if err != nil {
 			writeBadRequest(w, r, err)
 			return
@@ -747,7 +744,7 @@ func (h *Handler) authorizeWork(w http.ResponseWriter, r *http.Request) (db.Envi
 				WorkspaceID:      principal.WorkspaceID,
 				Name:             "python-data-analysis",
 				Description:      "Fixture environment",
-				Config:           defaultCloudConfig(),
+				Config:           defaultCloudEnvironmentConfig(),
 				Metadata:         json.RawMessage(`{}`),
 				Provider:         "e2b",
 				ResolvedTemplate: h.resolvedTemplate(nil),
@@ -799,7 +796,7 @@ func responseFromEnvironment(env db.Environment) environmentResponse {
 	return environmentResponse{
 		ID:          env.ExternalID,
 		ArchivedAt:  optionalTime(env.ArchivedAt),
-		Config:      platformEnvironmentConfigForResponse(env.Config),
+		Config:      environmentConfigForResponse(env.Config),
 		CreatedAt:   formatTime(env.CreatedAt),
 		Description: env.Description,
 		Metadata:    platformEnvironmentMetadataForResponse(env.Metadata),
@@ -853,7 +850,7 @@ func (h *Handler) fixtureEnvironment(environmentID string, archived bool) enviro
 	return environmentResponse{
 		ID:          environmentID,
 		ArchivedAt:  archivedAt,
-		Config:      platformEnvironmentConfigForResponse(defaultCloudConfig()),
+		Config:      environmentConfigForResponse(defaultCloudEnvironmentConfig()),
 		CreatedAt:   now,
 		Description: "Fixture environment",
 		Metadata:    json.RawMessage(`{}`),
@@ -870,70 +867,6 @@ func environmentStateForArchived(archived bool) string {
 		return "archived"
 	}
 	return "active"
-}
-
-func platformEnvironmentConfigForResponse(raw json.RawMessage) json.RawMessage {
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &fields); err != nil {
-		return platformDefaultCloudConfigForResponse()
-	}
-	configType := rawStringOrEmpty(fields["type"])
-	switch configType {
-	case "self_hosted":
-		out, _ := marshalRaw(map[string]any{"type": "self_hosted"})
-		return out
-	case "", "cloud":
-		out, _ := marshalRaw(map[string]any{
-			"type":        "cloud",
-			"packages":    platformPackagesForResponse(fields["packages"]),
-			"networking":  platformNetworkingForResponse(fields["networking"]),
-			"init_script": rawStringOrEmpty(fields["init_script"]),
-			"environment": platformObjectForResponse(fields["environment"]),
-		})
-		return out
-	default:
-		return raw
-	}
-}
-
-func platformDefaultCloudConfigForResponse() json.RawMessage {
-	out, _ := marshalRaw(map[string]any{
-		"type":        "cloud",
-		"packages":    platformPackagesForResponse(nil),
-		"networking":  platformNetworkingForResponse(nil),
-		"init_script": "",
-		"environment": map[string]any{},
-	})
-	return out
-}
-
-func platformPackagesForResponse(raw json.RawMessage) map[string]any {
-	var fields map[string]json.RawMessage
-	if len(raw) > 0 && !isJSONNull(raw) {
-		_ = json.Unmarshal(raw, &fields)
-	}
-	out := emptyPackages()
-	for _, manager := range []string{"apt", "cargo", "gem", "go", "npm", "pip"} {
-		out[manager] = platformStringArrayForResponse(fields[manager])
-	}
-	return out
-}
-
-func platformNetworkingForResponse(raw json.RawMessage) map[string]any {
-	var fields map[string]json.RawMessage
-	if len(raw) > 0 && !isJSONNull(raw) {
-		_ = json.Unmarshal(raw, &fields)
-	}
-	networkType := rawStringOrEmpty(fields["type"])
-	if networkType == "" {
-		networkType = "limited"
-	}
-	return map[string]any{
-		"type":                   networkType,
-		"allow_mcp_servers":      platformBoolForResponse(fields["allow_mcp_servers"]),
-		"allow_package_managers": platformBoolForResponse(fields["allow_package_managers"]),
-		"allowed_hosts":          platformStringArrayForResponse(fields["allowed_hosts"]),
-	}
 }
 
 func platformEnvironmentMetadataForResponse(raw json.RawMessage) json.RawMessage {
@@ -957,31 +890,6 @@ func platformObjectForResponse(raw json.RawMessage) map[string]any {
 func platformObjectRawForResponse(raw json.RawMessage) json.RawMessage {
 	out, _ := marshalRaw(platformObjectForResponse(raw))
 	return out
-}
-
-func platformStringArrayForResponse(raw json.RawMessage) []string {
-	var values []string
-	if len(raw) == 0 || isJSONNull(raw) {
-		return []string{}
-	}
-	if err := json.Unmarshal(raw, &values); err != nil {
-		return []string{}
-	}
-	if values == nil {
-		return []string{}
-	}
-	return values
-}
-
-func platformBoolForResponse(raw json.RawMessage) bool {
-	var value bool
-	if len(raw) == 0 || isJSONNull(raw) {
-		return false
-	}
-	if err := json.Unmarshal(raw, &value); err != nil {
-		return false
-	}
-	return value
 }
 
 func platformWorkersPollingForResponse(value *int) *int {
@@ -1095,196 +1003,6 @@ func parseScope(raw json.RawMessage) (*string, error) {
 	return &value, nil
 }
 
-func normalizeConfigForCreate(raw json.RawMessage) (json.RawMessage, error) {
-	if len(raw) == 0 || isJSONNull(raw) {
-		return defaultCloudConfig(), nil
-	}
-	return normalizeFullConfig(raw)
-}
-
-func normalizeConfigForUpdate(current json.RawMessage, raw json.RawMessage) (json.RawMessage, error) {
-	if isJSONNull(raw) {
-		return defaultCloudConfig(), nil
-	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &fields); err != nil {
-		return nil, errors.New("config must be an object")
-	}
-	configType := rawStringOrEmpty(fields["type"])
-	if configType == "" {
-		configType = rawConfigType(current)
-	}
-	if configType == "self_hosted" {
-		return marshalRaw(map[string]any{"type": "self_hosted"})
-	}
-	if configType != "cloud" {
-		return nil, errors.New("config.type must be cloud or self_hosted")
-	}
-	base := normalizedCloudValue(defaultCloudConfig())
-	if rawConfigType(current) == "cloud" {
-		base = normalizedCloudValue(current)
-	}
-	if rawPackages, ok := fields["packages"]; ok {
-		packages, err := normalizePackages(rawPackages)
-		if err != nil {
-			return nil, err
-		}
-		base["packages"] = packages
-	}
-	if rawNetworking, ok := fields["networking"]; ok {
-		networking, err := normalizeNetworking(rawNetworking)
-		if err != nil {
-			return nil, err
-		}
-		base["networking"] = networking
-	}
-	return marshalRaw(base)
-}
-
-func normalizeFullConfig(raw json.RawMessage) (json.RawMessage, error) {
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &fields); err != nil {
-		return nil, errors.New("config must be an object")
-	}
-	configType := rawStringOrEmpty(fields["type"])
-	if configType == "" {
-		configType = "cloud"
-	}
-	switch configType {
-	case "self_hosted":
-		return marshalRaw(map[string]any{"type": "self_hosted"})
-	case "cloud":
-		packages, err := normalizePackages(fields["packages"])
-		if err != nil {
-			return nil, err
-		}
-		networking, err := normalizeNetworking(fields["networking"])
-		if err != nil {
-			return nil, err
-		}
-		return marshalRaw(map[string]any{"type": "cloud", "packages": packages, "networking": networking})
-	default:
-		return nil, errors.New("config.type must be cloud or self_hosted")
-	}
-}
-
-func defaultCloudConfig() json.RawMessage {
-	raw, _ := marshalRaw(map[string]any{
-		"type":       "cloud",
-		"packages":   emptyPackages(),
-		"networking": map[string]any{"type": "unrestricted"},
-	})
-	return raw
-}
-
-func normalizedCloudValue(raw json.RawMessage) map[string]any {
-	var value map[string]any
-	if err := json.Unmarshal(raw, &value); err != nil {
-		value = map[string]any{}
-	}
-	if _, ok := value["packages"]; !ok {
-		value["packages"] = emptyPackages()
-	}
-	if _, ok := value["networking"]; !ok {
-		value["networking"] = map[string]any{"type": "unrestricted"}
-	}
-	value["type"] = "cloud"
-	return value
-}
-
-func emptyPackages() map[string]any {
-	return map[string]any{
-		"type":  "packages",
-		"apt":   []string{},
-		"cargo": []string{},
-		"gem":   []string{},
-		"go":    []string{},
-		"npm":   []string{},
-		"pip":   []string{},
-	}
-}
-
-func normalizePackages(raw json.RawMessage) (map[string]any, error) {
-	if len(raw) == 0 || isJSONNull(raw) {
-		return emptyPackages(), nil
-	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &fields); err != nil {
-		return nil, errors.New("config.packages must be an object or null")
-	}
-	out := emptyPackages()
-	for _, manager := range []string{"apt", "cargo", "gem", "go", "npm", "pip"} {
-		rawList, ok := fields[manager]
-		if !ok || isJSONNull(rawList) {
-			continue
-		}
-		values, err := stringArray(rawList, "config.packages."+manager)
-		if err != nil {
-			return nil, err
-		}
-		out[manager] = values
-	}
-	return out, nil
-}
-
-func normalizeNetworking(raw json.RawMessage) (map[string]any, error) {
-	if len(raw) == 0 || isJSONNull(raw) {
-		return map[string]any{"type": "unrestricted"}, nil
-	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &fields); err != nil {
-		return nil, errors.New("config.networking must be an object or null")
-	}
-	networkType := rawStringOrEmpty(fields["type"])
-	if networkType == "" {
-		networkType = "unrestricted"
-	}
-	switch networkType {
-	case "unrestricted":
-		return map[string]any{"type": "unrestricted"}, nil
-	case "limited":
-		hosts := []string{}
-		if rawHosts, ok := fields["allowed_hosts"]; ok && !isJSONNull(rawHosts) {
-			values, err := stringArray(rawHosts, "config.networking.allowed_hosts")
-			if err != nil {
-				return nil, err
-			}
-			for _, host := range values {
-				if err := validateAllowedHost(host); err != nil {
-					return nil, err
-				}
-			}
-			hosts = values
-		}
-		allowMCP, err := optionalBool(fields["allow_mcp_servers"], false, "config.networking.allow_mcp_servers")
-		if err != nil {
-			return nil, err
-		}
-		allowPackages, err := optionalBool(fields["allow_package_managers"], false, "config.networking.allow_package_managers")
-		if err != nil {
-			return nil, err
-		}
-		return map[string]any{
-			"type":                   "limited",
-			"allowed_hosts":          hosts,
-			"allow_mcp_servers":      allowMCP,
-			"allow_package_managers": allowPackages,
-		}, nil
-	default:
-		return nil, errors.New("config.networking.type must be unrestricted or limited")
-	}
-}
-
-func validateAllowedHost(host string) error {
-	if strings.Contains(host, "://") || strings.Contains(host, "/") || !allowedHostPattern.MatchString(host) {
-		return errors.New("config.networking.allowed_hosts entries must be hostnames without URL schemes")
-	}
-	if len(host) > 253 {
-		return errors.New("config.networking.allowed_hosts entries must be at most 253 characters")
-	}
-	return nil
-}
-
 func normalizeMetadata(raw json.RawMessage) (json.RawMessage, error) {
 	if isJSONNull(raw) {
 		return json.RawMessage(`{}`), nil
@@ -1341,33 +1059,6 @@ func validateMetadata(metadata map[string]string) error {
 	return nil
 }
 
-func stringArray(raw json.RawMessage, name string) ([]string, error) {
-	var values []string
-	if err := json.Unmarshal(raw, &values); err != nil {
-		return nil, fmt.Errorf("%s must be an array of strings", name)
-	}
-	for _, value := range values {
-		if strings.TrimSpace(value) == "" {
-			return nil, fmt.Errorf("%s entries must be non-empty strings", name)
-		}
-		if len(value) > 255 {
-			return nil, fmt.Errorf("%s entries must be at most 255 characters", name)
-		}
-	}
-	return values, nil
-}
-
-func optionalBool(raw json.RawMessage, fallback bool, name string) (bool, error) {
-	if len(raw) == 0 || isJSONNull(raw) {
-		return fallback, nil
-	}
-	var value bool
-	if err := json.Unmarshal(raw, &value); err != nil {
-		return false, fmt.Errorf("%s must be a boolean", name)
-	}
-	return value, nil
-}
-
 func rawStringOrEmpty(raw json.RawMessage) string {
 	if len(raw) == 0 || isJSONNull(raw) {
 		return ""
@@ -1377,14 +1068,6 @@ func rawStringOrEmpty(raw json.RawMessage) string {
 		return ""
 	}
 	return value
-}
-
-func rawConfigType(raw json.RawMessage) string {
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &fields); err != nil {
-		return ""
-	}
-	return rawStringOrEmpty(fields["type"])
 }
 
 func fieldOrDefault(fields map[string]json.RawMessage, name, fallback string) json.RawMessage {

--- a/scripts/go-file-line-budgets.txt
+++ b/scripts/go-file-line-budgets.txt
@@ -4,7 +4,7 @@
 1921 internal/deployments/handler.go
 1829 internal/memory/handler.go
 1815 internal/codesessions/ingress.go
-1544 internal/environments/handler.go
+1227 internal/environments/handler.go
 1489 internal/vaults/handler.go
 1376 tests/files_api_test.go
 1369 internal/db/code_sessions.go


### PR DESCRIPTION
## Summary

- extract Cloud and Self-hosted Environment Config normalization, defaults, update semantics, networking validation, and response mapping into a focused boundary
- keep the Environment Handler focused on HTTP/resource orchestration
- preserve the existing Packages, Networking, API response, and official SDK fixture behavior
- lower the historical Handler line budget from 1544 to 1227

## Review

- Standards axis: 0 findings
- Spec axis: 0 findings
- Fixed point: `origin/main` (`562758004b6c8dccbff6c182491156024d33dc9d`)

## Validation

- `go test ./internal/environments -count=1`
- `go test ./tests -run 'TestEnvironments(API|OfficialSDKFixture)$' -count=1`
- `just dead-code`
- `just duplicates`
- `just complexity`
- `just large-files`
- all commit-time managed hooks passed

## Repository baseline

The all-files lint hook still reports the two pre-existing redundant `// +build e2e` lines in `tests/sdk_go_deployments_e2e_test.go` and `tests/sdk_go_quickstart_demo_test.go`. The full test suite also retains the pre-existing Files API `routing_group_auth_applies_only_to_v1` 404/401 failure. Neither file or behavior is changed by this PR.

Closes #73


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved environment configuration handling for creation, updates, and API responses.
  * Added support for cloud and self-hosted configuration types with appropriate defaults and validation.
  * Preserved compatibility with existing and legacy environment configuration formats.

* **Bug Fixes**
  * Invalid configuration values are now rejected consistently.
  * Partial updates now affect only the fields provided, while null updates reset configurations to cloud defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->