### PR TITLE
refactor(db): migrate skills to sqlx

### DIFF
--- a/internal/db/builtin_skills.go
+++ b/internal/db/builtin_skills.go
@@ -2,11 +2,145 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
+)
 
-	"github.com/jackc/pgx/v5"
+const (
+	builtinSkillColumns = `
+		id,
+		CAST(uuid AS text) AS uuid,
+		external_id,
+		display_title,
+		latest_version,
+		created_at,
+		updated_at,
+		deleted_at
+	`
+	builtinSkillVersionColumns = `
+		id,
+		CAST(uuid AS text) AS uuid,
+		external_id,
+		skill_id,
+		skill_external_id,
+		version,
+		name,
+		description,
+		directory,
+		s3_bucket,
+		s3_key,
+		size_bytes,
+		sha256,
+		created_at,
+		deleted_at
+	`
+	upsertBuiltinSkillQuery = `
+		insert into builtin_skills (
+			external_id, display_title, latest_version, created_at, updated_at, deleted_at
+		)
+		values (:external_id, :display_title, :latest_version, :created_at, :created_at, null)
+		on conflict (external_id) do update set
+			display_title = excluded.display_title,
+			latest_version = excluded.latest_version,
+			updated_at = excluded.updated_at,
+			deleted_at = null
+		returning ` + builtinSkillColumns + `
+	`
+	upsertBuiltinSkillVersionQuery = `
+		insert into builtin_skill_versions (
+			external_id, skill_id, skill_external_id, version, name, description,
+			directory, s3_bucket, s3_key, size_bytes, sha256, created_at, deleted_at
+		)
+		values (
+			:external_id, :skill_id, :skill_external_id, :version, :name, :description,
+			:directory, :s3_bucket, :s3_key, :size_bytes, :sha256, :created_at, null
+		)
+		on conflict (skill_id, version) do update set
+			name = excluded.name,
+			description = excluded.description,
+			directory = excluded.directory,
+			s3_bucket = excluded.s3_bucket,
+			s3_key = excluded.s3_key,
+			size_bytes = excluded.size_bytes,
+			sha256 = excluded.sha256,
+			created_at = case
+				when builtin_skill_versions.deleted_at is not null then excluded.created_at
+				else builtin_skill_versions.created_at
+			end,
+			deleted_at = null
+		where builtin_skill_versions.sha256 = excluded.sha256
+		returning ` + builtinSkillVersionColumns + `
+	`
+	listBuiltinSkillsPageQuery = `
+		select ` + builtinSkillColumns + `
+		from builtin_skills
+		where deleted_at is null
+		order by created_at desc, id desc
+		limit :limit offset :offset
+	`
+	countBuiltinSkillsQuery = `
+		select count(*)
+		from builtin_skills
+		where deleted_at is null
+	`
+	getBuiltinSkillQuery = `
+		select ` + builtinSkillColumns + `
+		from builtin_skills
+		where external_id = :external_id and deleted_at is null
+	`
+	getBuiltinSkillIDQuery = `
+		select id
+		from builtin_skills
+		where external_id = :external_id and deleted_at is null
+	`
+	listBuiltinSkillVersionsPageQuery = `
+		select ` + builtinSkillVersionColumns + `
+		from builtin_skill_versions
+		where skill_id = :skill_id and deleted_at is null
+		order by created_at desc, id desc
+		limit :limit offset :offset
+	`
+	getBuiltinSkillVersionQuery = `
+		select ` + builtinSkillVersionColumns + `
+		from builtin_skill_versions
+		where skill_external_id = :skill_external_id
+			and version = :version
+			and deleted_at is null
+	`
+	listMissingBuiltinSkillVersionsQuery = `
+		select ` + builtinSkillVersionColumns + `
+		from builtin_skill_versions
+		where deleted_at is null
+			and not exists (
+				select 1
+				from jsonb_array_elements_text(CAST(:keep_external_ids AS jsonb)) AS kept(external_id)
+				where kept.external_id = builtin_skill_versions.skill_external_id
+			)
+		order by skill_external_id, version
+	`
+	softDeleteMissingBuiltinSkillVersionsQuery = `
+		update builtin_skill_versions
+		set deleted_at = :deleted_at
+		where deleted_at is null
+			and not exists (
+				select 1
+				from jsonb_array_elements_text(CAST(:keep_external_ids AS jsonb)) AS kept(external_id)
+				where kept.external_id = builtin_skill_versions.skill_external_id
+			)
+	`
+	softDeleteMissingBuiltinSkillsQuery = `
+		update builtin_skills
+		set deleted_at = :deleted_at,
+			updated_at = :deleted_at
+		where deleted_at is null
+			and not exists (
+				select 1
+				from jsonb_array_elements_text(CAST(:keep_external_ids AS jsonb)) AS kept(external_id)
+				where kept.external_id = builtin_skills.external_id
+			)
+	`
 )
 
 type BuiltinSkill struct {
@@ -49,25 +183,52 @@ type ListBuiltinSkillVersionsPageParams struct {
 	Offset          int
 }
 
-func (d *DB) UpsertBuiltinSkillWithVersion(ctx context.Context, skill BuiltinSkill, version BuiltinSkillVersion) (BuiltinSkill, BuiltinSkillVersion, error) {
-	tx, err := d.Pool.Begin(ctx)
+type builtinSkillRow struct {
+	ID            int64      `db:"id"`
+	UUID          string     `db:"uuid"`
+	ExternalID    string     `db:"external_id"`
+	DisplayTitle  string     `db:"display_title"`
+	LatestVersion *string    `db:"latest_version"`
+	CreatedAt     time.Time  `db:"created_at"`
+	UpdatedAt     time.Time  `db:"updated_at"`
+	DeletedAt     *time.Time `db:"deleted_at"`
+}
+
+type builtinSkillVersionRow struct {
+	ID              int64      `db:"id"`
+	UUID            string     `db:"uuid"`
+	ExternalID      string     `db:"external_id"`
+	SkillID         int64      `db:"skill_id"`
+	SkillExternalID string     `db:"skill_external_id"`
+	Version         string     `db:"version"`
+	Name            string     `db:"name"`
+	Description     string     `db:"description"`
+	Directory       string     `db:"directory"`
+	S3Bucket        string     `db:"s3_bucket"`
+	S3Key           string     `db:"s3_key"`
+	SizeBytes       int64      `db:"size_bytes"`
+	SHA256          string     `db:"sha256"`
+	CreatedAt       time.Time  `db:"created_at"`
+	DeletedAt       *time.Time `db:"deleted_at"`
+}
+
+func (d *DB) UpsertBuiltinSkillWithVersion(
+	ctx context.Context,
+	skill BuiltinSkill,
+	version BuiltinSkillVersion,
+) (BuiltinSkill, BuiltinSkillVersion, error) {
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return BuiltinSkill{}, BuiltinSkillVersion{}, err
 	}
-	defer tx.Rollback(ctx)
+	defer func() { _ = tx.Rollback() }()
 
-	createdSkill, err := scanBuiltinSkill(tx.QueryRow(ctx, `
-		insert into builtin_skills (
-			external_id, display_title, latest_version, created_at, updated_at, deleted_at
-		)
-		values ($1, $2, $3, $4, $4, null)
-		on conflict (external_id) do update set
-			display_title = excluded.display_title,
-			latest_version = excluded.latest_version,
-			updated_at = excluded.updated_at,
-			deleted_at = null
-		returning id, uuid::text, external_id, display_title, latest_version, created_at, updated_at, deleted_at
-	`, skill.ExternalID, skill.DisplayTitle, version.Version, skill.CreatedAt))
+	createdSkill, err := getBuiltinSkillSQLX(ctx, tx, upsertBuiltinSkillQuery, map[string]any{
+		"external_id":    skill.ExternalID,
+		"display_title":  skill.DisplayTitle,
+		"latest_version": version.Version,
+		"created_at":     skill.CreatedAt,
+	})
 	if err != nil {
 		return BuiltinSkill{}, BuiltinSkillVersion{}, err
 	}
@@ -76,65 +237,52 @@ func (d *DB) UpsertBuiltinSkillWithVersion(ctx context.Context, skill BuiltinSki
 	version.SkillExternalID = createdSkill.ExternalID
 	createdVersion, err := upsertBuiltinSkillVersion(ctx, tx, version)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) || errors.Is(err, ErrNotFound) {
+		if errors.Is(err, ErrNotFound) {
 			return BuiltinSkill{}, BuiltinSkillVersion{}, ErrVersionConflict
 		}
 		return BuiltinSkill{}, BuiltinSkillVersion{}, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return BuiltinSkill{}, BuiltinSkillVersion{}, err
 	}
 	return createdSkill, createdVersion, nil
 }
 
-func upsertBuiltinSkillVersion(ctx context.Context, tx skillTx, version BuiltinSkillVersion) (BuiltinSkillVersion, error) {
-	return scanBuiltinSkillVersion(tx.QueryRow(ctx, `
-		insert into builtin_skill_versions (
-			external_id, skill_id, skill_external_id, version, name, description,
-			directory, s3_bucket, s3_key, size_bytes, sha256, created_at, deleted_at
-		)
-		values (
-			$1, $2, $3, $4, $5, $6,
-			$7, $8, $9, $10, $11, $12, null
-		)
-		on conflict (skill_id, version) do update set
-			name = excluded.name,
-			description = excluded.description,
-			directory = excluded.directory,
-			s3_bucket = excluded.s3_bucket,
-			s3_key = excluded.s3_key,
-			size_bytes = excluded.size_bytes,
-			sha256 = excluded.sha256,
-			created_at = case
-				when builtin_skill_versions.deleted_at is not null then excluded.created_at
-				else builtin_skill_versions.created_at
-			end,
-			deleted_at = null
-		where builtin_skill_versions.sha256 = excluded.sha256
-		returning id, uuid::text, external_id, skill_id, skill_external_id, version,
-			name, description, directory, s3_bucket, s3_key, size_bytes, sha256, created_at, deleted_at
-	`, version.ExternalID, version.SkillID, version.SkillExternalID, version.Version, version.Name, version.Description,
-		version.Directory, version.S3Bucket, version.S3Key, version.SizeBytes, version.SHA256, version.CreatedAt))
+func upsertBuiltinSkillVersion(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	version BuiltinSkillVersion,
+) (BuiltinSkillVersion, error) {
+	return getBuiltinSkillVersionSQLX(ctx, database, upsertBuiltinSkillVersionQuery, map[string]any{
+		"external_id":       version.ExternalID,
+		"skill_id":          version.SkillID,
+		"skill_external_id": version.SkillExternalID,
+		"version":           version.Version,
+		"name":              version.Name,
+		"description":       version.Description,
+		"directory":         version.Directory,
+		"s3_bucket":         version.S3Bucket,
+		"s3_key":            version.S3Key,
+		"size_bytes":        version.SizeBytes,
+		"sha256":            version.SHA256,
+		"created_at":        version.CreatedAt,
+	})
 }
 
-func (d *DB) ListBuiltinSkillsPage(ctx context.Context, params ListBuiltinSkillsPageParams) ([]BuiltinSkill, bool, error) {
+func (d *DB) ListBuiltinSkillsPage(
+	ctx context.Context,
+	params ListBuiltinSkillsPageParams,
+) ([]BuiltinSkill, bool, error) {
 	if params.Limit <= 0 {
 		params.Limit = 20
 	}
 	if params.Offset < 0 {
 		params.Offset = 0
 	}
-	rows, err := d.Pool.Query(ctx, builtinSkillSelectSQL()+`
-		where deleted_at is null
-		order by created_at desc, id desc
-		limit $1 offset $2
-	`, params.Limit+1, params.Offset)
-	if err != nil {
-		return nil, false, err
-	}
-	defer rows.Close()
-
-	skills, err := scanBuiltinSkillRows(rows)
+	skills, err := selectBuiltinSkillsSQLX(ctx, d.sql, listBuiltinSkillsPageQuery, map[string]any{
+		"limit":  params.Limit + 1,
+		"offset": params.Offset,
+	})
 	if err != nil {
 		return nil, false, err
 	}
@@ -147,21 +295,20 @@ func (d *DB) ListBuiltinSkillsPage(ctx context.Context, params ListBuiltinSkills
 
 func (d *DB) CountBuiltinSkills(ctx context.Context) (int, error) {
 	var count int
-	err := d.Pool.QueryRow(ctx, `
-		select count(*)
-		from builtin_skills
-		where deleted_at is null
-	`).Scan(&count)
+	err := namedGetContext(ctx, d.sql, &count, countBuiltinSkillsQuery, map[string]any{})
 	return count, err
 }
 
 func (d *DB) GetBuiltinSkill(ctx context.Context, externalID string) (BuiltinSkill, error) {
-	return scanBuiltinSkill(d.Pool.QueryRow(ctx, builtinSkillSelectSQL()+`
-		where external_id = $1 and deleted_at is null
-	`, externalID))
+	return getBuiltinSkillSQLX(ctx, d.sql, getBuiltinSkillQuery, map[string]any{
+		"external_id": externalID,
+	})
 }
 
-func (d *DB) ListBuiltinSkillVersionsPage(ctx context.Context, params ListBuiltinSkillVersionsPageParams) ([]BuiltinSkillVersion, bool, error) {
+func (d *DB) ListBuiltinSkillVersionsPage(
+	ctx context.Context,
+	params ListBuiltinSkillVersionsPageParams,
+) ([]BuiltinSkillVersion, bool, error) {
 	if params.Limit <= 0 {
 		params.Limit = 20
 	}
@@ -169,27 +316,21 @@ func (d *DB) ListBuiltinSkillVersionsPage(ctx context.Context, params ListBuilti
 		params.Offset = 0
 	}
 	var skillID int64
-	if err := d.Pool.QueryRow(ctx, `
-		select id
-		from builtin_skills
-		where external_id = $1 and deleted_at is null
-	`, params.SkillExternalID).Scan(&skillID); errors.Is(err, pgx.ErrNoRows) {
-		return nil, false, ErrNotFound
-	} else if err != nil {
-		return nil, false, err
+	if err := namedGetContext(ctx, d.sql, &skillID, getBuiltinSkillIDQuery, map[string]any{
+		"external_id": params.SkillExternalID,
+	}); err != nil {
+		return nil, false, mapNoRows(err)
 	}
-
-	rows, err := d.Pool.Query(ctx, builtinSkillVersionSelectSQL()+`
-		where skill_id = $1 and deleted_at is null
-		order by created_at desc, id desc
-		limit $2 offset $3
-	`, skillID, params.Limit+1, params.Offset)
-	if err != nil {
-		return nil, false, err
-	}
-	defer rows.Close()
-
-	versions, err := scanBuiltinSkillVersionRows(rows)
+	versions, err := selectBuiltinSkillVersionsSQLX(
+		ctx,
+		d.sql,
+		listBuiltinSkillVersionsPageQuery,
+		map[string]any{
+			"skill_id": skillID,
+			"limit":    params.Limit + 1,
+			"offset":   params.Offset,
+		},
+	)
 	if err != nil {
 		return nil, false, err
 	}
@@ -200,7 +341,11 @@ func (d *DB) ListBuiltinSkillVersionsPage(ctx context.Context, params ListBuilti
 	return versions, hasMore, nil
 }
 
-func (d *DB) GetBuiltinSkillVersion(ctx context.Context, skillExternalID, version string) (BuiltinSkillVersion, error) {
+func (d *DB) GetBuiltinSkillVersion(
+	ctx context.Context,
+	skillExternalID string,
+	version string,
+) (BuiltinSkillVersion, error) {
 	if version == "latest" {
 		skill, err := d.GetBuiltinSkill(ctx, skillExternalID)
 		if err != nil {
@@ -211,113 +356,141 @@ func (d *DB) GetBuiltinSkillVersion(ctx context.Context, skillExternalID, versio
 		}
 		version = *skill.LatestVersion
 	}
-	return scanBuiltinSkillVersion(d.Pool.QueryRow(ctx, builtinSkillVersionSelectSQL()+`
-		where skill_external_id = $1
-			and version = $2
-			and deleted_at is null
-	`, skillExternalID, version))
+	return getBuiltinSkillVersionSQLX(ctx, d.sql, getBuiltinSkillVersionQuery, map[string]any{
+		"skill_external_id": skillExternalID,
+		"version":           version,
+	})
 }
 
-func (d *DB) SoftDeleteMissingBuiltinSkills(ctx context.Context, keepExternalIDs []string, deletedAt time.Time) ([]BuiltinSkillVersion, error) {
-	tx, err := d.Pool.Begin(ctx)
+func (d *DB) SoftDeleteMissingBuiltinSkills(
+	ctx context.Context,
+	keepExternalIDs []string,
+	deletedAt time.Time,
+) ([]BuiltinSkillVersion, error) {
+	keepExternalIDsJSON, err := json.Marshal(append([]string{}, keepExternalIDs...))
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback(ctx)
+	arguments := map[string]any{
+		"keep_external_ids": keepExternalIDsJSON,
+		"deleted_at":        deletedAt,
+	}
+	tx, err := d.sql.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
 
-	rows, err := tx.Query(ctx, builtinSkillVersionSelectSQL()+`
-		where deleted_at is null
-			and skill_external_id <> all($1::text[])
-		order by skill_external_id, version
-	`, keepExternalIDs)
+	versions, err := selectBuiltinSkillVersionsSQLX(
+		ctx,
+		tx,
+		listMissingBuiltinSkillVersionsQuery,
+		arguments,
+	)
 	if err != nil {
 		return nil, err
 	}
-	versions, err := scanBuiltinSkillVersionRows(rows)
-	rows.Close()
-	if err != nil {
+	if _, err := namedExecContext(ctx, tx, softDeleteMissingBuiltinSkillVersionsQuery, arguments); err != nil {
 		return nil, err
 	}
-
-	if _, err := tx.Exec(ctx, `
-		update builtin_skill_versions
-		set deleted_at = $2
-		where deleted_at is null
-			and skill_external_id <> all($1::text[])
-	`, keepExternalIDs, deletedAt); err != nil {
+	if _, err := namedExecContext(ctx, tx, softDeleteMissingBuiltinSkillsQuery, arguments); err != nil {
 		return nil, err
 	}
-	if _, err := tx.Exec(ctx, `
-		update builtin_skills
-		set deleted_at = $2,
-			updated_at = $2
-		where deleted_at is null
-			and external_id <> all($1::text[])
-	`, keepExternalIDs, deletedAt); err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 	return versions, nil
 }
 
-func builtinSkillSelectSQL() string {
-	return `
-		select id, uuid::text, external_id, display_title, latest_version, created_at, updated_at, deleted_at
-		from builtin_skills
-	`
-}
-
-func builtinSkillVersionSelectSQL() string {
-	return `
-		select id, uuid::text, external_id, skill_id, skill_external_id, version,
-			name, description, directory, s3_bucket, s3_key, size_bytes, sha256, created_at, deleted_at
-		from builtin_skill_versions
-	`
-}
-
-func scanBuiltinSkill(row skillScanner) (BuiltinSkill, error) {
-	var skill BuiltinSkill
-	err := row.Scan(&skill.ID, &skill.UUID, &skill.ExternalID, &skill.DisplayTitle, &skill.LatestVersion,
-		&skill.CreatedAt, &skill.UpdatedAt, &skill.DeletedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return BuiltinSkill{}, ErrNotFound
+func getBuiltinSkillSQLX(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	query string,
+	arguments map[string]any,
+) (BuiltinSkill, error) {
+	var row builtinSkillRow
+	if err := namedGetContext(ctx, database, &row, query, arguments); err != nil {
+		return BuiltinSkill{}, mapNoRows(err)
 	}
-	return skill, err
+	return row.skill(), nil
 }
 
-func scanBuiltinSkillRows(rows skillRows) ([]BuiltinSkill, error) {
-	var skills []BuiltinSkill
-	for rows.Next() {
-		skill, err := scanBuiltinSkill(rows)
-		if err != nil {
-			return nil, err
-		}
-		skills = append(skills, skill)
+func selectBuiltinSkillsSQLX(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	query string,
+	arguments map[string]any,
+) ([]BuiltinSkill, error) {
+	var rows []builtinSkillRow
+	if err := namedSelectContext(ctx, database, &rows, query, arguments); err != nil {
+		return nil, err
 	}
-	return skills, rows.Err()
+	skills := make([]BuiltinSkill, 0, len(rows))
+	for _, row := range rows {
+		skills = append(skills, row.skill())
+	}
+	return skills, nil
 }
 
-func scanBuiltinSkillVersion(row skillScanner) (BuiltinSkillVersion, error) {
-	var version BuiltinSkillVersion
-	err := row.Scan(&version.ID, &version.UUID, &version.ExternalID, &version.SkillID, &version.SkillExternalID,
-		&version.Version, &version.Name, &version.Description, &version.Directory, &version.S3Bucket,
-		&version.S3Key, &version.SizeBytes, &version.SHA256, &version.CreatedAt, &version.DeletedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return BuiltinSkillVersion{}, ErrNotFound
+func getBuiltinSkillVersionSQLX(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	query string,
+	arguments map[string]any,
+) (BuiltinSkillVersion, error) {
+	var row builtinSkillVersionRow
+	if err := namedGetContext(ctx, database, &row, query, arguments); err != nil {
+		return BuiltinSkillVersion{}, mapNoRows(err)
 	}
-	return version, err
+	return row.skillVersion(), nil
 }
 
-func scanBuiltinSkillVersionRows(rows skillRows) ([]BuiltinSkillVersion, error) {
-	var versions []BuiltinSkillVersion
-	for rows.Next() {
-		version, err := scanBuiltinSkillVersion(rows)
-		if err != nil {
-			return nil, err
-		}
-		versions = append(versions, version)
+func selectBuiltinSkillVersionsSQLX(
+	ctx context.Context,
+	database sqlxNamedQueryer,
+	query string,
+	arguments map[string]any,
+) ([]BuiltinSkillVersion, error) {
+	var rows []builtinSkillVersionRow
+	if err := namedSelectContext(ctx, database, &rows, query, arguments); err != nil {
+		return nil, err
 	}
-	return versions, rows.Err()
+	versions := make([]BuiltinSkillVersion, 0, len(rows))
+	for _, row := range rows {
+		versions = append(versions, row.skillVersion())
+	}
+	return versions, nil
+}
+
+func (r builtinSkillRow) skill() BuiltinSkill {
+	return BuiltinSkill{
+		ID:            r.ID,
+		UUID:          r.UUID,
+		ExternalID:    r.ExternalID,
+		DisplayTitle:  r.DisplayTitle,
+		LatestVersion: r.LatestVersion,
+		CreatedAt:     r.CreatedAt,
+		UpdatedAt:     r.UpdatedAt,
+		DeletedAt:     r.DeletedAt,
+	}
+}
+
+func (r builtinSkillVersionRow) skillVersion() BuiltinSkillVersion {
+	return BuiltinSkillVersion{
+		ID:              r.ID,
+		UUID:            r.UUID,
+		ExternalID:      r.ExternalID,
+		SkillID:         r.SkillID,
+		SkillExternalID: r.SkillExternalID,
+		Version:         r.Version,
+		Name:            r.Name,
+		Description:     r.Description,
+		Directory:       r.Directory,
+		S3Bucket:        r.S3Bucket,
+		S3Key:           r.S3Key,
+		SizeBytes:       r.SizeBytes,
+		SHA256:          r.SHA256,
+		CreatedAt:       r.CreatedAt,
+		DeletedAt:       r.DeletedAt,
+	}
 }

--- a/internal/db/builtin_skills_sqlx_test.go
+++ b/internal/db/builtin_skills_sqlx_test.go
@@ -1,0 +1,131 @@
+package db
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuiltinSkillQueriesUseSQLXNamedParameters(t *testing.T) {
+	now := time.Date(2026, time.July, 27, 14, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name         string
+		query        string
+		arguments    map[string]any
+		wantArgCount int
+	}{
+		{
+			name:  "upsert skill",
+			query: upsertBuiltinSkillQuery,
+			arguments: map[string]any{
+				"external_id":    "builtin_test",
+				"display_title":  "Test",
+				"latest_version": "20260727",
+				"created_at":     now,
+			},
+			wantArgCount: 5,
+		},
+		{
+			name:  "upsert version",
+			query: upsertBuiltinSkillVersionQuery,
+			arguments: map[string]any{
+				"external_id":       "bsv_test",
+				"skill_id":          int64(1),
+				"skill_external_id": "builtin_test",
+				"version":           "20260727",
+				"name":              "test",
+				"description":       "Test",
+				"directory":         "test",
+				"s3_bucket":         "bucket",
+				"s3_key":            "key",
+				"size_bytes":        int64(10),
+				"sha256":            "sha",
+				"created_at":        now,
+			},
+			wantArgCount: 12,
+		},
+		{
+			name:  "list skills",
+			query: listBuiltinSkillsPageQuery,
+			arguments: map[string]any{
+				"limit":  21,
+				"offset": 0,
+			},
+			wantArgCount: 2,
+		},
+		{
+			name:         "count skills",
+			query:        countBuiltinSkillsQuery,
+			arguments:    map[string]any{},
+			wantArgCount: 0,
+		},
+		{
+			name:  "get skill",
+			query: getBuiltinSkillQuery,
+			arguments: map[string]any{
+				"external_id": "builtin_test",
+			},
+			wantArgCount: 1,
+		},
+		{
+			name:  "list versions",
+			query: listBuiltinSkillVersionsPageQuery,
+			arguments: map[string]any{
+				"skill_id": int64(1),
+				"limit":    21,
+				"offset":   0,
+			},
+			wantArgCount: 3,
+		},
+		{
+			name:  "get version",
+			query: getBuiltinSkillVersionQuery,
+			arguments: map[string]any{
+				"skill_external_id": "builtin_test",
+				"version":           "20260727",
+			},
+			wantArgCount: 2,
+		},
+		{
+			name:  "list missing versions",
+			query: listMissingBuiltinSkillVersionsQuery,
+			arguments: map[string]any{
+				"keep_external_ids": []byte(`["builtin_test"]`),
+			},
+			wantArgCount: 1,
+		},
+		{
+			name:  "soft delete missing versions",
+			query: softDeleteMissingBuiltinSkillVersionsQuery,
+			arguments: map[string]any{
+				"keep_external_ids": []byte(`["builtin_test"]`),
+				"deleted_at":        now,
+			},
+			wantArgCount: 2,
+		},
+		{
+			name:  "soft delete missing skills",
+			query: softDeleteMissingBuiltinSkillsQuery,
+			arguments: map[string]any{
+				"keep_external_ids": []byte(`["builtin_test"]`),
+				"deleted_at":        now,
+			},
+			wantArgCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, arguments, err := bindNamed(postgresRebinder{}, tt.query, tt.arguments)
+			if err != nil {
+				t.Fatalf("bindNamed() error = %v", err)
+			}
+			if len(arguments) != tt.wantArgCount {
+				t.Fatalf("bindNamed() arguments = %#v, want %d arguments", arguments, tt.wantArgCount)
+			}
+			if strings.Contains(query, ":") {
+				t.Fatalf("bound query still contains a named parameter: %s", query)
+			}
+		})
+	}
+}

--- a/internal/db/skills.go
+++ b/internal/db/skills.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"time"
 
@@ -44,6 +45,40 @@ type SkillVersion struct {
 	DeletedAt         *time.Time
 }
 
+type skillRow struct {
+	ID                int64      `db:"id"`
+	UUID              string     `db:"uuid"`
+	ExternalID        string     `db:"external_id"`
+	WorkspaceID       int64      `db:"workspace_id"`
+	CreatedByAPIKeyID int64      `db:"created_by_api_key_id"`
+	DisplayTitle      *string    `db:"display_title"`
+	LatestVersion     *string    `db:"latest_version"`
+	Source            string     `db:"source"`
+	CreatedAt         time.Time  `db:"created_at"`
+	UpdatedAt         time.Time  `db:"updated_at"`
+	DeletedAt         *time.Time `db:"deleted_at"`
+}
+
+type skillVersionRow struct {
+	ID                int64      `db:"id"`
+	UUID              string     `db:"uuid"`
+	ExternalID        string     `db:"external_id"`
+	WorkspaceID       int64      `db:"workspace_id"`
+	SkillID           int64      `db:"skill_id"`
+	SkillExternalID   string     `db:"skill_external_id"`
+	Version           string     `db:"version"`
+	Name              string     `db:"name"`
+	Description       string     `db:"description"`
+	Directory         string     `db:"directory"`
+	S3Bucket          string     `db:"s3_bucket"`
+	S3Key             string     `db:"s3_key"`
+	SizeBytes         int64      `db:"size_bytes"`
+	SHA256            string     `db:"sha256"`
+	CreatedByAPIKeyID int64      `db:"created_by_api_key_id"`
+	CreatedAt         time.Time  `db:"created_at"`
+	DeletedAt         *time.Time `db:"deleted_at"`
+}
+
 type ListSkillsPageParams struct {
 	WorkspaceID int64
 	Limit       int
@@ -66,42 +101,51 @@ func (e *SkillDisplayTitleConflictError) Error() string {
 }
 
 func (d *DB) CreateSkillWithVersion(ctx context.Context, skill Skill, version SkillVersion) (Skill, SkillVersion, error) {
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return Skill{}, SkillVersion{}, err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback()
 
 	if skill.DisplayTitle == nil {
 		return Skill{}, SkillVersion{}, ErrInvalidState
 	}
 
 	var existingID string
-	err = tx.QueryRow(ctx, `
+	err = namedGetContext(ctx, tx, &existingID, `
 		select external_id
 		from skills
-		where workspace_id = $1
-			and display_title = $2
+		where workspace_id = :workspace_id
+			and display_title = :display_title
 			and deleted_at is null
 		limit 1
-	`, skill.WorkspaceID, *skill.DisplayTitle).Scan(&existingID)
+	`, map[string]any{"workspace_id": skill.WorkspaceID, "display_title": *skill.DisplayTitle})
 	if err == nil {
 		return Skill{}, SkillVersion{}, &SkillDisplayTitleConflictError{DisplayTitle: *skill.DisplayTitle}
 	}
-	if !errors.Is(err, pgx.ErrNoRows) {
+	if !errors.Is(err, sql.ErrNoRows) {
 		return Skill{}, SkillVersion{}, err
 	}
 
-	createdSkill, err := scanSkill(tx.QueryRow(ctx, `
+	createdSkill, err := getSkillSQLX(ctx, tx, `
 		insert into skills (
 			uuid, external_id, workspace_id, created_by_api_key_id,
 			display_title, latest_version, source, created_at, updated_at
 		)
-		values ($1, $2, $3, $4, $5, $6, 'custom', $7, $7)
-		returning id, uuid::text, external_id, workspace_id, created_by_api_key_id,
-			display_title, latest_version, source, created_at, updated_at, deleted_at
-	`, skill.UUID, skill.ExternalID, skill.WorkspaceID, skill.CreatedByAPIKeyID,
-		skill.DisplayTitle, version.Version, skill.CreatedAt))
+		values (
+			:uuid, :external_id, :workspace_id, :created_by_api_key_id,
+			:display_title, :latest_version, 'custom', :created_at, :created_at
+		)
+		returning `+skillColumns()+`
+	`, map[string]any{
+		"uuid":                  skill.UUID,
+		"external_id":           skill.ExternalID,
+		"workspace_id":          skill.WorkspaceID,
+		"created_by_api_key_id": skill.CreatedByAPIKeyID,
+		"display_title":         skill.DisplayTitle,
+		"latest_version":        version.Version,
+		"created_at":            skill.CreatedAt,
+	})
 	if err != nil {
 		if isUniqueViolationOnConstraint(err, skillDisplayTitleUniqueIndex) {
 			return Skill{}, SkillVersion{}, &SkillDisplayTitleConflictError{DisplayTitle: *skill.DisplayTitle}
@@ -115,23 +159,23 @@ func (d *DB) CreateSkillWithVersion(ctx context.Context, skill Skill, version Sk
 	if err != nil {
 		return Skill{}, SkillVersion{}, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return Skill{}, SkillVersion{}, err
 	}
 	return createdSkill, createdVersion, nil
 }
 
 func (d *DB) CreateSkillVersion(ctx context.Context, workspaceID int64, skillExternalID string, version SkillVersion) (Skill, SkillVersion, error) {
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return Skill{}, SkillVersion{}, err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback()
 
-	skill, err := scanSkill(tx.QueryRow(ctx, skillSelectSQL()+`
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
+	skill, err := getSkillSQLX(ctx, tx, skillSelectSQL()+`
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
 		for update
-	`, workspaceID, skillExternalID))
+	`, map[string]any{"workspace_id": workspaceID, "external_id": skillExternalID})
 	if err != nil {
 		return Skill{}, SkillVersion{}, err
 	}
@@ -146,27 +190,31 @@ func (d *DB) CreateSkillVersion(ctx context.Context, workspaceID int64, skillExt
 	if err != nil {
 		return Skill{}, SkillVersion{}, err
 	}
-	updatedSkill, err := scanSkill(tx.QueryRow(ctx, `
+	updatedSkill, err := getSkillSQLX(ctx, tx, `
 		update skills
-		set latest_version = $3,
-			updated_at = $4
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
-		returning id, uuid::text, external_id, workspace_id, created_by_api_key_id,
-			display_title, latest_version, source, created_at, updated_at, deleted_at
-	`, workspaceID, skillExternalID, createdVersion.Version, createdVersion.CreatedAt))
+		set latest_version = :latest_version,
+			updated_at = :updated_at
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
+		returning `+skillColumns()+`
+	`, map[string]any{
+		"workspace_id":   workspaceID,
+		"external_id":    skillExternalID,
+		"latest_version": createdVersion.Version,
+		"updated_at":     createdVersion.CreatedAt,
+	})
 	if err != nil {
 		return Skill{}, SkillVersion{}, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return Skill{}, SkillVersion{}, err
 	}
 	return updatedSkill, createdVersion, nil
 }
 
 func (d *DB) GetSkill(ctx context.Context, workspaceID int64, externalID string) (Skill, error) {
-	return scanSkill(d.Pool.QueryRow(ctx, skillSelectSQL()+`
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
-	`, workspaceID, externalID))
+	return getSkillSQLX(ctx, d.sql, skillSelectSQL()+`
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
+	`, map[string]any{"workspace_id": workspaceID, "external_id": externalID})
 }
 
 func (d *DB) ListSkillsPage(ctx context.Context, params ListSkillsPageParams) ([]Skill, bool, error) {
@@ -176,17 +224,15 @@ func (d *DB) ListSkillsPage(ctx context.Context, params ListSkillsPageParams) ([
 	if params.Offset < 0 {
 		params.Offset = 0
 	}
-	rows, err := d.Pool.Query(ctx, skillSelectSQL()+`
-		where workspace_id = $1 and deleted_at is null
+	skills, err := selectSkillsSQLX(ctx, d.sql, skillSelectSQL()+`
+		where workspace_id = :workspace_id and deleted_at is null
 		order by created_at desc, id desc
-		limit $2 offset $3
-	`, params.WorkspaceID, params.Limit+1, params.Offset)
-	if err != nil {
-		return nil, false, err
-	}
-	defer rows.Close()
-
-	skills, err := scanSkillRows(rows)
+		limit :limit offset :offset
+	`, map[string]any{
+		"workspace_id": params.WorkspaceID,
+		"limit":        params.Limit + 1,
+		"offset":       params.Offset,
+	})
 	if err != nil {
 		return nil, false, err
 	}
@@ -198,17 +244,21 @@ func (d *DB) ListSkillsPage(ctx context.Context, params ListSkillsPageParams) ([
 }
 
 func (d *DB) GetSkillVersion(ctx context.Context, workspaceID int64, skillExternalID, version string) (SkillVersion, error) {
-	return scanSkillVersion(d.Pool.QueryRow(ctx, skillVersionSelectSQL()+`
-			where workspace_id = $1
-				and skill_external_id = $2
-				and version = $3
+	return getSkillVersionSQLX(ctx, d.sql, skillVersionSelectSQL()+`
+			where workspace_id = :workspace_id
+				and skill_external_id = :skill_external_id
+				and version = :version
 				and deleted_at is null
-		`, workspaceID, skillExternalID, version))
+		`, map[string]any{
+		"workspace_id":      workspaceID,
+		"skill_external_id": skillExternalID,
+		"version":           version,
+	})
 }
 
 func (d *DB) GetLatestSkillVersion(ctx context.Context, workspaceID int64, skillExternalID string) (SkillVersion, error) {
-	return scanSkillVersion(d.Pool.QueryRow(ctx, `
-			select sv.id, sv.uuid::text, sv.external_id, sv.workspace_id, sv.skill_id, sv.skill_external_id,
+	return getSkillVersionSQLX(ctx, d.sql, `
+			select sv.id, CAST(sv.uuid AS text) AS uuid, sv.external_id, sv.workspace_id, sv.skill_id, sv.skill_external_id,
 				sv.version, sv.name, sv.description, sv.directory, sv.s3_bucket, sv.s3_key, sv.size_bytes, sv.sha256,
 				sv.created_by_api_key_id, sv.created_at, sv.deleted_at
 			from skills s
@@ -216,12 +266,12 @@ func (d *DB) GetLatestSkillVersion(ctx context.Context, workspaceID int64, skill
 				on sv.skill_id = s.id
 				and sv.version = s.latest_version
 				and sv.deleted_at is null
-			where s.workspace_id = $1
-				and s.external_id = $2
+			where s.workspace_id = :workspace_id
+				and s.external_id = :skill_external_id
 				and s.deleted_at is null
 				and s.latest_version is not null
 				and s.latest_version <> ''
-		`, workspaceID, skillExternalID))
+		`, map[string]any{"workspace_id": workspaceID, "skill_external_id": skillExternalID})
 }
 
 func (d *DB) ListSkillVersionsPage(ctx context.Context, params ListSkillVersionsPageParams) ([]SkillVersion, bool, error) {
@@ -232,27 +282,24 @@ func (d *DB) ListSkillVersionsPage(ctx context.Context, params ListSkillVersions
 		params.Offset = 0
 	}
 	var skillID int64
-	if err := d.Pool.QueryRow(ctx, `
+	if err := namedGetContext(ctx, d.sql, &skillID, `
 		select id
 		from skills
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
-	`, params.WorkspaceID, params.SkillExternalID).Scan(&skillID); errors.Is(err, pgx.ErrNoRows) {
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
+	`, map[string]any{
+		"workspace_id": params.WorkspaceID,
+		"external_id":  params.SkillExternalID,
+	}); errors.Is(err, sql.ErrNoRows) {
 		return nil, false, ErrNotFound
 	} else if err != nil {
 		return nil, false, err
 	}
 
-	rows, err := d.Pool.Query(ctx, skillVersionSelectSQL()+`
-		where skill_id = $1 and deleted_at is null
+	versions, err := selectSkillVersionsSQLX(ctx, d.sql, skillVersionSelectSQL()+`
+		where skill_id = :skill_id and deleted_at is null
 		order by created_at desc, id desc
-		limit $2 offset $3
-	`, skillID, params.Limit+1, params.Offset)
-	if err != nil {
-		return nil, false, err
-	}
-	defer rows.Close()
-
-	versions, err := scanSkillVersionRows(rows)
+		limit :limit offset :offset
+	`, map[string]any{"skill_id": skillID, "limit": params.Limit + 1, "offset": params.Offset})
 	if err != nil {
 		return nil, false, err
 	}
@@ -264,94 +311,86 @@ func (d *DB) ListSkillVersionsPage(ctx context.Context, params ListSkillVersions
 }
 
 func (d *DB) SoftDeleteSkill(ctx context.Context, workspaceID int64, externalID string) (Skill, []SkillVersion, error) {
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return Skill{}, nil, err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback()
 
-	skill, err := scanSkill(tx.QueryRow(ctx, skillSelectSQL()+`
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
+	skill, err := getSkillSQLX(ctx, tx, skillSelectSQL()+`
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
 		for update
-	`, workspaceID, externalID))
+	`, map[string]any{"workspace_id": workspaceID, "external_id": externalID})
 	if err != nil {
 		return Skill{}, nil, err
 	}
 
-	rows, err := tx.Query(ctx, skillVersionSelectSQL()+`
-		where skill_id = $1 and deleted_at is null
+	versions, err := selectSkillVersionsSQLX(ctx, tx, skillVersionSelectSQL()+`
+		where skill_id = :skill_id and deleted_at is null
 		order by created_at desc, id desc
-	`, skill.ID)
-	if err != nil {
-		return Skill{}, nil, err
-	}
-	versions, err := scanSkillVersionRows(rows)
-	rows.Close()
+	`, map[string]any{"skill_id": skill.ID})
 	if err != nil {
 		return Skill{}, nil, err
 	}
 
-	if _, err := tx.Exec(ctx, `
+	if _, err := namedExecContext(ctx, tx, `
 		update skill_versions
 		set deleted_at = now()
-		where skill_id = $1 and deleted_at is null
-	`, skill.ID); err != nil {
+		where skill_id = :skill_id and deleted_at is null
+	`, map[string]any{"skill_id": skill.ID}); err != nil {
 		return Skill{}, nil, err
 	}
-	deletedSkill, err := scanSkill(tx.QueryRow(ctx, `
+	deletedSkill, err := getSkillSQLX(ctx, tx, `
 		update skills
 		set deleted_at = now(),
 			updated_at = now()
-		where id = $1 and deleted_at is null
-		returning id, uuid::text, external_id, workspace_id, created_by_api_key_id,
-			display_title, latest_version, source, created_at, updated_at, deleted_at
-	`, skill.ID))
+		where id = :skill_id and deleted_at is null
+		returning `+skillColumns()+`
+	`, map[string]any{"skill_id": skill.ID})
 	if err != nil {
 		return Skill{}, nil, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return Skill{}, nil, err
 	}
 	return deletedSkill, versions, nil
 }
 
 func (d *DB) SoftDeleteSkillVersion(ctx context.Context, workspaceID int64, skillExternalID, version string) (SkillVersion, *string, error) {
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return SkillVersion{}, nil, err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback()
 
-	skill, err := scanSkill(tx.QueryRow(ctx, skillSelectSQL()+`
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
+	skill, err := getSkillSQLX(ctx, tx, skillSelectSQL()+`
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
 		for update
-	`, workspaceID, skillExternalID))
+	`, map[string]any{"workspace_id": workspaceID, "external_id": skillExternalID})
 	if err != nil {
 		return SkillVersion{}, nil, err
 	}
 
-	deletedVersion, err := scanSkillVersion(tx.QueryRow(ctx, `
+	deletedVersion, err := getSkillVersionSQLX(ctx, tx, `
 		update skill_versions
 		set deleted_at = now()
-		where skill_id = $1 and version = $2 and deleted_at is null
-		returning id, uuid::text, external_id, workspace_id, skill_id, skill_external_id,
-			version, name, description, directory, s3_bucket, s3_key, size_bytes, sha256,
-			created_by_api_key_id, created_at, deleted_at
-	`, skill.ID, version))
+		where skill_id = :skill_id and version = :version and deleted_at is null
+		returning `+skillVersionColumns()+`
+	`, map[string]any{"skill_id": skill.ID, "version": version})
 	if err != nil {
 		return SkillVersion{}, nil, err
 	}
 
 	var latestVersion *string
 	var latest string
-	err = tx.QueryRow(ctx, `
+	err = namedGetContext(ctx, tx, &latest, `
 		select version
 		from skill_versions
-		where skill_id = $1 and deleted_at is null
+		where skill_id = :skill_id and deleted_at is null
 		order by created_at desc, id desc
 		limit 1
-	`, skill.ID).Scan(&latest)
-	if errors.Is(err, pgx.ErrNoRows) {
+	`, map[string]any{"skill_id": skill.ID})
+	if errors.Is(err, sql.ErrNoRows) {
 		latestVersion = nil
 	} else if err != nil {
 		return SkillVersion{}, nil, err
@@ -359,59 +398,160 @@ func (d *DB) SoftDeleteSkillVersion(ctx context.Context, workspaceID int64, skil
 		latestVersion = &latest
 	}
 
-	if _, err := tx.Exec(ctx, `
+	if _, err := namedExecContext(ctx, tx, `
 		update skills
-		set latest_version = $2,
+		set latest_version = :latest_version,
 			updated_at = now()
-		where id = $1
-	`, skill.ID, latestVersion); err != nil {
+		where id = :skill_id
+	`, map[string]any{"skill_id": skill.ID, "latest_version": latestVersion}); err != nil {
 		return SkillVersion{}, nil, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return SkillVersion{}, nil, err
 	}
 	return deletedVersion, latestVersion, nil
 }
 
-type skillTx interface {
-	QueryRow(context.Context, string, ...any) pgx.Row
-}
-
-func insertSkillVersion(ctx context.Context, tx skillTx, version SkillVersion) (SkillVersion, error) {
-	return scanSkillVersion(tx.QueryRow(ctx, `
+const insertSkillVersionQuery = `
 		insert into skill_versions (
 			uuid, external_id, workspace_id, skill_id, skill_external_id, version,
 			name, description, directory, s3_bucket, s3_key, size_bytes, sha256,
 			created_by_api_key_id, created_at
 		)
 		values (
-			$1, $2, $3, $4, $5, $6,
-			$7, $8, $9, $10, $11, $12, $13,
-			$14, $15
+			:uuid, :external_id, :workspace_id, :skill_id, :skill_external_id, :version,
+			:name, :description, :directory, :s3_bucket, :s3_key, :size_bytes, :sha256,
+			:created_by_api_key_id, :created_at
 		)
-		returning id, uuid::text, external_id, workspace_id, skill_id, skill_external_id,
+		returning ` + `id, CAST(uuid AS text) AS uuid, external_id, workspace_id, skill_id, skill_external_id,
 			version, name, description, directory, s3_bucket, s3_key, size_bytes, sha256,
-			created_by_api_key_id, created_at, deleted_at
-	`, version.UUID, version.ExternalID, version.WorkspaceID, version.SkillID, version.SkillExternalID,
-		version.Version, version.Name, version.Description, version.Directory, version.S3Bucket,
-		version.S3Key, version.SizeBytes, version.SHA256, version.CreatedByAPIKeyID, version.CreatedAt))
+			created_by_api_key_id, created_at, deleted_at`
+
+func insertSkillVersion(ctx context.Context, database sqlxNamedQueryer, version SkillVersion) (SkillVersion, error) {
+	return getSkillVersionSQLX(ctx, database, insertSkillVersionQuery, map[string]any{
+		"uuid":                  version.UUID,
+		"external_id":           version.ExternalID,
+		"workspace_id":          version.WorkspaceID,
+		"skill_id":              version.SkillID,
+		"skill_external_id":     version.SkillExternalID,
+		"version":               version.Version,
+		"name":                  version.Name,
+		"description":           version.Description,
+		"directory":             version.Directory,
+		"s3_bucket":             version.S3Bucket,
+		"s3_key":                version.S3Key,
+		"size_bytes":            version.SizeBytes,
+		"sha256":                version.SHA256,
+		"created_by_api_key_id": version.CreatedByAPIKeyID,
+		"created_at":            version.CreatedAt,
+	})
 }
 
 func skillSelectSQL() string {
-	return `
-		select id, uuid::text, external_id, workspace_id, created_by_api_key_id,
-			display_title, latest_version, source, created_at, updated_at, deleted_at
-		from skills
-	`
+	return `select ` + skillColumns() + ` from skills`
 }
 
 func skillVersionSelectSQL() string {
-	return `
-		select id, uuid::text, external_id, workspace_id, skill_id, skill_external_id,
-			version, name, description, directory, s3_bucket, s3_key, size_bytes, sha256,
-			created_by_api_key_id, created_at, deleted_at
-		from skill_versions
-	`
+	return `select ` + skillVersionColumns() + ` from skill_versions`
+}
+
+func skillColumns() string {
+	return `id, CAST(uuid AS text) AS uuid, external_id, workspace_id, created_by_api_key_id,
+		display_title, latest_version, source, created_at, updated_at, deleted_at`
+}
+
+func skillVersionColumns() string {
+	return `id, CAST(uuid AS text) AS uuid, external_id, workspace_id, skill_id, skill_external_id,
+		version, name, description, directory, s3_bucket, s3_key, size_bytes, sha256,
+		created_by_api_key_id, created_at, deleted_at`
+}
+
+func getSkillSQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) (Skill, error) {
+	var row skillRow
+	if err := namedGetContext(ctx, database, &row, query, arguments); errors.Is(err, sql.ErrNoRows) {
+		return Skill{}, ErrNotFound
+	} else if err != nil {
+		return Skill{}, err
+	}
+	return row.skill(), nil
+}
+
+func selectSkillsSQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) ([]Skill, error) {
+	var rows []skillRow
+	if err := namedSelectContext(ctx, database, &rows, query, arguments); err != nil {
+		return nil, err
+	}
+	skills := make([]Skill, len(rows))
+	for index := range rows {
+		skills[index] = rows[index].skill()
+	}
+	return skills, nil
+}
+
+func getSkillVersionSQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) (SkillVersion, error) {
+	var row skillVersionRow
+	if err := namedGetContext(ctx, database, &row, query, arguments); errors.Is(err, sql.ErrNoRows) {
+		return SkillVersion{}, ErrNotFound
+	} else if err != nil {
+		return SkillVersion{}, err
+	}
+	return row.version(), nil
+}
+
+func selectSkillVersionsSQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) ([]SkillVersion, error) {
+	var rows []skillVersionRow
+	if err := namedSelectContext(ctx, database, &rows, query, arguments); err != nil {
+		return nil, err
+	}
+	versions := make([]SkillVersion, len(rows))
+	for index := range rows {
+		versions[index] = rows[index].version()
+	}
+	return versions, nil
+}
+
+func (r skillRow) skill() Skill {
+	return Skill{
+		ID:                r.ID,
+		UUID:              r.UUID,
+		ExternalID:        r.ExternalID,
+		WorkspaceID:       r.WorkspaceID,
+		CreatedByAPIKeyID: r.CreatedByAPIKeyID,
+		DisplayTitle:      r.DisplayTitle,
+		LatestVersion:     r.LatestVersion,
+		Source:            r.Source,
+		CreatedAt:         r.CreatedAt,
+		UpdatedAt:         r.UpdatedAt,
+		DeletedAt:         r.DeletedAt,
+	}
+}
+
+func (r skillVersionRow) version() SkillVersion {
+	return SkillVersion{
+		ID:                r.ID,
+		UUID:              r.UUID,
+		ExternalID:        r.ExternalID,
+		WorkspaceID:       r.WorkspaceID,
+		SkillID:           r.SkillID,
+		SkillExternalID:   r.SkillExternalID,
+		Version:           r.Version,
+		Name:              r.Name,
+		Description:       r.Description,
+		Directory:         r.Directory,
+		S3Bucket:          r.S3Bucket,
+		S3Key:             r.S3Key,
+		SizeBytes:         r.SizeBytes,
+		SHA256:            r.SHA256,
+		CreatedByAPIKeyID: r.CreatedByAPIKeyID,
+		CreatedAt:         r.CreatedAt,
+		DeletedAt:         r.DeletedAt,
+	}
+}
+
+// These legacy scanner interfaces are still used by builtin_skills.go. They can
+// be removed once that file's independent sqlx migration is merged.
+type skillTx interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
 }
 
 type skillScanner interface {
@@ -422,49 +562,4 @@ type skillRows interface {
 	Next() bool
 	Scan(dest ...any) error
 	Err() error
-}
-
-func scanSkill(row skillScanner) (Skill, error) {
-	var skill Skill
-	err := row.Scan(&skill.ID, &skill.UUID, &skill.ExternalID, &skill.WorkspaceID, &skill.CreatedByAPIKeyID,
-		&skill.DisplayTitle, &skill.LatestVersion, &skill.Source, &skill.CreatedAt, &skill.UpdatedAt, &skill.DeletedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return Skill{}, ErrNotFound
-	}
-	return skill, err
-}
-
-func scanSkillRows(rows skillRows) ([]Skill, error) {
-	var skills []Skill
-	for rows.Next() {
-		skill, err := scanSkill(rows)
-		if err != nil {
-			return nil, err
-		}
-		skills = append(skills, skill)
-	}
-	return skills, rows.Err()
-}
-
-func scanSkillVersion(row skillScanner) (SkillVersion, error) {
-	var version SkillVersion
-	err := row.Scan(&version.ID, &version.UUID, &version.ExternalID, &version.WorkspaceID, &version.SkillID, &version.SkillExternalID,
-		&version.Version, &version.Name, &version.Description, &version.Directory, &version.S3Bucket, &version.S3Key,
-		&version.SizeBytes, &version.SHA256, &version.CreatedByAPIKeyID, &version.CreatedAt, &version.DeletedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return SkillVersion{}, ErrNotFound
-	}
-	return version, err
-}
-
-func scanSkillVersionRows(rows skillRows) ([]SkillVersion, error) {
-	var versions []SkillVersion
-	for rows.Next() {
-		version, err := scanSkillVersion(rows)
-		if err != nil {
-			return nil, err
-		}
-		versions = append(versions, version)
-	}
-	return versions, rows.Err()
 }

--- a/internal/db/skills.go
+++ b/internal/db/skills.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"time"
-
-	"github.com/jackc/pgx/v5"
 )
 
 const skillDisplayTitleUniqueIndex = "skills_workspace_display_title_active_key"
@@ -546,20 +544,4 @@ func (r skillVersionRow) version() SkillVersion {
 		CreatedAt:         r.CreatedAt,
 		DeletedAt:         r.DeletedAt,
 	}
-}
-
-// These legacy scanner interfaces are still used by builtin_skills.go. They can
-// be removed once that file's independent sqlx migration is merged.
-type skillTx interface {
-	QueryRow(context.Context, string, ...any) pgx.Row
-}
-
-type skillScanner interface {
-	Scan(dest ...any) error
-}
-
-type skillRows interface {
-	Next() bool
-	Scan(dest ...any) error
-	Err() error
 }

--- a/internal/db/skills_sqlx_test.go
+++ b/internal/db/skills_sqlx_test.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSkillVersionInsertQueryBindsNamedArguments(t *testing.T) {
+	now := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
+	query, arguments, err := bindNamed(postgresRebinder{}, insertSkillVersionQuery, map[string]any{
+		"uuid":                  "11111111-1111-4111-8111-111111111111",
+		"external_id":           "skillv_test",
+		"workspace_id":          int64(1),
+		"skill_id":              int64(2),
+		"skill_external_id":     "skill_test",
+		"version":               "1.0.0",
+		"name":                  "test",
+		"description":           "test skill",
+		"directory":             "test",
+		"s3_bucket":             "bucket",
+		"s3_key":                "skills/test",
+		"size_bytes":            int64(42),
+		"sha256":                strings.Repeat("a", 64),
+		"created_by_api_key_id": int64(3),
+		"created_at":            now,
+	})
+	if err != nil {
+		t.Fatalf("bind named query: %v", err)
+	}
+	if strings.Contains(query, ":") {
+		t.Fatalf("query retains named parameter syntax: %q", query)
+	}
+	if len(arguments) != 15 {
+		t.Fatalf("argument count = %d, want 15", len(arguments))
+	}
+}
+
+func TestSkillSQLXColumnListsAvoidPostgreSQLShorthandCasts(t *testing.T) {
+	for _, columns := range []string{skillColumns(), skillVersionColumns()} {
+		if strings.Contains(columns, "::") {
+			t.Fatalf("column list contains shorthand cast that conflicts with sqlx named parsing: %q", columns)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- migrate custom skill CRUD, pagination, version management, and delete transactions to sqlx named queries
- use typed database rows and explicit mappings for skills and skill versions
- replace positional parameters, PostgreSQL shorthand casts, and the final pgx scanner adapters in `skills.go`
- add named-binding and column-list regression tests

## Dependency

This Draft PR is stacked on #169 because `builtin_skills.go` previously shared scanner interfaces declared in `skills.go`. With #169 as the base, those pgx-only compatibility interfaces are removed and `skills.go` is fully migrated.

## Validation

- `go test ./internal/db -run 'Test.*Skill' -count=1`
- `go test ./tests -run 'Test(Skills|RuntimeResolver)' -count=1`
- `just lint`
- `just dead-code`
- `just duplicates`
- `just complexity`
- `just large-files`
- managed pre-commit hook

## Design docs

No design document update is needed because this changes only the database access implementation without changing behavior, API contracts, schema, permissions, or state transitions.
