### PR TITLE
[Managed Agents] 修复 Environment 创建请求的 scope

### DIFF
--- a/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
@@ -2090,6 +2090,7 @@ export function registerManagedAgentsResourceTests() {
     expect(request?.body).toMatchObject({
       name: '中文环境',
       description: '用于测试',
+      scope: 'organization',
       metadata: {},
       config: {
         type: 'cloud',

--- a/web/src/features/managed-agents/api.ts
+++ b/web/src/features/managed-agents/api.ts
@@ -1604,7 +1604,7 @@ export function createManagedEntityBody(section: ManagedEntitySection, values: M
       return {
         name,
         description,
-        scope: 'workspace',
+        scope: 'organization',
         metadata: {},
         config: {
           type: 'cloud',


### PR DESCRIPTION
## 解决的问题

Closes #107

本 PR 从 #101 中独立拆出 Environment 手动创建失败的最小修复，保留 #101 继续处理 Environment Packages provisioning。

Managed Agents 页面此前在 `POST /v1/environments` 请求中发送 `scope: "workspace"`，但后端只接受 `organization` 或 `account`，因此创建请求返回 400。

## 修改内容

- 将手动创建 Environment 的请求 scope 改为 `organization`，与 Quickstart 路径及后端合同保持一致。
- 在现有 Environment 创建流程测试中断言 `scope: "organization"`，防止回归。

## 影响

通过 `/workspaces/:workspace/environments` 表单创建 Environment 可以正常完成。Quickstart、Environment 更新流程以及 #101 中的 package provisioning 行为均未改动。

## 验证

- `bun test src/features/managed-agents/ManagedAgentsPage.test.tsx --test-name-pattern "keeps environment creation fields and default payload unchanged in Chinese"`
- `bun test`（373 tests passed）
- `bun run build`
- `bun run format:check`
- `bun run lint:naming`
- `just complexity`
- `just duplicates`
- `just large-files`
- 受管 pre-commit hook 全部通过

`just hooks-run` 的本次全仓复检中，除仓库既有的两个私钥测试夹具被 `detect-private-key` 命中外，其余检查通过：

- `scripts/tests/generate-code-session-jwt-key_test.sh`
- `scripts/tests/generate-upstream-proxy-ca-key_test.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Managed environments are now created with organization-wide scope, ensuring they’re available at the intended level.
* **Tests**
  * Updated creation-flow validation to confirm the organization scope is included in requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->