### PR TITLE
fix(workbench): 工具栏与抽屉硬编码深色颜色改用主题 CSS 变量

### DIFF
--- a/web/src/styles/workbench/drawer-layout-history.css
+++ b/web/src/styles/workbench/drawer-layout-history.css
@@ -9,11 +9,11 @@
   min-width: 320px;
   flex-direction: column;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border);
   border-radius: 12px;
-  background: #080807;
+  background: var(--popover);
   color: var(--foreground);
-  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.38);
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.12);
 }
 
 .workbench-drawer-panel.is-tools {

--- a/web/src/styles/workbench/shell-editor.css
+++ b/web/src/styles/workbench/shell-editor.css
@@ -153,7 +153,7 @@
   border: 1px solid transparent;
   border-radius: 8px;
   padding: 0 8px;
-  color: rgb(195, 194, 183);
+  color: var(--muted-foreground);
   font-size: 12px;
   font-weight: 400;
   line-height: 16px;
@@ -171,7 +171,8 @@
 }
 
 .workbench-toolbar-button svg {
-  color: rgb(137, 135, 129);
+  color: var(--muted-foreground);
+  opacity: 0.7;
 }
 
 .workbench-toolbar-button:hover {
@@ -180,12 +181,13 @@
 
 .workbench-toolbar-button.is-active {
   border-color: var(--border);
-  background: #151515;
-  color: var(--foreground);
+  background: var(--accent);
+  color: var(--accent-foreground);
 }
 
 .workbench-toolbar-button.is-active svg {
-  color: var(--foreground);
+  color: var(--accent-foreground);
+  opacity: 1;
 }
 
 .workbench-toolbar-button[aria-disabled='true'],


### PR DESCRIPTION
## Summary

- `.workbench-toolbar-button.is-active` used `background: #151515` — a hardcoded near-black that made active toolbar buttons (Variables, Tools, Model, etc.) render as black rectangles in light mode.
- `.workbench-drawer-panel` used `background: #080807` and `border: rgba(255,255,255,0.08)` — drawer panels always appeared dark regardless of the theme.
- Default toolbar button text/icon colors (`rgb(195,194,183)` / `rgb(137,135,129)`) were hardcoded dark-theme grays that looked washed out in light mode.

All three replaced with semantic CSS variables (`--accent`, `--accent-foreground`, `--popover`, `--border`, `--muted-foreground`).

Closes #126

## Test plan

- [ ] Switch to **light** theme, open `/workbench/`, click Variables / Tools / Model buttons — active state should show a light accent background with readable text/icon
- [ ] The drawer panel that opens should have a white/light background matching the theme
- [ ] Switch to **dark** theme and verify the same buttons still look correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved workbench drawer and toolbar styling across themes.
  * Updated panel borders, backgrounds, shadows, and toolbar controls to use theme-aware colors.
  * Refined toolbar icon visibility and active-state contrast for clearer interaction feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->