### PR TITLE
fix(workspace): 修复侧边栏 workspace 图标未显示自定义颜色

### DIFF
--- a/web/src/app/layout/ConsoleLayout.tsx
+++ b/web/src/app/layout/ConsoleLayout.tsx
@@ -75,6 +75,7 @@ import { CreateWorkspaceDialog } from '../../shared/workspaces/CreateWorkspaceDi
 import {
   buildCreateWorkspaceInput,
   workspaceApiKeysPath,
+  workspaceColor,
   workspaceIdFromPath,
   workspaceWebhooksPath,
 } from '../../shared/workspaces/presentation';
@@ -478,7 +479,7 @@ function WorkspaceSwitcher({ currentPath, onNavigate }: { currentPath: string; o
             }
           >
             <span className="grid aspect-square size-8 shrink-0 place-items-center rounded-lg border border-sidebar-border bg-sidebar-accent text-sidebar-accent-foreground">
-              <Box className="size-4" aria-hidden />
+              <Box className="size-4" style={{ color: workspaceColor(activeWorkspace) }} aria-hidden />
             </span>
             {collapsed ? null : (
               <>
@@ -511,7 +512,7 @@ function WorkspaceSwitcher({ currentPath, onNavigate }: { currentPath: string; o
                     onClick={() => handleSelect(workspace)}
                   >
                     <span className="grid size-6 shrink-0 place-items-center rounded-md border bg-background text-muted-foreground">
-                      <Box className="size-4" aria-hidden />
+                      <Box className="size-4" style={{ color: workspaceColor(workspace) }} aria-hidden />
                     </span>
                     <span className="min-w-0 flex-1 truncate">{workspace.name}</span>
                     <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>


### PR DESCRIPTION
## Summary

侧边栏 workspace switcher 的两处图标未读取 `display_color` 字段，导致始终呈灰色，与 `/settings/workspaces` 页面的显示效果不一致。

## Changes

- `web/src/app/layout/ConsoleLayout.tsx`：
  - 补充 `workspaceColor` 函数的 import
  - switcher 按钮（active workspace icon）补充 `style={{ color: workspaceColor(activeWorkspace) }}`
  - 下拉列表每个 workspace 条目的 icon 补充 `style={{ color: workspaceColor(workspace) }}`

## Verification

1. 创建多个颜色不同的 workspace
2. 访问任意控制台页面，侧边栏顶部 workspace switcher 图标现在显示对应颜色
3. 展开 switcher 下拉列表，每个 workspace 条目图标也显示各自颜色
4. `bun run build` 通过，TypeScript 无报错

效果图如下
<img width="970" height="420" alt="image" src="https://github.com/user-attachments/assets/dce359e0-3f53-4978-84f7-bf424c0b34ed" />


Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated workspace avatars in the workspace switcher with workspace-specific colors.
  * Applied consistent coloring to both the active workspace and workspace selection list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->