### PR TITLE
Add configurable effective model mappings

### DIFF
--- a/docs/configuration-reference.yaml
+++ b/docs/configuration-reference.yaml
@@ -34,6 +34,9 @@ storage:
 anthropic_upstream:
   base_url: https://api.anthropic.com
   api_key: ""
+  # Optional exact model ID overrides. Mapped IDs are displayed and saved; unmapped IDs keep the original behavior.
+  # Chained mappings are rejected; multiple logical IDs may share one upstream ID.
+  model_mappings: {}
 
 batch:
   worker_enabled: true

--- a/docs/design/be/messages-proxy.md
+++ b/docs/design/be/messages-proxy.md
@@ -23,7 +23,7 @@ handler 不解析 JSON，直接流式转发请求 body、query 和 Anthropic 合
 - SSE 响应逐块 flush，并关闭代理缓冲；
 - 请求 body 上限为 32 MiB。
 
-管理后台继续使用原平台路径 `POST /api/organizations/{orgUuid}/proxy/v1/messages`。该路由及其独立代理实现保持不变，不作为 `/v1/messages` 的兼容别名，也不承载 Claude Code 的 session-scoped token。
+管理后台继续使用原平台路径 `POST /api/organizations/{orgUuid}/proxy/v1/messages`。该路由及其独立代理实现不作为 `/v1/messages` 的兼容别名，也不承载 Claude Code 的 session-scoped token。它在 `anthropic_upstream.model_mappings` 命中请求顶层 `model` 时把该逻辑模型 ID 替换为配置的上游模型 ID。Messages 的已知改写字段通过命名 DTO 解析；只有为保留第三方未知字段而使用的 request envelope 在该 HTTP 边界保留 `json.RawMessage`，不会把动态 JSON 结构传入内部领域模型。Quickstart Builder 返回的 Agent config 在前端的命名配置归一化边界解析模型字段，Agent 写入边界再执行防御性解析。未配置、未命中或请求体无法按 JSON object 解析时，请求体保持不变并交给上游处理。公共 `POST /v1/messages` 继续透明流式转发请求体，不应用该 Console 映射。
 
 服务端不提供 `/v1/code/sessions/{code_session_id}/bridge`。managed-agent 在创建 code session 时直接获得 OAuth FD、WebSocket FD 和初始 worker epoch；后续 worker 所有权切换统一使用 `/worker/register`。
 

--- a/docs/design/be/runtime-configuration.md
+++ b/docs/design/be/runtime-configuration.md
@@ -114,7 +114,7 @@ Docker Compose 同样只挂载一份完整 YAML，不再通过 `.env` 插值业�
 | `RedisConfig` | `redis` | 平台会话 Redis 连接 |
 | `StorageConfig` | `storage` | 对象存储类型选择和文件容量限制 |
 | `S3Config` | `storage.s3` | S3 兼容对象存储连接、bucket 和寻址方式 |
-| `AnthropicUpstreamConfig` | `anthropic_upstream` | Anthropic 上游地址和服务端凭证 |
+| `AnthropicUpstreamConfig` | `anthropic_upstream` | Anthropic 上游地址、服务端凭证和可选的 Console 模型映射 |
 | `BatchConfig` | `batch` | Message Batch 限制、worker、lease 和清理策略 |
 | `E2BConfig` | `e2b` | E2B provider 连接、模板和超时 |
 | `EnvironmentRunnerConfig` | `environment_runner` | Environment runner 并发及 Claude 运行命令 |
@@ -141,6 +141,10 @@ Docker Compose 同样只挂载一份完整 YAML，不再通过 `.env` 插值业�
 
 - `CONFIG_FILE` 只选择 YAML 文件；业务环境变量不参与配置合并。
 - Workbench 访问 Anthropic 时使用同一份 `anthropic_upstream.base_url` 和 `anthropic_upstream.api_key`，不从 `ANTHROPIC_*` 环境变量回退读取。
+- `anthropic_upstream.model_mappings` 对模型 ID 执行可选的精确覆盖；解析时对 source/target 两侧做 trim，未配置、空映射或未命中的模型均保留 trim 后的原 ID。命中项在模型目录和 Workbench 中以映射后的 ID 展示，Workbench 的 completions、prompt/title 和 test case 生成统一在 Anthropic 请求构造边界使用映射后的 ID。组织级 `GET /api/organizations/{orgUuid}/models` 同时返回有效目录及 `model_mappings`，由 Managed Agents 功能自行读取，不把模型状态耦合进账户 Bootstrap。Quickstart Builder 的请求模型使用映射后的 ID；Builder 返回的 Agent config 在前端配置归一化边界映射，Agent 创建或更新时也把映射后的 ID 写入新的不可变 Agent Version。
+- 映射不能形成 `A -> B -> C` 链或循环，以保证前端展示、Console 代理和 Agent 写入等多个边界重复解析时结果一致；多个逻辑模型可以映射到同一个上游模型 ID，模型目录按最终 ID 去重，并保留目录中第一个逻辑槽位的能力元数据。
+- 映射项是部署方声明的模型别名覆盖，不是 OMA 维护的独立能力目录；兼容模型项沿用原逻辑槽位的能力元数据，部署方应只把逻辑模型映射到满足相同运行合同的上游模型。需要准确的供应商能力目录时，应由公司 AI gateway 提供完整 catalog，而不是继续扩展该映射配置。
+- Environment Runner 和独立 Environment Manager 不读取映射配置；运行链路直接使用 Agent Snapshot 已保存的最终模型 ID。OMA 在 `environment-manager` v0 启动 payload 中把该 ID 同时投射为 `ANTHROPIC_MODEL`、`ANTHROPIC_DEFAULT_OPUS_MODEL`、`ANTHROPIC_DEFAULT_SONNET_MODEL` 和 `ANTHROPIC_DEFAULT_HAIKU_MODEL`，确保 Claude Code 的主 Agent 与内置子 Agent 使用同一个不可变 Session 模型。Snapshot 没有模型时不注入这些变量，继续沿用原运行时默认逻辑。修改映射不会改变既有 Agent Version，只影响后续创建或更新的版本。
 - 数据库配置不接受独立的管理员 URL 或管理员凭证；启动回退只能使用 `database.url` 派生的 maintenance DB 连接和当前系统用户候选。
 - 上游 API key、Webhook signing key 等秘密只保存在服务端配置边界，不得进入 sandbox payload 或日志。
 - JWT 和 CCR MITM 私钥继续通过只读文件路径配置；路径校验仍在相应的 code-session 启动边界执行。

--- a/internal/agents/handler.go
+++ b/internal/agents/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
+	"github.com/superduck-ai/open-managed-agents/internal/modelmapping"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -462,11 +463,13 @@ func (h *Handler) stateFromCreate(r *http.Request, principal auth.Principal, age
 	if !ok {
 		return agentState{}, errors.New("model is required")
 	}
-	model, err := normalizeModel(modelRaw)
+	model, err := normalizeModel(modelRaw, h.cfg.AnthropicUpstream.ModelMappings)
 	if err != nil {
 		return agentState{}, err
 	}
-	state.Model = model
+	if state.Model, err = httpapi.MarshalRaw(model); err != nil {
+		return agentState{}, err
+	}
 	if state.Description, err = parseNullableStringField(fields, "description"); err != nil {
 		return agentState{}, err
 	}
@@ -492,11 +495,19 @@ func (h *Handler) stateFromCreate(r *http.Request, principal auth.Principal, age
 }
 
 func (h *Handler) stateFromUpdate(r *http.Request, principal auth.Principal, current db.Agent, fields map[string]json.RawMessage) (agentState, error) {
+	model, err := normalizeModel(current.Model, h.cfg.AnthropicUpstream.ModelMappings)
+	if err != nil {
+		return agentState{}, err
+	}
+	modelRaw, err := httpapi.MarshalRaw(model)
+	if err != nil {
+		return agentState{}, err
+	}
 	state := agentState{
 		Name:        current.Name,
 		Description: current.Description,
 		System:      current.System,
-		Model:       current.Model,
+		Model:       modelRaw,
 		MCPServers:  current.MCPServers,
 		Metadata:    current.Metadata,
 		Multiagent:  current.Multiagent,
@@ -510,58 +521,67 @@ func (h *Handler) stateFromUpdate(r *http.Request, principal auth.Principal, cur
 		}
 		state.Name = name
 	}
-	var err error
 	if raw, ok := fields["model"]; ok {
-		state.Model, err = normalizeModel(raw)
+		mapped, err := normalizeModel(raw, h.cfg.AnthropicUpstream.ModelMappings)
 		if err != nil {
+			return agentState{}, err
+		}
+		if state.Model, err = httpapi.MarshalRaw(mapped); err != nil {
 			return agentState{}, err
 		}
 	}
 	if raw, ok := fields["description"]; ok {
-		state.Description, err = nullableStringFromRaw(raw, "description")
+		description, err := nullableStringFromRaw(raw, "description")
 		if err != nil {
 			return agentState{}, err
 		}
+		state.Description = description
 	}
 	if raw, ok := fields["system"]; ok {
-		state.System, err = nullableStringFromRaw(raw, "system")
+		system, err := nullableStringFromRaw(raw, "system")
 		if err != nil {
 			return agentState{}, err
 		}
+		state.System = system
 	}
 	if raw, ok := fields["mcp_servers"]; ok {
-		state.MCPServers, err = normalizeMCPServers(clearableArray(raw))
+		mcpServers, err := normalizeMCPServers(clearableArray(raw))
 		if err != nil {
 			return agentState{}, err
 		}
+		state.MCPServers = mcpServers
 	}
 	if raw, ok := fields["skills"]; ok {
-		state.Skills, err = normalizeSkills(clearableArray(raw))
+		skills, err := normalizeSkills(clearableArray(raw))
 		if err != nil {
 			return agentState{}, err
 		}
+		state.Skills = skills
 	}
 	if raw, ok := fields["tools"]; ok {
-		state.Tools, err = normalizeTools(clearableArray(raw), state.MCPServers)
+		tools, err := normalizeTools(clearableArray(raw), state.MCPServers)
 		if err != nil {
 			return agentState{}, err
 		}
+		state.Tools = tools
 	} else if _, ok := fields["mcp_servers"]; ok {
 		if err := validateMCPToolReferences(state.Tools, state.MCPServers); err != nil {
 			return agentState{}, err
 		}
 	}
 	if raw, ok := fields["metadata"]; ok {
-		state.Metadata, err = httpapi.PatchMetadata(state.Metadata, raw, validateMetadata)
+		metadata, err := httpapi.PatchMetadata(state.Metadata, raw, validateMetadata)
 		if err != nil {
 			return agentState{}, err
 		}
+		state.Metadata = metadata
 	}
 	if raw, ok := fields["multiagent"]; ok {
-		state.Multiagent, err = h.normalizeMultiagent(r, principal, current.ExternalID, current.CurrentVersion+1, raw)
+		multiagent, err := h.normalizeMultiagent(r, principal, current.ExternalID, current.CurrentVersion+1, raw)
 		if err != nil {
 			return agentState{}, err
 		}
+		state.Multiagent = multiagent
 	}
 	return state, nil
 }
@@ -748,37 +768,53 @@ func parseRequiredVersion(raw json.RawMessage) (int, error) {
 	return version, nil
 }
 
-func normalizeModel(raw json.RawMessage) (json.RawMessage, error) {
+type agentModelInput struct {
+	ID    *string `json:"id"`
+	Speed *string `json:"speed"`
+}
+
+type normalizedAgentModel struct {
+	ID    string `json:"id"`
+	Speed string `json:"speed"`
+}
+
+func normalizeModel(raw json.RawMessage, mappings map[string]string) (normalizedAgentModel, error) {
 	if httpapi.IsJSONNull(raw) {
-		return nil, errors.New("model cannot be null")
+		return normalizedAgentModel{}, errors.New("model cannot be null")
 	}
 	var modelID string
 	if json.Unmarshal(raw, &modelID) == nil {
-		if strings.TrimSpace(modelID) == "" {
-			return nil, errors.New("model id must be non-empty")
+		modelID = modelmapping.Resolve(modelID, mappings)
+		if modelID == "" {
+			return normalizedAgentModel{}, errors.New("model id must be non-empty")
 		}
-		return httpapi.MarshalRaw(map[string]any{"id": modelID, "speed": "standard"})
+		return normalizedAgentModel{
+			ID:    modelID,
+			Speed: "standard",
+		}, nil
 	}
-	var model map[string]json.RawMessage
+	var model agentModelInput
 	if err := json.Unmarshal(raw, &model); err != nil {
-		return nil, errors.New("model must be a string or object")
+		return normalizedAgentModel{}, errors.New("model must be a string or object")
 	}
-	rawID, ok := model["id"]
-	if !ok {
-		return nil, errors.New("model.id is required")
+	if model.ID == nil {
+		return normalizedAgentModel{}, errors.New("model.id is required")
 	}
-	if err := json.Unmarshal(rawID, &modelID); err != nil || strings.TrimSpace(modelID) == "" {
-		return nil, errors.New("model.id must be a non-empty string")
+	modelID = modelmapping.Resolve(*model.ID, mappings)
+	if modelID == "" {
+		return normalizedAgentModel{}, errors.New("model.id must be a non-empty string")
 	}
-	normalized := map[string]any{"id": modelID, "speed": "standard"}
-	if rawSpeed, ok := model["speed"]; ok && !httpapi.IsJSONNull(rawSpeed) {
-		var speed string
-		if err := json.Unmarshal(rawSpeed, &speed); err != nil || (speed != "standard" && speed != "fast") {
-			return nil, errors.New("model.speed must be standard or fast")
+	normalized := normalizedAgentModel{
+		ID:    modelID,
+		Speed: "standard",
+	}
+	if model.Speed != nil {
+		if *model.Speed != "standard" && *model.Speed != "fast" {
+			return normalizedAgentModel{}, errors.New("model.speed must be standard or fast")
 		}
-		normalized["speed"] = speed
+		normalized.Speed = *model.Speed
 	}
-	return httpapi.MarshalRaw(normalized)
+	return normalized, nil
 }
 
 func normalizeMCPServers(raw json.RawMessage) (json.RawMessage, error) {

--- a/internal/agents/model_test.go
+++ b/internal/agents/model_test.go
@@ -1,0 +1,118 @@
+package agents
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/superduck-ai/open-managed-agents/internal/auth"
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+)
+
+func TestNormalizeModelRejectsInvalidObjectFields(t *testing.T) {
+	testCases := []struct {
+		name      string
+		raw       string
+		wantError string
+	}{
+		{
+			name:      "missing id",
+			raw:       `{"speed":"standard"}`,
+			wantError: "model.id is required",
+		},
+		{
+			name:      "empty id",
+			raw:       `{"id":" "}`,
+			wantError: "model.id must be a non-empty string",
+		},
+		{
+			name:      "invalid speed",
+			raw:       `{"id":"claude-sonnet-4-6","speed":"slow"}`,
+			wantError: "model.speed must be standard or fast",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := normalizeModel(json.RawMessage(testCase.raw), nil)
+			if err == nil || !strings.Contains(err.Error(), testCase.wantError) {
+				t.Fatalf("normalizeModel() error = %v, want %q", err, testCase.wantError)
+			}
+		})
+	}
+}
+
+func TestNormalizeModelUsesMappedID(t *testing.T) {
+	mappings := map[string]string{"claude-sonnet-4-6": "glm-5-turbo"}
+	testCases := []struct {
+		name string
+		raw  string
+		want normalizedAgentModel
+	}{
+		{
+			name: "string model uses standard speed",
+			raw:  `"claude-sonnet-4-6"`,
+			want: normalizedAgentModel{ID: "glm-5-turbo", Speed: "standard"},
+		},
+		{
+			name: "object model preserves fast speed",
+			raw:  `{"id":"claude-sonnet-4-6","speed":"fast"}`,
+			want: normalizedAgentModel{ID: "glm-5-turbo", Speed: "fast"},
+		},
+		{
+			name: "string model trims surrounding whitespace",
+			raw:  `" claude-sonnet-4-6 "`,
+			want: normalizedAgentModel{ID: "glm-5-turbo", Speed: "standard"},
+		},
+		{
+			name: "object model trims surrounding whitespace",
+			raw:  `{"id":" claude-sonnet-4-6 ","speed":"fast"}`,
+			want: normalizedAgentModel{ID: "glm-5-turbo", Speed: "fast"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := normalizeModel(json.RawMessage(testCase.raw), mappings)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != testCase.want {
+				t.Fatalf("normalizeModel() = %#v, want %#v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestStateFromUpdateMapsInheritedModel(t *testing.T) {
+	handler := Handler{
+		cfg: config.Config{
+			AnthropicUpstream: config.AnthropicUpstreamConfig{
+				ModelMappings: map[string]string{"claude-sonnet-4-6": "glm-5-turbo"},
+			},
+		},
+	}
+	state, err := handler.stateFromUpdate(
+		nil,
+		auth.Principal{},
+		db.Agent{
+			Model: json.RawMessage(`{"id":"claude-sonnet-4-6","speed":"fast"}`),
+		},
+		map[string]json.RawMessage{
+			"description": json.RawMessage(`"updated without model"`),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got normalizedAgentModel
+	if err := json.Unmarshal(state.Model, &got); err != nil {
+		t.Fatal(err)
+	}
+	want := normalizedAgentModel{ID: "glm-5-turbo", Speed: "fast"}
+	if got != want {
+		t.Fatalf("stateFromUpdate() model = %#v, want %#v", got, want)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -105,7 +105,7 @@ func NewServer(deps ServerDeps) *Server {
 		filestore:            filestoreHandler,
 		memory:               memoryapi.NewHandler(deps.Config, deps.DB, deps.ObjectStore),
 		messages:             messagesapi.NewHandler(deps.Config),
-		models:               modelsapi.NewHandler(),
+		models:               modelsapi.NewHandler(deps.Config.AnthropicUpstream),
 		sessions:             sessionsapi.NewHandler(deps.Config, deps.DB, codeSessionService),
 		skills:               skillsapi.NewHandlerWithSkillPrewarm(deps.Config, deps.DB, deps.ObjectStore, skillPrewarmEnqueuer),
 		vaults:               vaultsapi.NewHandler(deps.Config, deps.DB),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/superduck-ai/open-managed-agents/internal/modelmapping"
 )
 
 const (
@@ -68,6 +70,9 @@ func validate(cfg Config) error {
 	}
 	if strings.TrimSpace(cfg.Storage.S3.AccessKeyID) == "" || strings.TrimSpace(cfg.Storage.S3.SecretAccessKey) == "" {
 		return errors.New("storage.s3.access_key_id and storage.s3.secret_access_key are required")
+	}
+	if err := modelmapping.Validate(cfg.AnthropicUpstream.ModelMappings); err != nil {
+		return fmt.Errorf("anthropic_upstream.model_mappings: %w", err)
 	}
 	if err := validatePositiveValues(cfg); err != nil {
 		return err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -127,6 +128,39 @@ bootstrap:
 	}
 	if cfg.Bootstrap.WorkspaceName != "yaml-workspace" {
 		t.Fatalf("Bootstrap.WorkspaceName = %q, want yaml-workspace", cfg.Bootstrap.WorkspaceName)
+	}
+}
+
+func TestLoadRejectsChainedAnthropicUpstreamModelMappings(t *testing.T) {
+	prepareLoadTest(t)
+	_, err := loadConfigTestYAML(t, `
+anthropic_upstream:
+  model_mappings:
+    claude-sonnet-4-6: glm-5-turbo
+    glm-5-turbo: glm-5.2
+`)
+	if err == nil || !strings.Contains(err.Error(), "model_mappings") {
+		t.Fatalf("Load() error = %v, want chained model_mappings error", err)
+	}
+}
+
+func TestLoadYAMLAnthropicUpstreamModelMappings(t *testing.T) {
+	prepareLoadTest(t)
+	cfg, err := loadConfigTestYAML(t, `
+anthropic_upstream:
+  model_mappings:
+    claude-sonnet-4-6: glm-5-turbo
+    claude-opus-4-8: glm-5.2
+`)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	want := map[string]string{
+		"claude-sonnet-4-6": "glm-5-turbo",
+		"claude-opus-4-8":   "glm-5.2",
+	}
+	if !maps.Equal(cfg.AnthropicUpstream.ModelMappings, want) {
+		t.Fatalf("AnthropicUpstream.ModelMappings = %#v, want %#v", cfg.AnthropicUpstream.ModelMappings, want)
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -54,8 +54,9 @@ type S3Config struct {
 }
 
 type AnthropicUpstreamConfig struct {
-	BaseURL string `yaml:"base_url"`
-	APIKey  string `yaml:"api_key"`
+	BaseURL       string            `yaml:"base_url"`
+	APIKey        string            `yaml:"api_key"`
+	ModelMappings map[string]string `yaml:"model_mappings"`
 }
 
 type BatchConfig struct {

--- a/internal/environments/environment_manager.go
+++ b/internal/environments/environment_manager.go
@@ -268,6 +268,9 @@ func buildEnvironmentManagerV0Payload(codeSessionID string, sessionIngressToken 
 	environmentVariables["CLAUDE_CODE_USE_CCR_V2"] = "1"
 	environmentVariables["CLAUDE_CODE_WORKER_EPOCH"] = "1"
 	environmentVariables["CCR_UPSTREAM_PROXY_ENABLED"] = "1" // 还需 REMOTE_SESSION_ID 和 /run/ccr/session_token 才会注入 HTTPS_PROXY。
+	for key, value := range claudeRuntimeModelEnvironment(stringFromMap(startupContext, "model")) {
+		environmentVariables[key] = value
+	}
 	applyCodeSessionOTLPEnvironment(environmentVariables, stringFromMap(startupContext, "api_base_url"), codeSessionID, sessionIngressToken, "1")
 	startupContext["environment_variables"] = environmentVariables
 	if _, ok := startupContext["sources"]; !ok {
@@ -297,6 +300,19 @@ func buildEnvironmentManagerV0Payload(codeSessionID string, sessionIngressToken 
 		"environment":     environment,
 		"auth":            auth,
 	})
+}
+
+func claudeRuntimeModelEnvironment(modelID string) map[string]string {
+	modelID = strings.TrimSpace(modelID)
+	if modelID == "" {
+		return nil
+	}
+	return map[string]string{
+		"ANTHROPIC_MODEL":                modelID,
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":   modelID,
+		"ANTHROPIC_DEFAULT_SONNET_MODEL": modelID,
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  modelID,
+	}
 }
 
 func applyCodeSessionOTLPEnvironment(environmentVariables map[string]any, apiBaseURL string, codeSessionID string, sessionIngressToken string, workerEpoch string) {

--- a/internal/environments/environment_manager_test.go
+++ b/internal/environments/environment_manager_test.go
@@ -69,6 +69,16 @@ func TestBuildEnvironmentManagerPayloadAndCommand(t *testing.T) {
 		startupEnv["CCR_UPSTREAM_PROXY_ENABLED"] != "1" {
 		t.Fatalf("unexpected startup environment variables: %#v", startupEnv)
 	}
+	for _, key := range []string{
+		"ANTHROPIC_MODEL",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+	} {
+		if startupEnv[key] != "claude-opus-4-8" {
+			t.Fatalf("%s = %q, want session model", key, startupEnv[key])
+		}
+	}
 	if _, ok := startupEnv["CLAUDE_CODE_SESSION_ACCESS_TOKEN"]; ok {
 		t.Fatalf("session access token environment variable must not mask the WebSocket auth FD: %#v", startupEnv)
 	}
@@ -138,6 +148,21 @@ func TestBuildEnvironmentManagerPayloadAndCommand(t *testing.T) {
 	if strings.Contains(allCommands, "installed managed agent skills") ||
 		strings.Contains(allCommands, "$HOME/.claude/skills") {
 		t.Fatalf("command should not install managed agent skills directly:\n%s", allCommands)
+	}
+}
+
+func TestClaudeRuntimeModelEnvironment(t *testing.T) {
+	if environment := claudeRuntimeModelEnvironment(" \t "); environment != nil {
+		t.Fatalf("empty model environment = %#v, want nil", environment)
+	}
+	want := map[string]string{
+		"ANTHROPIC_MODEL":                "glm-5-turbo",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":   "glm-5-turbo",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5-turbo",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  "glm-5-turbo",
+	}
+	if environment := claudeRuntimeModelEnvironment(" glm-5-turbo "); !reflect.DeepEqual(environment, want) {
+		t.Fatalf("model environment = %#v, want %#v", environment, want)
 	}
 }
 

--- a/internal/modelmapping/modelmapping.go
+++ b/internal/modelmapping/modelmapping.go
@@ -1,0 +1,43 @@
+package modelmapping
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Resolve returns the deployment model ID configured for modelID. Source and
+// target IDs are trimmed. Missing, blank, and identity mappings preserve the
+// trimmed original ID.
+func Resolve(modelID string, mappings map[string]string) string {
+	modelID = strings.TrimSpace(modelID)
+	mappedID := strings.TrimSpace(mappings[modelID])
+	if mappedID == "" {
+		return modelID
+	}
+	return mappedID
+}
+
+// Validate rejects ambiguous mappings that could resolve differently at
+// separate API boundaries.
+func Validate(mappings map[string]string) error {
+	for sourceID, configuredTargetID := range mappings {
+		if strings.TrimSpace(sourceID) != sourceID || sourceID == "" {
+			return fmt.Errorf("model mapping source %q must be a non-empty model ID without surrounding whitespace", sourceID)
+		}
+		targetID := strings.TrimSpace(configuredTargetID)
+		if targetID == "" || targetID == sourceID {
+			continue
+		}
+		nextTargetID := strings.TrimSpace(mappings[targetID])
+		if nextTargetID != "" && nextTargetID != targetID {
+			return fmt.Errorf(
+				"model mapping %q to %q is ambiguous because %q also maps to %q",
+				sourceID,
+				targetID,
+				targetID,
+				nextTargetID,
+			)
+		}
+	}
+	return nil
+}

--- a/internal/modelmapping/modelmapping_test.go
+++ b/internal/modelmapping/modelmapping_test.go
@@ -1,0 +1,48 @@
+package modelmapping_test
+
+import (
+	"testing"
+
+	"github.com/superduck-ai/open-managed-agents/internal/modelmapping"
+)
+
+func TestValidateRejectsChainedMappings(t *testing.T) {
+	err := modelmapping.Validate(map[string]string{
+		"claude-sonnet-4-6": "glm-5-turbo",
+		"glm-5-turbo":       "glm-5.2",
+	})
+	if err == nil {
+		t.Fatal("Validate() error = nil, want chained mapping error")
+	}
+}
+
+func TestResolvePreservesUnmappedModelAndUsesNonBlankMapping(t *testing.T) {
+	mappings := map[string]string{
+		"claude-sonnet-4-6": "glm-5-turbo",
+		"claude-opus-4-8":   " ",
+	}
+	if got := modelmapping.Resolve("claude-sonnet-4-6", mappings); got != "glm-5-turbo" {
+		t.Fatalf("Resolve(mapped) = %q, want glm-5-turbo", got)
+	}
+	if got := modelmapping.Resolve("claude-opus-4-8", mappings); got != "claude-opus-4-8" {
+		t.Fatalf("Resolve(blank) = %q, want original ID", got)
+	}
+	if got := modelmapping.Resolve("claude-haiku-4-5", mappings); got != "claude-haiku-4-5" {
+		t.Fatalf("Resolve(unmapped) = %q, want original ID", got)
+	}
+	if got := modelmapping.Resolve(" claude-sonnet-4-6 ", mappings); got != "glm-5-turbo" {
+		t.Fatalf("Resolve(padded mapped) = %q, want glm-5-turbo", got)
+	}
+	if got := modelmapping.Resolve(" claude-haiku-4-5 ", mappings); got != "claude-haiku-4-5" {
+		t.Fatalf("Resolve(padded unmapped) = %q, want trimmed original ID", got)
+	}
+}
+
+func TestValidateAllowsAliasesToShareAnUpstreamModel(t *testing.T) {
+	if err := modelmapping.Validate(map[string]string{
+		"claude-sonnet-4-6":        "glm-5-turbo",
+		"claude-sonnet-4-5-latest": "glm-5-turbo",
+	}); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}

--- a/internal/models/handler.go
+++ b/internal/models/handler.go
@@ -1,15 +1,21 @@
 package models
 
 import (
+	"maps"
 	"net/http"
+	"strings"
 
+	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
+	"github.com/superduck-ai/open-managed-agents/internal/modelmapping"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/samber/lo"
 )
 
 type Handler struct {
-	router chi.Router
+	router        chi.Router
+	modelMappings map[string]string
 }
 
 type listResponse struct {
@@ -19,8 +25,8 @@ type listResponse struct {
 	LastID  string           `json:"last_id"`
 }
 
-func NewHandler() *Handler {
-	h := &Handler{}
+func NewHandler(upstream config.AnthropicUpstreamConfig) *Handler {
+	h := &Handler{modelMappings: upstream.ModelMappings}
 	router := chi.NewRouter()
 	router.NotFound(notFound)
 	router.MethodNotAllowed(notFound)
@@ -38,7 +44,7 @@ func notFound(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) list(w http.ResponseWriter, _ *http.Request) {
-	models := buildPlatformModels()
+	models := resolvePlatformModels(buildPlatformModels(), h.modelMappings)
 	firstID := ""
 	lastID := ""
 	if len(models) > 0 {
@@ -50,6 +56,24 @@ func (h *Handler) list(w http.ResponseWriter, _ *http.Request) {
 		HasMore: false,
 		FirstID: firstID,
 		LastID:  lastID,
+	})
+}
+
+func resolvePlatformModels(models []map[string]any, mappings map[string]string) []map[string]any {
+	resolved := lo.Map(models, func(model map[string]any, _ int) map[string]any {
+		out := maps.Clone(model)
+		modelID, _ := out["id"].(string)
+		sourceID := strings.TrimSpace(modelID)
+		effectiveID := modelmapping.Resolve(modelID, mappings)
+		out["id"] = effectiveID
+		if effectiveID != sourceID {
+			out["display_name"] = effectiveID
+		}
+		return out
+	})
+	return lo.UniqBy(resolved, func(model map[string]any) string {
+		modelID, _ := model["id"].(string)
+		return modelID
 	})
 }
 

--- a/internal/models/handler_test.go
+++ b/internal/models/handler_test.go
@@ -1,0 +1,76 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+)
+
+func TestListDisplaysMappedModelIDsAndPreservesUnmappedModels(t *testing.T) {
+	handler := NewHandler(config.AnthropicUpstreamConfig{ModelMappings: map[string]string{
+		"claude-sonnet-4-6": "glm-5-turbo",
+		"claude-opus-4-8":   "glm-5.2",
+	}})
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", response.Code)
+	}
+	var body listResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	byID := make(map[string]map[string]any, len(body.Data))
+	for _, model := range body.Data {
+		modelID, _ := model["id"].(string)
+		byID[modelID] = model
+	}
+	if byID["glm-5-turbo"]["display_name"] != "glm-5-turbo" {
+		t.Fatalf("mapped Sonnet = %#v", byID["glm-5-turbo"])
+	}
+	if byID["glm-5.2"]["display_name"] != "glm-5.2" {
+		t.Fatalf("mapped Opus = %#v", byID["glm-5.2"])
+	}
+	if byID["claude-opus-4-7"]["display_name"] != "Claude Opus 4.7" {
+		t.Fatalf("unmapped Opus = %#v", byID["claude-opus-4-7"])
+	}
+}
+
+func TestResolvePlatformModelsDoesNotMutateInputAndTrimsIDs(t *testing.T) {
+	input := []map[string]any{
+		{"id": " claude-sonnet-4-6 ", "display_name": "Claude Sonnet 4.6"},
+		{"id": "claude-opus-4-7", "display_name": "Claude Opus 4.7"},
+	}
+	got := resolvePlatformModels(input, map[string]string{"claude-sonnet-4-6": "glm-5-turbo"})
+	if input[0]["id"] != " claude-sonnet-4-6 " {
+		t.Fatalf("input mutated: %#v", input[0])
+	}
+	if got[0]["id"] != "glm-5-turbo" || got[0]["display_name"] != "glm-5-turbo" {
+		t.Fatalf("mapped model = %#v", got[0])
+	}
+	if got[1]["id"] != "claude-opus-4-7" || got[1]["display_name"] != "Claude Opus 4.7" {
+		t.Fatalf("unmapped model = %#v", got[1])
+	}
+}
+
+func TestListWithoutMappingsPreservesOriginalCatalog(t *testing.T) {
+	handler := NewHandler(config.AnthropicUpstreamConfig{})
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	var body listResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.FirstID != "claude-fable-5" || body.LastID != "claude-sonnet-4-5-20250929" {
+		t.Fatalf("catalog bounds = %q..%q", body.FirstID, body.LastID)
+	}
+}

--- a/internal/platformapi/platform_proxy.go
+++ b/internal/platformapi/platform_proxy.go
@@ -3,12 +3,14 @@ package platformapi
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/superduck-ai/open-managed-agents/internal/config"
+	"github.com/superduck-ai/open-managed-agents/internal/modelmapping"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -16,6 +18,12 @@ import (
 func RegisterOrganizationProxyRoutes(r chi.Router, cfg config.Config) {
 	r.Post("/proxy/v1/messages", handleProxyMessages(cfg))
 }
+
+type messagesRewriteFields struct {
+	Model string `json:"model"`
+}
+
+type rawJSONEnvelope map[string]json.RawMessage
 
 func handleProxyMessages(cfg config.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -35,6 +43,13 @@ func handleProxyMessages(cfg config.Config) http.HandlerFunc {
 			return
 		}
 		defer func() { _ = r.Body.Close() }()
+
+		rewrittenBody, err := rewriteMappedModel(body, cfg.AnthropicUpstream.ModelMappings)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request_error", "message": err.Error()})
+			return
+		}
+		body = rewrittenBody
 
 		upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, targetURL, bytes.NewReader(body))
 		if err != nil {
@@ -80,6 +95,34 @@ func handleProxyMessages(cfg config.Config) http.HandlerFunc {
 		w.WriteHeader(upstreamRes.StatusCode)
 		_, _ = w.Write(responseBody)
 	}
+}
+
+func rewriteMappedModel(body []byte, mappings map[string]string) ([]byte, error) {
+	if len(mappings) == 0 {
+		return body, nil
+	}
+	var fields messagesRewriteFields
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return body, nil
+	}
+	upstreamModel := modelmapping.Resolve(fields.Model, mappings)
+	if upstreamModel == fields.Model {
+		return body, nil
+	}
+	var payload rawJSONEnvelope
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return body, nil
+	}
+	encodedModel, err := json.Marshal(upstreamModel)
+	if err != nil {
+		return nil, fmt.Errorf("encode mapped Messages model: %w", err)
+	}
+	payload["model"] = encodedModel
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("encode Messages request: %w", err)
+	}
+	return rewritten, nil
 }
 
 func anthropicMessagesEndpointFromConfig(cfg config.Config) (string, error) {

--- a/internal/platformapi/platform_proxy_test.go
+++ b/internal/platformapi/platform_proxy_test.go
@@ -1,0 +1,172 @@
+package platformapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/superduck-ai/open-managed-agents/internal/auth"
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestRewriteMappedModelOnlyUpdatesTopLevelModel(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-sonnet-4-6",
+		"tools":[{
+			"name":"build_agent_config",
+			"input_schema":{"properties":{"model":{"anyOf":[
+				{"type":"string","enum":["claude-sonnet-4-6"]}
+			]}}}
+		}]
+	}`)
+	got, err := rewriteMappedModel(body, map[string]string{
+		"claude-sonnet-4-6": "glm-5-turbo",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request struct {
+		Model string            `json:"model"`
+		Tools []json.RawMessage `json:"tools"`
+	}
+	if err := json.Unmarshal(got, &request); err != nil {
+		t.Fatalf("decode rewritten request: %v", err)
+	}
+	if request.Model != "glm-5-turbo" {
+		t.Fatalf("model = %q, want glm-5-turbo", request.Model)
+	}
+	var schema struct {
+		InputSchema json.RawMessage `json:"input_schema"`
+	}
+	if err := json.Unmarshal(request.Tools[0], &schema); err != nil {
+		t.Fatalf("decode preserved tool: %v", err)
+	}
+	if !bytes.Contains(schema.InputSchema, []byte(`claude-sonnet-4-6`)) {
+		t.Fatalf("tool schema was unexpectedly rewritten: %s", schema.InputSchema)
+	}
+}
+
+func TestRewriteMappedModelTrimsRequestModelID(t *testing.T) {
+	got, err := rewriteMappedModel(
+		[]byte(`{"model":" claude-sonnet-4-6 ","max_tokens":16}`),
+		map[string]string{"claude-sonnet-4-6": "glm-5-turbo"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(got, &request); err != nil {
+		t.Fatal(err)
+	}
+	if request.Model != "glm-5-turbo" {
+		t.Fatalf("model = %q, want glm-5-turbo", request.Model)
+	}
+}
+
+func TestRewriteMappedModelPreservesInvalidJSONForUpstream(t *testing.T) {
+	body := []byte(`not-json`)
+
+	got, err := rewriteMappedModel(body, map[string]string{
+		"claude-sonnet-4-6": "glm-5-turbo",
+	})
+	if err != nil {
+		t.Fatalf("rewriteMappedModel() error = %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("rewriteMappedModel() = %q, want original body %q", got, body)
+	}
+}
+
+func TestOrganizationProxyModelMappings(t *testing.T) {
+	testCases := []struct {
+		name           string
+		mappings       map[string]string
+		requestedModel string
+		wantModel      string
+	}{
+		{
+			name: "mapped model",
+			mappings: map[string]string{
+				"claude-sonnet-4-6": "glm-5-turbo",
+			},
+			requestedModel: "claude-sonnet-4-6",
+			wantModel:      "glm-5-turbo",
+		},
+		{
+			name: "unmapped model",
+			mappings: map[string]string{
+				"claude-opus-4-8": "glm-5.2",
+			},
+			requestedModel: "claude-sonnet-4-6",
+			wantModel:      "claude-sonnet-4-6",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var upstreamBody []byte
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var err error
+				upstreamBody, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("read upstream body: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"msg_model_mapping","type":"message"}`))
+			}))
+			defer upstream.Close()
+
+			cfg := config.Config{
+				AnthropicUpstream: config.AnthropicUpstreamConfig{
+					BaseURL:       upstream.URL,
+					APIKey:        "upstream-key",
+					ModelMappings: testCase.mappings,
+				},
+			}
+			requestBody := `{"model":"` + testCase.requestedModel + `","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`
+			req := httptest.NewRequest(
+				http.MethodPost,
+				"/api/organizations/org_test/proxy/v1/messages",
+				strings.NewReader(requestBody),
+			)
+			routeContext := chi.NewRouteContext()
+			routeContext.URLParams.Add("orgUuid", "org_test")
+			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeContext)
+			ctx = auth.WithPrincipal(ctx, auth.Principal{OrganizationUUID: "org_test"})
+			req = req.WithContext(ctx)
+			rec := httptest.NewRecorder()
+
+			handleProxyMessages(cfg).ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("proxy status = %d, want 200: %s", rec.Code, rec.Body.String())
+			}
+			var payload struct {
+				Model     string `json:"model"`
+				MaxTokens int    `json:"max_tokens"`
+				Messages  []struct {
+					Role    string `json:"role"`
+					Content string `json:"content"`
+				} `json:"messages"`
+			}
+			if err := json.Unmarshal(upstreamBody, &payload); err != nil {
+				t.Fatalf("decode upstream body: %v", err)
+			}
+			if payload.Model != testCase.wantModel {
+				t.Fatalf("upstream model = %v, want %s", payload.Model, testCase.wantModel)
+			}
+			if payload.MaxTokens != 16 || len(payload.Messages) != 1 {
+				t.Fatalf("upstream body lost request fields: %#v", payload)
+			}
+		})
+	}
+}

--- a/internal/workbench/console_platform_workbench.go
+++ b/internal/workbench/console_platform_workbench.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"maps"
 	"net/http"
 	"os"
 	"sort"
@@ -17,9 +18,11 @@ import (
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
+	"github.com/superduck-ai/open-managed-agents/internal/modelmapping"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 )
 
 const (
@@ -574,19 +577,40 @@ func handleWorkbenchModels(w http.ResponseWriter, r *http.Request) {
 	if !visibleOrgUUIDOrPlatformClaudeMirror(w, r) {
 		return
 	}
+	mappings := workbenchAnthropicUpstreamFromRequest(r).ModelMappings
 	writeJSON(w, http.StatusOK, map[string]any{
 		"default_prompt_settings": map[string]any{
-			"model_name":           workbenchDefaultModel,
+			"model_name":           modelmapping.Resolve(workbenchDefaultModel, mappings),
 			"system_prompt":        "",
 			"temperature":          1,
 			"max_tokens_to_sample": 20000,
 		},
-		"models": []any{
+		"model_mappings": mappings,
+		"models": resolveWorkbenchModels([]map[string]any{
 			workbenchModel("claude-fable-5", "Claude Fable 5", "claude_fable_5", 1000000, 128000, true, true, true),
 			workbenchModel("claude-opus-4-8", "Claude Opus Active", "claude_opus_4_5", 1000000, 128000, true, true, true),
 			workbenchModel("claude-sonnet-4-6", "Claude Sonnet Active", "claude_sonnet_4", 1000000, 64000, true, true, true),
 			workbenchModel("claude-haiku-4-5-20251001", "Claude Haiku 4.5", "claude_haiku_4", 200000, 64000, true, false, false),
-		},
+		}, mappings),
+	})
+}
+
+func resolveWorkbenchModels(models []map[string]any, mappings map[string]string) []map[string]any {
+	resolved := lo.Map(models, func(model map[string]any, _ int) map[string]any {
+		out := maps.Clone(model)
+		modelID := workbenchString(out["model_name"])
+		sourceID := strings.TrimSpace(modelID)
+		effectiveID := modelmapping.Resolve(modelID, mappings)
+		out["model_name"] = effectiveID
+		if effectiveID != sourceID {
+			out["display_name"] = effectiveID
+			out["name"] = effectiveID
+			out["rate_limit_display_name"] = effectiveID
+		}
+		return out
+	})
+	return lo.UniqBy(resolved, func(model map[string]any) string {
+		return strings.TrimSpace(workbenchString(model["model_name"]))
 	})
 }
 
@@ -763,18 +787,10 @@ func workbenchAnthropicTextFromBody(r *http.Request, upstreamBody map[string]any
 	if err != nil {
 		return "", 0, 0, false
 	}
-	body, err := json.Marshal(upstreamBody)
+	upstreamReq, err := newWorkbenchAnthropicRequest(r.Context(), endpoint, upstreamConfig, upstreamBody, "application/json")
 	if err != nil {
 		return "", 0, 0, false
 	}
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, endpoint, bytes.NewReader(body))
-	if err != nil {
-		return "", 0, 0, false
-	}
-	upstreamReq.Header.Set("Accept", "application/json")
-	upstreamReq.Header.Set("Content-Type", "application/json")
-	upstreamReq.Header.Set("X-API-Key", token)
-	upstreamReq.Header.Set("Anthropic-Version", anthropicAPIVersion)
 
 	upstreamRes, err := http.DefaultClient.Do(upstreamReq)
 	if err != nil {
@@ -801,6 +817,35 @@ func workbenchAnthropicTextFromBody(r *http.Request, upstreamBody map[string]any
 		text.WriteString(block.Text)
 	}
 	return strings.TrimSpace(text.String()), upstream.Usage.InputTokens, upstream.Usage.OutputTokens, text.Len() > 0
+}
+
+// newWorkbenchAnthropicRequest is the Workbench request-construction boundary
+// for Anthropic-compatible inference. It resolves the top-level model before
+// any payload can be sent upstream.
+func newWorkbenchAnthropicRequest(
+	ctx context.Context,
+	endpoint string,
+	upstream config.AnthropicUpstreamConfig,
+	upstreamBody map[string]any,
+	accept string,
+) (*http.Request, error) {
+	body := maps.Clone(upstreamBody)
+	if modelID := workbenchString(body["model"]); strings.TrimSpace(modelID) != "" {
+		body["model"] = modelmapping.Resolve(modelID, upstream.ModelMappings)
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(encoded))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", accept)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", proxyMessagesAnthropicToken(upstream))
+	req.Header.Set("Anthropic-Version", anthropicAPIVersion)
+	return req, nil
 }
 
 func workbenchGenerateTestCaseAnthropicBody(body map[string]any, variableNames []string) map[string]any {
@@ -1157,12 +1202,12 @@ func handleWorkbenchCompletions(w http.ResponseWriter, r *http.Request) {
 		writeProxyMessagesAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "request body must match WorkbenchCompletionRequest")
 		return
 	}
+	upstreamConfig := workbenchAnthropicUpstreamFromRequest(r)
 	upstreamBody := workbenchCompletionAnthropicBody(payload)
 	if len(chatArrayFromValue(upstreamBody["messages"])) == 0 {
 		writeProxyMessagesAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "at least one non-empty message is required")
 		return
 	}
-	upstreamConfig := workbenchAnthropicUpstreamFromRequest(r)
 	token := proxyMessagesAnthropicToken(upstreamConfig)
 	if token == "" {
 		writeProxyMessagesAnthropicError(w, http.StatusInternalServerError, "authentication_error", "anthropic_upstream.api_key is not configured")
@@ -1173,20 +1218,11 @@ func handleWorkbenchCompletions(w http.ResponseWriter, r *http.Request) {
 		writeProxyMessagesAnthropicError(w, http.StatusBadGateway, "api_error", err.Error())
 		return
 	}
-	body, err := json.Marshal(upstreamBody)
+	upstreamReq, err := newWorkbenchAnthropicRequest(r.Context(), endpoint, upstreamConfig, upstreamBody, "text/event-stream")
 	if err != nil {
 		writeProxyMessagesAnthropicError(w, http.StatusInternalServerError, "api_error", "failed to build Anthropic request")
 		return
 	}
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, endpoint, bytes.NewReader(body))
-	if err != nil {
-		writeProxyMessagesAnthropicError(w, http.StatusBadGateway, "api_error", err.Error())
-		return
-	}
-	upstreamReq.Header.Set("Accept", "text/event-stream")
-	upstreamReq.Header.Set("Content-Type", "application/json")
-	upstreamReq.Header.Set("X-API-Key", token)
-	upstreamReq.Header.Set("Anthropic-Version", anthropicAPIVersion)
 	if beta := workbenchAnthropicBetaHeader(payload["betas"]); beta != "" {
 		upstreamReq.Header.Set("Anthropic-Beta", beta)
 	}
@@ -1627,18 +1663,11 @@ func workbenchGenerateTitleFromAnthropic(r *http.Request, messageContent string,
 	if err != nil {
 		return "", 0, 0
 	}
-	body, err := json.Marshal(workbenchGenerateTitleAnthropicBody(messageContent, model))
+	upstreamBody := workbenchGenerateTitleAnthropicBody(messageContent, model)
+	upstreamReq, err := newWorkbenchAnthropicRequest(r.Context(), endpoint, upstreamConfig, upstreamBody, "application/json")
 	if err != nil {
 		return "", 0, 0
 	}
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, endpoint, bytes.NewReader(body))
-	if err != nil {
-		return "", 0, 0
-	}
-	upstreamReq.Header.Set("Accept", "application/json")
-	upstreamReq.Header.Set("Content-Type", "application/json")
-	upstreamReq.Header.Set("X-API-Key", token)
-	upstreamReq.Header.Set("Anthropic-Version", anthropicAPIVersion)
 
 	upstreamRes, err := http.DefaultClient.Do(upstreamReq)
 	if err != nil {
@@ -1748,40 +1777,33 @@ func handleWorkbenchGeneratePrompt(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	upstreamConfig := workbenchAnthropicUpstreamFromRequest(r)
+	model := workbenchGeneratePromptModel()
+	effectiveModel := modelmapping.Resolve(model, upstreamConfig.ModelMappings)
 	token := proxyMessagesAnthropicToken(upstreamConfig)
 	if token == "" {
 		log.Printf("workbench generate_prompt fallback reason=no_anthropic_token org=%s task_chars=%d thinking=%t", chi.URLParam(r, "orgUUID"), len([]rune(task)), payload.TargetThinkingMode)
-		workbenchWriteGeneratePromptFallbackStream(w, task, payload.TargetThinkingMode)
+		workbenchWriteGeneratePromptFallbackStream(w, effectiveModel, task, payload.TargetThinkingMode)
 		return
 	}
 	endpoint, err := anthropicMessagesEndpoint(upstreamConfig)
 	if err != nil {
 		log.Printf("workbench generate_prompt fallback reason=invalid_anthropic_endpoint org=%s err=%v", chi.URLParam(r, "orgUUID"), err)
-		workbenchWriteGeneratePromptFallbackStream(w, task, payload.TargetThinkingMode)
+		workbenchWriteGeneratePromptFallbackStream(w, effectiveModel, task, payload.TargetThinkingMode)
 		return
 	}
-	body, err := json.Marshal(workbenchGeneratePromptAnthropicBody(task, payload.TargetThinkingMode))
-	if err != nil {
-		log.Printf("workbench generate_prompt fallback reason=marshal_request_failed org=%s err=%v", chi.URLParam(r, "orgUUID"), err)
-		workbenchWriteGeneratePromptFallbackStream(w, task, payload.TargetThinkingMode)
-		return
-	}
-	upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, endpoint, bytes.NewReader(body))
+	upstreamBody := workbenchGeneratePromptAnthropicBody(task, payload.TargetThinkingMode, model)
+	upstreamReq, err := newWorkbenchAnthropicRequest(r.Context(), endpoint, upstreamConfig, upstreamBody, "text/event-stream")
 	if err != nil {
 		log.Printf("workbench generate_prompt fallback reason=build_upstream_request_failed org=%s endpoint=%s err=%v", chi.URLParam(r, "orgUUID"), endpoint, err)
-		workbenchWriteGeneratePromptFallbackStream(w, task, payload.TargetThinkingMode)
+		workbenchWriteGeneratePromptFallbackStream(w, effectiveModel, task, payload.TargetThinkingMode)
 		return
 	}
-	upstreamReq.Header.Set("Accept", "text/event-stream")
-	upstreamReq.Header.Set("Content-Type", "application/json")
-	upstreamReq.Header.Set("X-API-Key", token)
-	upstreamReq.Header.Set("Anthropic-Version", anthropicAPIVersion)
 
-	log.Printf("workbench generate_prompt upstream_start org=%s endpoint=%s model=%s task_chars=%d thinking=%t", chi.URLParam(r, "orgUUID"), endpoint, workbenchGeneratePromptModel(), len([]rune(task)), payload.TargetThinkingMode)
+	log.Printf("workbench generate_prompt upstream_start org=%s endpoint=%s model=%s task_chars=%d thinking=%t", chi.URLParam(r, "orgUUID"), endpoint, effectiveModel, len([]rune(task)), payload.TargetThinkingMode)
 	upstreamRes, err := http.DefaultClient.Do(upstreamReq)
 	if err != nil {
 		log.Printf("workbench generate_prompt fallback reason=upstream_request_failed org=%s endpoint=%s err=%v", chi.URLParam(r, "orgUUID"), endpoint, err)
-		workbenchWriteGeneratePromptFallbackStream(w, task, payload.TargetThinkingMode)
+		workbenchWriteGeneratePromptFallbackStream(w, effectiveModel, task, payload.TargetThinkingMode)
 		return
 	}
 	defer upstreamRes.Body.Close()
@@ -1789,7 +1811,7 @@ func handleWorkbenchGeneratePrompt(w http.ResponseWriter, r *http.Request) {
 	if upstreamRes.StatusCode < 200 || upstreamRes.StatusCode >= 300 {
 		_, _ = io.Copy(io.Discard, upstreamRes.Body)
 		log.Printf("workbench generate_prompt fallback reason=upstream_status org=%s endpoint=%s status=%d", chi.URLParam(r, "orgUUID"), endpoint, upstreamRes.StatusCode)
-		workbenchWriteGeneratePromptFallbackStream(w, task, payload.TargetThinkingMode)
+		workbenchWriteGeneratePromptFallbackStream(w, effectiveModel, task, payload.TargetThinkingMode)
 		return
 	}
 
@@ -1805,8 +1827,8 @@ func handleWorkbenchGeneratePrompt(w http.ResponseWriter, r *http.Request) {
 	workbenchProxyGeneratePromptStream(w, upstreamRes.Body)
 }
 
-func workbenchWriteGeneratePromptFallbackStream(w http.ResponseWriter, task string, targetThinkingMode bool) {
-	writeWorkbenchTextStream(w, workbenchGeneratePromptModel(), workbenchGeneratePromptFallbackText(task, targetThinkingMode), 0, 0)
+func workbenchWriteGeneratePromptFallbackStream(w http.ResponseWriter, model string, task string, targetThinkingMode bool) {
+	writeWorkbenchTextStream(w, model, workbenchGeneratePromptFallbackText(task, targetThinkingMode), 0, 0)
 }
 
 func workbenchGeneratePromptFallbackText(task string, targetThinkingMode bool) string {
@@ -1841,9 +1863,9 @@ func workbenchGeneratePromptFallbackText(task string, targetThinkingMode bool) s
 	return b.String()
 }
 
-func workbenchGeneratePromptAnthropicBody(task string, targetThinkingMode bool) map[string]any {
+func workbenchGeneratePromptAnthropicBody(task string, targetThinkingMode bool, model string) map[string]any {
 	return map[string]any{
-		"model":       workbenchGeneratePromptModel(),
+		"model":       model,
 		"max_tokens":  2048,
 		"temperature": 0.2,
 		"stream":      true,
@@ -1978,7 +2000,7 @@ func workbenchStoredLatestRevision(r *http.Request, promptID string, includeMess
 func workbenchRevision(r *http.Request, revisionID string, includeMessages bool, includeCreator bool) map[string]any {
 	revision := map[string]any{
 		"system_prompt":            "",
-		"model_name":               workbenchDefaultModel,
+		"model_name":               modelmapping.Resolve(workbenchDefaultModel, workbenchAnthropicUpstreamFromRequest(r).ModelMappings),
 		"variables":                []any{},
 		"max_tokens_to_sample":     20000,
 		"temperature":              1,
@@ -2029,6 +2051,7 @@ func workbenchRevisionFromBody(r *http.Request, body map[string]any, fallbackID 
 	revision["created_at"] = formatJSISOString(time.Now())
 	workbenchSetStringField(revision, body, "system_prompt")
 	workbenchSetStringField(revision, body, "model_name")
+	resolveWorkbenchRevisionModel(r, revision)
 	workbenchSetNumberField(revision, body, "max_tokens_to_sample")
 	workbenchSetNumberField(revision, body, "temperature")
 	workbenchSetBoolField(revision, body, "show_raw_thinking")
@@ -2084,6 +2107,7 @@ func workbenchStoredRevision(r *http.Request, promptID string, revisionID string
 			} else {
 				delete(revision, "creator")
 			}
+			resolveWorkbenchRevisionModel(r, revision)
 			return revision, true
 		}
 		if err != nil && !errors.Is(err, ErrNotFound) {
@@ -2107,7 +2131,16 @@ func workbenchStoredRevision(r *http.Request, promptID string, revisionID string
 	} else {
 		delete(revision, "creator")
 	}
+	resolveWorkbenchRevisionModel(r, revision)
 	return revision, true
+}
+
+func resolveWorkbenchRevisionModel(r *http.Request, revision map[string]any) {
+	modelID := strings.TrimSpace(workbenchString(revision["model_name"]))
+	if modelID == "" {
+		return
+	}
+	revision["model_name"] = modelmapping.Resolve(modelID, workbenchAnthropicUpstreamFromRequest(r).ModelMappings)
 }
 
 func workbenchPromptStoreKey(r *http.Request, promptID string) string {

--- a/internal/workbench/console_platform_workbench_test.go
+++ b/internal/workbench/console_platform_workbench_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/samber/lo"
 )
 
 func TestWorkbenchCreatorUsesPrincipalWhenCookiePresent(t *testing.T) {
@@ -56,17 +57,137 @@ func TestWorkbenchGeneratePromptFallsBackWithoutAnthropicToken(t *testing.T) {
 		`{"task":"Summarize support tickets into action items"}`,
 	)
 	rec := httptest.NewRecorder()
+	upstream := config.AnthropicUpstreamConfig{ModelMappings: map[string]string{
+		"claude-sonnet-4-6": "glm-5-turbo",
+	}}
 
-	withWorkbenchDependencies(nil, config.AnthropicUpstreamConfig{}, handleWorkbenchGeneratePrompt)(rec, req)
+	withWorkbenchDependencies(nil, upstream, handleWorkbenchGeneratePrompt)(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"event: content_block_delta", `\u003cplanning\u003e`, `\u003c/planning\u003e`, `\u003cInstructions\u003e`, "Summarize support tickets into action items", `\u003c/Instructions\u003e`} {
+	for _, want := range []string{`"model":"glm-5-turbo"`, "event: content_block_delta", `\u003cplanning\u003e`, `\u003c/planning\u003e`, `\u003cInstructions\u003e`, "Summarize support tickets into action items", `\u003c/Instructions\u003e`} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("fallback generate prompt stream missing %q: %s", want, body)
 		}
+	}
+}
+
+func TestWorkbenchGeneratePromptUsesMappedUpstreamModel(t *testing.T) {
+	var upstreamModel string
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		upstreamModel = body.Model
+		http.Error(w, "force fallback", http.StatusBadGateway)
+	}))
+	defer upstreamServer.Close()
+
+	req := workbenchPostTestRequest(
+		"7482d00f-2e42-478b-b2db-07c3d056a3b6",
+		"/api/organizations/7482d00f-2e42-478b-b2db-07c3d056a3b6/workbench/generate_prompt",
+		`{"task":"Summarize support tickets into action items"}`,
+	)
+	rec := httptest.NewRecorder()
+	upstream := config.AnthropicUpstreamConfig{
+		BaseURL: upstreamServer.URL,
+		APIKey:  "yaml-key",
+		ModelMappings: map[string]string{
+			"claude-sonnet-4-6": "glm-5-turbo",
+		},
+	}
+
+	withWorkbenchDependencies(nil, upstream, handleWorkbenchGeneratePrompt)(rec, req)
+
+	if upstreamModel != "glm-5-turbo" {
+		t.Fatalf("upstream model = %q, want glm-5-turbo", upstreamModel)
+	}
+}
+
+func TestWorkbenchCompletionsUseMappedUpstreamModel(t *testing.T) {
+	var upstreamModel string
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		upstreamModel = body.Model
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
+	}))
+	defer upstreamServer.Close()
+
+	req := workbenchPostTestRequest(
+		"7482d00f-2e42-478b-b2db-07c3d056a3b6",
+		"/api/organizations/7482d00f-2e42-478b-b2db-07c3d056a3b6/workbench/completions",
+		`{"model_name":"claude-sonnet-4-6","messages":[{"role":"user","content":"Hello"}]}`,
+	)
+	rec := httptest.NewRecorder()
+	upstream := config.AnthropicUpstreamConfig{
+		BaseURL: upstreamServer.URL,
+		APIKey:  "yaml-key",
+		ModelMappings: map[string]string{
+			"claude-sonnet-4-6": "glm-5-turbo",
+		},
+	}
+
+	withWorkbenchDependencies(nil, upstream, handleWorkbenchCompletions)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if upstreamModel != "glm-5-turbo" {
+		t.Fatalf("upstream model = %q, want glm-5-turbo", upstreamModel)
+	}
+}
+
+func TestWorkbenchAnthropicTextResolvesUpstreamModelAtRequestBoundary(t *testing.T) {
+	var upstreamModel string
+	upstreamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		upstreamModel = body.Model
+		writeJSON(w, http.StatusOK, map[string]any{
+			"content": []any{map[string]any{"type": "text", "text": "Generated value"}},
+			"usage":   map[string]any{"input_tokens": 1, "output_tokens": 1},
+		})
+	}))
+	defer upstreamServer.Close()
+
+	req := workbenchCreatorTestRequest("7482d00f-2e42-478b-b2db-07c3d056a3b6")
+	rec := httptest.NewRecorder()
+	upstream := config.AnthropicUpstreamConfig{
+		BaseURL: upstreamServer.URL,
+		APIKey:  "yaml-key",
+		ModelMappings: map[string]string{
+			"claude-sonnet-4-6": "glm-5-turbo",
+		},
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if _, _, _, ok := workbenchAnthropicTextFromBody(r, map[string]any{
+			"model":    "claude-sonnet-4-6",
+			"messages": []any{},
+		}); !ok {
+			t.Fatal("workbenchAnthropicTextFromBody() failed")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+
+	withWorkbenchDependencies(nil, upstream, handler)(rec, req)
+
+	if upstreamModel != "glm-5-turbo" {
+		t.Fatalf("upstream model = %q, want glm-5-turbo", upstreamModel)
 	}
 }
 
@@ -106,6 +227,75 @@ func TestWorkbenchAnthropicTokenUsesConfig(t *testing.T) {
 	}
 }
 
+func TestWorkbenchModelsExposeEffectiveModelMappings(t *testing.T) {
+	orgUUID := "7482d00f-2e42-478b-b2db-07c3d056a3b6"
+	req := workbenchCreatorTestRequest(orgUUID)
+	rec := httptest.NewRecorder()
+	upstream := config.AnthropicUpstreamConfig{
+		ModelMappings: map[string]string{
+			"claude-sonnet-4-6": "glm-5-turbo",
+			"claude-opus-4-8":   "glm-5.2",
+		},
+	}
+
+	withWorkbenchDependencies(nil, upstream, handleWorkbenchModels)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		ModelMappings map[string]string `json:"model_mappings"`
+		Models        []struct {
+			ModelName string `json:"model_name"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.ModelMappings["claude-sonnet-4-6"] != "glm-5-turbo" {
+		t.Fatalf("model_mappings = %#v", body.ModelMappings)
+	}
+	modelNames := make([]string, 0, len(body.Models))
+	for _, model := range body.Models {
+		modelNames = append(modelNames, model.ModelName)
+	}
+	for _, want := range []string{"glm-5-turbo", "glm-5.2"} {
+		if !lo.Contains(modelNames, want) {
+			t.Fatalf("models = %#v, missing %q", modelNames, want)
+		}
+	}
+}
+
+func TestWorkbenchRevisionModelUsesMappingAtWriteAndReadBoundaries(t *testing.T) {
+	orgUUID := "3458f354-f4ba-4bcd-95ef-ef48b2534447"
+	promptID := "prompt_model_mapping"
+	revisionID := "revision_model_mapping"
+	req := workbenchCreatorTestRequest(orgUUID)
+	ctx := context.WithValue(req.Context(), workbenchAnthropicUpstreamContextKey{}, config.AnthropicUpstreamConfig{
+		ModelMappings: map[string]string{"claude-sonnet-4-6": "glm-5-turbo"},
+	})
+	req = req.WithContext(ctx)
+
+	created := workbenchRevisionFromBody(
+		req,
+		map[string]any{"model_name": "claude-sonnet-4-6"},
+		revisionID,
+		false,
+		false,
+	)
+	if created["model_name"] != "glm-5-turbo" {
+		t.Fatalf("created revision model = %#v, want glm-5-turbo", created["model_name"])
+	}
+
+	key := workbenchRevisionStoreKey(req, promptID, revisionID)
+	workbenchLocalRevisions.Store(key, map[string]any{"id": revisionID, "model_name": "claude-sonnet-4-6"})
+	defer workbenchLocalRevisions.Delete(key)
+	stored, ok := workbenchStoredRevision(req, promptID, revisionID, false, false)
+	if !ok || stored["model_name"] != "glm-5-turbo" {
+		t.Fatalf("stored revision = %#v, want mapped model", stored)
+	}
+}
+
 func TestWorkbenchGenerateTitleReturnsCompletionJSON(t *testing.T) {
 	req := workbenchPostTestRequest(
 		"7482d00f-2e42-478b-b2db-07c3d056a3b6",
@@ -135,6 +325,7 @@ func TestWorkbenchGenerateTitleReturnsCompletionJSON(t *testing.T) {
 }
 
 func TestWorkbenchGenerateTitleUsesConfiguredAnthropicUpstream(t *testing.T) {
+	var upstreamModel string
 	upstreamServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/anthropic/v1/messages" {
 			http.Error(w, "unexpected path", http.StatusNotFound)
@@ -144,6 +335,13 @@ func TestWorkbenchGenerateTitleUsesConfiguredAnthropicUpstream(t *testing.T) {
 			http.Error(w, "unexpected API key", http.StatusUnauthorized)
 			return
 		}
+		var requestBody struct {
+			Model string `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+			t.Fatalf("decode upstream request: %v", err)
+		}
+		upstreamModel = requestBody.Model
 		writeJSON(w, http.StatusOK, map[string]any{
 			"content": []any{map[string]any{"type": "text", "text": "Configured YAML title"}},
 			"usage":   map[string]any{"input_tokens": 7, "output_tokens": 3},
@@ -157,7 +355,13 @@ func TestWorkbenchGenerateTitleUsesConfiguredAnthropicUpstream(t *testing.T) {
 		`{"message_content":"Summarize planning notes","model":"claude-opus-4-8"}`,
 	)
 	rec := httptest.NewRecorder()
-	upstream := config.AnthropicUpstreamConfig{BaseURL: upstreamServer.URL + "/anthropic", APIKey: "yaml-key"}
+	upstream := config.AnthropicUpstreamConfig{
+		BaseURL: upstreamServer.URL + "/anthropic",
+		APIKey:  "yaml-key",
+		ModelMappings: map[string]string{
+			"claude-opus-4-8": "glm-5.2",
+		},
+	}
 
 	withWorkbenchDependencies(nil, upstream, handleWorkbenchGenerateTitle)(rec, req)
 
@@ -170,6 +374,9 @@ func TestWorkbenchGenerateTitleUsesConfiguredAnthropicUpstream(t *testing.T) {
 	}
 	if body["completion"] != "Configured YAML title" || body["input_tokens"] != float64(7) || body["output_tokens"] != float64(3) {
 		t.Fatalf("unexpected configured upstream response: %#v", body)
+	}
+	if upstreamModel != "glm-5.2" {
+		t.Fatalf("upstream model = %q, want glm-5.2", upstreamModel)
 	}
 }
 

--- a/tests/agents_api_test.go
+++ b/tests/agents_api_test.go
@@ -37,6 +37,30 @@ type agentPageResponse struct {
 	NextPage *string            `json:"next_page"`
 }
 
+func TestAgentsPersistMappedModelIDs(t *testing.T) {
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.AnthropicUpstream.ModelMappings = map[string]string{
+		"claude-sonnet-4-6": "glm-5-turbo",
+		"claude-opus-4-8":   "glm-5.2",
+	}
+	app := newTestAppWithStore(t, &cfg, newFakeStore("agents-model-mappings-bucket"))
+	defer app.close()
+
+	created := createAgent(t, app, `{"model":"claude-sonnet-4-6","name":"mapped-agent"}`)
+	defer cleanupAgentRows(t, app.db, created.ID)
+	assertRawContains(t, created.Model, `"id":"glm-5-turbo"`)
+
+	updated := updateAgent(t, app, created.ID, `{"version":1,"model":{"id":"claude-opus-4-8","speed":"fast"}}`, http.StatusOK)
+	assertRawContains(t, updated.Model, `"id":"glm-5.2"`)
+	assertRawContains(t, updated.Model, `"speed":"fast"`)
+
+	versionOne := retrieveAgent(t, app, created.ID, "version=1")
+	assertRawContains(t, versionOne.Model, `"id":"glm-5-turbo"`)
+}
+
 func TestAgentsAPI(t *testing.T) {
 	app := newTestAppWithStore(t, nil, newFakeStore("agents-bucket"))
 	defer app.close()

--- a/tests/environments_runner_cloud_test.go
+++ b/tests/environments_runner_cloud_test.go
@@ -34,6 +34,7 @@ func TestEnvironmentRunnerLaunchesManagedAgentCloudSession(t *testing.T) {
 	cfg.EnvironmentRunner.ClaudeAgentVersion = "2.1.120"
 	cfg.E2B.Template = "fake-template"
 	cfg.AnthropicUpstream.APIKey = "sk-ant-upstream-must-not-enter-sandbox"
+	cfg.AnthropicUpstream.ModelMappings = map[string]string{"claude-opus-4-8": "glm-5-turbo"}
 
 	app := newTestAppWithStore(t, &cfg, newFakeStore("runner-cloud-bucket"))
 	defer app.close()
@@ -125,6 +126,9 @@ func TestEnvironmentRunnerLaunchesManagedAgentCloudSession(t *testing.T) {
 	if codeSession.PermissionMode != "bypassPermissions" {
 		t.Fatalf("local code session permission mode = %q", codeSession.PermissionMode)
 	}
+	if codeSession.Model != "glm-5-turbo" {
+		t.Fatalf("local code session model = %q, want mapped snapshot model", codeSession.Model)
+	}
 	queued, err := app.db.ListQueuedCodeSessionInboundEvents(ctx, codeSession.ExternalID)
 	if err != nil {
 		t.Fatalf("list queued inbound events: %v", err)
@@ -164,6 +168,16 @@ func TestEnvironmentRunnerLaunchesManagedAgentCloudSession(t *testing.T) {
 		t.Fatalf("unexpected model auth: %#v", modelAuth)
 	}
 	startupEnvironment := startup["environment_variables"].(map[string]any)
+	for _, key := range []string{
+		"ANTHROPIC_MODEL",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+	} {
+		if startupEnvironment[key] != "glm-5-turbo" {
+			t.Fatalf("%s = %q, want mapped snapshot model", key, startupEnvironment[key])
+		}
+	}
 	if _, ok := startupEnvironment["CLAUDE_CODE_SESSION_ACCESS_TOKEN"]; ok {
 		t.Fatalf("startup environment masks WebSocket auth FD: %#v", startupEnvironment)
 	}

--- a/tests/platform_proxy_directory_api_test.go
+++ b/tests/platform_proxy_directory_api_test.go
@@ -160,6 +160,71 @@ func TestPlatformOrganizationProxyMessages(t *testing.T) {
 	}
 }
 
+func TestPlatformOrganizationProxyMessagesMapsConfiguredModel(t *testing.T) {
+	var seenBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		seenBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read upstream body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_proxy_mapped_model","type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.AnthropicUpstream.BaseURL = upstream.URL
+	cfg.AnthropicUpstream.APIKey = "sk-ant-upstream-model-mapping-test"
+	cfg.AnthropicUpstream.ModelMappings = map[string]string{
+		"claude-sonnet-4-6": "glm-5-turbo",
+	}
+	app := newTestAppWithStore(t, &cfg, newFakeStore("platform-proxy-model-mapping-bucket"))
+	defer app.close()
+
+	orgUUID := loadDefaultOrganizationUUID(t, app)
+	cookies := app.platformLoginCookies(t, "proxy-model-mapping@example.com")
+	payload := `{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`
+	req, err := http.NewRequest(http.MethodPost, app.baseURL+"/api/organizations/"+orgUUID+"/proxy/v1/messages", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("new proxy request: %v", err)
+	}
+	req.Host = "platform.claude.com"
+	req.Header.Set("Content-Type", "application/json")
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+	resp, err := app.client.Do(req)
+	if err != nil {
+		t.Fatalf("do proxy request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("proxy status = %d, want 200: %s", resp.StatusCode, readAll(t, resp.Body))
+	}
+
+	var upstreamBody struct {
+		Model     string `json:"model"`
+		MaxTokens int    `json:"max_tokens"`
+		Messages  []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(seenBody, &upstreamBody); err != nil {
+		t.Fatalf("decode upstream body: %v", err)
+	}
+	if upstreamBody.Model != "glm-5-turbo" {
+		t.Fatalf("upstream model = %v, want glm-5-turbo", upstreamBody.Model)
+	}
+	if upstreamBody.MaxTokens != 16 || len(upstreamBody.Messages) != 1 {
+		t.Fatalf("upstream body lost request fields: %#v", upstreamBody)
+	}
+}
+
 func TestPlatformOrganizationProxyMessagesStream(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/web/src/features/managed-agents/ManagedAgentsPage.agents.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.agents.suite.tsx
@@ -25,6 +25,24 @@ import {
 } from './ManagedAgentsPage.test-utils';
 
 export function registerManagedAgentsAgentsTests() {
+  test('does not mark the create dialog busy after model configuration loading fails', async () => {
+    resetTestDom('https://oma.duck.ai/workspaces/default/agents');
+    mockAgentsApi([], { modelMappingsErrorOnce: true });
+    render(
+      <WorkspaceContext.Provider value={workspaceContextValue('default')}>
+        <ManagedAgentsPage section="agents" />
+      </WorkspaceContext.Provider>,
+      undefined,
+      { seedModelMappings: false },
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Create agent' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Create agent' });
+    expect(await within(dialog).findByText('Could not load model configuration.')).toBeTruthy();
+    expect(dialog.getAttribute('aria-busy')).not.toBe('true');
+  });
+
   test('renders agent rows and creates an agent through the real v1 API', async () => {
     resetTestDom('https://oma.duck.ai/workspaces/default/agents');
     const api = mockAgentsApi([serverAgent]);

--- a/web/src/features/managed-agents/ManagedAgentsPage.test-utils.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.test-utils.tsx
@@ -56,6 +56,7 @@ const managedAgentsAuthContextValue: AuthContextValue = {
 export function render(
   ui: Parameters<typeof testingLibrary.render>[0],
   options?: Parameters<typeof testingLibrary.render>[1],
+  queryOptions: { seedModelMappings?: boolean } = {},
 ) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -63,6 +64,9 @@ export function render(
       mutations: { retry: false },
     },
   });
+  if (queryOptions.seedModelMappings !== false) {
+    queryClient.setQueryData(['managed-agents', 'model-mappings', 'org_test'], {});
+  }
   return testingLibrary.render(
     <AuthContext.Provider value={managedAgentsAuthContextValue}>
       <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
@@ -136,6 +140,7 @@ export function renderManagedAgentsPage(
       },
     },
   });
+  queryClient.setQueryData(['managed-agents', 'model-mappings', 'org_test'], {});
   const history = createBrowserHistory({ window });
   const router = createRouter({ history, routeTree: managedAgentsTestRouteTree });
   const result = render(
@@ -227,6 +232,8 @@ export type MockAgentsApiOptions = {
   mcpToolCatalogRefreshWait?: Promise<void>;
   analyticsOverview?: Record<string, unknown>;
   analyticsTimeseries?: Array<Record<string, unknown>>;
+  modelMappings?: Record<string, string>;
+  modelMappingsErrorOnce?: boolean;
   quickstartStream?: string | ((body: Record<string, unknown>) => string);
   quickstartStreamErrorOnce?: boolean;
   agentUpdateErrorStatus?: number;
@@ -250,6 +257,7 @@ export function mockAgentsApi(initialAgents: AgentFixture[], options: MockAgents
   let agentArchiveErrorsRemaining = options.agentArchiveErrorOnce ? 1 : 0;
   let mcpDirectoryErrorsRemaining = options.mcpDirectoryErrorOnce ? 1 : 0;
   let mcpToolCatalogRefreshErrorsRemaining = options.mcpToolCatalogRefreshErrorOnce ? 1 : 0;
+  let modelMappingsErrorsRemaining = options.modelMappingsErrorOnce ? 1 : 0;
   let quickstartStreamErrorsRemaining = options.quickstartStreamErrorOnce ? 1 : 0;
   let mcpToolCatalogs = options.mcpToolCatalogs?.map((catalog) => ({ ...catalog }));
   const now = new Date().toISOString();
@@ -299,6 +307,14 @@ export function mockAgentsApi(initialAgents: AgentFixture[], options: MockAgents
     const headers = Object.fromEntries(new Headers(init?.headers).entries());
     const body = parseBody(init?.body);
     requests.push({ url, method, headers, body });
+
+    if (url.match(/^\/api\/organizations\/[^/]+\/models$/) && method === 'GET') {
+      if (modelMappingsErrorsRemaining > 0) {
+        modelMappingsErrorsRemaining -= 1;
+        return jsonResponse({ error: { message: 'Model configuration unavailable' } }, 503);
+      }
+      return jsonResponse({ model_mappings: options.modelMappings ?? {} });
+    }
 
     const mcpCatalogMatch = url.match(
       /^\/api\/console\/organizations\/[^/]+\/workspaces\/[^/]+\/agents\/([^/]+)\/mcp_tool_catalogs(?:\/refresh)?(?:\?|$)/,

--- a/web/src/features/managed-agents/agentConfig.test.ts
+++ b/web/src/features/managed-agents/agentConfig.test.ts
@@ -5,7 +5,11 @@ import {
   createDialogAgentConfig,
   createDialogTemplateConfigs,
   createDialogTemplateConfigsZh,
+  jsonForTemplate,
+  quickstartBuildAgentConfigInput,
+  resolveAgentModelInput,
   templateSystem,
+  yamlForTemplate,
 } from './agentConfig';
 
 describe('localized create-agent template configs', () => {
@@ -38,6 +42,50 @@ describe('localized create-agent template configs', () => {
   test('uses locale as the second argument and defaults to English', () => {
     expect(createDialogAgentConfig(blankAgentTemplate)).toEqual(createDialogTemplateConfigs.blank);
     expect(createDialogAgentConfig(blankAgentTemplate, 'zh-CN')).toEqual(createDialogTemplateConfigsZh.blank);
+  });
+
+  test('uses the configured effective model id in template configs', () => {
+    const config = createDialogAgentConfig(blankAgentTemplate, 'en', undefined, {
+      'claude-sonnet-4-6': 'glm-5-turbo',
+    });
+
+    expect(config.model).toBe('glm-5-turbo');
+  });
+
+  test('uses the configured effective model id in template previews', () => {
+    const mappings = {
+      'claude-sonnet-4-6': 'glm-5-turbo',
+    };
+
+    expect(yamlForTemplate(blankAgentTemplate, 'en', mappings)).toContain('model: glm-5-turbo');
+    expect(jsonForTemplate(blankAgentTemplate, 'en', mappings)).toContain('"model": "glm-5-turbo"');
+  });
+
+  test('uses the configured effective model id in generated agent configs', () => {
+    const fallback = createDialogAgentConfig(blankAgentTemplate);
+    const mappings = { 'claude-sonnet-4-6': 'glm-5-turbo' };
+
+    expect(quickstartBuildAgentConfigInput({ model: 'claude-sonnet-4-6' }, fallback, mappings).model).toBe(
+      'glm-5-turbo',
+    );
+    expect(
+      quickstartBuildAgentConfigInput({ model: { id: 'claude-sonnet-4-6', speed: 'fast' } }, fallback, mappings).model,
+    ).toEqual({ id: 'glm-5-turbo', speed: 'fast' });
+  });
+
+  test('trims mapped and unmapped model ids at the configuration boundary', () => {
+    const mappings = { 'claude-sonnet-4-6': ' glm-5-turbo ' };
+
+    expect(resolveAgentModelInput(' claude-sonnet-4-6 ', mappings)).toBe('glm-5-turbo');
+    expect(resolveAgentModelInput(' glm-5 ', mappings)).toBe('glm-5');
+    expect(resolveAgentModelInput({ id: ' claude-sonnet-4-6 ', speed: 'fast' }, mappings)).toEqual({
+      id: 'glm-5-turbo',
+      speed: 'fast',
+    });
+    expect(resolveAgentModelInput({ id: ' glm-5 ', speed: 'standard' }, mappings)).toEqual({
+      id: 'glm-5',
+      speed: 'standard',
+    });
   });
 
   test('uses the localized config table as the system prompt source for every built-in template', () => {

--- a/web/src/features/managed-agents/agentConfig.ts
+++ b/web/src/features/managed-agents/agentConfig.ts
@@ -51,16 +51,35 @@ export const agentEditConfigSchema = z
   })
   .strict();
 
-export function yamlForTemplate(template: AgentTemplate, locale: Locale = 'en') {
-  return yamlStringify(displayAgentConfig(createDialogAgentConfig(template, locale)));
+export function yamlForTemplate(
+  template: AgentTemplate,
+  locale: Locale = 'en',
+  modelMappings: Record<string, string> = {},
+) {
+  return yamlStringify(displayAgentConfig(createDialogAgentConfig(template, locale, undefined, modelMappings)));
 }
 
-export function jsonForTemplate(template: AgentTemplate, locale: Locale = 'en') {
-  return JSON.stringify(displayAgentConfig(createDialogAgentConfig(template, locale)), null, 2);
+export function jsonForTemplate(
+  template: AgentTemplate,
+  locale: Locale = 'en',
+  modelMappings: Record<string, string> = {},
+) {
+  return JSON.stringify(
+    displayAgentConfig(createDialogAgentConfig(template, locale, undefined, modelMappings)),
+    null,
+    2,
+  );
 }
 
-export function codeForTemplate(template: AgentTemplate, format: CodeFormat, locale: Locale = 'en') {
-  return format === 'YAML' ? yamlForTemplate(template, locale) : jsonForTemplate(template, locale);
+export function codeForTemplate(
+  template: AgentTemplate,
+  format: CodeFormat,
+  locale: Locale = 'en',
+  modelMappings: Record<string, string> = {},
+) {
+  return format === 'YAML'
+    ? yamlForTemplate(template, locale, modelMappings)
+    : jsonForTemplate(template, locale, modelMappings);
 }
 
 export function createAgentToolset() {
@@ -324,6 +343,7 @@ export function createDialogAgentConfig(
   template: AgentTemplate,
   locale: Locale = 'en',
   descriptionOverride?: string | null,
+  modelMappings: Record<string, string> = {},
 ): CreateAgentInput {
   const zh = locale === 'zh-CN';
   const configuredTemplate = templateConfigsForLocale(locale)[template.id];
@@ -340,6 +360,7 @@ export function createDialogAgentConfig(
     },
   );
   const trimmedDescription = descriptionOverride?.trim();
+  config.model = resolveAgentModelInput(config.model, modelMappings);
 
   if (trimmedDescription) {
     config.description = trimmedDescription;
@@ -352,6 +373,7 @@ export function createDialogAgentConfig(
 export function quickstartBuildAgentConfigInput(
   input: Record<string, unknown>,
   fallback: CreateAgentInput,
+  modelMappings: Record<string, string> = {},
 ): CreateAgentInput {
   const rawConfig = toRecord(input.config) ?? input;
   const name = typeof rawConfig.name === 'string' && rawConfig.name.trim() ? rawConfig.name.trim() : fallback.name;
@@ -361,7 +383,7 @@ export function quickstartBuildAgentConfigInput(
       : rawConfig.description === null
         ? null
         : (fallback.description ?? null);
-  const model = quickstartModelInput(rawConfig.model, fallback.model);
+  const model = resolveAgentModelInput(quickstartModelInput(rawConfig.model, fallback.model), modelMappings);
   const system =
     typeof rawConfig.system === 'string'
       ? rawConfig.system
@@ -387,6 +409,13 @@ export function quickstartBuildAgentConfigInput(
     skills,
     ...(metadata ? { metadata } : {}),
   };
+}
+
+export function resolveAgentModelInput(model: AgentModelInput, modelMappings: Record<string, string>): AgentModelInput {
+  const modelID = typeof model === 'string' ? model : model.id;
+  const sourceID = modelID.trim();
+  const effectiveID = modelMappings[sourceID]?.trim() || sourceID;
+  return typeof model === 'string' ? effectiveID : { ...model, id: effectiveID };
 }
 
 export function quickstartModelInput(value: unknown, fallback: AgentModelInput): AgentModelInput {
@@ -462,6 +491,7 @@ export async function generateCreateAgentConfig({
   workspaceId,
   description,
   currentConfig,
+  modelMappings = {},
   signal,
   locale = 'en',
 }: {
@@ -469,6 +499,7 @@ export async function generateCreateAgentConfig({
   workspaceId: string;
   description: string;
   currentConfig: CreateAgentInput;
+  modelMappings?: Record<string, string>;
   signal: AbortSignal;
   locale?: Locale;
 }) {
@@ -513,7 +544,7 @@ export async function generateCreateAgentConfig({
       if (type === 'content_block_stop' && currentTool) {
         const input = parseToolInput(currentTool.inputJson, currentTool.input);
         if (currentTool.name === 'build_agent_config') {
-          generatedConfig = quickstartBuildAgentConfigInput(input, currentConfig);
+          generatedConfig = quickstartBuildAgentConfigInput(input, currentConfig, modelMappings);
         }
         currentTool = null;
       }

--- a/web/src/features/managed-agents/agents/create-dialog.tsx
+++ b/web/src/features/managed-agents/agents/create-dialog.tsx
@@ -26,22 +26,82 @@ import {
   generateCreateAgentConfig,
   parseCreateAgentConfigText,
 } from '../agentConfig';
+import { ManagedErrorAlert } from '../components/common';
 import { templateBody, templateTitle } from '../labels';
+import { useEffectiveModelMappings } from '../modelMappings';
 import { type AgentApiResponse, type AgentTemplate, type CodeFormat, type CreateAgentInput } from '../types';
 import { errorMessage, navigateToAgentConfig } from '../utils';
 import { CreateDialogConfigEditor } from './create-dialog-config-editor';
 
-export function CreateAgentDialog({
-  workspaceId,
-  onClose,
-  onCreate,
-}: {
+type CreateAgentDialogProps = {
   workspaceId: string;
   onClose: () => void;
   onCreate: (input: CreateAgentInput) => Promise<AgentApiResponse>;
-}) {
-  const { msg, locale } = useI18n();
+};
+
+export function CreateAgentDialog(props: CreateAgentDialogProps) {
   const { orgUuid } = useWorkspace();
+  const modelMappingsQuery = useEffectiveModelMappings(orgUuid);
+  if (orgUuid && modelMappingsQuery.isPending) {
+    return <CreateAgentDialogLoading onClose={props.onClose} />;
+  }
+  if (orgUuid && modelMappingsQuery.isError) {
+    return <CreateAgentDialogLoading error onClose={props.onClose} onRetry={() => void modelMappingsQuery.refetch()} />;
+  }
+  return <CreateAgentDialogContent {...props} orgUuid={orgUuid} modelMappings={modelMappingsQuery.data ?? {}} />;
+}
+
+function CreateAgentDialogLoading({
+  error = false,
+  onClose,
+  onRetry,
+}: {
+  error?: boolean;
+  onClose: () => void;
+  onRetry?: () => void;
+}) {
+  const { msg } = useI18n();
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent
+        aria-label={msg('managedAgents.agents.createLabel', 'Create agent')}
+        aria-busy={error ? undefined : true}
+        className="max-w-[720px] sm:max-w-[720px]"
+      >
+        <DialogHeader>
+          <DialogTitle>{msg('managedAgents.agents.createLabel', 'Create agent')}</DialogTitle>
+          <DialogDescription>
+            {error
+              ? msg('managedAgents.models.loadFailed', 'Could not load model configuration.')
+              : msg('common.loading', 'Loading...')}
+          </DialogDescription>
+        </DialogHeader>
+        {error ? (
+          <>
+            <ManagedErrorAlert>
+              {msg(
+                'managedAgents.models.loadFailedBody',
+                'Retry before creating an agent so its displayed and saved model IDs stay consistent.',
+              )}
+            </ManagedErrorAlert>
+            <Button type="button" className="justify-self-end" onClick={onRetry}>
+              {msg('common.retry', 'Retry')}
+            </Button>
+          </>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CreateAgentDialogContent({
+  workspaceId,
+  onClose,
+  onCreate,
+  orgUuid,
+  modelMappings,
+}: CreateAgentDialogProps & { orgUuid?: string; modelMappings: Record<string, string> }) {
+  const { msg, locale } = useI18n();
   const [startingPointOpen, setStartingPointOpen] = useState(true);
   const [mode, setMode] = useState<'describe' | 'template'>('describe');
   const [selectedTemplateId, setSelectedTemplateId] = useState(blankAgentTemplate.id);
@@ -49,10 +109,10 @@ export function CreateAgentDialog({
   const [description, setDescription] = useState('');
   const [generatedConfig, setGeneratedConfig] = useState<CreateAgentInput | null>(null);
   const [configInput, setConfigInput] = useState<CreateAgentInput>(() =>
-    createDialogAgentConfig(blankAgentTemplate, locale),
+    createDialogAgentConfig(blankAgentTemplate, locale, undefined, modelMappings),
   );
   const [configText, setConfigText] = useState(() =>
-    createAgentConfigText(createDialogAgentConfig(blankAgentTemplate, locale), 'YAML'),
+    createAgentConfigText(createDialogAgentConfig(blankAgentTemplate, locale, undefined, modelMappings), 'YAML'),
   );
   const [configError, setConfigError] = useState<string | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
@@ -126,9 +186,9 @@ export function CreateAgentDialog({
     setMode(nextMode);
     if (nextMode === 'describe') {
       setGeneratedConfig(null);
-      hydrateConfig(createDialogAgentConfig(blankAgentTemplate, locale));
+      hydrateConfig(createDialogAgentConfig(blankAgentTemplate, locale, undefined, modelMappings));
     } else {
-      hydrateConfig(createDialogAgentConfig(selectedTemplate, locale));
+      hydrateConfig(createDialogAgentConfig(selectedTemplate, locale, undefined, modelMappings));
     }
     setCreateError(null);
   };
@@ -137,7 +197,7 @@ export function CreateAgentDialog({
     setSelectedTemplateId(template.id);
     setMode('template');
     setGeneratedConfig(null);
-    hydrateConfig(createDialogAgentConfig(template, locale));
+    hydrateConfig(createDialogAgentConfig(template, locale, undefined, modelMappings));
     setStartingPointOpen(false);
   };
 
@@ -164,6 +224,7 @@ export function CreateAgentDialog({
         workspaceId,
         description: prompt,
         currentConfig: baseConfig,
+        modelMappings,
         signal: controller.signal,
         locale,
       });

--- a/web/src/features/managed-agents/api.ts
+++ b/web/src/features/managed-agents/api.ts
@@ -64,6 +64,13 @@ export const agentSearchMaxPages = 3;
 
 export const exactAgentIdPattern = /^agent_(?:staging_|local_)?[0-9a-zA-Z]{20,}$/i;
 
+export async function getEffectiveModelMappings(orgUuid: string) {
+  const response = await consoleApi<{ model_mappings?: Record<string, string> }>(
+    `/api/organizations/${encodeURIComponent(orgUuid)}/models`,
+  );
+  return response.model_mappings ?? {};
+}
+
 export function createdFilterStartISOString(filter: AgentCreatedFilter) {
   const now = Date.now();
   if (filter === 'last7') {

--- a/web/src/features/managed-agents/modelMappings.ts
+++ b/web/src/features/managed-agents/modelMappings.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getEffectiveModelMappings } from './api';
+
+export function useEffectiveModelMappings(orgUuid?: string) {
+  const organizationID = orgUuid ?? '';
+  return useQuery({
+    queryKey: ['managed-agents', 'model-mappings', organizationID],
+    queryFn: () => getEffectiveModelMappings(organizationID),
+    enabled: Boolean(organizationID),
+    retry: false,
+  });
+}

--- a/web/src/features/managed-agents/quickstart/AgentQuickstartPage.tsx
+++ b/web/src/features/managed-agents/quickstart/AgentQuickstartPage.tsx
@@ -1,4 +1,5 @@
 import { type Locale, useI18n } from '../../../shared/i18n';
+import { Button } from '../../../shared/ui/button';
 import {
   ResizableHandle,
   ResizablePanel,
@@ -22,6 +23,7 @@ import {
   createDialogAgentConfig,
   quickstartBuildAgentConfigInput,
 } from '../agentConfig';
+import { ManagedErrorAlert } from '../components/common';
 import {
   createAgent,
   createQuickstartDeployment,
@@ -35,6 +37,7 @@ import {
   postQuickstartSessionMessage,
 } from '../api';
 import { templateBody, templateSearchText } from '../labels';
+import { useEffectiveModelMappings } from '../modelMappings';
 import {
   type AgentApiResponse,
   type AgentPanelTab,
@@ -84,6 +87,33 @@ export function clampQuickstartInspectorPaneWidth(width: number, containerWidth:
 }
 
 export function AgentQuickstartPage() {
+  const { msg } = useI18n();
+  const { orgUuid } = useWorkspace();
+  const modelMappingsQuery = useEffectiveModelMappings(orgUuid);
+  if (orgUuid && modelMappingsQuery.isPending) {
+    return <section aria-busy="true" className="h-[calc(100vh-48px)] min-h-[650px]" />;
+  }
+  if (orgUuid && modelMappingsQuery.isError) {
+    return (
+      <section className="flex h-[calc(100vh-48px)] min-h-[650px] items-center justify-center px-6">
+        <div className="flex w-full max-w-xl flex-col gap-3">
+          <ManagedErrorAlert>
+            {msg(
+              'managedAgents.models.loadFailedBody',
+              'Retry before creating an agent so its displayed and saved model IDs stay consistent.',
+            )}
+          </ManagedErrorAlert>
+          <Button type="button" className="self-start" onClick={() => void modelMappingsQuery.refetch()}>
+            {msg('common.retry', 'Retry')}
+          </Button>
+        </div>
+      </section>
+    );
+  }
+  return <AgentQuickstartContent modelMappings={modelMappingsQuery.data ?? {}} />;
+}
+
+function AgentQuickstartContent({ modelMappings }: { modelMappings: Record<string, string> }) {
   const { msg, locale } = useI18n();
   const { activeWorkspaceId, orgUuid } = useWorkspace();
   const [query, setQuery] = useState('');
@@ -408,7 +438,9 @@ export function AgentQuickstartPage() {
         case 'build_agent_config': {
           const nextConfig = quickstartBuildAgentConfigInput(
             call.input,
-            createdAgentConfigRef.current ?? createDialogAgentConfig(blankAgentTemplate, promptLocaleRef.current),
+            createdAgentConfigRef.current ??
+              createDialogAgentConfig(blankAgentTemplate, promptLocaleRef.current, undefined, modelMappings),
+            modelMappings,
           );
           setCreatedAgentConfig(nextConfig);
           createdAgentConfigRef.current = nextConfig;
@@ -565,7 +597,7 @@ export function AgentQuickstartPage() {
 
   const handleUseTemplate = async (template: AgentTemplate, descriptionOverride?: string | null) => {
     promptLocaleRef.current = locale;
-    const config = createDialogAgentConfig(template, locale, descriptionOverride);
+    const config = createDialogAgentConfig(template, locale, descriptionOverride, modelMappings);
     setCreatingTemplateId(template.id);
     setChatError(null);
     try {
@@ -691,7 +723,7 @@ export function AgentQuickstartPage() {
       return;
     }
     promptLocaleRef.current = locale;
-    const config = createDialogAgentConfig(blankAgentTemplate, locale);
+    const config = createDialogAgentConfig(blankAgentTemplate, locale, undefined, modelMappings);
     setCreatingTemplateId(blankAgentTemplate.id);
     setChatError(null);
     setPrompt('');
@@ -728,7 +760,9 @@ export function AgentQuickstartPage() {
   const createAgentFromBuildConfig = async (call: QuickstartToolCall) => {
     const config = quickstartBuildAgentConfigInput(
       call.input,
-      createdAgentConfigRef.current ?? createDialogAgentConfig(blankAgentTemplate, promptLocaleRef.current),
+      createdAgentConfigRef.current ??
+        createDialogAgentConfig(blankAgentTemplate, promptLocaleRef.current, undefined, modelMappings),
+      modelMappings,
     );
     setCreatedAgentConfig(config);
     createdAgentConfigRef.current = config;
@@ -1154,6 +1188,7 @@ export function AgentQuickstartPage() {
                 onConfigureEnvironment={openPreviewEnvironmentStep}
                 onFormatChange={setFormat}
                 onTabChange={setAgentTab}
+                modelMappings={modelMappings}
               />
             ) : detailTemplate ? (
               <TemplateDetailPanel
@@ -1163,6 +1198,7 @@ export function AgentQuickstartPage() {
                 onFormatChange={setFormat}
                 onUseTemplate={() => handleUseTemplate(detailTemplate)}
                 isUsing={creatingTemplateId === detailTemplate.id}
+                modelMappings={modelMappings}
               />
             ) : (
               <BrowseTemplatesPanel

--- a/web/src/features/managed-agents/quickstart/components.tsx
+++ b/web/src/features/managed-agents/quickstart/components.tsx
@@ -1822,6 +1822,7 @@ export function TemplateDetailPanel({
   onFormatChange,
   onUseTemplate,
   isUsing,
+  modelMappings,
 }: {
   template: AgentTemplate;
   format: CodeFormat;
@@ -1829,9 +1830,10 @@ export function TemplateDetailPanel({
   onFormatChange: (format: CodeFormat) => void;
   onUseTemplate: () => void;
   isUsing: boolean;
+  modelMappings: Record<string, string>;
 }) {
   const { msg, locale } = useI18n();
-  const code = codeForTemplate(template, format, locale);
+  const code = codeForTemplate(template, format, locale, modelMappings);
   const title = templateTitle(template, msg);
   return (
     <Card className="relative h-full min-h-0 overflow-hidden border border-border bg-card py-0 shadow-sm ring-0">
@@ -1894,6 +1896,7 @@ export function CreatedAgentConfigPanel({
   onConfigureEnvironment,
   onFormatChange,
   onTabChange,
+  modelMappings,
 }: {
   template: AgentTemplate;
   agent: AgentApiResponse | null;
@@ -1912,9 +1915,12 @@ export function CreatedAgentConfigPanel({
   onConfigureEnvironment: () => Promise<void>;
   onFormatChange: (format: CodeFormat) => void;
   onTabChange: (tab: AgentPanelTab) => void;
+  modelMappings: Record<string, string>;
 }) {
   const { msg, locale } = useI18n();
-  const displayedConfig = displayAgentConfig(agentConfig ?? createDialogAgentConfig(template, locale));
+  const displayedConfig = displayAgentConfig(
+    agentConfig ?? createDialogAgentConfig(template, locale, undefined, modelMappings),
+  );
   const code = format === 'YAML' ? yamlStringify(displayedConfig) : JSON.stringify(displayedConfig, null, 2);
   return (
     <aside className="flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-border bg-popover shadow-sm">

--- a/web/src/shared/i18n/messages/en.json
+++ b/web/src/shared/i18n/messages/en.json
@@ -632,6 +632,8 @@
   "managedAgents.memoryStores.manage": "Manage memory stores",
   "managedAgents.memoryStores.searchPlaceholder": "Search by name or exact ID",
   "managedAgents.memoryStores.title": "Memory stores",
+  "managedAgents.models.loadFailed": "Could not load model configuration.",
+  "managedAgents.models.loadFailedBody": "Retry before creating an agent so its displayed and saved model IDs stay consistent.",
   "managedAgents.quickstart.accessToken": "Access token",
   "managedAgents.quickstart.addCredentialFor": "Add credential for",
   "managedAgents.quickstart.agentCreated": "Agent created",

--- a/web/src/shared/i18n/messages/zh-CN.json
+++ b/web/src/shared/i18n/messages/zh-CN.json
@@ -632,6 +632,8 @@
   "managedAgents.memoryStores.manage": "管理 memory stores",
   "managedAgents.memoryStores.searchPlaceholder": "按名称或精确 ID 搜索",
   "managedAgents.memoryStores.title": "Memory stores",
+  "managedAgents.models.loadFailed": "无法加载模型配置。",
+  "managedAgents.models.loadFailedBody": "请先重试再创建 Agent，以确保展示和保存的模型 ID 一致。",
   "managedAgents.quickstart.accessToken": "访问 token",
   "managedAgents.quickstart.addCredentialFor": "添加凭据给",
   "managedAgents.quickstart.agentCreated": "Agent 已创建",


### PR DESCRIPTION
## Summary

- add optional `anthropic_upstream.model_mappings`
- display and persist effective model IDs across model directories, Workbench, Quickstart, and Agent versions
- project the Session Snapshot model into Claude Code primary and Opus/Sonnet/Haiku runtime slots
- preserve original model IDs when mappings are absent or unmatched

## Root cause

OMA resolved and displayed models at some Console boundaries, but Agent runtime and several Workbench paths could still forward logical Claude IDs to Anthropic-compatible upstreams that only accept provider-specific IDs. Claude Code subagents also select default model slots independently from the primary model.

## Validation

- relevant Go package and end-to-end model-mapping tests
- 376 frontend tests
- frontend production build and format check
- lint, dead-code, duplicate-code, complexity, and large-file checks

## Known unrelated checks

- the full `go test ./... -count=1` suite still has the pre-existing SQLite `added_at` scan failure in `TestPlatformConsoleBackendMigratedRoutes`
- `just hooks-run` detects existing test fixture private keys outside this change; the staged pre-commit hook passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `model_mappings` configuration for Anthropic-compatible upstreams to remap model IDs.
  * Applied effective mapped model IDs across model listings, managed-agent creation/quickstart configs, Workbench upstream requests, revision handling, and organization messages proxying.
  * Added managed-agent session model-related runtime environment variables.
  * Introduced UI loading, retry, and error states when model mappings can’t be retrieved.

* **Bug Fixes**
  * Mapping validation now rejects chained mappings; whitespace-safe resolution preserves unmapped models and supports shared upstream aliases.

* **Documentation**
  * Updated configuration and runtime boundary docs for how model mappings are displayed, saved, and enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->