### PR TITLE
fix(analytics): 修正成本视图 Range 预设顺序与其它视图不一致

### DIFF
--- a/web/src/features/analytics/AnalyticsPages.tsx
+++ b/web/src/features/analytics/AnalyticsPages.tsx
@@ -390,9 +390,9 @@ export function CostPage() {
   ];
   const modelOptions: FilterOption[] = [{ value: 'all', label: msg('common.all', 'All') }, ...analyticsModelOptions];
   const rangeOptions: FilterOption[] = [
-    { value: 'month-to-date', label: msg('analytics.filter.monthToDate', 'Month to date') },
-    { value: 'last-30-days', label: msg('analytics.filter.last30Days', 'Last 30 days') },
     { value: 'last-7-days', label: msg('analytics.filter.last7Days', 'Last 7 days') },
+    { value: 'last-30-days', label: msg('analytics.filter.last30Days', 'Last 30 days') },
+    { value: 'month-to-date', label: msg('analytics.filter.monthToDate', 'Month to date') },
   ];
   const [filters, setFilters] = useState({
     workspace: routeWorkspaceId ? 'current' : 'all-workspaces',


### PR DESCRIPTION
## 背景

Analytics 成本视图（`/workspaces/.../analytics`，标题「Cost」）的「Range」过滤器预设顺序为 `Month to date → Last 30 days → Last 7 days`，与同模块 Caching 视图（`Last 7 days → Last 30 days → Month to date`）相反。

## 修复

将 Cost 视图 `rangeOptions` 顺序调整为 `Last 7 days → Last 30 days → Month to date`，与 Caching 视图一致（从短到长）。默认值 `month-to-date` 保持不变。

## 改动

- `web/src/features/analytics/AnalyticsPages.tsx`：Cost 视图 `rangeOptions` 预设顺序

## 验证

- `bun run build` 通过
- `bun test`：368 pass / 0 fail
- prettier 通过