### PR TITLE
fix(dashboard): 修复切换 workspace 后页面文案名称不更新

### DIFF
--- a/web/src/features/dashboard/DashboardPage.test.tsx
+++ b/web/src/features/dashboard/DashboardPage.test.tsx
@@ -1,6 +1,13 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  RouterContextProvider,
+  createBrowserHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from '@tanstack/react-router';
 import { afterEach, describe, expect, mock, test } from 'bun:test';
-import type { ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { AuthContext, type AuthContextValue } from '../../shared/auth/context';
 import { I18nProvider, type Locale } from '../../shared/i18n';
 import { setConsoleRequestContext } from '../../shared/api/client';
@@ -587,6 +594,29 @@ describe('Files page', () => {
     expect(screen.queryByText('import anthropic')).toBeNull();
     expect((screen.getByRole('button', { name: 'Previous page' }) as HTMLButtonElement).disabled).toBe(true);
     expect((screen.getByRole('button', { name: 'Next page' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('refreshes the workspace name in the empty state when only the route changes', async () => {
+    resetTestDom('https://oma.duck.ai/workspaces/asdf/files');
+    mockFilesList(() => ({
+      data: [],
+      has_more: false,
+      first_id: null,
+      last_id: null,
+    }));
+
+    renderFilesPage();
+
+    // `asdf` is not a known workspace, so the name falls back to the route id.
+    expect(await screen.findByText('No files have been uploaded to the asdf workspace.')).toBeTruthy();
+
+    // Navigating to the default workspace must update the name even though the
+    // active workspace context is unchanged — this is the regression for the
+    // useLocation-driven scope.
+    window.history.pushState(null, '', 'https://oma.duck.ai/workspaces/default/files');
+
+    expect(await screen.findByText('No files have been uploaded to the Default workspace.')).toBeTruthy();
+    expect(screen.queryByText('No files have been uploaded to the asdf workspace.')).toBeNull();
   });
 
   test('renders the standardized files error row and retries successfully', async () => {
@@ -1556,6 +1586,32 @@ function mockWebhooksList() {
   return { requests };
 }
 
+const dashboardTestRootRoute = createRootRoute();
+const dashboardTestFallbackRoute = createRoute({
+  getParentRoute: () => dashboardTestRootRoute,
+  path: '$',
+});
+const dashboardTestRouteTree = dashboardTestRootRoute.addChildren([dashboardTestFallbackRoute]);
+
+function DashboardTestRouterProvider({
+  router,
+  children,
+}: {
+  router: ReturnType<typeof createRouter<typeof dashboardTestRouteTree>>;
+  children: ReactNode;
+}) {
+  useEffect(() => {
+    // Mirror the subscription that <RouterProvider>'s Transitioner sets up, so
+    // useLocation() reflects window.history.pushState calls in tests.
+    const unsubscribe = router.history.subscribe(router.load);
+    return () => {
+      unsubscribe();
+      router.history.destroy();
+    };
+  }, [router]);
+  return <RouterContextProvider router={router}>{children}</RouterContextProvider>;
+}
+
 function renderDashboardPage(
   children: ReactNode,
   workspace?: Partial<Workspace>,
@@ -1570,16 +1626,22 @@ function renderDashboardPage(
       },
     },
   });
+  const router = createRouter({
+    history: createBrowserHistory({ window }),
+    routeTree: dashboardTestRouteTree,
+  });
   const renderWithWorkspace = (nextWorkspace?: Partial<Workspace>) => {
     const value = makeWorkspaceContextValue(nextWorkspace);
     return (
-      <I18nProvider initialLocale={locale}>
-        <AuthContext.Provider value={authValue}>
-          <WorkspaceContext.Provider value={value}>
-            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-          </WorkspaceContext.Provider>
-        </AuthContext.Provider>
-      </I18nProvider>
+      <DashboardTestRouterProvider router={router}>
+        <I18nProvider initialLocale={locale}>
+          <AuthContext.Provider value={authValue}>
+            <WorkspaceContext.Provider value={value}>
+              <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+            </WorkspaceContext.Provider>
+          </AuthContext.Provider>
+        </I18nProvider>
+      </DashboardTestRouterProvider>
     );
   };
 

--- a/web/src/features/dashboard/model.ts
+++ b/web/src/features/dashboard/model.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from 'react';
+import { useLocation } from '@tanstack/react-router';
 import { copyText } from '@/shared/lib/clipboard';
 import { anthropicBetaApi } from '../../shared/api/anthropic';
 import { filesRequestHeaders, messageBatchesRequestHeaders, skillsRequestHeaders } from '../../shared/api/client';
@@ -119,7 +120,8 @@ function workspaceRequestHeaders(workspaceId: string) {
 
 export function useDashboardWorkspaceScope() {
   const { activeWorkspace, activeWorkspaceId, workspaces } = useWorkspace();
-  const routeWorkspaceId = workspaceIdFromCurrentPath();
+  const { pathname } = useLocation();
+  const routeWorkspaceId = workspaceIdFromPath(pathname);
   const workspaceId = routeWorkspaceId || activeWorkspaceId;
   const routeWorkspace = workspaces.find((workspace) => workspace.id === workspaceId);
   return {
@@ -129,11 +131,8 @@ export function useDashboardWorkspaceScope() {
   };
 }
 
-function workspaceIdFromCurrentPath() {
-  if (typeof window === 'undefined') {
-    return '';
-  }
-  const match = window.location.pathname.match(/^\/workspaces\/([^/]+)/);
+function workspaceIdFromPath(pathname: string) {
+  const match = pathname.match(/^\/workspaces\/([^/]+)/);
   return match ? decodeURIComponent(match[1]) : '';
 }
 export function listFiles(cursor: FilesPageCursor, workspaceId: string) {

--- a/web/src/features/dashboard/model.ts
+++ b/web/src/features/dashboard/model.ts
@@ -5,6 +5,7 @@ import { anthropicBetaApi } from '../../shared/api/anthropic';
 import { filesRequestHeaders, messageBatchesRequestHeaders, skillsRequestHeaders } from '../../shared/api/client';
 import type { useI18n } from '../../shared/i18n';
 import { useWorkspace } from '../../shared/workspaces/context';
+import { workspaceIdFromPath } from '../../shared/workspaces/presentation';
 
 export type IconComponent = ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
 
@@ -120,7 +121,7 @@ function workspaceRequestHeaders(workspaceId: string) {
 
 export function useDashboardWorkspaceScope() {
   const { activeWorkspace, activeWorkspaceId, workspaces } = useWorkspace();
-  const { pathname } = useLocation();
+  const pathname = useLocation({ select: (location) => location.pathname });
   const routeWorkspaceId = workspaceIdFromPath(pathname);
   const workspaceId = routeWorkspaceId || activeWorkspaceId;
   const routeWorkspace = workspaces.find((workspace) => workspace.id === workspaceId);
@@ -131,10 +132,6 @@ export function useDashboardWorkspaceScope() {
   };
 }
 
-function workspaceIdFromPath(pathname: string) {
-  const match = pathname.match(/^\/workspaces\/([^/]+)/);
-  return match ? decodeURIComponent(match[1]) : '';
-}
 export function listFiles(cursor: FilesPageCursor, workspaceId: string) {
   const params: Record<string, string | number> = {
     limit: filesPageLimit,


### PR DESCRIPTION
## Summary

Files、Skills、Batches 三个页面的文案中包含 workspace 名称占位符（共 5 处）。切换 workspace 后 URL 正确更新，但文案中的名称停留在旧值，未同步刷新。

## 根因

`useDashboardWorkspaceScope` 内部调用 `workspaceIdFromCurrentPath()`，后者直接读取 `window.location.pathname`。该值不是 React 响应式状态，路由变化不会触发重渲染。

## Changes

- `web/src/features/dashboard/model.ts`：
  - 引入 `useLocation`（`@tanstack/react-router`）
  - 将 `workspaceIdFromCurrentPath()` 替换为接收 `pathname` 参数的纯函数 `workspaceIdFromPath(pathname)`
  - 在 `useDashboardWorkspaceScope` 内用 `useLocation().pathname` 驱动，路由变化时自动重渲染

## Verification

1. 创建两个名称不同的 workspace
2. 访问 `/workspaces/asdf/skills`，确认空状态文案显示 "asdf"
3. 切换到另一个 workspace，确认文案立即更新为新名称
4. files、batches 页面同样验证通过
5. `tsc --noEmit` 无报错，`vite build` 通过

Closes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace detection by using router-driven location during dashboard navigation.
  * Correctly handles URL-encoded workspace identifiers.
  * Prevents incorrect workspace selection when no workspace id is present, including refreshing the empty-state workspace name correctly when switching dashboard routes.
* **Tests**
  * Added a regression test to verify the empty-state workspace name updates when navigation changes only via route URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->