### PR TITLE
[Environment] 修复 resolveNetwork 缺少 DenyOut 导致 limited 网络模式未生效

### DIFF
--- a/internal/runtime/e2bruntime/resolve_network_test.go
+++ b/internal/runtime/e2bruntime/resolve_network_test.go
@@ -1,0 +1,180 @@
+package e2bruntime
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestResolveNetworkInvalidConfigs 验证 resolveNetwork 对各种异常输入的处理。
+func TestResolveNetworkInvalidConfigs(t *testing.T) {
+	tests := []struct {
+		name             string
+		raw              string
+		wantAllowOut     []string
+		wantDenyOut      []string
+		wantInternet     bool
+		wantErr          bool
+		wantNilNetwork   bool // 期望返回 nil Network
+	}{
+		{
+			name:           "nil config returns unrestricted",
+			raw:            "",
+			wantInternet:   true,
+			wantNilNetwork: true,
+		},
+		{
+			name:           "empty object returns unrestricted",
+			raw:            "{}",
+			wantInternet:   true,
+			wantNilNetwork: true,
+		},
+		{
+			name:           "type not cloud returns unrestricted",
+			raw:            `{"type":"self_hosted","networking":{"type":"limited","allowed_hosts":["example.com"]}}`,
+			wantInternet:   true,
+			wantNilNetwork: true,
+		},
+		{
+			name:           "networking is nil returns unrestricted",
+			raw:            `{"type":"cloud"}`,
+			wantInternet:   true,
+			wantNilNetwork: true,
+		},
+		{
+			name:           "unrestricted networking returns unrestricted",
+			raw:            `{"type":"cloud","networking":{"type":"unrestricted"}}`,
+			wantInternet:   true,
+			wantNilNetwork: true,
+		},
+		{
+			name:           "unknown networking type returns no internet but nil network",
+			raw:            `{"type":"cloud","networking":{"type":"custom_firewall"}}`,
+			wantInternet:   false,
+			wantNilNetwork: true,
+		},
+		{
+			name:           "invalid json returns error",
+			raw:            `{"type":"cloud","networking":broken}`,
+			wantErr:        true,
+		},
+		{
+			name:           "empty networking type treated as unknown → no internet, nil network",
+			raw:            `{"type":"cloud","networking":{"type":"","allowed_hosts":["example.com"]}}`,
+			wantInternet:   false,
+			wantNilNetwork: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw json.RawMessage
+			if tt.raw != "" {
+				raw = json.RawMessage(tt.raw)
+			}
+			network, internet, err := resolveNetwork(raw, nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if internet != tt.wantInternet {
+				t.Fatalf("AllowInternetAccess = %v, want %v", internet, tt.wantInternet)
+			}
+			if tt.wantNilNetwork {
+				if network != nil {
+					t.Fatalf("expected nil network, got %#v", network)
+				}
+				return
+			}
+			if network == nil {
+				t.Fatal("expected non-nil network")
+			}
+			if tt.wantAllowOut != nil {
+				if !reflect.DeepEqual(network.AllowOut, tt.wantAllowOut) {
+					t.Fatalf("AllowOut = %#v, want %#v", network.AllowOut, tt.wantAllowOut)
+				}
+			}
+			if tt.wantDenyOut != nil {
+				if !reflect.DeepEqual(network.DenyOut, tt.wantDenyOut) {
+					t.Fatalf("DenyOut = %#v, want %#v", network.DenyOut, tt.wantDenyOut)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveNetworkUnrestricted 验证 unrestricted 模式始终返回 nil network + internet=true。
+func TestResolveNetworkUnrestricted(t *testing.T) {
+	raw := json.RawMessage(`{"type":"cloud","networking":{"type":"unrestricted"}}`)
+	network, internet, err := resolveNetwork(raw, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !internet {
+		t.Fatal("unrestricted should allow internet")
+	}
+	if network != nil {
+		t.Fatalf("unrestricted should return nil network, got %#v", network)
+	}
+}
+
+// TestResolveNetworkLimited 验证 limited 模式返回 AllowOut + DenyOut ALL_TRAFFIC。
+func TestResolveNetworkLimited(t *testing.T) {
+	raw := json.RawMessage(`{"type":"cloud","networking":{"type":"limited","allowed_hosts":["allowed.example.com"],"allow_mcp_servers":false,"allow_package_managers":false}}`)
+	network, internet, err := resolveNetwork(raw, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if internet {
+		t.Fatal("limited should disable internet")
+	}
+	if network == nil {
+		t.Fatal("expected non-nil network")
+	}
+	wantAllow := []string{"allowed.example.com"}
+	if !reflect.DeepEqual(network.AllowOut, wantAllow) {
+		t.Fatalf("AllowOut = %#v, want %#v", network.AllowOut, wantAllow)
+	}
+	wantDeny := []string{"0.0.0.0/0"}
+	if !reflect.DeepEqual(network.DenyOut, wantDeny) {
+		t.Fatalf("DenyOut = %#v, want %#v", network.DenyOut, wantDeny)
+	}
+}
+
+// TestResolveNetworkLimitedWithPackageManagers 验证 allow_package_managers 追加包管理器 host。
+func TestResolveNetworkLimitedWithPackageManagers(t *testing.T) {
+	raw := json.RawMessage(`{"type":"cloud","networking":{"type":"limited","allowed_hosts":[],"allow_package_managers":true}}`)
+	network, internet, err := resolveNetwork(raw, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if internet {
+		t.Fatal("limited should disable internet")
+	}
+	if network == nil {
+		t.Fatal("expected non-nil network")
+	}
+
+	allowOut, ok := network.AllowOut.([]string)
+	if !ok {
+		t.Fatalf("AllowOut type = %T, want []string", network.AllowOut)
+	}
+	pmHosts := packageManagerHosts()
+	for _, pm := range pmHosts {
+		found := false
+		for _, h := range allowOut {
+			if h == pm {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("AllowOut missing package manager host %q; got %#v", pm, allowOut)
+		}
+	}
+}

--- a/internal/runtime/e2bruntime/runtime.go
+++ b/internal/runtime/e2bruntime/runtime.go
@@ -428,7 +428,13 @@ func resolveNetwork(raw json.RawMessage, mcpAllowedHosts []string) (*e2b.Sandbox
 	if config.Networking.AllowMCPServers {
 		hosts = append(hosts, mcpAllowedHosts...)
 	}
-	return &e2b.SandboxNetworkOpts{AllowOut: uniqueStrings(hosts)}, false, nil
+	// When networking is limited, E2B Cloud requires an explicit DenyOut to
+	// block all traffic not in AllowOut. Without this, non-allowed hosts
+	// remain reachable.
+	return &e2b.SandboxNetworkOpts{
+		AllowOut: uniqueStrings(hosts),
+		DenyOut:  []string{e2b.ALL_TRAFFIC},
+	}, false, nil
 }
 
 func mcpAllowedHostsFromWork(work *db.EnvironmentWork) []string {

--- a/internal/runtime/e2bruntime/runtime_test.go
+++ b/internal/runtime/e2bruntime/runtime_test.go
@@ -86,6 +86,10 @@ func TestResolveLimitedNetworkIncludesMCPHostsWhenAllowed(t *testing.T) {
 	if !reflect.DeepEqual(resolution.Network.AllowOut, want) {
 		t.Fatalf("AllowOut = %#v, want %#v", resolution.Network.AllowOut, want)
 	}
+	denyWant := []string{"0.0.0.0/0"}
+	if !reflect.DeepEqual(resolution.Network.DenyOut, denyWant) {
+		t.Fatalf("DenyOut = %#v, want %#v", resolution.Network.DenyOut, denyWant)
+	}
 }
 
 func TestSkillMountVolumeNameUsesFullManifestHash(t *testing.T) {

--- a/tests/environments_networking_e2b_integration_test.go
+++ b/tests/environments_networking_e2b_integration_test.go
@@ -1,0 +1,325 @@
+//go:build e2b_integration
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/superduck-ai/open-managed-agents/internal/auth"
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/environments"
+	"github.com/superduck-ai/open-managed-agents/internal/ids"
+	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
+
+	"github.com/google/uuid"
+	e2b "github.com/superduck-ai/e2b-go-sdk"
+)
+
+// TestUnrestrictedNetwork — unrestricted 环境应允许访问任何外网地址。
+func TestUnrestrictedNetwork(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	cfg, database, apiKey, template, cleanup := setupE2BNetworkingTest(t, ctx)
+	defer cleanup()
+
+	envConfig := mustJSON(t, map[string]any{
+		"type":       "cloud",
+		"runtime":    "self_hosted",
+		"image":      template,
+		"packages":   []any{},
+		"networking": map[string]any{"type": "unrestricted"},
+	})
+	_, _, provider, sandboxID := createSandboxForNetworkTest(t, ctx, database, apiKey, template, envConfig, cfg)
+	defer killE2BSandbox(t, ctx, provider, sandboxID)
+
+	sandbox, err := e2b.Connect(ctx, sandboxID, &e2b.SandboxConnectOpts{
+		ConnectionOpts: e2bConnectionOptsFromConfig(cfg),
+	})
+	if err != nil {
+		t.Fatalf("connect sandbox: %v", err)
+	}
+
+	assertCurlOK(t, sandbox, ctx, "https://example.com", "unrestricted")
+	assertCurlOK(t, sandbox, ctx, "https://google.com", "unrestricted")
+}
+
+// TestLimitedNetworkBlocksAll — limited 且无 allowed_hosts 时，所有外网访问应被阻断。
+func TestLimitedNetworkBlocksAll(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	cfg, database, apiKey, template, cleanup := setupE2BNetworkingTest(t, ctx)
+	defer cleanup()
+
+	envConfig := mustJSON(t, map[string]any{
+		"type":    "cloud",
+		"runtime": "self_hosted",
+		"image":   template,
+		"packages": []any{},
+		"networking": map[string]any{
+			"type":                   "limited",
+			"allowed_hosts":          []string{},
+			"allow_mcp_servers":      false,
+			"allow_package_managers": false,
+		},
+	})
+	_, _, provider, sandboxID := createSandboxForNetworkTest(t, ctx, database, apiKey, template, envConfig, cfg)
+	defer killE2BSandbox(t, ctx, provider, sandboxID)
+
+	sandbox, err := e2b.Connect(ctx, sandboxID, &e2b.SandboxConnectOpts{
+		ConnectionOpts: e2bConnectionOptsFromConfig(cfg),
+	})
+	if err != nil {
+		t.Fatalf("connect sandbox: %v", err)
+	}
+
+	assertCurlFails(t, sandbox, ctx, "https://example.com", "limited (empty allowlist)")
+	assertCurlFails(t, sandbox, ctx, "https://google.com", "limited (empty allowlist)")
+}
+
+// TestLimitedNetworkWithAllowedHosts — limited 且 allowed_hosts 包含特定域名时，
+// 应允许访问该域名，但阻断其他外网域名。
+func TestLimitedNetworkWithAllowedHosts(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	cfg, database, apiKey, template, cleanup := setupE2BNetworkingTest(t, ctx)
+	defer cleanup()
+
+	envConfig := mustJSON(t, map[string]any{
+		"type":    "cloud",
+		"runtime": "self_hosted",
+		"image":   template,
+		"packages": []any{},
+		"networking": map[string]any{
+			"type":                   "limited",
+			"allowed_hosts":          []string{"example.com"},
+			"allow_mcp_servers":      false,
+			"allow_package_managers": false,
+		},
+	})
+	_, _, provider, sandboxID := createSandboxForNetworkTest(t, ctx, database, apiKey, template, envConfig, cfg)
+	defer killE2BSandbox(t, ctx, provider, sandboxID)
+
+	sandbox, err := e2b.Connect(ctx, sandboxID, &e2b.SandboxConnectOpts{
+		ConnectionOpts: e2bConnectionOptsFromConfig(cfg),
+	})
+	if err != nil {
+		t.Fatalf("connect sandbox: %v", err)
+	}
+
+	assertCurlOK(t, sandbox, ctx, "https://example.com", "allowed host")
+	assertCurlFails(t, sandbox, ctx, "https://google.com", "disallowed host")
+}
+
+// TestLimitedNetworkAllowsPackageManagers — limited 且 allow_package_managers=true 时，
+// 包管理器域名应可访问。
+func TestLimitedNetworkAllowsPackageManagers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	cfg, database, apiKey, template, cleanup := setupE2BNetworkingTest(t, ctx)
+	defer cleanup()
+
+	envConfig := mustJSON(t, map[string]any{
+		"type":    "cloud",
+		"runtime": "self_hosted",
+		"image":   template,
+		"packages": []any{},
+		"networking": map[string]any{
+			"type":                   "limited",
+			"allowed_hosts":          []string{},
+			"allow_mcp_servers":      false,
+			"allow_package_managers": true,
+		},
+	})
+	_, _, provider, sandboxID := createSandboxForNetworkTest(t, ctx, database, apiKey, template, envConfig, cfg)
+	defer killE2BSandbox(t, ctx, provider, sandboxID)
+
+	sandbox, err := e2b.Connect(ctx, sandboxID, &e2b.SandboxConnectOpts{
+		ConnectionOpts: e2bConnectionOptsFromConfig(cfg),
+	})
+	if err != nil {
+		t.Fatalf("connect sandbox: %v", err)
+	}
+
+	assertCurlOK(t, sandbox, ctx, "https://pypi.org", "package manager")
+	assertCurlFails(t, sandbox, ctx, "https://google.com", "package manager (disallowed)")
+}
+
+// ---------------------------------------------------------------------------
+// 测试辅助函数
+// ---------------------------------------------------------------------------
+
+func setupE2BNetworkingTest(t *testing.T, ctx context.Context) (
+	cfg config.Config, database *db.DB, apiKey db.APIKey,
+	template string, cleanup func(),
+) {
+	t.Helper()
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if strings.TrimSpace(cfg.E2BAPIKey) == "" {
+		t.Fatal("E2B_API_KEY is required for the real E2B integration test")
+	}
+	if cfg.E2BRequestTimeout < 2*time.Minute {
+		cfg.E2BRequestTimeout = 2 * time.Minute
+	}
+	if cfg.E2BSandboxTimeout < time.Minute {
+		cfg.E2BSandboxTimeout = time.Minute
+	}
+	cfg.E2BDebug = false
+
+	database, err = db.Open(ctx, cfg)
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	if err := database.Migrate(ctx); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+	if err := database.Seed(ctx, cfg.SeedAPIKeys); err != nil {
+		t.Fatalf("seed database: %v", err)
+	}
+
+	apiKey, err = database.GetAPIKey(ctx, auth.HashAPIKey(config.DefaultAPIKey))
+	if err != nil {
+		t.Fatalf("load default api key: %v", err)
+	}
+
+	template = strings.TrimSpace(cfg.E2BTemplate)
+	if template == "" {
+		template = "claude-code-interpreter"
+	}
+
+	cleanup = func() { database.Close() }
+	return
+}
+
+func createSandboxForNetworkTest(
+	t *testing.T, ctx context.Context, database *db.DB,
+	apiKey db.APIKey, template string, envConfig json.RawMessage,
+	cfg config.Config,
+) (envExternalID, workExternalID string, provider *e2bruntime.E2BProvider, sandboxID string) {
+	t.Helper()
+
+	envID, err := ids.New("env_")
+	if err != nil {
+		t.Fatalf("create environment id: %v", err)
+	}
+	workID, err := ids.New("work_")
+	if err != nil {
+		t.Fatalf("create work id: %v", err)
+	}
+
+	now := time.Now().UTC()
+	env, err := database.CreateEnvironment(ctx, db.Environment{
+		UUID:              uuid.NewString(),
+		ExternalID:        envID,
+		OrganizationID:    apiKey.OrganizationID,
+		WorkspaceID:       apiKey.WorkspaceID,
+		CreatedByAPIKeyID: apiKey.ID,
+		Name:              "networking-test-" + envID[len("env_"):len("env_")+8],
+		Description:       "E2B networking integration test",
+		Config:            envConfig,
+		Metadata:          mustJSON(t, map[string]any{"source": "e2b_networking_test"}),
+		Provider:          "e2b",
+		ResolvedTemplate:  template,
+		CreatedAt:         now,
+	})
+	if err != nil {
+		t.Fatalf("create environment: %v", err)
+	}
+	t.Cleanup(func() {
+		cpCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_, _ = database.Pool.Exec(cpCtx, `delete from environment_sandboxes where environment_external_id = $1`, env.ExternalID)
+		_, _ = database.Pool.Exec(cpCtx, `delete from environment_work where environment_external_id = $1`, env.ExternalID)
+		_, _ = database.Pool.Exec(cpCtx, `delete from environments where external_id = $1`, env.ExternalID)
+	})
+
+	_, err = database.CreateEnvironmentWork(ctx, db.EnvironmentWork{
+		UUID:                  uuid.NewString(),
+		ExternalID:            workID,
+		OrganizationID:        env.OrganizationID,
+		WorkspaceID:           env.WorkspaceID,
+		EnvironmentID:         env.ID,
+		EnvironmentExternalID: env.ExternalID,
+		Data:                  mustJSON(t, map[string]any{"task": "networking e2b test"}),
+		Metadata:              mustJSON(t, map[string]any{"source": "e2b_networking_test"}),
+		State:                 "queued",
+		CreatedAt:             now,
+	})
+	if err != nil {
+		t.Fatalf("create environment work: %v", err)
+	}
+
+	provider = e2bruntime.NewProvider(cfg)
+	runner := environments.NewRunner(database, provider)
+	processed, err := runner.RunOnce(ctx, "e2b-networking-test")
+	if err != nil {
+		t.Fatalf("run environment runner once: %v", err)
+	}
+	if !processed {
+		t.Fatal("environment runner did not process queued work")
+	}
+
+	sbxID, _, state, _, errMsg := loadE2BSandboxRow(t, database, env.ExternalID, workID)
+	if errMsg != "" {
+		t.Fatalf("sandbox row has last_error: %s", errMsg)
+	}
+	if state != "running" {
+		t.Fatalf("sandbox state = %s, want running", state)
+	}
+	if strings.TrimSpace(sbxID) == "" {
+		t.Fatal("provider sandbox id was not recorded")
+	}
+
+	return env.ExternalID, workID, provider, sbxID
+}
+
+func assertCurlOK(t *testing.T, sandbox *e2b.Sandbox, ctx context.Context, url, label string) {
+	t.Helper()
+	timeoutMs := 20_000
+	execution, err := sandbox.Commands.Run(ctx, curlCommand(url), &e2b.CommandStartOpts{TimeoutMs: &timeoutMs})
+	if err != nil {
+		t.Fatalf("[%s] curl %s should succeed but got error: %v", label, url, err)
+	}
+	result, ok := execution.(*e2b.CommandResult)
+	if !ok {
+		t.Fatalf("[%s] curl %s unexpected result type %T", label, url, execution)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("[%s] curl %s exited with code %d, want 0: stdout=%q stderr=%q", label, url, result.ExitCode, result.Stdout, result.Stderr)
+	}
+}
+
+func assertCurlFails(t *testing.T, sandbox *e2b.Sandbox, ctx context.Context, url, label string) {
+	t.Helper()
+	timeoutMs := 20_000
+	execution, err := sandbox.Commands.Run(ctx, curlCommand(url), &e2b.CommandStartOpts{TimeoutMs: &timeoutMs})
+	if err == nil {
+		if result, ok := execution.(*e2b.CommandResult); ok && result.ExitCode == 0 {
+			t.Fatalf("[%s] curl %s should fail but succeeded: stdout=%q", label, url, result.Stdout)
+		}
+		return
+	}
+}
+
+func curlCommand(url string) string {
+	return "curl -sS --connect-timeout 10 -o /dev/null -w '%{http_code}' " + url
+}
+
+func killE2BSandbox(t *testing.T, ctx context.Context, provider *e2bruntime.E2BProvider, sandboxID string) {
+	t.Helper()
+	killCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	_ = provider.Kill(killCtx, sandboxID)
+}


### PR DESCRIPTION
## 概述

`resolveNetwork` 在 limited 网络模式下只设置了 `AllowOut`，未设置 `DenyOut`。E2B Cloud 要求显式传入 `DenyOut: ["0.0.0.0/0"]` 才能阻断非允许域名，否则 limited 模式实际允许所有流量。

## 改动

| 文件 | 改动 |
|------|------|
| `internal/runtime/e2bruntime/runtime.go` | `resolveNetwork` limited 模式返回 `DenyOut: []string{e2b.ALL_TRAFFIC}` |
| `internal/runtime/e2bruntime/runtime_test.go` | `TestResolveLimitedNetworkIncludesMCPHostsWhenAllowed` 新增 DenyOut 断言 |
| `internal/runtime/e2bruntime/resolve_network_test.go` | **新增** — 12 个测试用例覆盖所有输入边界（nil、空、无效 JSON、未知 type 等） |
| `tests/environments_networking_e2b_integration_test.go` | **新增** — 4 个 E2E 测试用例（Runner 链路被 E2B Volumes Private Beta 阻塞） |

## 验证

直接调用 E2B SDK 在真实 E2B Cloud 上验证通过：
- `unrestricted` → example.com ✅ 200
- `limited` + `DenyOut: ["0.0.0.0/0"]` → example.com ❌ exit 28
- `limited` + `AllowOut: ["example.com"]` + `DenyOut: ["0.0.0.0/0"]` → example.com ✅ 200, google.com ❌ exit 35

Closes #69