### PR TITLE
refactor(db): migrate memory to sqlx

### DIFF
--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"time"
-
-	"github.com/jackc/pgx/v5"
 )
 
 type MemoryStore struct {
@@ -178,144 +176,155 @@ func (e *MemoryPathConflictError) Error() string {
 }
 
 func (d *DB) CreateMemoryStore(ctx context.Context, store MemoryStore) (MemoryStore, error) {
-	return scanMemoryStore(d.Pool.QueryRow(ctx, `
+	return getMemoryStoreSQLX(ctx, d.sql, `
 		insert into memory_stores (
 			uuid, external_id, organization_id, workspace_id, created_by_api_key_id,
 			name, description, metadata, created_at, updated_at
 		)
-		values ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $9)
-		returning id, uuid::text, external_id, organization_id, workspace_id,
-			created_by_api_key_id, name, description, metadata, created_at, updated_at,
-			archived_at, deleted_at
-	`, store.UUID, store.ExternalID, store.OrganizationID, store.WorkspaceID, store.CreatedByAPIKeyID,
-		store.Name, store.Description, jsonArg(store.Metadata), store.CreatedAt))
+		values (
+			:uuid, :external_id, :organization_id, :workspace_id, :created_by_api_key_id,
+			:name, :description, CAST(:metadata AS jsonb), :created_at, :created_at
+		)
+		returning `+memoryStoreColumns()+`
+	`, map[string]any{
+		"uuid":                  store.UUID,
+		"external_id":           store.ExternalID,
+		"organization_id":       store.OrganizationID,
+		"workspace_id":          store.WorkspaceID,
+		"created_by_api_key_id": store.CreatedByAPIKeyID,
+		"name":                  store.Name,
+		"description":           store.Description,
+		"metadata":              jsonArg(store.Metadata),
+		"created_at":            store.CreatedAt,
+	})
 }
 
 func (d *DB) GetMemoryStore(ctx context.Context, workspaceID int64, externalID string) (MemoryStore, error) {
-	return scanMemoryStore(d.Pool.QueryRow(ctx, memoryStoreSelectSQL()+`
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
-	`, workspaceID, externalID))
+	return getMemoryStoreSQLX(ctx, d.sql, memoryStoreSelectSQL()+`
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
+	`, map[string]any{"workspace_id": workspaceID, "external_id": externalID})
 }
 
 func (d *DB) GetMemoryStoreByExternalID(ctx context.Context, externalID string) (MemoryStore, error) {
-	return scanMemoryStore(d.Pool.QueryRow(ctx, memoryStoreSelectSQL()+`
-		where external_id = $1 and deleted_at is null
-	`, externalID))
+	return getMemoryStoreSQLX(ctx, d.sql, memoryStoreSelectSQL()+`
+		where external_id = :external_id and deleted_at is null
+	`, map[string]any{"external_id": externalID})
 }
 
 func (d *DB) UpdateMemoryStore(ctx context.Context, workspaceID int64, externalID string, next MemoryStore) (MemoryStore, error) {
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return MemoryStore{}, err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback()
 
-	current, err := scanMemoryStore(tx.QueryRow(ctx, memoryStoreSelectSQL()+`
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
+	current, err := getMemoryStoreSQLX(ctx, tx, memoryStoreSelectSQL()+`
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
 		for update
-	`, workspaceID, externalID))
+	`, map[string]any{"workspace_id": workspaceID, "external_id": externalID})
 	if err != nil {
 		return MemoryStore{}, err
 	}
 	if current.ArchivedAt != nil {
 		return MemoryStore{}, ErrInvalidState
 	}
-	updated, err := scanMemoryStore(tx.QueryRow(ctx, `
+	updated, err := getMemoryStoreSQLX(ctx, tx, `
 		update memory_stores
-		set name = $3,
-			description = $4,
-			metadata = $5::jsonb,
-			updated_at = $6
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
-		returning id, uuid::text, external_id, organization_id, workspace_id,
-			created_by_api_key_id, name, description, metadata, created_at, updated_at,
-			archived_at, deleted_at
-	`, workspaceID, externalID, next.Name, next.Description, jsonArg(next.Metadata), next.UpdatedAt))
+		set name = :name,
+			description = :description,
+			metadata = CAST(:metadata AS jsonb),
+			updated_at = :updated_at
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
+		returning `+memoryStoreColumns()+`
+	`, map[string]any{
+		"workspace_id": workspaceID,
+		"external_id":  externalID,
+		"name":         next.Name,
+		"description":  next.Description,
+		"metadata":     jsonArg(next.Metadata),
+		"updated_at":   next.UpdatedAt,
+	})
 	if err != nil {
 		return MemoryStore{}, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return MemoryStore{}, err
 	}
 	return updated, nil
 }
 
 func (d *DB) ArchiveMemoryStore(ctx context.Context, workspaceID int64, externalID string) (MemoryStore, error) {
-	return scanMemoryStore(d.Pool.QueryRow(ctx, `
+	return getMemoryStoreSQLX(ctx, d.sql, `
 		update memory_stores
 		set archived_at = coalesce(archived_at, now()),
 			updated_at = now()
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
-		returning id, uuid::text, external_id, organization_id, workspace_id,
-			created_by_api_key_id, name, description, metadata, created_at, updated_at,
-			archived_at, deleted_at
-	`, workspaceID, externalID))
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
+		returning `+memoryStoreColumns()+`
+	`, map[string]any{"workspace_id": workspaceID, "external_id": externalID})
 }
 
 func (d *DB) DeleteMemoryStore(ctx context.Context, workspaceID int64, externalID string) ([]ObjectRef, error) {
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback()
 
 	var storeID int64
-	if err := tx.QueryRow(ctx, `
+	arguments := map[string]any{"workspace_id": workspaceID, "external_id": externalID}
+	if err := namedGetContext(ctx, tx, &storeID, `
 		select id
 		from memory_stores
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
 		for update
-	`, workspaceID, externalID).Scan(&storeID); errors.Is(err, pgx.ErrNoRows) {
+	`, arguments); errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	} else if err != nil {
 		return nil, err
 	}
 
-	rows, err := tx.Query(ctx, `
-		select workspace_id, coalesce(s3_bucket, ''), coalesce(s3_key, ''), external_id
+	var refRows []objectRefRow
+	arguments["store_id"] = storeID
+	if err := namedSelectContext(ctx, tx, &refRows, `
+		select workspace_id, coalesce(s3_bucket, '') AS bucket,
+			coalesce(s3_key, '') AS key, external_id AS resource_id
 		from memory_versions
-		where workspace_id = $1
-			and memory_store_id = $2
+		where workspace_id = :workspace_id
+			and memory_store_id = :store_id
 			and s3_key is not null
-	`, workspaceID, storeID)
-	if err != nil {
+	`, arguments); err != nil {
 		return nil, err
 	}
-	var refs []ObjectRef
-	for rows.Next() {
-		var ref ObjectRef
-		if err := rows.Scan(&ref.WorkspaceID, &ref.Bucket, &ref.Key, &ref.ResourceID); err != nil {
-			rows.Close()
-			return nil, err
+	refs := make([]ObjectRef, len(refRows))
+	for index := range refRows {
+		refs[index] = ObjectRef{
+			WorkspaceID:  refRows[index].WorkspaceID,
+			Bucket:       refRows[index].Bucket,
+			Key:          refRows[index].Key,
+			ResourceType: "memory_version",
+			ResourceID:   refRows[index].ResourceID,
 		}
-		ref.ResourceType = "memory_version"
-		refs = append(refs, ref)
 	}
-	if err := rows.Err(); err != nil {
-		rows.Close()
-		return nil, err
-	}
-	rows.Close()
 
-	if _, err := tx.Exec(ctx, `
+	if _, err := namedExecContext(ctx, tx, `
 		delete from memory_versions
-		where workspace_id = $1 and memory_store_id = $2
-	`, workspaceID, storeID); err != nil {
+		where workspace_id = :workspace_id and memory_store_id = :store_id
+	`, arguments); err != nil {
 		return nil, err
 	}
-	if _, err := tx.Exec(ctx, `
+	if _, err := namedExecContext(ctx, tx, `
 		delete from memories
-		where workspace_id = $1 and memory_store_id = $2
-	`, workspaceID, storeID); err != nil {
+		where workspace_id = :workspace_id and memory_store_id = :store_id
+	`, arguments); err != nil {
 		return nil, err
 	}
-	if _, err := tx.Exec(ctx, `
+	if _, err := namedExecContext(ctx, tx, `
 		delete from memory_stores
-		where workspace_id = $1 and id = $2
-	`, workspaceID, storeID); err != nil {
+		where workspace_id = :workspace_id and id = :store_id
+	`, arguments); err != nil {
 		return nil, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 	return refs, nil
@@ -326,37 +335,28 @@ func (d *DB) ListMemoryStoresPage(ctx context.Context, params ListMemoryStoresPa
 		params.Limit = 20
 	}
 	query := memoryStoreSelectSQL() + `
-		where workspace_id = $1 and deleted_at is null
+		where workspace_id = :workspace_id and deleted_at is null
 	`
-	args := []any{params.WorkspaceID}
-	nextArg := 2
+	arguments := map[string]any{"workspace_id": params.WorkspaceID, "limit": params.Limit + 1}
 	if !params.IncludeArchived {
 		query += " and archived_at is null"
 	}
 	if params.CreatedAtGTE != nil {
-		query += fmt.Sprintf(" and created_at >= $%d", nextArg)
-		args = append(args, *params.CreatedAtGTE)
-		nextArg++
+		query += " and created_at >= :created_at_gte"
+		arguments["created_at_gte"] = *params.CreatedAtGTE
 	}
 	if params.CreatedAtLTE != nil {
-		query += fmt.Sprintf(" and created_at <= $%d", nextArg)
-		args = append(args, *params.CreatedAtLTE)
-		nextArg++
+		query += " and created_at <= :created_at_lte"
+		arguments["created_at_lte"] = *params.CreatedAtLTE
 	}
 	if params.Cursor != nil {
-		query += fmt.Sprintf(" and (created_at < $%d or (created_at = $%d and id < $%d))", nextArg, nextArg, nextArg+1)
-		args = append(args, params.Cursor.CreatedAt, params.Cursor.ID)
-		nextArg += 2
+		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and id < :cursor_id))"
+		arguments["cursor_created_at"] = params.Cursor.CreatedAt
+		arguments["cursor_id"] = params.Cursor.ID
 	}
-	query += fmt.Sprintf(" order by created_at desc, id desc limit $%d", nextArg)
-	args = append(args, params.Limit+1)
+	query += " order by created_at desc, id desc limit :limit"
 
-	rows, err := d.Pool.Query(ctx, query, args...)
-	if err != nil {
-		return nil, false, err
-	}
-	defer rows.Close()
-	stores, err := scanMemoryStoreRows(rows)
+	stores, err := selectMemoryStoresSQLX(ctx, d.sql, query, arguments)
 	if err != nil {
 		return nil, false, err
 	}
@@ -368,16 +368,16 @@ func (d *DB) ListMemoryStoresPage(ctx context.Context, params ListMemoryStoresPa
 }
 
 func (d *DB) CreateMemory(ctx context.Context, memory Memory, version MemoryVersion) (Memory, error) {
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return Memory{}, err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback()
 
-	store, err := scanMemoryStore(tx.QueryRow(ctx, memoryStoreSelectSQL()+`
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
+	store, err := getMemoryStoreSQLX(ctx, tx, memoryStoreSelectSQL()+`
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
 		for update
-	`, memory.WorkspaceID, memory.MemoryStoreExternalID))
+	`, map[string]any{"workspace_id": memory.WorkspaceID, "external_id": memory.MemoryStoreExternalID})
 	if err != nil {
 		return Memory{}, err
 	}
@@ -388,20 +388,33 @@ func (d *DB) CreateMemory(ctx context.Context, memory Memory, version MemoryVers
 		return Memory{}, err
 	}
 
-	created, err := scanMemory(tx.QueryRow(ctx, `
+	created, err := getMemorySQLX(ctx, tx, `
 		insert into memories (
 			uuid, external_id, organization_id, workspace_id, memory_store_id,
 			memory_store_external_id, current_version_external_id, path,
 			content_size_bytes, content_sha256, s3_bucket, s3_key, created_at, updated_at
 		)
-		values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $13)
-		returning id, uuid::text, external_id, organization_id, workspace_id,
-			memory_store_id, memory_store_external_id, coalesce(current_version_id, 0),
-			coalesce(current_version_external_id, ''), path, content_size_bytes,
-			content_sha256, s3_bucket, s3_key, created_at, updated_at, deleted_at
-	`, memory.UUID, memory.ExternalID, store.OrganizationID, store.WorkspaceID, store.ID,
-		store.ExternalID, version.ExternalID, memory.Path, memory.ContentSizeBytes,
-		memory.ContentSHA256, memory.S3Bucket, memory.S3Key, memory.CreatedAt))
+		values (
+			:uuid, :external_id, :organization_id, :workspace_id, :memory_store_id,
+			:memory_store_external_id, :current_version_external_id, :path,
+			:content_size_bytes, :content_sha256, :s3_bucket, :s3_key, :created_at, :created_at
+		)
+		returning `+memoryColumns()+`
+	`, map[string]any{
+		"uuid":                        memory.UUID,
+		"external_id":                 memory.ExternalID,
+		"organization_id":             store.OrganizationID,
+		"workspace_id":                store.WorkspaceID,
+		"memory_store_id":             store.ID,
+		"memory_store_external_id":    store.ExternalID,
+		"current_version_external_id": version.ExternalID,
+		"path":                        memory.Path,
+		"content_size_bytes":          memory.ContentSizeBytes,
+		"content_sha256":              memory.ContentSHA256,
+		"s3_bucket":                   memory.S3Bucket,
+		"s3_key":                      memory.S3Key,
+		"created_at":                  memory.CreatedAt,
+	})
 	if isUniqueViolation(err) {
 		return Memory{}, d.memoryPathConflict(ctx, tx, store.ID, memory.Path)
 	}
@@ -419,40 +432,46 @@ func (d *DB) CreateMemory(ctx context.Context, memory Memory, version MemoryVers
 	if err != nil {
 		return Memory{}, err
 	}
-	updated, err := scanMemory(tx.QueryRow(ctx, `
+	updated, err := getMemorySQLX(ctx, tx, `
 		update memories
-		set current_version_id = $3,
-			current_version_external_id = $4
-		where workspace_id = $1 and id = $2
-		returning id, uuid::text, external_id, organization_id, workspace_id,
-			memory_store_id, memory_store_external_id, coalesce(current_version_id, 0),
-			coalesce(current_version_external_id, ''), path, content_size_bytes,
-			content_sha256, s3_bucket, s3_key, created_at, updated_at, deleted_at
-	`, store.WorkspaceID, created.ID, insertedVersion.ID, insertedVersion.ExternalID))
+		set current_version_id = :version_id,
+			current_version_external_id = :version_external_id
+		where workspace_id = :workspace_id and id = :memory_id
+		returning `+memoryColumns()+`
+	`, map[string]any{
+		"workspace_id":        store.WorkspaceID,
+		"memory_id":           created.ID,
+		"version_id":          insertedVersion.ID,
+		"version_external_id": insertedVersion.ExternalID,
+	})
 	if err != nil {
 		return Memory{}, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return Memory{}, err
 	}
 	return updated, nil
 }
 
 func (d *DB) GetMemory(ctx context.Context, workspaceID int64, memoryStoreExternalID, memoryExternalID string) (Memory, error) {
-	return scanMemory(d.Pool.QueryRow(ctx, memorySelectSQL()+`
-		where workspace_id = $1
-			and memory_store_external_id = $2
-			and external_id = $3
+	return getMemorySQLX(ctx, d.sql, memorySelectSQL()+`
+		where workspace_id = :workspace_id
+			and memory_store_external_id = :memory_store_external_id
+			and external_id = :memory_external_id
 			and deleted_at is null
-	`, workspaceID, memoryStoreExternalID, memoryExternalID))
+	`, map[string]any{
+		"workspace_id":             workspaceID,
+		"memory_store_external_id": memoryStoreExternalID,
+		"memory_external_id":       memoryExternalID,
+	})
 }
 
 func (d *DB) UpdateMemory(ctx context.Context, input UpdateMemoryInput) (MemoryMutationResult, error) {
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return MemoryMutationResult{}, err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback()
 
 	current, storeArchived, err := d.getActiveMemoryForMutation(ctx, tx, input.WorkspaceID, input.MemoryStoreExternalID, input.MemoryExternalID)
 	if err != nil {
@@ -478,7 +497,7 @@ func (d *DB) UpdateMemory(ctx context.Context, input UpdateMemoryInput) (MemoryM
 	}
 	if input.ExpectedContentSHA256 != nil && current.ContentSHA256 != *input.ExpectedContentSHA256 {
 		if current.Path == targetPath && current.ContentSHA256 == targetSHA {
-			if err := tx.Commit(ctx); err != nil {
+			if err := tx.Commit(); err != nil {
 				return MemoryMutationResult{}, err
 			}
 			return MemoryMutationResult{Memory: current}, nil
@@ -489,7 +508,7 @@ func (d *DB) UpdateMemory(ctx context.Context, input UpdateMemoryInput) (MemoryM
 		return MemoryMutationResult{}, ErrVersionConflict
 	}
 	if current.Path == targetPath && current.ContentSHA256 == targetSHA {
-		if err := tx.Commit(ctx); err != nil {
+		if err := tx.Commit(); err != nil {
 			return MemoryMutationResult{}, err
 		}
 		return MemoryMutationResult{Memory: current}, nil
@@ -526,44 +545,52 @@ func (d *DB) UpdateMemory(ctx context.Context, input UpdateMemoryInput) (MemoryM
 	if err != nil {
 		return MemoryMutationResult{}, err
 	}
-	updated, err := scanMemory(tx.QueryRow(ctx, `
+	updated, err := getMemorySQLX(ctx, tx, `
 		update memories
-		set current_version_id = $4,
-			current_version_external_id = $5,
-			path = $6,
-			content_size_bytes = $7,
-			content_sha256 = $8,
-			s3_bucket = $9,
-			s3_key = $10,
-			updated_at = $11
-		where workspace_id = $1
-			and memory_store_external_id = $2
-			and external_id = $3
+		set current_version_id = :version_id,
+			current_version_external_id = :version_external_id,
+			path = :path,
+			content_size_bytes = :content_size_bytes,
+			content_sha256 = :content_sha256,
+			s3_bucket = :s3_bucket,
+			s3_key = :s3_key,
+			updated_at = :updated_at
+		where workspace_id = :workspace_id
+			and memory_store_external_id = :memory_store_external_id
+			and external_id = :memory_external_id
 			and deleted_at is null
-		returning id, uuid::text, external_id, organization_id, workspace_id,
-			memory_store_id, memory_store_external_id, coalesce(current_version_id, 0),
-			coalesce(current_version_external_id, ''), path, content_size_bytes,
-			content_sha256, s3_bucket, s3_key, created_at, updated_at, deleted_at
-	`, input.WorkspaceID, input.MemoryStoreExternalID, input.MemoryExternalID, version.ID,
-		version.ExternalID, targetPath, targetSize, targetSHA, targetBucket, targetKey, input.Now))
+		returning `+memoryColumns()+`
+	`, map[string]any{
+		"workspace_id":             input.WorkspaceID,
+		"memory_store_external_id": input.MemoryStoreExternalID,
+		"memory_external_id":       input.MemoryExternalID,
+		"version_id":               version.ID,
+		"version_external_id":      version.ExternalID,
+		"path":                     targetPath,
+		"content_size_bytes":       targetSize,
+		"content_sha256":           targetSHA,
+		"s3_bucket":                targetBucket,
+		"s3_key":                   targetKey,
+		"updated_at":               input.Now,
+	})
 	if isUniqueViolation(err) {
 		return MemoryMutationResult{}, d.memoryPathConflict(ctx, tx, current.MemoryStoreID, targetPath)
 	}
 	if err != nil {
 		return MemoryMutationResult{}, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return MemoryMutationResult{}, err
 	}
 	return MemoryMutationResult{Memory: updated, VersionCreated: true}, nil
 }
 
 func (d *DB) DeleteMemory(ctx context.Context, input DeleteMemoryInput) error {
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback()
 
 	current, storeArchived, err := d.getActiveMemoryForMutation(ctx, tx, input.WorkspaceID, input.MemoryStoreExternalID, input.MemoryExternalID)
 	if err != nil {
@@ -594,25 +621,31 @@ func (d *DB) DeleteMemory(ctx context.Context, input DeleteMemoryInput) error {
 	if err != nil {
 		return err
 	}
-	tag, err := tx.Exec(ctx, `
+	rowsAffected, err := namedExecRowsAffected(ctx, tx, `
 		update memories
-		set current_version_id = $4,
-			current_version_external_id = $5,
-			updated_at = $6,
-			deleted_at = $6
-		where workspace_id = $1
-			and memory_store_external_id = $2
-			and external_id = $3
+		set current_version_id = :version_id,
+			current_version_external_id = :version_external_id,
+			updated_at = :updated_at,
+			deleted_at = :updated_at
+		where workspace_id = :workspace_id
+			and memory_store_external_id = :memory_store_external_id
+			and external_id = :memory_external_id
 			and deleted_at is null
-	`, input.WorkspaceID, input.MemoryStoreExternalID, input.MemoryExternalID,
-		version.ID, version.ExternalID, input.Now)
+	`, map[string]any{
+		"workspace_id":             input.WorkspaceID,
+		"memory_store_external_id": input.MemoryStoreExternalID,
+		"memory_external_id":       input.MemoryExternalID,
+		"version_id":               version.ID,
+		"version_external_id":      version.ExternalID,
+		"updated_at":               input.Now,
+	})
 	if err != nil {
 		return err
 	}
-	if tag.RowsAffected() == 0 {
+	if rowsAffected == 0 {
 		return ErrNotFound
 	}
-	return tx.Commit(ctx)
+	return tx.Commit()
 }
 
 func (d *DB) ListMemoriesPage(ctx context.Context, params ListMemoriesPageParams) ([]Memory, bool, error) {
@@ -632,54 +665,48 @@ func (d *DB) ListMemoriesPage(ctx context.Context, params ListMemoriesPageParams
 	}
 
 	query := memorySelectSQL() + `
-		where workspace_id = $1
-			and memory_store_external_id = $2
+		where workspace_id = :workspace_id
+			and memory_store_external_id = :memory_store_external_id
 			and deleted_at is null
 	`
-	args := []any{params.WorkspaceID, params.MemoryStoreExternalID}
-	nextArg := 3
+	arguments := map[string]any{
+		"workspace_id":             params.WorkspaceID,
+		"memory_store_external_id": params.MemoryStoreExternalID,
+		"limit":                    params.Limit + 1,
+	}
 	if params.PathPrefix != "" {
-		query += fmt.Sprintf(" and left(path, length($%d)) = $%d", nextArg, nextArg)
-		args = append(args, params.PathPrefix)
-		nextArg++
+		query += " and left(path, length(:path_prefix)) = :path_prefix"
+		arguments["path_prefix"] = params.PathPrefix
 	}
 	if params.Cursor != nil {
+		arguments["cursor_id"] = params.Cursor.ID
 		switch orderBy {
 		case "path":
 			op := ">"
 			if order == "desc" {
 				op = "<"
 			}
-			query += fmt.Sprintf(" and (path %s $%d or (path = $%d and id %s $%d))", op, nextArg, nextArg, op, nextArg+1)
-			args = append(args, params.Cursor.Path, params.Cursor.ID)
-			nextArg += 2
+			query += fmt.Sprintf(" and (path %s :cursor_path or (path = :cursor_path and id %s :cursor_id))", op, op)
+			arguments["cursor_path"] = params.Cursor.Path
 		case "created_at":
 			op := ">"
 			if order == "desc" {
 				op = "<"
 			}
-			query += fmt.Sprintf(" and (created_at %s $%d or (created_at = $%d and id %s $%d))", op, nextArg, nextArg, op, nextArg+1)
-			args = append(args, params.Cursor.CreatedAt, params.Cursor.ID)
-			nextArg += 2
+			query += fmt.Sprintf(" and (created_at %s :cursor_created_at or (created_at = :cursor_created_at and id %s :cursor_id))", op, op)
+			arguments["cursor_created_at"] = params.Cursor.CreatedAt
 		case "updated_at":
 			op := ">"
 			if order == "desc" {
 				op = "<"
 			}
-			query += fmt.Sprintf(" and (updated_at %s $%d or (updated_at = $%d and id %s $%d))", op, nextArg, nextArg, op, nextArg+1)
-			args = append(args, params.Cursor.UpdatedAt, params.Cursor.ID)
-			nextArg += 2
+			query += fmt.Sprintf(" and (updated_at %s :cursor_updated_at or (updated_at = :cursor_updated_at and id %s :cursor_id))", op, op)
+			arguments["cursor_updated_at"] = params.Cursor.UpdatedAt
 		}
 	}
-	query += fmt.Sprintf(" order by %s %s, id %s limit $%d", orderBy, order, order, nextArg)
-	args = append(args, params.Limit+1)
+	query += fmt.Sprintf(" order by %s %s, id %s limit :limit", orderBy, order, order)
 
-	rows, err := d.Pool.Query(ctx, query, args...)
-	if err != nil {
-		return nil, false, err
-	}
-	defer rows.Close()
-	memories, err := scanMemoryRows(rows)
+	memories, err := selectMemoriesSQLX(ctx, d.sql, query, arguments)
 	if err != nil {
 		return nil, false, err
 	}
@@ -695,30 +722,32 @@ func (d *DB) ListMemoriesForDepth(ctx context.Context, params ListMemoriesPagePa
 		return nil, err
 	}
 	query := memorySelectSQL() + `
-		where workspace_id = $1
-			and memory_store_external_id = $2
+		where workspace_id = :workspace_id
+			and memory_store_external_id = :memory_store_external_id
 			and deleted_at is null
 	`
-	args := []any{params.WorkspaceID, params.MemoryStoreExternalID}
+	arguments := map[string]any{
+		"workspace_id":             params.WorkspaceID,
+		"memory_store_external_id": params.MemoryStoreExternalID,
+	}
 	if params.PathPrefix != "" {
-		query += " and left(path, length($3)) = $3"
-		args = append(args, params.PathPrefix)
+		query += " and left(path, length(:path_prefix)) = :path_prefix"
+		arguments["path_prefix"] = params.PathPrefix
 	}
 	query += " order by path asc, id asc"
-	rows, err := d.Pool.Query(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	return scanMemoryRows(rows)
+	return selectMemoriesSQLX(ctx, d.sql, query, arguments)
 }
 
 func (d *DB) GetMemoryVersion(ctx context.Context, workspaceID int64, memoryStoreExternalID, versionExternalID string) (MemoryVersion, error) {
-	return scanMemoryVersion(d.Pool.QueryRow(ctx, memoryVersionSelectSQL()+`
-		where workspace_id = $1
-			and memory_store_external_id = $2
-			and external_id = $3
-	`, workspaceID, memoryStoreExternalID, versionExternalID))
+	return getMemoryVersionSQLX(ctx, d.sql, memoryVersionSelectSQL()+`
+		where workspace_id = :workspace_id
+			and memory_store_external_id = :memory_store_external_id
+			and external_id = :version_external_id
+	`, map[string]any{
+		"workspace_id":             workspaceID,
+		"memory_store_external_id": memoryStoreExternalID,
+		"version_external_id":      versionExternalID,
+	})
 }
 
 func (d *DB) ListMemoryVersionsPage(ctx context.Context, params ListMemoryVersionsPageParams) ([]MemoryVersion, bool, error) {
@@ -729,55 +758,46 @@ func (d *DB) ListMemoryVersionsPage(ctx context.Context, params ListMemoryVersio
 		return nil, false, err
 	}
 	query := memoryVersionSelectSQL() + `
-		where workspace_id = $1
-			and memory_store_external_id = $2
+		where workspace_id = :workspace_id
+			and memory_store_external_id = :memory_store_external_id
 	`
-	args := []any{params.WorkspaceID, params.MemoryStoreExternalID}
-	nextArg := 3
+	arguments := map[string]any{
+		"workspace_id":             params.WorkspaceID,
+		"memory_store_external_id": params.MemoryStoreExternalID,
+		"limit":                    params.Limit + 1,
+	}
 	if params.MemoryExternalID != "" {
-		query += fmt.Sprintf(" and memory_external_id = $%d", nextArg)
-		args = append(args, params.MemoryExternalID)
-		nextArg++
+		query += " and memory_external_id = :memory_external_id"
+		arguments["memory_external_id"] = params.MemoryExternalID
 	}
 	if params.Operation != "" {
-		query += fmt.Sprintf(" and operation = $%d", nextArg)
-		args = append(args, params.Operation)
-		nextArg++
+		query += " and operation = :operation"
+		arguments["operation"] = params.Operation
 	}
 	if params.APIKeyExternalID != "" {
-		query += fmt.Sprintf(" and created_by_api_key_external_id = $%d", nextArg)
-		args = append(args, params.APIKeyExternalID)
-		nextArg++
+		query += " and created_by_api_key_external_id = :api_key_external_id"
+		arguments["api_key_external_id"] = params.APIKeyExternalID
 	}
 	if params.SessionID != "" {
-		query += fmt.Sprintf(" and created_by_session_id = $%d", nextArg)
-		args = append(args, params.SessionID)
-		nextArg++
+		query += " and created_by_session_id = :session_id"
+		arguments["session_id"] = params.SessionID
 	}
 	if params.CreatedAtGTE != nil {
-		query += fmt.Sprintf(" and created_at >= $%d", nextArg)
-		args = append(args, *params.CreatedAtGTE)
-		nextArg++
+		query += " and created_at >= :created_at_gte"
+		arguments["created_at_gte"] = *params.CreatedAtGTE
 	}
 	if params.CreatedAtLTE != nil {
-		query += fmt.Sprintf(" and created_at <= $%d", nextArg)
-		args = append(args, *params.CreatedAtLTE)
-		nextArg++
+		query += " and created_at <= :created_at_lte"
+		arguments["created_at_lte"] = *params.CreatedAtLTE
 	}
 	if params.Cursor != nil {
-		query += fmt.Sprintf(" and (created_at < $%d or (created_at = $%d and id < $%d))", nextArg, nextArg, nextArg+1)
-		args = append(args, params.Cursor.CreatedAt, params.Cursor.ID)
-		nextArg += 2
+		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and id < :cursor_id))"
+		arguments["cursor_created_at"] = params.Cursor.CreatedAt
+		arguments["cursor_id"] = params.Cursor.ID
 	}
-	query += fmt.Sprintf(" order by created_at desc, id desc limit $%d", nextArg)
-	args = append(args, params.Limit+1)
+	query += " order by created_at desc, id desc limit :limit"
 
-	rows, err := d.Pool.Query(ctx, query, args...)
-	if err != nil {
-		return nil, false, err
-	}
-	defer rows.Close()
-	versions, err := scanMemoryVersionRows(rows)
+	versions, err := selectMemoryVersionsSQLX(ctx, d.sql, query, arguments)
 	if err != nil {
 		return nil, false, err
 	}
@@ -789,38 +809,44 @@ func (d *DB) ListMemoryVersionsPage(ctx context.Context, params ListMemoryVersio
 }
 
 func (d *DB) RedactMemoryVersion(ctx context.Context, workspaceID int64, memoryStoreExternalID, versionExternalID string, actor MemoryActor, now time.Time) (MemoryVersion, *ObjectRef, error) {
-	tx, err := d.Pool.Begin(ctx)
+	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return MemoryVersion{}, nil, err
 	}
-	defer tx.Rollback(ctx)
+	defer tx.Rollback()
 
-	version, err := scanMemoryVersion(tx.QueryRow(ctx, memoryVersionSelectSQL()+`
-		where workspace_id = $1
-			and memory_store_external_id = $2
-			and external_id = $3
+	arguments := map[string]any{
+		"workspace_id":             workspaceID,
+		"memory_store_external_id": memoryStoreExternalID,
+		"version_external_id":      versionExternalID,
+	}
+	version, err := getMemoryVersionSQLX(ctx, tx, memoryVersionSelectSQL()+`
+		where workspace_id = :workspace_id
+			and memory_store_external_id = :memory_store_external_id
+			and external_id = :version_external_id
 		for update
-	`, workspaceID, memoryStoreExternalID, versionExternalID))
+	`, arguments)
 	if err != nil {
 		return MemoryVersion{}, nil, err
 	}
 
 	var activeHead int
-	if err := tx.QueryRow(ctx, `
-		select count(*)::int
+	arguments["version_id"] = version.ID
+	if err := namedGetContext(ctx, tx, &activeHead, `
+		select CAST(count(*) AS integer)
 		from memories
-		where workspace_id = $1
-			and memory_store_external_id = $2
-			and current_version_id = $3
+		where workspace_id = :workspace_id
+			and memory_store_external_id = :memory_store_external_id
+			and current_version_id = :version_id
 			and deleted_at is null
-	`, workspaceID, memoryStoreExternalID, version.ID).Scan(&activeHead); err != nil {
+	`, arguments); err != nil {
 		return MemoryVersion{}, nil, err
 	}
 	if activeHead > 0 {
 		return MemoryVersion{}, nil, ErrInvalidState
 	}
 	if version.RedactedAt != nil {
-		if err := tx.Commit(ctx); err != nil {
+		if err := tx.Commit(); err != nil {
 			return MemoryVersion{}, nil, err
 		}
 		return version, nil, nil
@@ -838,79 +864,78 @@ func (d *DB) RedactMemoryVersion(ctx context.Context, workspaceID int64, memoryS
 		}
 		ref.Key = *version.S3Key
 	}
-	updated, err := scanMemoryVersion(tx.QueryRow(ctx, `
+	arguments["now"] = now
+	arguments["actor_type"] = actor.Type
+	arguments["api_key_id"] = nullableInt64(actor.APIKeyID)
+	arguments["api_key_external_id"] = nullableString(actor.APIKeyExternalID)
+	arguments["session_id"] = nullableString(actor.SessionID)
+	arguments["user_id"] = nullableString(actor.UserID)
+	updated, err := getMemoryVersionSQLX(ctx, tx, `
 		update memory_versions
 		set path = null,
 			content_size_bytes = null,
 			content_sha256 = null,
 			s3_bucket = null,
 			s3_key = null,
-			redacted_at = $4,
-			redacted_by_actor_type = $5,
-			redacted_by_api_key_id = $6,
-			redacted_by_api_key_external_id = $7,
-			redacted_by_session_id = $8,
-			redacted_by_user_id = $9
-		where workspace_id = $1
-			and memory_store_external_id = $2
-			and external_id = $3
-		returning id, uuid::text, external_id, organization_id, workspace_id,
-			memory_store_id, memory_store_external_id, memory_id, memory_external_id,
-			operation, path, content_size_bytes, content_sha256, s3_bucket, s3_key,
-			created_by_actor_type, created_by_api_key_id, created_by_api_key_external_id,
-			created_by_session_id, created_by_user_id, redacted_at, redacted_by_actor_type,
-			redacted_by_api_key_id, redacted_by_api_key_external_id, redacted_by_session_id,
-			redacted_by_user_id, created_at
-	`, workspaceID, memoryStoreExternalID, versionExternalID, now, actor.Type, nullableInt64(actor.APIKeyID),
-		nullableString(actor.APIKeyExternalID), nullableString(actor.SessionID), nullableString(actor.UserID)))
+			redacted_at = :now,
+			redacted_by_actor_type = :actor_type,
+			redacted_by_api_key_id = :api_key_id,
+			redacted_by_api_key_external_id = :api_key_external_id,
+			redacted_by_session_id = :session_id,
+			redacted_by_user_id = :user_id
+		where workspace_id = :workspace_id
+			and memory_store_external_id = :memory_store_external_id
+			and external_id = :version_external_id
+		returning `+memoryVersionColumns()+`
+	`, arguments)
 	if err != nil {
 		return MemoryVersion{}, nil, err
 	}
-	if err := tx.Commit(ctx); err != nil {
+	if err := tx.Commit(); err != nil {
 		return MemoryVersion{}, nil, err
 	}
 	return updated, ref, nil
 }
 
-func (d *DB) getActiveMemoryForMutation(ctx context.Context, tx pgx.Tx, workspaceID int64, memoryStoreExternalID, memoryExternalID string) (Memory, bool, error) {
-	row := tx.QueryRow(ctx, `
-		select m.id, m.uuid::text, m.external_id, m.organization_id, m.workspace_id,
-			m.memory_store_id, m.memory_store_external_id, coalesce(m.current_version_id, 0),
-			coalesce(m.current_version_external_id, ''), m.path, m.content_size_bytes,
+func (d *DB) getActiveMemoryForMutation(ctx context.Context, tx sqlxNamedQueryer, workspaceID int64, memoryStoreExternalID, memoryExternalID string) (Memory, bool, error) {
+	var row activeMemoryRow
+	err := namedGetContext(ctx, tx, &row, `
+		select m.id, CAST(m.uuid AS text) AS uuid, m.external_id, m.organization_id, m.workspace_id,
+			m.memory_store_id, m.memory_store_external_id,
+			coalesce(m.current_version_id, 0) as current_version_id,
+			coalesce(m.current_version_external_id, '') as current_version_external_id,
+			m.path, m.content_size_bytes,
 			m.content_sha256, m.s3_bucket, m.s3_key, m.created_at, m.updated_at,
-			m.deleted_at, ms.archived_at
+			m.deleted_at, ms.archived_at AS archived_at
 		from memories m
 		join memory_stores ms on ms.id = m.memory_store_id
-		where m.workspace_id = $1
-			and m.memory_store_external_id = $2
-			and m.external_id = $3
+		where m.workspace_id = :workspace_id
+			and m.memory_store_external_id = :memory_store_external_id
+			and m.external_id = :memory_external_id
 			and m.deleted_at is null
 			and ms.deleted_at is null
 		for update of m, ms
-	`, workspaceID, memoryStoreExternalID, memoryExternalID)
-	var memory Memory
-	var archivedAt *time.Time
-	err := row.Scan(&memory.ID, &memory.UUID, &memory.ExternalID, &memory.OrganizationID,
-		&memory.WorkspaceID, &memory.MemoryStoreID, &memory.MemoryStoreExternalID,
-		&memory.CurrentVersionID, &memory.CurrentVersionExternalID, &memory.Path,
-		&memory.ContentSizeBytes, &memory.ContentSHA256, &memory.S3Bucket, &memory.S3Key,
-		&memory.CreatedAt, &memory.UpdatedAt, &memory.DeletedAt, &archivedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
+	`, map[string]any{
+		"workspace_id":             workspaceID,
+		"memory_store_external_id": memoryStoreExternalID,
+		"memory_external_id":       memoryExternalID,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
 		return Memory{}, false, ErrNotFound
 	}
 	if err != nil {
 		return Memory{}, false, err
 	}
-	return memory, archivedAt != nil, nil
+	return row.memory(), row.ArchivedAt != nil, nil
 }
 
 func (d *DB) ensureMemoryStoreExists(ctx context.Context, workspaceID int64, memoryStoreExternalID string) error {
 	var id int64
-	if err := d.Pool.QueryRow(ctx, `
+	if err := namedGetContext(ctx, d.sql, &id, `
 		select id
 		from memory_stores
-		where workspace_id = $1 and external_id = $2 and deleted_at is null
-	`, workspaceID, memoryStoreExternalID).Scan(&id); errors.Is(err, pgx.ErrNoRows) {
+		where workspace_id = :workspace_id and external_id = :external_id and deleted_at is null
+	`, map[string]any{"workspace_id": workspaceID, "external_id": memoryStoreExternalID}); errors.Is(err, sql.ErrNoRows) {
 		return ErrNotFound
 	} else if err != nil {
 		return err
@@ -918,16 +943,16 @@ func (d *DB) ensureMemoryStoreExists(ctx context.Context, workspaceID int64, mem
 	return nil
 }
 
-func (d *DB) ensureMemoryPathAvailable(ctx context.Context, tx pgx.Tx, storeID int64, path string, excludeMemoryID int64) error {
+func (d *DB) ensureMemoryPathAvailable(ctx context.Context, tx sqlxNamedQueryer, storeID int64, path string, excludeMemoryID int64) error {
 	var existingID string
-	if err := tx.QueryRow(ctx, `
+	if err := namedGetContext(ctx, tx, &existingID, `
 		select external_id
 		from memories
-		where memory_store_id = $1
-			and path = $2
-			and id <> $3
+		where memory_store_id = :store_id
+			and path = :path
+			and id <> :exclude_memory_id
 			and deleted_at is null
-	`, storeID, path, excludeMemoryID).Scan(&existingID); errors.Is(err, pgx.ErrNoRows) {
+	`, map[string]any{"store_id": storeID, "path": path, "exclude_memory_id": excludeMemoryID}); errors.Is(err, sql.ErrNoRows) {
 		return nil
 	} else if err != nil {
 		return err
@@ -935,25 +960,22 @@ func (d *DB) ensureMemoryPathAvailable(ctx context.Context, tx pgx.Tx, storeID i
 	return &MemoryPathConflictError{ConflictingMemoryID: existingID, ConflictingPath: path}
 }
 
-func (d *DB) memoryPathConflict(ctx context.Context, q interface {
-	QueryRow(context.Context, string, ...any) pgx.Row
-}, storeID int64, path string) error {
+func (d *DB) memoryPathConflict(ctx context.Context, database sqlxNamedQueryer, storeID int64, path string) error {
 	var existingID string
-	if err := q.QueryRow(ctx, `
+	if err := namedGetContext(ctx, database, &existingID, `
 		select external_id
 		from memories
-		where memory_store_id = $1
-			and path = $2
+		where memory_store_id = :store_id
+			and path = :path
 			and deleted_at is null
 		limit 1
-	`, storeID, path).Scan(&existingID); err == nil {
+	`, map[string]any{"store_id": storeID, "path": path}); err == nil {
 		return &MemoryPathConflictError{ConflictingMemoryID: existingID, ConflictingPath: path}
 	}
 	return ErrDuplicate
 }
 
-func insertMemoryVersion(ctx context.Context, tx pgx.Tx, version MemoryVersion) (MemoryVersion, error) {
-	return scanMemoryVersion(tx.QueryRow(ctx, `
+const insertMemoryVersionQuery = `
 		insert into memory_versions (
 			uuid, external_id, organization_id, workspace_id, memory_store_id,
 			memory_store_external_id, memory_id, memory_external_id, operation, path,
@@ -962,179 +984,80 @@ func insertMemoryVersion(ctx context.Context, tx pgx.Tx, version MemoryVersion) 
 			created_by_user_id, created_at
 		)
 		values (
-			$1, $2, $3, $4, $5,
-			$6, $7, $8, $9, $10,
-			$11, $12, $13, $14, $15,
-			$16, $17, $18, $19, $20
+			:uuid, :external_id, :organization_id, :workspace_id, :memory_store_id,
+			:memory_store_external_id, :memory_id, :memory_external_id, :operation, :path,
+			:content_size_bytes, :content_sha256, :s3_bucket, :s3_key, :created_by_actor_type,
+			:created_by_api_key_id, :created_by_api_key_external_id, :created_by_session_id,
+			:created_by_user_id, :created_at
 		)
-		returning id, uuid::text, external_id, organization_id, workspace_id,
+		returning ` + `id, CAST(uuid AS text) AS uuid, external_id, organization_id, workspace_id,
 			memory_store_id, memory_store_external_id, memory_id, memory_external_id,
 			operation, path, content_size_bytes, content_sha256, s3_bucket, s3_key,
 			created_by_actor_type, created_by_api_key_id, created_by_api_key_external_id,
 			created_by_session_id, created_by_user_id, redacted_at, redacted_by_actor_type,
 			redacted_by_api_key_id, redacted_by_api_key_external_id, redacted_by_session_id,
-			redacted_by_user_id, created_at
-	`, version.UUID, version.ExternalID, version.OrganizationID, version.WorkspaceID,
-		version.MemoryStoreID, version.MemoryStoreExternalID, version.MemoryID,
-		version.MemoryExternalID, version.Operation, nullableStringPtr(version.Path),
-		nullableInt64Ptr(version.ContentSizeBytes), nullableStringPtr(version.ContentSHA256),
-		nullableStringPtr(version.S3Bucket), nullableStringPtr(version.S3Key),
-		version.CreatedBy.Type, nullableInt64(version.CreatedBy.APIKeyID),
-		nullableString(version.CreatedBy.APIKeyExternalID), nullableString(version.CreatedBy.SessionID),
-		nullableString(version.CreatedBy.UserID), version.CreatedAt))
+			redacted_by_user_id, created_at`
+
+func insertMemoryVersion(ctx context.Context, tx sqlxNamedQueryer, version MemoryVersion) (MemoryVersion, error) {
+	return getMemoryVersionSQLX(ctx, tx, insertMemoryVersionQuery, map[string]any{
+		"uuid":                           version.UUID,
+		"external_id":                    version.ExternalID,
+		"organization_id":                version.OrganizationID,
+		"workspace_id":                   version.WorkspaceID,
+		"memory_store_id":                version.MemoryStoreID,
+		"memory_store_external_id":       version.MemoryStoreExternalID,
+		"memory_id":                      version.MemoryID,
+		"memory_external_id":             version.MemoryExternalID,
+		"operation":                      version.Operation,
+		"path":                           nullableStringPtr(version.Path),
+		"content_size_bytes":             nullableInt64Ptr(version.ContentSizeBytes),
+		"content_sha256":                 nullableStringPtr(version.ContentSHA256),
+		"s3_bucket":                      nullableStringPtr(version.S3Bucket),
+		"s3_key":                         nullableStringPtr(version.S3Key),
+		"created_by_actor_type":          version.CreatedBy.Type,
+		"created_by_api_key_id":          nullableInt64(version.CreatedBy.APIKeyID),
+		"created_by_api_key_external_id": nullableString(version.CreatedBy.APIKeyExternalID),
+		"created_by_session_id":          nullableString(version.CreatedBy.SessionID),
+		"created_by_user_id":             nullableString(version.CreatedBy.UserID),
+		"created_at":                     version.CreatedAt,
+	})
+}
+
+func memoryStoreColumns() string {
+	return `id, CAST(uuid AS text) as uuid, external_id, organization_id, workspace_id,
+		created_by_api_key_id, name, description, metadata, created_at, updated_at,
+		archived_at, deleted_at`
 }
 
 func memoryStoreSelectSQL() string {
-	return `
-		select id, uuid::text, external_id, organization_id, workspace_id,
-			created_by_api_key_id, name, description, metadata, created_at, updated_at,
-			archived_at, deleted_at
-		from memory_stores
-	`
+	return `select ` + memoryStoreColumns() + ` from memory_stores`
+}
+
+func memoryColumns() string {
+	return `id, CAST(uuid AS text) as uuid, external_id, organization_id, workspace_id,
+		memory_store_id, memory_store_external_id,
+		coalesce(current_version_id, 0) as current_version_id,
+		coalesce(current_version_external_id, '') as current_version_external_id,
+		path, content_size_bytes, content_sha256, s3_bucket, s3_key,
+		created_at, updated_at, deleted_at`
 }
 
 func memorySelectSQL() string {
-	return `
-		select id, uuid::text, external_id, organization_id, workspace_id,
-			memory_store_id, memory_store_external_id, coalesce(current_version_id, 0),
-			coalesce(current_version_external_id, ''), path, content_size_bytes,
-			content_sha256, s3_bucket, s3_key, created_at, updated_at, deleted_at
-		from memories
-	`
+	return `select ` + memoryColumns() + ` from memories`
+}
+
+func memoryVersionColumns() string {
+	return `id, CAST(uuid AS text) as uuid, external_id, organization_id, workspace_id,
+		memory_store_id, memory_store_external_id, memory_id, memory_external_id,
+		operation, path, content_size_bytes, content_sha256, s3_bucket, s3_key,
+		created_by_actor_type, created_by_api_key_id, created_by_api_key_external_id,
+		created_by_session_id, created_by_user_id, redacted_at, redacted_by_actor_type,
+		redacted_by_api_key_id, redacted_by_api_key_external_id, redacted_by_session_id,
+		redacted_by_user_id, created_at`
 }
 
 func memoryVersionSelectSQL() string {
-	return `
-		select id, uuid::text, external_id, organization_id, workspace_id,
-			memory_store_id, memory_store_external_id, memory_id, memory_external_id,
-			operation, path, content_size_bytes, content_sha256, s3_bucket, s3_key,
-			created_by_actor_type, created_by_api_key_id, created_by_api_key_external_id,
-			created_by_session_id, created_by_user_id, redacted_at, redacted_by_actor_type,
-			redacted_by_api_key_id, redacted_by_api_key_external_id, redacted_by_session_id,
-			redacted_by_user_id, created_at
-		from memory_versions
-	`
-}
-
-type memoryScanner interface {
-	Scan(dest ...any) error
-}
-
-type memoryRows interface {
-	Next() bool
-	Scan(dest ...any) error
-	Err() error
-}
-
-func scanMemoryStore(row memoryScanner) (MemoryStore, error) {
-	var store MemoryStore
-	var metadata []byte
-	err := row.Scan(&store.ID, &store.UUID, &store.ExternalID, &store.OrganizationID,
-		&store.WorkspaceID, &store.CreatedByAPIKeyID, &store.Name, &store.Description,
-		&metadata, &store.CreatedAt, &store.UpdatedAt, &store.ArchivedAt, &store.DeletedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return MemoryStore{}, ErrNotFound
-	}
-	if err != nil {
-		return MemoryStore{}, err
-	}
-	store.Metadata = copyRaw(metadata)
-	return store, nil
-}
-
-func scanMemoryStoreRows(rows memoryRows) ([]MemoryStore, error) {
-	var stores []MemoryStore
-	for rows.Next() {
-		store, err := scanMemoryStore(rows)
-		if err != nil {
-			return nil, err
-		}
-		stores = append(stores, store)
-	}
-	return stores, rows.Err()
-}
-
-func scanMemory(row memoryScanner) (Memory, error) {
-	var memory Memory
-	err := row.Scan(&memory.ID, &memory.UUID, &memory.ExternalID, &memory.OrganizationID,
-		&memory.WorkspaceID, &memory.MemoryStoreID, &memory.MemoryStoreExternalID,
-		&memory.CurrentVersionID, &memory.CurrentVersionExternalID, &memory.Path,
-		&memory.ContentSizeBytes, &memory.ContentSHA256, &memory.S3Bucket, &memory.S3Key,
-		&memory.CreatedAt, &memory.UpdatedAt, &memory.DeletedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return Memory{}, ErrNotFound
-	}
-	if err != nil {
-		return Memory{}, err
-	}
-	return memory, nil
-}
-
-func scanMemoryRows(rows memoryRows) ([]Memory, error) {
-	var memories []Memory
-	for rows.Next() {
-		memory, err := scanMemory(rows)
-		if err != nil {
-			return nil, err
-		}
-		memories = append(memories, memory)
-	}
-	return memories, rows.Err()
-}
-
-func scanMemoryVersion(row memoryScanner) (MemoryVersion, error) {
-	var version MemoryVersion
-	var path, contentSHA, bucket, key sql.NullString
-	var contentSize sql.NullInt64
-	var createdByAPIKeyID, redactedByAPIKeyID sql.NullInt64
-	var createdByAPIKeyExternalID, createdBySessionID, createdByUserID sql.NullString
-	var redactedByActorType, redactedByAPIKeyExternalID, redactedBySessionID, redactedByUserID sql.NullString
-	err := row.Scan(&version.ID, &version.UUID, &version.ExternalID, &version.OrganizationID,
-		&version.WorkspaceID, &version.MemoryStoreID, &version.MemoryStoreExternalID,
-		&version.MemoryID, &version.MemoryExternalID, &version.Operation, &path,
-		&contentSize, &contentSHA, &bucket, &key, &version.CreatedBy.Type,
-		&createdByAPIKeyID, &createdByAPIKeyExternalID, &createdBySessionID,
-		&createdByUserID, &version.RedactedAt, &redactedByActorType,
-		&redactedByAPIKeyID, &redactedByAPIKeyExternalID, &redactedBySessionID,
-		&redactedByUserID, &version.CreatedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return MemoryVersion{}, ErrNotFound
-	}
-	if err != nil {
-		return MemoryVersion{}, err
-	}
-	version.Path = nullStringPtr(path)
-	version.ContentSizeBytes = nullInt64Ptr(contentSize)
-	version.ContentSHA256 = nullStringPtr(contentSHA)
-	version.S3Bucket = nullStringPtr(bucket)
-	version.S3Key = nullStringPtr(key)
-	version.CreatedBy.APIKeyID = nullInt64Value(createdByAPIKeyID)
-	version.CreatedBy.APIKeyExternalID = nullStringValue(createdByAPIKeyExternalID)
-	version.CreatedBy.SessionID = nullStringValue(createdBySessionID)
-	version.CreatedBy.UserID = nullStringValue(createdByUserID)
-	if redactedByActorType.Valid {
-		actor := MemoryActor{
-			Type:             redactedByActorType.String,
-			APIKeyID:         nullInt64Value(redactedByAPIKeyID),
-			APIKeyExternalID: nullStringValue(redactedByAPIKeyExternalID),
-			SessionID:        nullStringValue(redactedBySessionID),
-			UserID:           nullStringValue(redactedByUserID),
-		}
-		version.RedactedBy = &actor
-	}
-	return version, nil
-}
-
-func scanMemoryVersionRows(rows memoryRows) ([]MemoryVersion, error) {
-	var versions []MemoryVersion
-	for rows.Next() {
-		version, err := scanMemoryVersion(rows)
-		if err != nil {
-			return nil, err
-		}
-		versions = append(versions, version)
-	}
-	return versions, rows.Err()
+	return `select ` + memoryVersionColumns() + ` from memory_versions`
 }
 
 func nullableString(value string) any {

--- a/internal/db/memory_sqlx.go
+++ b/internal/db/memory_sqlx.go
@@ -1,0 +1,231 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+)
+
+type memoryStoreRow struct {
+	ID                int64      `db:"id"`
+	UUID              string     `db:"uuid"`
+	ExternalID        string     `db:"external_id"`
+	OrganizationID    int64      `db:"organization_id"`
+	WorkspaceID       int64      `db:"workspace_id"`
+	CreatedByAPIKeyID int64      `db:"created_by_api_key_id"`
+	Name              string     `db:"name"`
+	Description       string     `db:"description"`
+	Metadata          []byte     `db:"metadata"`
+	CreatedAt         time.Time  `db:"created_at"`
+	UpdatedAt         time.Time  `db:"updated_at"`
+	ArchivedAt        *time.Time `db:"archived_at"`
+	DeletedAt         *time.Time `db:"deleted_at"`
+}
+
+type memoryRow struct {
+	ID                       int64      `db:"id"`
+	UUID                     string     `db:"uuid"`
+	ExternalID               string     `db:"external_id"`
+	OrganizationID           int64      `db:"organization_id"`
+	WorkspaceID              int64      `db:"workspace_id"`
+	MemoryStoreID            int64      `db:"memory_store_id"`
+	MemoryStoreExternalID    string     `db:"memory_store_external_id"`
+	CurrentVersionID         int64      `db:"current_version_id"`
+	CurrentVersionExternalID string     `db:"current_version_external_id"`
+	Path                     string     `db:"path"`
+	ContentSizeBytes         int64      `db:"content_size_bytes"`
+	ContentSHA256            string     `db:"content_sha256"`
+	S3Bucket                 string     `db:"s3_bucket"`
+	S3Key                    string     `db:"s3_key"`
+	CreatedAt                time.Time  `db:"created_at"`
+	UpdatedAt                time.Time  `db:"updated_at"`
+	DeletedAt                *time.Time `db:"deleted_at"`
+}
+
+type activeMemoryRow struct {
+	memoryRow
+	ArchivedAt *time.Time `db:"archived_at"`
+}
+
+type memoryVersionRow struct {
+	ID                         int64          `db:"id"`
+	UUID                       string         `db:"uuid"`
+	ExternalID                 string         `db:"external_id"`
+	OrganizationID             int64          `db:"organization_id"`
+	WorkspaceID                int64          `db:"workspace_id"`
+	MemoryStoreID              int64          `db:"memory_store_id"`
+	MemoryStoreExternalID      string         `db:"memory_store_external_id"`
+	MemoryID                   int64          `db:"memory_id"`
+	MemoryExternalID           string         `db:"memory_external_id"`
+	Operation                  string         `db:"operation"`
+	Path                       sql.NullString `db:"path"`
+	ContentSizeBytes           sql.NullInt64  `db:"content_size_bytes"`
+	ContentSHA256              sql.NullString `db:"content_sha256"`
+	S3Bucket                   sql.NullString `db:"s3_bucket"`
+	S3Key                      sql.NullString `db:"s3_key"`
+	CreatedByActorType         string         `db:"created_by_actor_type"`
+	CreatedByAPIKeyID          sql.NullInt64  `db:"created_by_api_key_id"`
+	CreatedByAPIKeyExternalID  sql.NullString `db:"created_by_api_key_external_id"`
+	CreatedBySessionID         sql.NullString `db:"created_by_session_id"`
+	CreatedByUserID            sql.NullString `db:"created_by_user_id"`
+	RedactedAt                 *time.Time     `db:"redacted_at"`
+	RedactedByActorType        sql.NullString `db:"redacted_by_actor_type"`
+	RedactedByAPIKeyID         sql.NullInt64  `db:"redacted_by_api_key_id"`
+	RedactedByAPIKeyExternalID sql.NullString `db:"redacted_by_api_key_external_id"`
+	RedactedBySessionID        sql.NullString `db:"redacted_by_session_id"`
+	RedactedByUserID           sql.NullString `db:"redacted_by_user_id"`
+	CreatedAt                  time.Time      `db:"created_at"`
+}
+
+type objectRefRow struct {
+	WorkspaceID int64  `db:"workspace_id"`
+	Bucket      string `db:"bucket"`
+	Key         string `db:"key"`
+	ResourceID  string `db:"resource_id"`
+}
+
+func getMemoryStoreSQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) (MemoryStore, error) {
+	var row memoryStoreRow
+	if err := namedGetContext(ctx, database, &row, query, arguments); errors.Is(err, sql.ErrNoRows) {
+		return MemoryStore{}, ErrNotFound
+	} else if err != nil {
+		return MemoryStore{}, err
+	}
+	return row.store(), nil
+}
+
+func selectMemoryStoresSQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) ([]MemoryStore, error) {
+	var rows []memoryStoreRow
+	if err := namedSelectContext(ctx, database, &rows, query, arguments); err != nil {
+		return nil, err
+	}
+	stores := make([]MemoryStore, len(rows))
+	for index := range rows {
+		stores[index] = rows[index].store()
+	}
+	return stores, nil
+}
+
+func getMemorySQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) (Memory, error) {
+	var row memoryRow
+	if err := namedGetContext(ctx, database, &row, query, arguments); errors.Is(err, sql.ErrNoRows) {
+		return Memory{}, ErrNotFound
+	} else if err != nil {
+		return Memory{}, err
+	}
+	return row.memory(), nil
+}
+
+func selectMemoriesSQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) ([]Memory, error) {
+	var rows []memoryRow
+	if err := namedSelectContext(ctx, database, &rows, query, arguments); err != nil {
+		return nil, err
+	}
+	memories := make([]Memory, len(rows))
+	for index := range rows {
+		memories[index] = rows[index].memory()
+	}
+	return memories, nil
+}
+
+func getMemoryVersionSQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) (MemoryVersion, error) {
+	var row memoryVersionRow
+	if err := namedGetContext(ctx, database, &row, query, arguments); errors.Is(err, sql.ErrNoRows) {
+		return MemoryVersion{}, ErrNotFound
+	} else if err != nil {
+		return MemoryVersion{}, err
+	}
+	return row.version(), nil
+}
+
+func selectMemoryVersionsSQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) ([]MemoryVersion, error) {
+	var rows []memoryVersionRow
+	if err := namedSelectContext(ctx, database, &rows, query, arguments); err != nil {
+		return nil, err
+	}
+	versions := make([]MemoryVersion, len(rows))
+	for index := range rows {
+		versions[index] = rows[index].version()
+	}
+	return versions, nil
+}
+
+func (r memoryStoreRow) store() MemoryStore {
+	return MemoryStore{
+		ID:                r.ID,
+		UUID:              r.UUID,
+		ExternalID:        r.ExternalID,
+		OrganizationID:    r.OrganizationID,
+		WorkspaceID:       r.WorkspaceID,
+		CreatedByAPIKeyID: r.CreatedByAPIKeyID,
+		Name:              r.Name,
+		Description:       r.Description,
+		Metadata:          copyRaw(r.Metadata),
+		CreatedAt:         r.CreatedAt,
+		UpdatedAt:         r.UpdatedAt,
+		ArchivedAt:        r.ArchivedAt,
+		DeletedAt:         r.DeletedAt,
+	}
+}
+
+func (r memoryRow) memory() Memory {
+	return Memory{
+		ID:                       r.ID,
+		UUID:                     r.UUID,
+		ExternalID:               r.ExternalID,
+		OrganizationID:           r.OrganizationID,
+		WorkspaceID:              r.WorkspaceID,
+		MemoryStoreID:            r.MemoryStoreID,
+		MemoryStoreExternalID:    r.MemoryStoreExternalID,
+		CurrentVersionID:         r.CurrentVersionID,
+		CurrentVersionExternalID: r.CurrentVersionExternalID,
+		Path:                     r.Path,
+		ContentSizeBytes:         r.ContentSizeBytes,
+		ContentSHA256:            r.ContentSHA256,
+		S3Bucket:                 r.S3Bucket,
+		S3Key:                    r.S3Key,
+		CreatedAt:                r.CreatedAt,
+		UpdatedAt:                r.UpdatedAt,
+		DeletedAt:                r.DeletedAt,
+	}
+}
+
+func (r memoryVersionRow) version() MemoryVersion {
+	version := MemoryVersion{
+		ID:                    r.ID,
+		UUID:                  r.UUID,
+		ExternalID:            r.ExternalID,
+		OrganizationID:        r.OrganizationID,
+		WorkspaceID:           r.WorkspaceID,
+		MemoryStoreID:         r.MemoryStoreID,
+		MemoryStoreExternalID: r.MemoryStoreExternalID,
+		MemoryID:              r.MemoryID,
+		MemoryExternalID:      r.MemoryExternalID,
+		Operation:             r.Operation,
+		Path:                  nullStringPtr(r.Path),
+		ContentSizeBytes:      nullInt64Ptr(r.ContentSizeBytes),
+		ContentSHA256:         nullStringPtr(r.ContentSHA256),
+		S3Bucket:              nullStringPtr(r.S3Bucket),
+		S3Key:                 nullStringPtr(r.S3Key),
+		CreatedBy: MemoryActor{
+			Type:             r.CreatedByActorType,
+			APIKeyID:         nullInt64Value(r.CreatedByAPIKeyID),
+			APIKeyExternalID: nullStringValue(r.CreatedByAPIKeyExternalID),
+			SessionID:        nullStringValue(r.CreatedBySessionID),
+			UserID:           nullStringValue(r.CreatedByUserID),
+		},
+		RedactedAt: r.RedactedAt,
+		CreatedAt:  r.CreatedAt,
+	}
+	if r.RedactedByActorType.Valid {
+		version.RedactedBy = &MemoryActor{
+			Type:             r.RedactedByActorType.String,
+			APIKeyID:         nullInt64Value(r.RedactedByAPIKeyID),
+			APIKeyExternalID: nullStringValue(r.RedactedByAPIKeyExternalID),
+			SessionID:        nullStringValue(r.RedactedBySessionID),
+			UserID:           nullStringValue(r.RedactedByUserID),
+		}
+	}
+	return version
+}

--- a/internal/db/memory_sqlx_test.go
+++ b/internal/db/memory_sqlx_test.go
@@ -1,0 +1,112 @@
+package db
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInsertMemoryVersionQueryUsesSQLXNamedParameters(t *testing.T) {
+	now := time.Date(2026, time.July, 27, 12, 0, 0, 0, time.UTC)
+	arguments := map[string]any{
+		"uuid":                           "11111111-1111-4111-8111-111111111111",
+		"external_id":                    "memver_test",
+		"organization_id":                int64(1),
+		"workspace_id":                   int64(2),
+		"memory_store_id":                int64(3),
+		"memory_store_external_id":       "memstore_test",
+		"memory_id":                      int64(4),
+		"memory_external_id":             "mem_test",
+		"operation":                      "created",
+		"path":                           "/test.md",
+		"content_size_bytes":             int64(4),
+		"content_sha256":                 "sha256",
+		"s3_bucket":                      "bucket",
+		"s3_key":                         "key",
+		"created_by_actor_type":          "api_key",
+		"created_by_api_key_id":          int64(5),
+		"created_by_api_key_external_id": "sk-ant-test",
+		"created_by_session_id":          nil,
+		"created_by_user_id":             nil,
+		"created_at":                     now,
+	}
+
+	query, values, err := bindNamed(postgresRebinder{}, insertMemoryVersionQuery, arguments)
+	if err != nil {
+		t.Fatalf("bindNamed() error = %v", err)
+	}
+	if strings.Contains(query, ":") {
+		t.Fatalf("bound query retains named parameters: %q", query)
+	}
+	if strings.Contains(query, "::") {
+		t.Fatalf("bound query contains PostgreSQL shorthand cast: %q", query)
+	}
+	if len(values) != len(arguments) {
+		t.Fatalf("bound argument count = %d, want %d", len(values), len(arguments))
+	}
+}
+
+func TestMemoryColumnListsSupportStructScan(t *testing.T) {
+	tests := []struct {
+		name    string
+		columns string
+		want    []string
+	}{
+		{
+			name:    "memory store",
+			columns: memoryStoreColumns(),
+			want:    []string{"CAST(uuid AS text) as uuid", "metadata", "archived_at"},
+		},
+		{
+			name:    "memory",
+			columns: memoryColumns(),
+			want: []string{
+				"coalesce(current_version_id, 0) as current_version_id",
+				"coalesce(current_version_external_id, '') as current_version_external_id",
+			},
+		},
+		{
+			name:    "memory version",
+			columns: memoryVersionColumns(),
+			want:    []string{"CAST(uuid AS text) as uuid", "redacted_by_actor_type", "created_at"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if strings.Contains(test.columns, "::") {
+				t.Fatalf("columns contain PostgreSQL shorthand cast: %q", test.columns)
+			}
+			for _, fragment := range test.want {
+				if !strings.Contains(test.columns, fragment) {
+					t.Fatalf("columns do not contain %q: %q", fragment, test.columns)
+				}
+			}
+		})
+	}
+}
+
+func TestMemoryVersionRowConvertsNullableFields(t *testing.T) {
+	row := memoryVersionRow{
+		CreatedByActorType:         "session",
+		CreatedBySessionID:         sql.NullString{String: "sesn_test", Valid: true},
+		Path:                       sql.NullString{String: "/test.md", Valid: true},
+		ContentSizeBytes:           sql.NullInt64{Int64: 4, Valid: true},
+		RedactedByActorType:        sql.NullString{String: "api_key", Valid: true},
+		RedactedByAPIKeyExternalID: sql.NullString{String: "sk-ant-test", Valid: true},
+	}
+
+	version := row.version()
+	if version.Path == nil || *version.Path != "/test.md" {
+		t.Fatalf("version path = %#v, want /test.md", version.Path)
+	}
+	if version.ContentSizeBytes == nil || *version.ContentSizeBytes != 4 {
+		t.Fatalf("version content size = %#v, want 4", version.ContentSizeBytes)
+	}
+	if version.CreatedBy.SessionID != "sesn_test" {
+		t.Fatalf("created by session = %q, want sesn_test", version.CreatedBy.SessionID)
+	}
+	if version.RedactedBy == nil || version.RedactedBy.APIKeyExternalID != "sk-ant-test" {
+		t.Fatalf("redacted by = %#v, want API key actor", version.RedactedBy)
+	}
+}


### PR DESCRIPTION
## Summary

- migrate all runtime SQL in `internal/db/memory.go` from raw pgx calls to sqlx named queries and transactions
- add `db`-tagged row schemas for memory stores, memories, versions, and cleanup object references
- replace PostgreSQL shorthand casts and positional placeholders with sqlx-safe `CAST(...)` expressions and named parameters
- add binding, column alias, nullable conversion, and real PostgreSQL API coverage

## Validation

- `go test ./internal/db -run 'Test(InsertMemoryVersionQueryUsesSQLXNamedParameters|MemoryColumnListsSupportStructScan|MemoryVersionRowConvertsNullableFields)$' -count=1`
- `go test ./tests -run 'TestMemory(Store|Stores)' -count=1`
- `just lint`
- `just dead-code`
- `just duplicates`
- `just complexity`
- `just large-files`

## Design docs

No design document update is needed because this is a persistence implementation migration with no behavior, API, schema, authorization, or architecture-contract change.
