### PR TITLE
refactor(db): migrate platform auth to sqlx

### DIFF
--- a/internal/db/platform_auth.go
+++ b/internal/db/platform_auth.go
@@ -7,7 +7,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/platformsession"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
+	"github.com/jmoiron/sqlx"
 )
 
 type PlatformAuthUserContext struct {
@@ -70,8 +70,64 @@ type PlatformAuthAPIKeyInput struct {
 	PartialKeyHint  string
 }
 
+const (
+	findPlatformAuthUserContextQuery = `
+		select u.external_id AS user_external_id, CAST(o.uuid AS text) AS org_uuid
+		from users u
+		join organizations o on o.id = u.organization_id
+		where lower(u.email) = lower(:email)
+		  and u.deleted_at is null
+		  and exists (
+			select 1
+			from workspace_members wm
+			where wm.organization_id = o.id
+			  and wm.user_id = u.id
+			  and wm.deleted_at is null
+		)
+		order by u.added_at asc, u.id asc
+		limit 1
+	`
+	resolvePlatformSessionIdentityQuery = `
+		select o.id AS organization_id, CAST(o.uuid AS text) AS organization_uuid,
+			o.external_id AS organization_external_id,
+			w.id AS workspace_id, CAST(w.uuid AS text) AS workspace_uuid,
+			w.external_id AS workspace_external_id,
+			u.id AS user_id, u.external_id AS user_external_id,
+			ak.id AS api_key_id, ak.external_id AS api_key_external_id
+		from organizations o
+		join users u on u.organization_id = o.id
+		join lateral (
+			select id, uuid, external_id
+			from workspaces
+			where organization_id = o.id
+			  and archived_at is null
+			order by case when external_id = 'workspace_default' then 0 else 1 end,
+				created_at asc, id asc
+			limit 1
+		) w on true
+		join lateral (
+			select id, external_id
+			from api_keys
+			where workspace_id = w.id
+			  and status = 'active'
+			  and (expires_at is null or expires_at > now())
+			order by case when external_id = 'api_key_default' then 0 else 1 end,
+				created_at asc, id asc
+			limit 1
+		) ak on true
+		where (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
+		  and u.deleted_at is null
+		  and (
+			u.external_id = :user_uuid
+			or CAST(u.uuid AS text) = :user_uuid
+			or 'user_' || left(replace(CAST(u.uuid AS text), '-', ''), 24) = :user_uuid
+		  )
+		limit 1
+	`
+)
+
 type PlatformAuthTx struct {
-	tx pgx.Tx
+	tx *sqlx.Tx
 }
 
 type PlatformAuthTxStore interface {
@@ -85,69 +141,59 @@ type PlatformAuthTxStore interface {
 }
 
 func (d *DB) WithPlatformAuthTx(ctx context.Context, fn func(PlatformAuthTxStore) error) error {
-	if d == nil || d.Pool == nil {
+	if d == nil || d.sql == nil {
 		return ErrNotFound
 	}
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	defer func() { _ = tx.Rollback() }()
 
 	if err := fn(PlatformAuthTx{tx: tx}); err != nil {
 		return err
 	}
-	return tx.Commit(ctx)
+	return tx.Commit()
 }
 
 func (tx PlatformAuthTx) FindUserContextByEmail(ctx context.Context, email string) (PlatformAuthUserContext, error) {
-	var out PlatformAuthUserContext
 	if strings.TrimSpace(email) == "" {
-		return out, ErrNotFound
+		return PlatformAuthUserContext{}, ErrNotFound
 	}
-	err := tx.tx.QueryRow(ctx, `
-		select u.external_id, o.uuid::text
-		from users u
-		join organizations o on o.id = u.organization_id
-		where lower(u.email) = lower($1)
-		  and u.deleted_at is null
-		  and exists (
-			select 1
-			from workspace_members wm
-			where wm.organization_id = o.id
-			  and wm.user_id = u.id
-			  and wm.deleted_at is null
-		)
-		order by u.added_at asc, u.id asc
-		limit 1
-	`, strings.TrimSpace(email)).Scan(&out.UserExternalID, &out.OrgUUID)
+	var row platformAuthUserContextRow
+	err := namedGetContext(ctx, tx.tx, &row, findPlatformAuthUserContextQuery, map[string]any{
+		"email": strings.TrimSpace(email),
+	})
 	if err != nil {
 		return PlatformAuthUserContext{}, mapNoRows(err)
 	}
-	return out, nil
+	return PlatformAuthUserContext{UserExternalID: row.UserExternalID, OrgUUID: row.OrgUUID}, nil
 }
 
 func (tx PlatformAuthTx) UpdateEmptyUserName(ctx context.Context, userExternalID string, defaultName string) error {
-	_, err := tx.tx.Exec(ctx, `
+	_, err := namedExecContext(ctx, tx.tx, `
 			update users
-			set name = $2,
+			set name = :default_name,
 				updated_at = now()
-			where external_id = $1
+			where external_id = :user_external_id
 			  and name = ''
-		`, strings.TrimSpace(userExternalID), strings.TrimSpace(defaultName))
+		`, map[string]any{
+		"user_external_id": strings.TrimSpace(userExternalID),
+		"default_name":     strings.TrimSpace(defaultName),
+	})
 	return err
 }
 
 func (tx PlatformAuthTx) InsertOrganization(ctx context.Context, input PlatformAuthOrganizationInput) (PlatformAuthOrganizationRef, error) {
-	var out PlatformAuthOrganizationRef
-	if err := tx.tx.QueryRow(ctx, `
+	var row platformAuthOrganizationRefRow
+	if err := namedGetContext(ctx, tx.tx, &row, `
 		insert into organizations (external_id, name)
-		values ($1, $2)
-		returning id, uuid::text
-	`, input.ExternalID, input.Name).Scan(&out.ID, &out.UUID); err != nil {
+		values (:external_id, :name)
+		returning id, CAST(uuid AS text) AS uuid
+	`, map[string]any{"external_id": input.ExternalID, "name": input.Name}); err != nil {
 		return PlatformAuthOrganizationRef{}, err
 	}
-	return out, nil
+	return PlatformAuthOrganizationRef{ID: row.ID, UUID: row.UUID}, nil
 }
 
 func (tx PlatformAuthTx) InsertUser(ctx context.Context, input PlatformAuthUserInput) (PlatformAuthUserRef, error) {
@@ -156,11 +202,18 @@ func (tx PlatformAuthTx) InsertUser(ctx context.Context, input PlatformAuthUserI
 	if role == "" {
 		role = "admin"
 	}
-	if err := tx.tx.QueryRow(ctx, `
+	if err := namedGetContext(ctx, tx.tx, &out.ID, `
 		insert into users (uuid, external_id, organization_id, email, name, role)
-		values ($1, $2, $3, $4, $5, $6)
+		values (:uuid, :external_id, :organization_id, :email, :name, :role)
 		returning id
-	`, input.UUID, input.ExternalID, input.OrganizationID, input.Email, input.Name, role).Scan(&out.ID); err != nil {
+	`, map[string]any{
+		"uuid":            input.UUID,
+		"external_id":     input.ExternalID,
+		"organization_id": input.OrganizationID,
+		"email":           input.Email,
+		"name":            input.Name,
+		"role":            role,
+	}); err != nil {
 		return PlatformAuthUserRef{}, err
 	}
 	return out, nil
@@ -168,11 +221,17 @@ func (tx PlatformAuthTx) InsertUser(ctx context.Context, input PlatformAuthUserI
 
 func (tx PlatformAuthTx) InsertWorkspace(ctx context.Context, input PlatformAuthWorkspaceInput) (PlatformAuthWorkspaceRef, error) {
 	var out PlatformAuthWorkspaceRef
-	if err := tx.tx.QueryRow(ctx, `
+	if err := namedGetContext(ctx, tx.tx, &out.ID, `
 		insert into workspaces (uuid, external_id, organization_id, name, compartment_id)
-		values ($1, $2, $3, $4, $5)
+		values (:uuid, :external_id, :organization_id, :name, :compartment_id)
 		returning id
-	`, input.UUID, input.ExternalID, input.OrganizationID, input.Name, input.CompartmentID).Scan(&out.ID); err != nil {
+	`, map[string]any{
+		"uuid":            input.UUID,
+		"external_id":     input.ExternalID,
+		"organization_id": input.OrganizationID,
+		"name":            input.Name,
+		"compartment_id":  input.CompartmentID,
+	}); err != nil {
 		return PlatformAuthWorkspaceRef{}, err
 	}
 	return out, nil
@@ -183,13 +242,24 @@ func (tx PlatformAuthTx) InsertWorkspaceMember(ctx context.Context, input Platfo
 	if workspaceRole == "" {
 		workspaceRole = "workspace_admin"
 	}
-	_, err := tx.tx.Exec(ctx, `
+	_, err := namedExecContext(ctx, tx.tx, `
 		insert into workspace_members (
 			external_id, organization_id, workspace_id, workspace_external_id,
 			user_id, user_external_id, workspace_role
 		)
-		values ($1, $2, $3, $4, $5, $6, $7)
-	`, input.ExternalID, input.OrganizationID, input.WorkspaceID, input.WorkspaceExternalID, input.UserID, input.UserExternalID, workspaceRole)
+		values (
+			:external_id, :organization_id, :workspace_id, :workspace_external_id,
+			:user_id, :user_external_id, :workspace_role
+		)
+	`, map[string]any{
+		"external_id":           input.ExternalID,
+		"organization_id":       input.OrganizationID,
+		"workspace_id":          input.WorkspaceID,
+		"workspace_external_id": input.WorkspaceExternalID,
+		"user_id":               input.UserID,
+		"user_external_id":      input.UserExternalID,
+		"workspace_role":        workspaceRole,
+	})
 	return err
 }
 
@@ -202,64 +272,80 @@ func (tx PlatformAuthTx) InsertAPIKey(ctx context.Context, input PlatformAuthAPI
 	if name == "" {
 		name = "default"
 	}
-	_, err := tx.tx.Exec(ctx, `
+	_, err := namedExecContext(ctx, tx.tx, `
 		insert into api_keys (external_id, workspace_id, key_hash, status, created_by_user_id, name, partial_key_hint)
-		values ($1, $2, $3, $4, $5, $6, $7)
-	`, input.ExternalID, input.WorkspaceID, input.KeyHash, status, input.CreatedByUserID, name, input.PartialKeyHint)
+		values (
+			:external_id, :workspace_id, :key_hash, :status, :created_by_user_id,
+			:name, :partial_key_hint
+		)
+	`, map[string]any{
+		"external_id":        input.ExternalID,
+		"workspace_id":       input.WorkspaceID,
+		"key_hash":           input.KeyHash,
+		"status":             status,
+		"created_by_user_id": input.CreatedByUserID,
+		"name":               name,
+		"partial_key_hint":   input.PartialKeyHint,
+	})
 	return err
 }
 
 func (d *DB) ResolvePlatformSessionIdentity(ctx context.Context, input platformsession.CreateInput) (platformsession.Session, error) {
-	if d == nil || d.Pool == nil {
+	if d == nil || d.sql == nil {
 		return platformsession.Session{}, ErrNotFound
 	}
 	if strings.TrimSpace(input.SessionKey) == "" || strings.TrimSpace(input.UserUUID) == "" || strings.TrimSpace(input.OrgUUID) == "" {
 		return platformsession.Session{}, ErrNotFound
 	}
 
-	var session platformsession.Session
-	if err := d.Pool.QueryRow(ctx, `
-			select o.id, o.uuid::text, o.external_id,
-				w.id, w.uuid::text, w.external_id,
-				u.id, u.external_id,
-				ak.id, ak.external_id
-			from organizations o
-			join users u on u.organization_id = o.id
-			join lateral (
-				select id, uuid, external_id
-				from workspaces
-				where organization_id = o.id
-				  and archived_at is null
-				order by case when external_id = 'workspace_default' then 0 else 1 end, created_at asc, id asc
-				limit 1
-			) w on true
-			join lateral (
-				select id, external_id
-				from api_keys
-				where workspace_id = w.id
-				  and status = 'active'
-				  and (expires_at is null or expires_at > now())
-				order by case when external_id = 'api_key_default' then 0 else 1 end, created_at asc, id asc
-				limit 1
-		) ak on true
-		where (o.uuid::text = $1 or o.external_id = $1)
-		  and u.deleted_at is null
-			  and (
-				u.external_id = $2
-				or u.uuid::text = $2
-				or 'user_' || left(replace(u.uuid::text, '-', ''), 24) = $2
-			  )
-			limit 1
-		`, strings.TrimSpace(input.OrgUUID), strings.TrimSpace(input.UserUUID)).Scan(
-		&session.OrganizationID, &session.OrganizationUUID, &session.OrganizationExternalID,
-		&session.WorkspaceID, &session.WorkspaceUUID, &session.WorkspaceExternalID,
-		&session.UserID, &session.UserExternalID,
-		&session.APIKeyID, &session.APIKeyExternalID,
-	); err != nil {
+	var row platformSessionIdentityRow
+	if err := namedGetContext(ctx, d.sql, &row, resolvePlatformSessionIdentityQuery, map[string]any{
+		"org_uuid":  strings.TrimSpace(input.OrgUUID),
+		"user_uuid": strings.TrimSpace(input.UserUUID),
+	}); err != nil {
 		return platformsession.Session{}, mapNoRows(err)
 	}
+	session := row.session()
 	sessionUUID := uuid.NewString()
 	session.ExternalID = "platform_session_" + strings.ReplaceAll(sessionUUID, "-", "")
 	session.ExpiresAt = input.ExpiresAt
 	return session, nil
+}
+
+type platformAuthUserContextRow struct {
+	UserExternalID string `db:"user_external_id"`
+	OrgUUID        string `db:"org_uuid"`
+}
+
+type platformAuthOrganizationRefRow struct {
+	ID   int64  `db:"id"`
+	UUID string `db:"uuid"`
+}
+
+type platformSessionIdentityRow struct {
+	OrganizationID         int64  `db:"organization_id"`
+	OrganizationUUID       string `db:"organization_uuid"`
+	OrganizationExternalID string `db:"organization_external_id"`
+	WorkspaceID            int64  `db:"workspace_id"`
+	WorkspaceUUID          string `db:"workspace_uuid"`
+	WorkspaceExternalID    string `db:"workspace_external_id"`
+	UserID                 int64  `db:"user_id"`
+	UserExternalID         string `db:"user_external_id"`
+	APIKeyID               int64  `db:"api_key_id"`
+	APIKeyExternalID       string `db:"api_key_external_id"`
+}
+
+func (r platformSessionIdentityRow) session() platformsession.Session {
+	return platformsession.Session{
+		OrganizationID:         r.OrganizationID,
+		OrganizationUUID:       r.OrganizationUUID,
+		OrganizationExternalID: r.OrganizationExternalID,
+		WorkspaceID:            r.WorkspaceID,
+		WorkspaceUUID:          r.WorkspaceUUID,
+		WorkspaceExternalID:    r.WorkspaceExternalID,
+		UserID:                 r.UserID,
+		UserExternalID:         r.UserExternalID,
+		APIKeyID:               r.APIKeyID,
+		APIKeyExternalID:       r.APIKeyExternalID,
+	}
 }

--- a/internal/db/platform_auth_sqlx_test.go
+++ b/internal/db/platform_auth_sqlx_test.go
@@ -1,0 +1,79 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPlatformAuthQueriesUseSQLXNamedParameters(t *testing.T) {
+	t.Run("rejects a missing named argument", func(t *testing.T) {
+		if _, _, err := bindNamed(postgresRebinder{}, resolvePlatformSessionIdentityQuery, map[string]any{
+			"org_uuid": "org_test",
+		}); err == nil {
+			t.Fatal("bindNamed() error = nil, want missing user_uuid error")
+		}
+	})
+
+	tests := []struct {
+		name         string
+		query        string
+		arguments    map[string]any
+		wantArgCount int
+	}{
+		{
+			name:         "find user context",
+			query:        findPlatformAuthUserContextQuery,
+			arguments:    map[string]any{"email": "owner@example.com"},
+			wantArgCount: 1,
+		},
+		{
+			name:  "resolve session identity",
+			query: resolvePlatformSessionIdentityQuery,
+			arguments: map[string]any{
+				"org_uuid":  "org_test",
+				"user_uuid": "user_test",
+			},
+			wantArgCount: 5,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			query, arguments, err := bindNamed(postgresRebinder{}, test.query, test.arguments)
+			if err != nil {
+				t.Fatalf("bind named query: %v", err)
+			}
+			if strings.Contains(query, ":") {
+				t.Fatalf("query retains named parameter syntax: %q", query)
+			}
+			if strings.Contains(test.query, "::") {
+				t.Fatalf("query uses PostgreSQL cast shorthand: %q", test.query)
+			}
+			if len(arguments) != test.wantArgCount {
+				t.Fatalf("argument count = %d, want %d", len(arguments), test.wantArgCount)
+			}
+		})
+	}
+}
+
+func TestPlatformSessionIdentityRowMapping(t *testing.T) {
+	row := platformSessionIdentityRow{
+		OrganizationID:         1,
+		OrganizationUUID:       "org-uuid",
+		OrganizationExternalID: "org_test",
+		WorkspaceID:            2,
+		WorkspaceUUID:          "workspace-uuid",
+		WorkspaceExternalID:    "workspace_test",
+		UserID:                 3,
+		UserExternalID:         "user_test",
+		APIKeyID:               4,
+		APIKeyExternalID:       "api_key_test",
+	}
+
+	session := row.session()
+	if session.OrganizationID != row.OrganizationID ||
+		session.WorkspaceExternalID != row.WorkspaceExternalID ||
+		session.APIKeyExternalID != row.APIKeyExternalID {
+		t.Fatalf("session = %#v, want values from row %#v", session, row)
+	}
+}


### PR DESCRIPTION
## Summary

- migrate platform-auth provisioning and identity resolution from native pgx calls to sqlx
- change the complete platform-auth store transaction wrapper to `sqlx.Tx`
- add binding and row-mapping coverage for user-context and platform-session identity queries

## Validation

- `go test ./internal/db -run 'TestPlatform(AuthQueriesUseSQLXNamedParameters|SessionIdentityRowMapping)' -count=1`
- `go test ./tests -run 'Test(PlatformEmailLoginRoutes|SessionsPlatformSessionAccess)$' -count=1`
- managed pre-commit quality gates

## Design docs

No update required: authentication behavior, resource provisioning, session identity, and transaction boundaries are unchanged.
