### PR TITLE
Migrate admin request listing to sqlx

### DIFF
--- a/internal/db/admin_requests.go
+++ b/internal/db/admin_requests.go
@@ -4,12 +4,113 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
 )
 
+const listAdminRequestsSQL = `
+	select
+		CAST(ar.request_uuid AS text) as request_uuid,
+		CAST(ar.org_uuid AS text) as org_uuid,
+		ar.request_type,
+		CAST(ar.requester_uuid AS text) as requester_uuid,
+		ar.requested_seat_tier,
+		ar.details,
+		ar.status,
+		ar.created_at,
+		ar.resolved_at,
+		u.email as requester_email,
+		nullif(u.name, '') as requester_name,
+		u.role as requester_role,
+		CAST(null AS text) as requester_seat_tier
+	from admin_requests ar
+	left join organizations o
+	  on CAST(o.uuid AS text) = CAST(ar.org_uuid AS text)
+	  or o.external_id = CAST(ar.org_uuid AS text)
+	left join users u
+	  on CAST(u.uuid AS text) = CAST(ar.requester_uuid AS text)
+	 and u.organization_id = o.id
+	 and u.deleted_at is null
+	where CAST(ar.org_uuid AS text) = :org_uuid
+	  and ar.request_type = :request_type
+	  and ar.status = :status
+	order by ar.created_at desc, ar.id desc
+	limit :limit
+`
+
+type adminRequestRow struct {
+	UUID              string     `db:"request_uuid"`
+	OrgUUID           string     `db:"org_uuid"`
+	RequestType       string     `db:"request_type"`
+	RequesterUUID     *string    `db:"requester_uuid"`
+	RequestedSeatTier *string    `db:"requested_seat_tier"`
+	Details           []byte     `db:"details"`
+	Status            string     `db:"status"`
+	CreatedAt         time.Time  `db:"created_at"`
+	ResolvedAt        *time.Time `db:"resolved_at"`
+	RequesterEmail    *string    `db:"requester_email"`
+	RequesterName     *string    `db:"requester_name"`
+	RequesterRole     *string    `db:"requester_role"`
+	RequesterSeatTier *string    `db:"requester_seat_tier"`
+}
+
+func (r adminRequestRow) toAdminRequest() (platform.AdminRequest, error) {
+	request := platform.AdminRequest{
+		UUID:              r.UUID,
+		OrgUUID:           r.OrgUUID,
+		RequestType:       r.RequestType,
+		RequesterUUID:     r.RequesterUUID,
+		RequestedSeatTier: r.RequestedSeatTier,
+		Status:            r.Status,
+		CreatedAt:         r.CreatedAt,
+		ResolvedAt:        r.ResolvedAt,
+		RequesterEmail:    r.RequesterEmail,
+		RequesterName:     r.RequesterName,
+		RequesterRole:     r.RequesterRole,
+		RequesterSeatTier: r.RequesterSeatTier,
+	}
+	if len(r.Details) == 0 {
+		return request, nil
+	}
+	request.Details = map[string]any{}
+	if err := json.Unmarshal(r.Details, &request.Details); err != nil {
+		return platform.AdminRequest{}, err
+	}
+	return request, nil
+}
+
+func listAdminRequestsSQLX(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	orgUUID string,
+	requestType string,
+	status string,
+	limit int,
+) ([]platform.AdminRequest, error) {
+	var rows []adminRequestRow
+	if err := namedSelectContext(ctx, database, &rows, listAdminRequestsSQL, map[string]any{
+		"org_uuid":     orgUUID,
+		"request_type": requestType,
+		"status":       status,
+		"limit":        limit,
+	}); err != nil {
+		return nil, err
+	}
+
+	requests := make([]platform.AdminRequest, 0, len(rows))
+	for _, row := range rows {
+		request, err := row.toAdminRequest()
+		if err != nil {
+			return nil, err
+		}
+		requests = append(requests, request)
+	}
+	return requests, nil
+}
+
 func (d *DB) ListAdminRequests(ctx context.Context, orgUUID string, requestType string, status string, limit int) ([]platform.AdminRequest, error) {
-	if d == nil || d.Pool == nil || strings.TrimSpace(orgUUID) == "" {
+	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" {
 		return []platform.AdminRequest{}, nil
 	}
 	if limit <= 0 || limit > 1000 {
@@ -18,71 +119,19 @@ func (d *DB) ListAdminRequests(ctx context.Context, orgUUID string, requestType 
 	if status == "" {
 		status = "pending"
 	}
-	rows, err := d.Pool.Query(ctx, `
-		select
-			ar.request_uuid::text,
-			ar.org_uuid::text,
-			ar.request_type,
-			ar.requester_uuid::text,
-			ar.requested_seat_tier,
-			ar.details,
-			ar.status,
-			ar.created_at,
-			ar.resolved_at,
-			u.email as requester_email,
-			nullif(u.name, '') as requester_name,
-			u.role as requester_role,
-			null::text as requester_seat_tier
-		from admin_requests ar
-		left join organizations o
-		  on o.uuid::text = ar.org_uuid::text
-		  or o.external_id = ar.org_uuid::text
-		left join users u
-		  on u.uuid::text = ar.requester_uuid::text
-		 and u.organization_id = o.id
-		 and u.deleted_at is null
-		where ar.org_uuid::text = $1
-		  and ar.request_type = $2
-		  and ar.status = $3
-		order by ar.created_at desc, ar.id desc
-		limit $4
-	`, strings.TrimSpace(orgUUID), requestType, status, limit)
+	requests, err := listAdminRequestsSQLX(
+		ctx,
+		d.sql,
+		strings.TrimSpace(orgUUID),
+		requestType,
+		status,
+		limit,
+	)
 	if err != nil {
 		if isUndefinedTableError(err) {
 			return []platform.AdminRequest{}, nil
 		}
 		return nil, err
 	}
-	defer rows.Close()
-
-	var out []platform.AdminRequest
-	for rows.Next() {
-		var request platform.AdminRequest
-		var detailsBytes []byte
-		if err := rows.Scan(
-			&request.UUID,
-			&request.OrgUUID,
-			&request.RequestType,
-			&request.RequesterUUID,
-			&request.RequestedSeatTier,
-			&detailsBytes,
-			&request.Status,
-			&request.CreatedAt,
-			&request.ResolvedAt,
-			&request.RequesterEmail,
-			&request.RequesterName,
-			&request.RequesterRole,
-			&request.RequesterSeatTier,
-		); err != nil {
-			return nil, err
-		}
-		if len(detailsBytes) > 0 {
-			request.Details = map[string]any{}
-			if err := json.Unmarshal(detailsBytes, &request.Details); err != nil {
-				return nil, err
-			}
-		}
-		out = append(out, request)
-	}
-	return out, rows.Err()
+	return requests, nil
 }

--- a/internal/db/admin_requests_test.go
+++ b/internal/db/admin_requests_test.go
@@ -1,0 +1,174 @@
+package db
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+)
+
+func TestAdminRequestRowRejectsInvalidDetails(t *testing.T) {
+	_, err := (adminRequestRow{Details: []byte(`{"reason":`)}).toAdminRequest()
+	if err == nil {
+		t.Fatal("toAdminRequest() error = nil, want invalid JSON error")
+	}
+}
+
+func TestListAdminRequestsQueryUsesNamedPostgreSQLArguments(t *testing.T) {
+	query, arguments, err := bindNamed(postgresRebinder{}, listAdminRequestsSQL, map[string]any{
+		"org_uuid":     "11111111-1111-1111-1111-111111111111",
+		"request_type": "join_org",
+		"status":       "pending",
+		"limit":        25,
+	})
+	if err != nil {
+		t.Fatalf("bindNamed() error = %v", err)
+	}
+	wantArguments := []any{
+		"11111111-1111-1111-1111-111111111111",
+		"join_org",
+		"pending",
+		25,
+	}
+	if !reflect.DeepEqual(arguments, wantArguments) {
+		t.Fatalf("bindNamed() arguments = %#v, want %#v", arguments, wantArguments)
+	}
+	if strings.Contains(query, "::") {
+		t.Fatalf("bindNamed() query contains PostgreSQL shorthand cast: %q", query)
+	}
+	for _, clause := range []string{
+		"where CAST(ar.org_uuid AS text) = $1",
+		"and ar.request_type = $2",
+		"and ar.status = $3",
+		"limit $4",
+	} {
+		if !strings.Contains(query, clause) {
+			t.Fatalf("bindNamed() query does not contain %q: %q", clause, query)
+		}
+	}
+}
+
+func TestListAdminRequestsSQLXScansPostgreSQLRows(t *testing.T) {
+	ctx := context.Background()
+	cfg, err := config.Load()
+	if err != nil {
+		t.Skipf("PostgreSQL integration test requires config: %v", err)
+	}
+	database, err := Open(ctx, cfg)
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	defer database.Close()
+
+	tx, err := database.sql.BeginTxx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		create temporary table organizations (
+			id bigint generated always as identity,
+			uuid uuid not null,
+			external_id text not null
+		) on commit drop;
+		create temporary table users (
+			id bigint generated always as identity,
+			uuid uuid not null,
+			organization_id bigint not null,
+			email text,
+			name text,
+			role text,
+			deleted_at timestamptz
+		) on commit drop;
+		create temporary table admin_requests (
+			id bigint generated always as identity,
+			request_uuid uuid not null,
+			org_uuid uuid not null,
+			request_type text not null,
+			requester_uuid uuid,
+			requested_seat_tier text,
+			details jsonb,
+			status text not null,
+			created_at timestamptz not null,
+			resolved_at timestamptz
+		) on commit drop;
+	`); err != nil {
+		t.Fatalf("create temporary tables: %v", err)
+	}
+
+	const (
+		orgUUID       = "11111111-1111-1111-1111-111111111111"
+		requestUUID   = "22222222-2222-2222-2222-222222222222"
+		requesterUUID = "33333333-3333-3333-3333-333333333333"
+	)
+	createdAt := time.Date(2026, time.July, 23, 9, 30, 0, 0, time.UTC)
+	if _, err := tx.ExecContext(ctx, `
+		insert into organizations (uuid, external_id)
+		values ($1, 'org_external')
+	`, orgUUID); err != nil {
+		t.Fatalf("seed temporary organization: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		insert into users (uuid, organization_id, email, name, role)
+		select $2, id, 'requester@example.com', 'Requester', 'user'
+		from organizations
+		where uuid = $1
+	`, orgUUID, requesterUUID); err != nil {
+		t.Fatalf("seed temporary user: %v", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		insert into admin_requests (
+			request_uuid,
+			org_uuid,
+			request_type,
+			requester_uuid,
+			requested_seat_tier,
+			details,
+			status,
+			created_at
+		)
+		values ($3, $1, 'join_org', $2, 'standard', '{"reason":"collaboration"}', 'pending', $4)
+	`, orgUUID, requesterUUID, requestUUID, createdAt); err != nil {
+		t.Fatalf("seed temporary admin request: %v", err)
+	}
+
+	requests, err := listAdminRequestsSQLX(ctx, tx, orgUUID, "join_org", "pending", 10)
+	if err != nil {
+		t.Fatalf("listAdminRequestsSQLX() error = %v", err)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("listAdminRequestsSQLX() returned %d requests, want 1", len(requests))
+	}
+	request := requests[0]
+	if request.UUID != requestUUID || request.OrgUUID != orgUUID || request.RequestType != "join_org" {
+		t.Fatalf("listAdminRequestsSQLX() identity fields = %#v", request)
+	}
+	if request.RequesterUUID == nil || *request.RequesterUUID != requesterUUID {
+		t.Fatalf("listAdminRequestsSQLX() requester UUID = %#v, want %q", request.RequesterUUID, requesterUUID)
+	}
+	if request.RequestedSeatTier == nil || *request.RequestedSeatTier != "standard" {
+		t.Fatalf("listAdminRequestsSQLX() requested seat tier = %#v, want standard", request.RequestedSeatTier)
+	}
+	if request.RequesterEmail == nil || *request.RequesterEmail != "requester@example.com" {
+		t.Fatalf("listAdminRequestsSQLX() requester email = %#v", request.RequesterEmail)
+	}
+	if request.RequesterName == nil || *request.RequesterName != "Requester" {
+		t.Fatalf("listAdminRequestsSQLX() requester name = %#v", request.RequesterName)
+	}
+	if request.RequesterRole == nil || *request.RequesterRole != "user" {
+		t.Fatalf("listAdminRequestsSQLX() requester role = %#v", request.RequesterRole)
+	}
+	if request.RequesterSeatTier != nil || request.ResolvedAt != nil {
+		t.Fatalf("listAdminRequestsSQLX() nullable fields = seat tier %#v, resolved at %#v", request.RequesterSeatTier, request.ResolvedAt)
+	}
+	if request.Details["reason"] != "collaboration" {
+		t.Fatalf("listAdminRequestsSQLX() details = %#v", request.Details)
+	}
+	if !request.CreatedAt.Equal(createdAt) {
+		t.Fatalf("listAdminRequestsSQLX() created at = %v, want %v", request.CreatedAt, createdAt)
+	}
+}


### PR DESCRIPTION
## Summary

- Replace the admin request listing query with named-parameter sqlx access.
- Map database rows through a typed boundary and preserve JSON details and nullable requester fields.
- Add coverage for invalid JSON, PostgreSQL argument binding, and row scanning.

## Testing

- Added unit and PostgreSQL integration coverage for the migrated query and row mapping.