### PR TITLE
refactor(db): migrate console api keys to sqlx

### DIFF
--- a/internal/db/console_api_keys.go
+++ b/internal/db/console_api_keys.go
@@ -7,93 +7,48 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-type consoleAPIKeyScanner interface {
-	Scan(dest ...any) error
-}
-
-func scanConsoleAPIKey(row consoleAPIKeyScanner) (platform.ConsoleAPIKey, error) {
-	var key platform.ConsoleAPIKey
-	err := row.Scan(
-		&key.ID,
-		&key.OrgUUID,
-		&key.WorkspaceID,
-		&key.Name,
-		&key.KeyPrefix,
-		&key.KeySuffix,
-		&key.Status,
-		&key.CreatedByUserUUID,
-		&key.LastUsedAt,
-		&key.ExpiresAt,
-		&key.ArchivedAt,
-		&key.CreatedAt,
-		&key.UpdatedAt,
-	)
-	if err != nil {
-		return platform.ConsoleAPIKey{}, mapNoRows(err)
-	}
-	return key, nil
-}
-
 func (d *DB) ListConsoleAPIKeys(ctx context.Context, orgUUID string, workspaceID *string) ([]platform.ConsoleAPIKey, error) {
-	if d == nil || d.Pool == nil || strings.TrimSpace(orgUUID) == "" {
+	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" {
 		return []platform.ConsoleAPIKey{}, nil
 	}
-	query := `
-		select
-			external_id,
-			org_uuid,
-			workspace_id,
-			name,
-			key_prefix,
-			key_suffix,
-			status,
-			created_by_user_uuid,
-			last_used_at,
-			expires_at,
-			archived_at,
-			created_at,
-			updated_at
-		from console_api_keys
-		where org_uuid = $1
-	`
-	args := []any{strings.TrimSpace(orgUUID)}
-	if workspaceID != nil {
-		query += ` and workspace_id = $2`
-		args = append(args, strings.TrimSpace(*workspaceID))
-	}
-	query += ` order by created_at desc, id desc`
-
-	rows, err := d.Pool.Query(ctx, query, args...)
+	query, arguments := listConsoleAPIKeysQuery(orgUUID, workspaceID)
+	keys, err := selectConsoleAPIKeysSQLX(ctx, d.sql, query, arguments)
 	if err != nil {
 		if isUndefinedTableError(err) {
 			return []platform.ConsoleAPIKey{}, nil
 		}
 		return nil, err
 	}
-	defer rows.Close()
+	return keys, nil
+}
 
-	var out []platform.ConsoleAPIKey
-	for rows.Next() {
-		key, err := scanConsoleAPIKey(rows)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, key)
+func listConsoleAPIKeysQuery(orgUUID string, workspaceID *string) (string, map[string]any) {
+	query := `
+		select
+			` + consoleAPIKeySQLXColumns + `
+		from console_api_keys
+		where org_uuid = :org_uuid
+	`
+	arguments := map[string]any{"org_uuid": strings.TrimSpace(orgUUID)}
+	if workspaceID != nil {
+		query += ` and workspace_id = :workspace_id`
+		arguments["workspace_id"] = strings.TrimSpace(*workspaceID)
 	}
-	return out, rows.Err()
+	query += ` order by created_at desc, id desc`
+	return query, arguments
 }
 
 func (d *DB) CreateConsoleAPIKey(ctx context.Context, input platform.CreateConsoleAPIKeyInput) (platform.CreateConsoleAPIKeyResult, error) {
-	if d == nil || d.Pool == nil || strings.TrimSpace(input.OrgUUID) == "" || strings.TrimSpace(input.WorkspaceID) == "" {
+	if d == nil || d.sql == nil || strings.TrimSpace(input.OrgUUID) == "" || strings.TrimSpace(input.WorkspaceID) == "" {
 		return platform.CreateConsoleAPIKeyResult{}, platform.ErrNotFound
 	}
 	orgUUID := strings.TrimSpace(input.OrgUUID)
@@ -110,18 +65,18 @@ func (d *DB) CreateConsoleAPIKey(ctx context.Context, input platform.CreateConso
 	externalID := consolePrefixedID("apikey", 18)
 	keyHash := auth.HashAPIKey(rawKey)
 
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return platform.CreateConsoleAPIKeyResult{}, err
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	defer func() { _ = tx.Rollback() }()
 
 	coreWorkspaceID, coreUserID, err := d.resolveConsoleAPIKeyCoreRefs(ctx, tx, orgUUID, workspaceID, input.CreatedByUserUUID)
 	if err != nil {
 		return platform.CreateConsoleAPIKeyResult{}, err
 	}
 
-	key, err := scanConsoleAPIKey(tx.QueryRow(ctx, `
+	key, err := getConsoleAPIKeySQLX(ctx, tx, `
 		insert into console_api_keys (
 			external_id,
 			api_key_uuid,
@@ -135,36 +90,27 @@ func (d *DB) CreateConsoleAPIKey(ctx context.Context, input platform.CreateConso
 			created_by_user_uuid,
 			expires_at
 		)
-		values ($1, $1, $2, $3, $4, $5, $6, $7, 'active', $8, $9)
-		returning
-			external_id,
-			org_uuid,
-			workspace_id,
-			name,
-			key_prefix,
-			key_suffix,
-			status,
-			created_by_user_uuid,
-			last_used_at,
-			expires_at,
-			archived_at,
-			created_at,
-			updated_at
-	`,
-		externalID,
-		orgUUID,
-		workspaceID,
-		strings.TrimSpace(input.Name),
-		keyPrefix,
-		keySuffix,
-		keyHash,
-		input.CreatedByUserUUID,
-		input.ExpiresAt,
-	))
+		values (
+			:external_id, :external_id, :org_uuid, :workspace_id, :name,
+			:key_prefix, :key_suffix, :key_hash, 'active',
+			:created_by_user_uuid, :expires_at
+		)
+		returning `+consoleAPIKeySQLXColumns+`
+	`, map[string]any{
+		"external_id":          externalID,
+		"org_uuid":             orgUUID,
+		"workspace_id":         workspaceID,
+		"name":                 strings.TrimSpace(input.Name),
+		"key_prefix":           keyPrefix,
+		"key_suffix":           keySuffix,
+		"key_hash":             keyHash,
+		"created_by_user_uuid": input.CreatedByUserUUID,
+		"expires_at":           input.ExpiresAt,
+	})
 	if err != nil {
 		return platform.CreateConsoleAPIKeyResult{}, err
 	}
-	if _, err := tx.Exec(ctx, `
+	if _, err := namedExecContext(ctx, tx, `
 		insert into api_keys (
 			external_id,
 			workspace_id,
@@ -175,11 +121,22 @@ func (d *DB) CreateConsoleAPIKey(ctx context.Context, input platform.CreateConso
 			partial_key_hint,
 			expires_at
 		)
-		values ($1, $2, $3, 'active', $4, $5, $6, $7)
-	`, externalID, coreWorkspaceID, keyHash, coreUserID, strings.TrimSpace(input.Name), partialAPIKeyHint(rawKey), input.ExpiresAt); err != nil {
+		values (
+			:external_id, :workspace_id, :key_hash, 'active', :created_by_user_id,
+			:name, :partial_key_hint, :expires_at
+		)
+	`, map[string]any{
+		"external_id":        externalID,
+		"workspace_id":       coreWorkspaceID,
+		"key_hash":           keyHash,
+		"created_by_user_id": coreUserID,
+		"name":               strings.TrimSpace(input.Name),
+		"partial_key_hint":   partialAPIKeyHint(rawKey),
+		"expires_at":         input.ExpiresAt,
+	}); err != nil {
 		return platform.CreateConsoleAPIKeyResult{}, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return platform.CreateConsoleAPIKeyResult{}, err
 	}
 	return platform.CreateConsoleAPIKeyResult{
@@ -189,7 +146,7 @@ func (d *DB) CreateConsoleAPIKey(ctx context.Context, input platform.CreateConso
 }
 
 func (d *DB) UpdateConsoleAPIKeyStatus(ctx context.Context, input platform.UpdateConsoleAPIKeyStatusInput) (platform.ConsoleAPIKey, error) {
-	if d == nil || d.Pool == nil ||
+	if d == nil || d.sql == nil ||
 		strings.TrimSpace(input.OrgUUID) == "" ||
 		strings.TrimSpace(input.WorkspaceID) == "" ||
 		strings.TrimSpace(input.APIKeyID) == "" ||
@@ -201,60 +158,58 @@ func (d *DB) UpdateConsoleAPIKeyStatus(ctx context.Context, input platform.Updat
 	apiKeyID := strings.TrimSpace(input.APIKeyID)
 	status := strings.TrimSpace(input.Status)
 
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return platform.ConsoleAPIKey{}, err
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	defer func() { _ = tx.Rollback() }()
 
-	key, err := scanConsoleAPIKey(tx.QueryRow(ctx, `
+	key, err := getConsoleAPIKeySQLX(ctx, tx, `
 		update console_api_keys
-		set status = $4,
+		set status = :status,
 			archived_at = case
-				when $4 = 'archived' then coalesce(archived_at, now())
+				when :status = 'archived' then coalesce(archived_at, now())
 				else null
 			end,
 			updated_at = now()
-		where org_uuid = $1
-		  and workspace_id = $2
-		  and (external_id = $3 or api_key_uuid = $3)
-		returning
-			external_id,
-			org_uuid,
-			workspace_id,
-			name,
-			key_prefix,
-			key_suffix,
-			status,
-			created_by_user_uuid,
-			last_used_at,
-			expires_at,
-			archived_at,
-			created_at,
-			updated_at
-	`, orgUUID, workspaceID, apiKeyID, status))
+		where org_uuid = :org_uuid
+		  and workspace_id = :workspace_id
+		  and (external_id = :api_key_id or api_key_uuid = :api_key_id)
+		returning `+consoleAPIKeySQLXColumns+`
+	`, map[string]any{
+		"org_uuid":     orgUUID,
+		"workspace_id": workspaceID,
+		"api_key_id":   apiKeyID,
+		"status":       status,
+	})
 	if err != nil {
 		return platform.ConsoleAPIKey{}, err
 	}
 
-	if _, err := tx.Exec(ctx, `
+	if _, err := namedExecContext(ctx, tx, `
 		update api_keys
-		set status = $2,
+		set status = :status,
 			updated_at = now()
-		where external_id = $1
-	`, key.ID, status); err != nil {
+		where external_id = :api_key_id
+	`, map[string]any{"api_key_id": key.ID, "status": status}); err != nil {
 		return platform.ConsoleAPIKey{}, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return platform.ConsoleAPIKey{}, err
 	}
 	return key, nil
 }
 
-func (d *DB) resolveConsoleAPIKeyCoreRefs(ctx context.Context, tx pgx.Tx, orgUUID string, workspaceID string, userUUID *string) (int64, *int64, error) {
+func (d *DB) resolveConsoleAPIKeyCoreRefs(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	orgUUID string,
+	workspaceID string,
+	userUUID *string,
+) (int64, *int64, error) {
 	var coreWorkspaceID int64
 	if workspaceID == "default" {
-		err := tx.QueryRow(ctx, `
+		err := namedGetContext(ctx, database, &coreWorkspaceID, `
 			select w.id
 			from organizations o
 			join lateral (
@@ -272,22 +227,22 @@ func (d *DB) resolveConsoleAPIKeyCoreRefs(ctx context.Context, tx pgx.Tx, orgUUI
 					id asc
 				limit 1
 			) w on true
-			where o.uuid::text = $1 or o.external_id = $1
+			where CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid
 			limit 1
-		`, orgUUID).Scan(&coreWorkspaceID)
+		`, map[string]any{"org_uuid": orgUUID})
 		if err != nil {
 			return 0, nil, mapNoRows(err)
 		}
 	} else {
-		err := tx.QueryRow(ctx, `
+		err := namedGetContext(ctx, database, &coreWorkspaceID, `
 			select w.id
 			from workspaces w
 			join organizations o on o.id = w.organization_id
-			where (o.uuid::text = $1 or o.external_id = $1)
-			  and (w.external_id = $2 or w.uuid::text = $2)
+			where (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
+			  and (w.external_id = :workspace_id or CAST(w.uuid AS text) = :workspace_id)
 			  and w.archived_at is null
 			limit 1
-		`, orgUUID, workspaceID).Scan(&coreWorkspaceID)
+		`, map[string]any{"org_uuid": orgUUID, "workspace_id": workspaceID})
 		if err != nil {
 			return 0, nil, mapNoRows(err)
 		}
@@ -296,20 +251,20 @@ func (d *DB) resolveConsoleAPIKeyCoreRefs(ctx context.Context, tx pgx.Tx, orgUUI
 	var coreUserID *int64
 	if userUUID != nil && strings.TrimSpace(*userUUID) != "" {
 		var userID int64
-		err := tx.QueryRow(ctx, `
+		err := namedGetContext(ctx, database, &userID, `
 			select u.id
 			from users u
 			join organizations o on o.id = u.organization_id
-			where (o.uuid::text = $1 or o.external_id = $1)
+			where (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
 			  and u.deleted_at is null
 			  and (
-				u.external_id = $2
-				or u.uuid::text = $2
-				or 'user_' || left(replace(u.uuid::text, '-', ''), 24) = $2
+				u.external_id = :user_uuid
+				or CAST(u.uuid AS text) = :user_uuid
+				or 'user_' || left(replace(CAST(u.uuid AS text), '-', ''), 24) = :user_uuid
 			  )
 			limit 1
-		`, orgUUID, strings.TrimSpace(*userUUID)).Scan(&userID)
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		`, map[string]any{"org_uuid": orgUUID, "user_uuid": strings.TrimSpace(*userUUID)})
+		if err != nil && !errors.Is(mapNoRows(err), platform.ErrNotFound) {
 			return 0, nil, err
 		}
 		if err == nil {
@@ -320,17 +275,20 @@ func (d *DB) resolveConsoleAPIKeyCoreRefs(ctx context.Context, tx pgx.Tx, orgUUI
 }
 
 func (d *DB) CountConsoleAPIKeys(ctx context.Context, orgUUID string, workspaceID string) (int, error) {
-	if d == nil || d.Pool == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(workspaceID) == "" {
+	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(workspaceID) == "" {
 		return 0, nil
 	}
 	var count int
-	err := d.Pool.QueryRow(ctx, `
+	err := namedGetContext(ctx, d.sql, &count, `
 		select count(*)
 		from console_api_keys
-		where org_uuid = $1
-		  and workspace_id = $2
+		where org_uuid = :org_uuid
+		  and workspace_id = :workspace_id
 		  and archived_at is null
-	`, strings.TrimSpace(orgUUID), strings.TrimSpace(workspaceID)).Scan(&count)
+	`, map[string]any{
+		"org_uuid":     strings.TrimSpace(orgUUID),
+		"workspace_id": strings.TrimSpace(workspaceID),
+	})
 	if isUndefinedTableError(err) {
 		return 0, nil
 	}
@@ -338,7 +296,7 @@ func (d *DB) CountConsoleAPIKeys(ctx context.Context, orgUUID string, workspaceI
 }
 
 func (d *DB) CreateConsoleWorkspace(ctx context.Context, input platform.CreateConsoleWorkspaceInput) (platform.ConsoleWorkspace, error) {
-	if d == nil || d.Pool == nil || strings.TrimSpace(input.OrgUUID) == "" || strings.TrimSpace(input.Name) == "" {
+	if d == nil || d.sql == nil || strings.TrimSpace(input.OrgUUID) == "" || strings.TrimSpace(input.Name) == "" {
 		return platform.ConsoleWorkspace{}, platform.ErrNotFound
 	}
 	externalID := consolePrefixedID("wrkspc", 18)
@@ -346,11 +304,11 @@ func (d *DB) CreateConsoleWorkspace(ctx context.Context, input platform.CreateCo
 	if err != nil {
 		return platform.ConsoleWorkspace{}, err
 	}
-	workspace, err := scanConsoleWorkspace(d.Pool.QueryRow(ctx, `
+	workspace, err := getConsoleWorkspaceSQLX(ctx, d.sql, `
 		with org as (
-			select id, uuid::text as org_uuid
+			select id, CAST(uuid AS text) as org_uuid
 			from organizations
-			where uuid::text = $1 or external_id = $1
+			where CAST(uuid AS text) = :org_uuid or external_id = :org_uuid
 			limit 1
 		)
 		insert into workspaces (
@@ -363,7 +321,8 @@ func (d *DB) CreateConsoleWorkspace(ctx context.Context, input platform.CreateCo
 			data_residency,
 			tags
 		)
-		select $2, $3, org.id, $4, $3, $5, $6::jsonb, '{}'::jsonb
+		select :uuid, :external_id, org.id, :name, :external_id, :display_color,
+			CAST(:data_residency AS jsonb), CAST('{}' AS jsonb)
 		from org
 		on conflict (organization_id, name) do update set
 			display_color = excluded.display_color,
@@ -371,18 +330,25 @@ func (d *DB) CreateConsoleWorkspace(ctx context.Context, input platform.CreateCo
 			archived_at = null,
 			updated_at = now()
 		returning
-			external_id,
-			(select org_uuid from org),
+			external_id AS uuid,
+			(select org_uuid from org) AS org_uuid,
 			name,
-			display_color,
-			display_color,
+			display_color AS display_color,
+			display_color AS color,
 			data_residency,
 			external_key_id,
 			tags,
 			archived_at,
 			created_at,
 			updated_at
-	`, strings.TrimSpace(input.OrgUUID), uuid.NewString(), externalID, strings.TrimSpace(input.Name), firstNonEmpty(strings.TrimSpace(input.DisplayColor), strings.TrimSpace(input.Color), "#9B87F5"), dataResidency))
+	`, map[string]any{
+		"org_uuid":       strings.TrimSpace(input.OrgUUID),
+		"uuid":           uuid.NewString(),
+		"external_id":    externalID,
+		"name":           strings.TrimSpace(input.Name),
+		"display_color":  firstNonEmpty(strings.TrimSpace(input.DisplayColor), strings.TrimSpace(input.Color), "#9B87F5"),
+		"data_residency": dataResidency,
+	})
 	if isUniqueViolation(err) {
 		return platform.ConsoleWorkspace{}, err
 	}
@@ -390,20 +356,32 @@ func (d *DB) CreateConsoleWorkspace(ctx context.Context, input platform.CreateCo
 }
 
 func (d *DB) ListConsoleWorkspaces(ctx context.Context, orgUUID string, includeArchived bool) ([]platform.ConsoleWorkspace, error) {
-	if d == nil || d.Pool == nil || strings.TrimSpace(orgUUID) == "" {
+	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" {
 		return []platform.ConsoleWorkspace{}, nil
 	}
+	query, arguments := listConsoleWorkspacesQuery(orgUUID, includeArchived)
+	workspaces, err := selectConsoleWorkspacesSQLX(ctx, d.sql, query, arguments)
+	if err != nil {
+		if isUndefinedTableError(err) {
+			return []platform.ConsoleWorkspace{}, nil
+		}
+		return nil, err
+	}
+	return workspaces, nil
+}
+
+func listConsoleWorkspacesQuery(orgUUID string, includeArchived bool) (string, map[string]any) {
 	archivedFilter := "and w.archived_at is null"
 	if includeArchived {
 		archivedFilter = ""
 	}
-	rows, err := d.Pool.Query(ctx, `
+	query := `
 		select
-			w.external_id,
-			o.uuid::text,
+			w.external_id AS uuid,
+			CAST(o.uuid AS text) AS org_uuid,
 			w.name,
-			w.display_color,
-			w.display_color,
+			w.display_color AS display_color,
+			w.display_color AS color,
 			w.data_residency,
 			w.external_key_id,
 			w.tags,
@@ -412,85 +390,152 @@ func (d *DB) ListConsoleWorkspaces(ctx context.Context, orgUUID string, includeA
 			w.updated_at
 		from workspaces w
 		join organizations o on o.id = w.organization_id
-		where (o.external_id = $1 or o.uuid::text = $1)
-		`+archivedFilter+`
+		where (o.external_id = :org_uuid or CAST(o.uuid AS text) = :org_uuid)
+		` + archivedFilter + `
 		order by w.name asc, w.id asc
-	`, strings.TrimSpace(orgUUID))
-	if err != nil {
-		if isUndefinedTableError(err) {
-			return []platform.ConsoleWorkspace{}, nil
-		}
-		return nil, err
-	}
-	defer rows.Close()
-
-	var out []platform.ConsoleWorkspace
-	for rows.Next() {
-		var workspace platform.ConsoleWorkspace
-		var dataResidencyBytes []byte
-		var tagsBytes []byte
-		if err := rows.Scan(
-			&workspace.UUID,
-			&workspace.OrgUUID,
-			&workspace.Name,
-			&workspace.DisplayColor,
-			&workspace.Color,
-			&dataResidencyBytes,
-			&workspace.ExternalKeyID,
-			&tagsBytes,
-			&workspace.ArchivedAt,
-			&workspace.CreatedAt,
-			&workspace.UpdatedAt,
-		); err != nil {
-			return nil, mapNoRows(err)
-		}
-		dataResidency, settings, err := parseConsoleWorkspaceDataResidencyJSON(dataResidencyBytes)
-		if err != nil {
-			return nil, err
-		}
-		workspace.DataResidency = dataResidency
-		workspace.DataResidencySettings = settings
-		tags, err := parseConsoleWorkspaceTagsJSON(tagsBytes)
-		if err != nil {
-			return nil, err
-		}
-		workspace.Tags = tags
-		out = append(out, workspace)
-	}
-	return out, rows.Err()
+	`
+	return query, map[string]any{"org_uuid": strings.TrimSpace(orgUUID)}
 }
 
-func scanConsoleWorkspace(row consoleAPIKeyScanner) (platform.ConsoleWorkspace, error) {
-	var workspace platform.ConsoleWorkspace
-	var dataResidencyBytes []byte
-	var tagsBytes []byte
-	if err := row.Scan(
-		&workspace.UUID,
-		&workspace.OrgUUID,
-		&workspace.Name,
-		&workspace.DisplayColor,
-		&workspace.Color,
-		&dataResidencyBytes,
-		&workspace.ExternalKeyID,
-		&tagsBytes,
-		&workspace.ArchivedAt,
-		&workspace.CreatedAt,
-		&workspace.UpdatedAt,
-	); err != nil {
+func (r consoleWorkspaceRow) workspace() (platform.ConsoleWorkspace, error) {
+	dataResidency, settings, err := parseConsoleWorkspaceDataResidencyJSON(r.DataResidency)
+	if err != nil {
+		return platform.ConsoleWorkspace{}, err
+	}
+	tags, err := parseConsoleWorkspaceTagsJSON(r.Tags)
+	if err != nil {
+		return platform.ConsoleWorkspace{}, err
+	}
+	return platform.ConsoleWorkspace{
+		UUID:                  r.UUID,
+		OrgUUID:               r.OrgUUID,
+		Name:                  r.Name,
+		DisplayColor:          r.DisplayColor,
+		Color:                 r.Color,
+		DataResidency:         dataResidency,
+		DataResidencySettings: settings,
+		ExternalKeyID:         r.ExternalKeyID,
+		Tags:                  tags,
+		ArchivedAt:            r.ArchivedAt,
+		CreatedAt:             r.CreatedAt,
+		UpdatedAt:             r.UpdatedAt,
+	}, nil
+}
+
+const consoleAPIKeySQLXColumns = `external_id AS id, org_uuid, workspace_id, name,
+	key_prefix, key_suffix, status, created_by_user_uuid, last_used_at, expires_at,
+	archived_at, created_at, updated_at`
+
+type consoleAPIKeyRow struct {
+	ID                string     `db:"id"`
+	OrgUUID           string     `db:"org_uuid"`
+	WorkspaceID       string     `db:"workspace_id"`
+	Name              string     `db:"name"`
+	KeyPrefix         string     `db:"key_prefix"`
+	KeySuffix         string     `db:"key_suffix"`
+	Status            string     `db:"status"`
+	CreatedByUserUUID *string    `db:"created_by_user_uuid"`
+	LastUsedAt        *time.Time `db:"last_used_at"`
+	ExpiresAt         *time.Time `db:"expires_at"`
+	ArchivedAt        *time.Time `db:"archived_at"`
+	CreatedAt         time.Time  `db:"created_at"`
+	UpdatedAt         time.Time  `db:"updated_at"`
+}
+
+type consoleWorkspaceRow struct {
+	UUID          string     `db:"uuid"`
+	OrgUUID       string     `db:"org_uuid"`
+	Name          string     `db:"name"`
+	DisplayColor  string     `db:"display_color"`
+	Color         string     `db:"color"`
+	DataResidency []byte     `db:"data_residency"`
+	ExternalKeyID *string    `db:"external_key_id"`
+	Tags          []byte     `db:"tags"`
+	ArchivedAt    *time.Time `db:"archived_at"`
+	CreatedAt     time.Time  `db:"created_at"`
+	UpdatedAt     time.Time  `db:"updated_at"`
+}
+
+func getConsoleAPIKeySQLX(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	query string,
+	arguments map[string]any,
+) (platform.ConsoleAPIKey, error) {
+	var row consoleAPIKeyRow
+	if err := namedGetContext(ctx, database, &row, query, arguments); err != nil {
+		return platform.ConsoleAPIKey{}, mapNoRows(err)
+	}
+	return row.key(), nil
+}
+
+func selectConsoleAPIKeysSQLX(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	query string,
+	arguments map[string]any,
+) ([]platform.ConsoleAPIKey, error) {
+	var rows []consoleAPIKeyRow
+	if err := namedSelectContext(ctx, database, &rows, query, arguments); err != nil {
+		return nil, err
+	}
+	keys := make([]platform.ConsoleAPIKey, len(rows))
+	for index := range rows {
+		keys[index] = rows[index].key()
+	}
+	return keys, nil
+}
+
+func getConsoleWorkspaceSQLX(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	query string,
+	arguments map[string]any,
+) (platform.ConsoleWorkspace, error) {
+	var row consoleWorkspaceRow
+	if err := namedGetContext(ctx, database, &row, query, arguments); err != nil {
 		return platform.ConsoleWorkspace{}, mapNoRows(err)
 	}
-	dataResidency, settings, err := parseConsoleWorkspaceDataResidencyJSON(dataResidencyBytes)
-	if err != nil {
-		return platform.ConsoleWorkspace{}, err
+	return row.workspace()
+}
+
+func selectConsoleWorkspacesSQLX(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	query string,
+	arguments map[string]any,
+) ([]platform.ConsoleWorkspace, error) {
+	var rows []consoleWorkspaceRow
+	if err := namedSelectContext(ctx, database, &rows, query, arguments); err != nil {
+		return nil, err
 	}
-	workspace.DataResidency = dataResidency
-	workspace.DataResidencySettings = settings
-	tags, err := parseConsoleWorkspaceTagsJSON(tagsBytes)
-	if err != nil {
-		return platform.ConsoleWorkspace{}, err
+	workspaces := make([]platform.ConsoleWorkspace, 0, len(rows))
+	for _, row := range rows {
+		workspace, err := row.workspace()
+		if err != nil {
+			return nil, err
+		}
+		workspaces = append(workspaces, workspace)
 	}
-	workspace.Tags = tags
-	return workspace, nil
+	return workspaces, nil
+}
+
+func (r consoleAPIKeyRow) key() platform.ConsoleAPIKey {
+	return platform.ConsoleAPIKey{
+		ID:                r.ID,
+		OrgUUID:           r.OrgUUID,
+		WorkspaceID:       r.WorkspaceID,
+		Name:              r.Name,
+		KeyPrefix:         r.KeyPrefix,
+		KeySuffix:         r.KeySuffix,
+		Status:            r.Status,
+		CreatedByUserUUID: r.CreatedByUserUUID,
+		LastUsedAt:        r.LastUsedAt,
+		ExpiresAt:         r.ExpiresAt,
+		ArchivedAt:        r.ArchivedAt,
+		CreatedAt:         r.CreatedAt,
+		UpdatedAt:         r.UpdatedAt,
+	}
 }
 
 func consoleWorkspaceDataResidencyJSON(dataResidency *string) ([]byte, error) {

--- a/internal/db/console_api_keys_sqlx_test.go
+++ b/internal/db/console_api_keys_sqlx_test.go
@@ -1,0 +1,78 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConsoleAPIKeyQueriesUseSQLXNamedParameters(t *testing.T) {
+	workspaceID := "workspace_test"
+	apiKeyQuery, apiKeyArguments := listConsoleAPIKeysQuery("org_test", &workspaceID)
+	workspaceQuery, workspaceArguments := listConsoleWorkspacesQuery("org_test", false)
+
+	t.Run("rejects a missing named argument", func(t *testing.T) {
+		if _, _, err := bindNamed(postgresRebinder{}, apiKeyQuery, map[string]any{
+			"org_uuid": "org_test",
+		}); err == nil {
+			t.Fatal("bindNamed() error = nil, want missing workspace_id error")
+		}
+	})
+
+	tests := []struct {
+		name         string
+		query        string
+		arguments    map[string]any
+		wantArgCount int
+	}{
+		{
+			name:         "list api keys by workspace",
+			query:        apiKeyQuery,
+			arguments:    apiKeyArguments,
+			wantArgCount: 2,
+		},
+		{
+			name:         "list workspaces",
+			query:        workspaceQuery,
+			arguments:    workspaceArguments,
+			wantArgCount: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			query, arguments, err := bindNamed(postgresRebinder{}, test.query, test.arguments)
+			if err != nil {
+				t.Fatalf("bind named query: %v", err)
+			}
+			if strings.Contains(query, ":") {
+				t.Fatalf("query retains named parameter syntax: %q", query)
+			}
+			if strings.Contains(test.query, "::") {
+				t.Fatalf("query uses PostgreSQL cast shorthand: %q", test.query)
+			}
+			if len(arguments) != test.wantArgCount {
+				t.Fatalf("argument count = %d, want %d", len(arguments), test.wantArgCount)
+			}
+		})
+	}
+}
+
+func TestConsoleWorkspaceRowMapsJSONFields(t *testing.T) {
+	row := consoleWorkspaceRow{
+		UUID:          "workspace_test",
+		OrgUUID:       "org_test",
+		DataResidency: []byte(`{"workspace_geo":"us","allowed_inference_geos":"unrestricted","default_inference_geo":"global"}`),
+		Tags:          []byte(`{"team":"platform"}`),
+	}
+
+	workspace, err := row.workspace()
+	if err != nil {
+		t.Fatalf("workspace(): %v", err)
+	}
+	if workspace.DataResidency == nil || *workspace.DataResidency != "us" {
+		t.Fatalf("data residency = %#v, want us", workspace.DataResidency)
+	}
+	if workspace.Tags["team"] != "platform" {
+		t.Fatalf("tags = %#v, want platform team", workspace.Tags)
+	}
+}


### PR DESCRIPTION
## Summary

- migrate console API key and workspace queries from native pgx calls to sqlx
- preserve atomic console/core API-key creation and status updates with complete `sqlx.Tx` transactions
- add named-query binding and workspace JSON mapping coverage

## Validation

- `go test ./internal/db -run 'TestConsole(APIKeyQueriesUseSQLXNamedParameters|WorkspaceRowMapsJSONFields)' -count=1`
- `go test ./tests -run TestPlatformConsoleBackendMigratedRoutes -count=1`
- managed pre-commit quality gates

## Design docs

No update required: the API, data model, authorization scope, and transaction behavior are unchanged.
