### PR TITLE
创建会话时持久化 github_repository 的 authorization_token

### DIFF
--- a/internal/sessions/service_helpers.go
+++ b/internal/sessions/service_helpers.go
@@ -164,6 +164,16 @@ func (h *Handler) resourceFromFields(r *http.Request, session db.Session, fields
 		if raw, ok := fields["checkout"]; ok && !httpapi.IsJSONNull(raw) {
 			payload["checkout"] = agentsnapshot.RawJSONValue(raw, nil)
 		}
+		if rawToken, ok := fields["authorization_token"]; ok && !httpapi.IsJSONNull(rawToken) {
+			token, err := parseRequiredStringField(fields, "authorization_token")
+			if err != nil {
+				return db.SessionResource{}, err
+			}
+			secret, err = httpapi.MarshalRaw(map[string]any{"authorization_token": token})
+			if err != nil {
+				return db.SessionResource{}, err
+			}
+		}
 	case "memory_store":
 		memoryStoreID, err := parseRequiredStringField(fields, "memory_store_id")
 		if err != nil {

--- a/tests/sessions_github_repository_token_test.go
+++ b/tests/sessions_github_repository_token_test.go
@@ -1,0 +1,82 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestSessionCreateGitHubRepositoryAuthorizationToken(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("github-token-bucket"))
+	defer app.close()
+	suffix := uuid.NewString()[:8]
+	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"github-token-agent-`+suffix+`"}`)
+	defer cleanupAgentRows(t, app.db, agent.ID)
+	env := createEnvironment(t, app, `{"name":"github-token-env-`+suffix+`"}`)
+	defer cleanupEnvironmentRows(t, app.db, env.ID)
+
+	t.Run("failure empty authorization_token rejected", func(t *testing.T) {
+		body := `{"agent":` + quoteJSON(agent.ID) + `,"environment_id":` + quoteJSON(env.ID) + `,"resources":[{"type":"github_repository","url":"https://github.com/example/repo","authorization_token":""}]}`
+		resp := doSessionRequest(t, app, http.MethodPost, "/v1/sessions?beta=true", strings.NewReader(body), defaultTestKey, true)
+		defer resp.Body.Close()
+		assertError(t, resp, http.StatusBadRequest, "invalid_request_error")
+	})
+
+	t.Run("success token persisted into secret_payload and not echoed", func(t *testing.T) {
+		created := createSession(t, app, `{
+			"agent":`+quoteJSON(agent.ID)+`,
+			"environment_id":`+quoteJSON(env.ID)+`,
+			"resources":[
+				{"type":"github_repository","url":"https://github.com/example/private-repo","authorization_token":"ghp_secret_token_123"}
+			]
+		}`)
+		if len(created.Resources) != 1 {
+			t.Fatalf("created resources len = %d, want 1", len(created.Resources))
+		}
+		if bytes.Contains(created.Resources[0], []byte("ghp_secret_token_123")) {
+			t.Fatalf("response resource leaked authorization_token: %s", created.Resources[0])
+		}
+		var secretPayload []byte
+		err := app.db.Pool.QueryRow(context.Background(),
+			`select secret_payload from session_resources where session_external_id = $1 and resource_type = 'github_repository'`,
+			created.ID).Scan(&secretPayload)
+		if err != nil {
+			t.Fatalf("query secret_payload: %v", err)
+		}
+		var secret map[string]string
+		if err := json.Unmarshal(secretPayload, &secret); err != nil {
+			t.Fatalf("unmarshal secret_payload %s: %v", secretPayload, err)
+		}
+		if secret["authorization_token"] != "ghp_secret_token_123" {
+			t.Fatalf("secret authorization_token = %q, want ghp_secret_token_123", secret["authorization_token"])
+		}
+	})
+
+	t.Run("success public repo without token leaves secret_payload empty", func(t *testing.T) {
+		created := createSession(t, app, `{
+			"agent":`+quoteJSON(agent.ID)+`,
+			"environment_id":`+quoteJSON(env.ID)+`,
+			"resources":[
+				{"type":"github_repository","url":"https://github.com/example/public-repo"}
+			]
+		}`)
+		if len(created.Resources) != 1 {
+			t.Fatalf("created resources len = %d, want 1", len(created.Resources))
+		}
+		var secretPayload []byte
+		err := app.db.Pool.QueryRow(context.Background(),
+			`select secret_payload from session_resources where session_external_id = $1 and resource_type = 'github_repository'`,
+			created.ID).Scan(&secretPayload)
+		if err != nil {
+			t.Fatalf("query secret_payload: %v", err)
+		}
+		if len(secretPayload) != 0 {
+			t.Fatalf("secret_payload = %s, want empty for public repo", secretPayload)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

创建会话挂载 `github_repository` 资源时传入的 `authorization_token` 此前不会被持久化——session create 路径未解析该字段，私有仓 token 直接丢失，与 session update、deployment create 两条路径行为不一致（详见 #90）。现在在 `resourceFromFields` 的 `github_repository` 分支补读 `authorization_token`（可选），写入 `secret_payload`，与 update 路径一致；token 只进 `secret_payload` 不进 `payload`，响应天然不回显。

## Changes
- `internal/sessions/service_helpers.go`：`github_repository` 分支补读 `authorization_token`，写入 `secret_payload`。
- `tests/sessions_github_repository_token_test.go`：空 token 被拒、有效 token 写入 `secret_payload` 且不回显、公开仓无 token 时 `secret_payload` 为空。

## Verification
- `go test ./tests -run TestSessionCreateGitHubRepositoryAuthorizationToken -v`（3/3 通过）
- gofmt / golangci-lint / file-lines / dead-code / jscpd 通过

## 范围说明
token 的写入/持久化一致性在本 PR 修复；token 实际传递到沙箱属 #52 凭证 sandbox 集成范畴，本 PR 不涉及。

Closes #90
