### PR TITLE
refactor(db): migrate MCP OAuth flows to sqlx

### DIFF
--- a/internal/db/mcp_oauth_flows.go
+++ b/internal/db/mcp_oauth_flows.go
@@ -2,10 +2,90 @@ package db
 
 import (
 	"context"
-	"errors"
 	"time"
+)
 
-	"github.com/jackc/pgx/v5"
+const (
+	createMCPOAuthFlowQuery = `
+		insert into mcp_oauth_flows (
+			uuid, external_id, organization_id, workspace_id, vault_id, vault_external_id,
+			user_id, user_external_id, platform_session_external_id, mcp_server_url,
+			redirect_url, display_name, source, authorization_endpoint, token_endpoint,
+			registration_endpoint, issuer, resource, scope, client_id, client_secret,
+			token_endpoint_auth_method, code_verifier, code_challenge_method, status,
+			created_at, updated_at, expires_at
+		)
+		values (
+			:uuid, :external_id, :organization_id, :workspace_id, :vault_id, :vault_external_id,
+			nullif(:user_id, 0), nullif(:user_external_id, ''),
+			nullif(:platform_session_external_id, ''), :mcp_server_url,
+			:redirect_url, :display_name, :source, :authorization_endpoint, :token_endpoint,
+			nullif(:registration_endpoint, ''), nullif(:issuer, ''), :resource,
+			nullif(:scope, ''), :client_id, nullif(:client_secret, ''),
+			:token_endpoint_auth_method, :code_verifier, :code_challenge_method, :status,
+			:created_at, :created_at, :expires_at
+		)
+		returning ` + mcpOAuthFlowReturnColumns + `
+	`
+	getMCPOAuthFlowQuery = `
+		select ` + mcpOAuthFlowReturnColumns + `
+		from mcp_oauth_flows
+		where external_id = :external_id
+	`
+	completeMCPOAuthFlowQuery = `
+		update mcp_oauth_flows
+		set status = 'completed',
+			credential_external_id = :credential_external_id,
+			error_code = null,
+			client_secret = null,
+			code_verifier = '',
+			completed_at = :completed_at,
+			updated_at = :completed_at
+		where external_id = :external_id and status = 'pending'
+	`
+	failMCPOAuthFlowQuery = `
+		update mcp_oauth_flows
+		set status = 'failed',
+			error_code = :error_code,
+			client_secret = null,
+			code_verifier = '',
+			updated_at = :failed_at
+		where external_id = :external_id and status = 'pending'
+	`
+	mcpOAuthFlowReturnColumns = `
+		id,
+		CAST(uuid AS text) AS uuid,
+		external_id,
+		organization_id,
+		workspace_id,
+		vault_id,
+		vault_external_id,
+		coalesce(user_id, 0) AS user_id,
+		coalesce(user_external_id, '') AS user_external_id,
+		coalesce(platform_session_external_id, '') AS platform_session_external_id,
+		mcp_server_url,
+		redirect_url,
+		display_name,
+		source,
+		authorization_endpoint,
+		token_endpoint,
+		coalesce(registration_endpoint, '') AS registration_endpoint,
+		coalesce(issuer, '') AS issuer,
+		resource,
+		coalesce(scope, '') AS scope,
+		client_id,
+		coalesce(client_secret, '') AS client_secret,
+		token_endpoint_auth_method,
+		code_verifier,
+		code_challenge_method,
+		status,
+		coalesce(credential_external_id, '') AS credential_external_id,
+		coalesce(error_code, '') AS error_code,
+		created_at,
+		updated_at,
+		expires_at,
+		completed_at
+	`
 )
 
 type MCPOAuthFlow struct {
@@ -43,112 +123,159 @@ type MCPOAuthFlow struct {
 	CompletedAt               *time.Time
 }
 
+type mcpOAuthFlowRow struct {
+	ID                        int64      `db:"id"`
+	UUID                      string     `db:"uuid"`
+	ExternalID                string     `db:"external_id"`
+	OrganizationID            int64      `db:"organization_id"`
+	WorkspaceID               int64      `db:"workspace_id"`
+	VaultID                   int64      `db:"vault_id"`
+	VaultExternalID           string     `db:"vault_external_id"`
+	UserID                    int64      `db:"user_id"`
+	UserExternalID            string     `db:"user_external_id"`
+	PlatformSessionExternalID string     `db:"platform_session_external_id"`
+	MCPServerURL              string     `db:"mcp_server_url"`
+	RedirectURL               string     `db:"redirect_url"`
+	DisplayName               string     `db:"display_name"`
+	Source                    string     `db:"source"`
+	AuthorizationEndpoint     string     `db:"authorization_endpoint"`
+	TokenEndpoint             string     `db:"token_endpoint"`
+	RegistrationEndpoint      string     `db:"registration_endpoint"`
+	Issuer                    string     `db:"issuer"`
+	Resource                  string     `db:"resource"`
+	Scope                     string     `db:"scope"`
+	ClientID                  string     `db:"client_id"`
+	ClientSecret              string     `db:"client_secret"`
+	TokenEndpointAuthMethod   string     `db:"token_endpoint_auth_method"`
+	CodeVerifier              string     `db:"code_verifier"`
+	CodeChallengeMethod       string     `db:"code_challenge_method"`
+	Status                    string     `db:"status"`
+	CredentialExternalID      string     `db:"credential_external_id"`
+	ErrorCode                 string     `db:"error_code"`
+	CreatedAt                 time.Time  `db:"created_at"`
+	UpdatedAt                 time.Time  `db:"updated_at"`
+	ExpiresAt                 time.Time  `db:"expires_at"`
+	CompletedAt               *time.Time `db:"completed_at"`
+}
+
 func (d *DB) CreateMCPOAuthFlow(ctx context.Context, flow MCPOAuthFlow) (MCPOAuthFlow, error) {
-	return scanMCPOAuthFlow(d.Pool.QueryRow(ctx, `
-		insert into mcp_oauth_flows (
-			uuid, external_id, organization_id, workspace_id, vault_id, vault_external_id,
-			user_id, user_external_id, platform_session_external_id, mcp_server_url,
-			redirect_url, display_name, source, authorization_endpoint, token_endpoint,
-			registration_endpoint, issuer, resource, scope, client_id, client_secret,
-			token_endpoint_auth_method, code_verifier, code_challenge_method, status,
-			created_at, updated_at, expires_at
-		)
-		values (
-			$1, $2, $3, $4, $5, $6,
-			nullif($7, 0), nullif($8, ''), nullif($9, ''), $10,
-			$11, $12, $13, $14, $15,
-			nullif($16, ''), nullif($17, ''), $18, nullif($19, ''), $20, nullif($21, ''),
-			$22, $23, $24, $25,
-			$26, $26, $27
-		)
-		returning `+mcpOAuthFlowReturnColumns(), flow.UUID, flow.ExternalID,
-		flow.OrganizationID, flow.WorkspaceID, flow.VaultID, flow.VaultExternalID,
-		flow.UserID, flow.UserExternalID, flow.PlatformSessionExternalID,
-		flow.MCPServerURL, flow.RedirectURL, flow.DisplayName, flow.Source,
-		flow.AuthorizationEndpoint, flow.TokenEndpoint, flow.RegistrationEndpoint,
-		flow.Issuer, flow.Resource, flow.Scope, flow.ClientID, flow.ClientSecret,
-		flow.TokenEndpointAuthMethod, flow.CodeVerifier, flow.CodeChallengeMethod,
-		flow.Status, flow.CreatedAt, flow.ExpiresAt))
+	return getMCPOAuthFlowSQLX(ctx, d.sql, createMCPOAuthFlowQuery, mcpOAuthFlowArguments(flow))
 }
 
 func (d *DB) GetMCPOAuthFlow(ctx context.Context, externalID string) (MCPOAuthFlow, error) {
-	return scanMCPOAuthFlow(d.Pool.QueryRow(ctx, `
-		select `+mcpOAuthFlowReturnColumns()+`
-		from mcp_oauth_flows
-		where external_id = $1
-	`, externalID))
+	return getMCPOAuthFlowSQLX(ctx, d.sql, getMCPOAuthFlowQuery, map[string]any{
+		"external_id": externalID,
+	})
 }
 
 func (d *DB) CompleteMCPOAuthFlow(ctx context.Context, externalID, credentialExternalID string, completedAt time.Time) error {
-	tag, err := d.Pool.Exec(ctx, `
-		update mcp_oauth_flows
-		set status = 'completed',
-			credential_external_id = $2,
-			error_code = null,
-			client_secret = null,
-			code_verifier = '',
-			completed_at = $3,
-			updated_at = $3
-		where external_id = $1 and status = 'pending'
-	`, externalID, credentialExternalID, completedAt)
+	rowsAffected, err := namedExecRowsAffected(ctx, d.sql, completeMCPOAuthFlowQuery, map[string]any{
+		"external_id":            externalID,
+		"credential_external_id": credentialExternalID,
+		"completed_at":           completedAt,
+	})
 	if err != nil {
 		return err
 	}
-	if tag.RowsAffected() == 0 {
+	if rowsAffected == 0 {
 		return ErrNotFound
 	}
 	return nil
 }
 
 func (d *DB) FailMCPOAuthFlow(ctx context.Context, externalID, errorCode string, failedAt time.Time) error {
-	tag, err := d.Pool.Exec(ctx, `
-		update mcp_oauth_flows
-		set status = 'failed',
-			error_code = $2,
-			client_secret = null,
-			code_verifier = '',
-			updated_at = $3
-		where external_id = $1 and status = 'pending'
-	`, externalID, errorCode, failedAt)
+	rowsAffected, err := namedExecRowsAffected(ctx, d.sql, failMCPOAuthFlowQuery, map[string]any{
+		"external_id": externalID,
+		"error_code":  errorCode,
+		"failed_at":   failedAt,
+	})
 	if err != nil {
 		return err
 	}
-	if tag.RowsAffected() == 0 {
+	if rowsAffected == 0 {
 		return ErrNotFound
 	}
 	return nil
 }
 
-func mcpOAuthFlowReturnColumns() string {
-	return `
-		id, uuid::text, external_id, organization_id, workspace_id, vault_id,
-		vault_external_id, coalesce(user_id, 0), coalesce(user_external_id, ''),
-		coalesce(platform_session_external_id, ''), mcp_server_url, redirect_url,
-		display_name, source, authorization_endpoint, token_endpoint,
-		coalesce(registration_endpoint, ''), coalesce(issuer, ''), resource,
-		coalesce(scope, ''), client_id, coalesce(client_secret, ''),
-		token_endpoint_auth_method, code_verifier, code_challenge_method, status,
-		coalesce(credential_external_id, ''), coalesce(error_code, ''),
-		created_at, updated_at, expires_at, completed_at
-	`
+func getMCPOAuthFlowSQLX(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	query string,
+	arguments map[string]any,
+) (MCPOAuthFlow, error) {
+	var row mcpOAuthFlowRow
+	if err := namedGetContext(ctx, database, &row, query, arguments); err != nil {
+		return MCPOAuthFlow{}, mapNoRows(err)
+	}
+	return row.flow(), nil
 }
 
-func scanMCPOAuthFlow(row vaultScanner) (MCPOAuthFlow, error) {
-	var flow MCPOAuthFlow
-	err := row.Scan(&flow.ID, &flow.UUID, &flow.ExternalID, &flow.OrganizationID,
-		&flow.WorkspaceID, &flow.VaultID, &flow.VaultExternalID, &flow.UserID,
-		&flow.UserExternalID, &flow.PlatformSessionExternalID, &flow.MCPServerURL,
-		&flow.RedirectURL, &flow.DisplayName, &flow.Source, &flow.AuthorizationEndpoint,
-		&flow.TokenEndpoint, &flow.RegistrationEndpoint, &flow.Issuer, &flow.Resource,
-		&flow.Scope, &flow.ClientID, &flow.ClientSecret, &flow.TokenEndpointAuthMethod,
-		&flow.CodeVerifier, &flow.CodeChallengeMethod, &flow.Status,
-		&flow.CredentialExternalID, &flow.ErrorCode, &flow.CreatedAt, &flow.UpdatedAt,
-		&flow.ExpiresAt, &flow.CompletedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return MCPOAuthFlow{}, ErrNotFound
+func mcpOAuthFlowArguments(flow MCPOAuthFlow) map[string]any {
+	return map[string]any{
+		"uuid":                         flow.UUID,
+		"external_id":                  flow.ExternalID,
+		"organization_id":              flow.OrganizationID,
+		"workspace_id":                 flow.WorkspaceID,
+		"vault_id":                     flow.VaultID,
+		"vault_external_id":            flow.VaultExternalID,
+		"user_id":                      flow.UserID,
+		"user_external_id":             flow.UserExternalID,
+		"platform_session_external_id": flow.PlatformSessionExternalID,
+		"mcp_server_url":               flow.MCPServerURL,
+		"redirect_url":                 flow.RedirectURL,
+		"display_name":                 flow.DisplayName,
+		"source":                       flow.Source,
+		"authorization_endpoint":       flow.AuthorizationEndpoint,
+		"token_endpoint":               flow.TokenEndpoint,
+		"registration_endpoint":        flow.RegistrationEndpoint,
+		"issuer":                       flow.Issuer,
+		"resource":                     flow.Resource,
+		"scope":                        flow.Scope,
+		"client_id":                    flow.ClientID,
+		"client_secret":                flow.ClientSecret,
+		"token_endpoint_auth_method":   flow.TokenEndpointAuthMethod,
+		"code_verifier":                flow.CodeVerifier,
+		"code_challenge_method":        flow.CodeChallengeMethod,
+		"status":                       flow.Status,
+		"created_at":                   flow.CreatedAt,
+		"expires_at":                   flow.ExpiresAt,
 	}
-	if err != nil {
-		return MCPOAuthFlow{}, err
+}
+
+func (r mcpOAuthFlowRow) flow() MCPOAuthFlow {
+	return MCPOAuthFlow{
+		ID:                        r.ID,
+		UUID:                      r.UUID,
+		ExternalID:                r.ExternalID,
+		OrganizationID:            r.OrganizationID,
+		WorkspaceID:               r.WorkspaceID,
+		VaultID:                   r.VaultID,
+		VaultExternalID:           r.VaultExternalID,
+		UserID:                    r.UserID,
+		UserExternalID:            r.UserExternalID,
+		PlatformSessionExternalID: r.PlatformSessionExternalID,
+		MCPServerURL:              r.MCPServerURL,
+		RedirectURL:               r.RedirectURL,
+		DisplayName:               r.DisplayName,
+		Source:                    r.Source,
+		AuthorizationEndpoint:     r.AuthorizationEndpoint,
+		TokenEndpoint:             r.TokenEndpoint,
+		RegistrationEndpoint:      r.RegistrationEndpoint,
+		Issuer:                    r.Issuer,
+		Resource:                  r.Resource,
+		Scope:                     r.Scope,
+		ClientID:                  r.ClientID,
+		ClientSecret:              r.ClientSecret,
+		TokenEndpointAuthMethod:   r.TokenEndpointAuthMethod,
+		CodeVerifier:              r.CodeVerifier,
+		CodeChallengeMethod:       r.CodeChallengeMethod,
+		Status:                    r.Status,
+		CredentialExternalID:      r.CredentialExternalID,
+		ErrorCode:                 r.ErrorCode,
+		CreatedAt:                 r.CreatedAt,
+		UpdatedAt:                 r.UpdatedAt,
+		ExpiresAt:                 r.ExpiresAt,
+		CompletedAt:               r.CompletedAt,
 	}
-	return flow, nil
 }

--- a/internal/db/mcp_oauth_flows_sqlx_test.go
+++ b/internal/db/mcp_oauth_flows_sqlx_test.go
@@ -1,0 +1,86 @@
+package db
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMCPOAuthFlowQueriesUseSQLXNamedParameters(t *testing.T) {
+	now := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
+	flow := MCPOAuthFlow{
+		UUID:                    "11111111-1111-4111-8111-111111111111",
+		ExternalID:              "mcpoauth_test",
+		OrganizationID:          1,
+		WorkspaceID:             2,
+		VaultID:                 3,
+		VaultExternalID:         "vault_test",
+		MCPServerURL:            "https://mcp.example.test",
+		RedirectURL:             "https://app.example.test/callback",
+		DisplayName:             "Test MCP",
+		AuthorizationEndpoint:   "https://auth.example.test/authorize",
+		TokenEndpoint:           "https://auth.example.test/token",
+		Resource:                "https://mcp.example.test",
+		ClientID:                "client_test",
+		TokenEndpointAuthMethod: "none",
+		CodeVerifier:            "verifier",
+		CodeChallengeMethod:     "S256",
+		Status:                  "pending",
+		CreatedAt:               now,
+		ExpiresAt:               now.Add(10 * time.Minute),
+	}
+	tests := []struct {
+		name         string
+		query        string
+		arguments    map[string]any
+		wantArgCount int
+	}{
+		{
+			name:         "create",
+			query:        createMCPOAuthFlowQuery,
+			arguments:    mcpOAuthFlowArguments(flow),
+			wantArgCount: 28,
+		},
+		{
+			name:         "get",
+			query:        getMCPOAuthFlowQuery,
+			arguments:    map[string]any{"external_id": flow.ExternalID},
+			wantArgCount: 1,
+		},
+		{
+			name:  "complete",
+			query: completeMCPOAuthFlowQuery,
+			arguments: map[string]any{
+				"external_id":            flow.ExternalID,
+				"credential_external_id": "vaultcred_test",
+				"completed_at":           now,
+			},
+			wantArgCount: 4,
+		},
+		{
+			name:  "fail",
+			query: failMCPOAuthFlowQuery,
+			arguments: map[string]any{
+				"external_id": flow.ExternalID,
+				"error_code":  "authorization_failed",
+				"failed_at":   now,
+			},
+			wantArgCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, arguments, err := bindNamed(postgresRebinder{}, tt.query, tt.arguments)
+			if err != nil {
+				t.Fatalf("bindNamed() error = %v", err)
+			}
+			if len(arguments) != tt.wantArgCount {
+				t.Fatalf("bindNamed() arguments = %#v, want %d arguments", arguments, tt.wantArgCount)
+			}
+			if strings.Contains(query, ":") {
+				t.Fatalf("bound query still contains a named parameter: %s", query)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- migrate MCP OAuth flow create/read/complete/fail SQL from direct `pgxpool` calls to the shared `sqlx` wrapper
- keep each state transition atomic while using named parameters and explicit row mapping
- add binding coverage for all four query paths, including repeated timestamps and nullable inputs

## Why

Runtime SQL in `internal/db` must use `sqlx`; the OAuth flow store was still using positional `pgx` queries and scan-order mapping.

## Impact

No API or state-machine behavior changes are intended. Pending-only completion/failure, secret clearing, null handling, and not-found behavior are preserved.

## Validation

- `go test ./internal/db -run TestMCPOAuthFlowQueriesUseSQLXNamedParameters -count=1`
- `go test ./internal/db -count=1`
- `go test ./tests -run 'TestPlatformConsoleBackendMigratedRoutes/(success_mcp_vault_auth_start_route|failure_mcp_vault_auth_callback_token_exchange|failure_mcp_vault_auth_start_discovery)' -count=1`
- managed pre-commit hook (format, lint, dead code, complexity, duplicates, large files)

Design documentation does not need an update because the public API, OAuth state transitions, data model, and transaction boundaries are unchanged.
