### PR TITLE
feat: 为 Environment 提供 package provisioning

### DIFF
--- a/docs/configuration-reference.yaml
+++ b/docs/configuration-reference.yaml
@@ -63,6 +63,7 @@ e2b:
 environment_runner:
   enabled: true
   concurrency: 2
+  package_provision_timeout: 2m
   manager_path: /usr/local/bin/environment-manager
   claude_agent_version: 2.1.120
   claude_path: /opt/claude-code/bin/claude

--- a/docs/design/be/environment-package-provisioning.md
+++ b/docs/design/be/environment-package-provisioning.md
@@ -1,0 +1,22 @@
+# Environment Package 安装
+
+Cloud Environment 可以通过与 Claude 兼容的 `config.packages` 配置 `apt`、`cargo`、`gem`、`go`、`npm` 和 `pip` package。HTTP 边界负责校验 package 对象与 spec，将省略的列表规范化为 `[]`，并将编码后的 v1 manifest 限制在 1 MiB 以内。package 配置为空时，保持既有 Sandbox 启动与 runtime 发布流程不变。
+
+对于非空 package 配置，Runner 创建 Sandbox、持久化 provider ID，然后执行：
+
+```text
+/usr/local/bin/environment-manager provision-packages --protocol v1 --stdin
+```
+
+JSON manifest 只通过 stdin 发送。命令结果必须是单个严格的 v1 JSON 值，且不得超过 16 KiB。仅当 status 与进程退出码一致时才继续启动；错误只暴露白名单内的 category、manager 和 stage，不包含 package spec 或原始 stdout/stderr。
+
+Package 安装发生在 rclone 和 Environment Manager 启动之前。安装失败时，Runner 停止 Work 并终止已创建的 Sandbox。安装成功后，Runner 检查 Work heartbeat；如果并发 stop 已经生效，则执行清理，不再启动 rclone 或 Manager。没有 package 的 Environment 保持原有顺序：创建 Code Session、启动 Manager，然后发布 runtime metadata。
+
+Sandbox 镜像或自定义 E2B template 必须提供 `/usr/local/bin/environment-manager`，并实现 `provision-packages` v1 合同。Registry credential、重试、派生 template、持久化清理协调以及事务化 Session event 交接均不在本功能范围内。
+
+聚焦验证命令：
+
+```text
+go test ./internal/environments -run 'Test(BuildPackage|NormalizePackages|ValidatePackage|ProvisionPackages)' -count=1
+go test ./internal/runtime/e2bruntime -count=1
+```

--- a/docs/design/be/environment-package-provisioning.md
+++ b/docs/design/be/environment-package-provisioning.md
@@ -12,6 +12,8 @@ JSON manifest 只通过 stdin 发送。命令结果必须是单个严格的 v1 J
 
 Package 安装发生在 rclone 和 Environment Manager 启动之前。安装失败时，Runner 停止 Work 并终止已创建的 Sandbox。安装成功后，Runner 检查 Work heartbeat；如果并发 stop 已经生效，则执行清理，不再启动 rclone 或 Manager。没有 package 的 Environment 保持原有顺序：创建 Code Session、启动 Manager，然后发布 runtime metadata。
 
+安装命令使用独立的 `environment_runner.package_provision_timeout`，默认 2 分钟。E2B 命令超时与本地 context deadline 使用同一预算：前者约束 Sandbox 进程，后者保证网络或 Wait 调用不会无限阻塞。
+
 Sandbox 镜像或自定义 E2B template 必须提供 `/usr/local/bin/environment-manager`，并实现 `provision-packages` v1 合同。Registry credential、重试、派生 template、持久化清理协调以及事务化 Session event 交接均不在本功能范围内。
 
 聚焦验证命令：

--- a/internal/common/collections/strings.go
+++ b/internal/common/collections/strings.go
@@ -7,6 +7,11 @@ import (
 	"github.com/samber/lo"
 )
 
+// IsBlank reports whether value is empty after trimming whitespace.
+func IsBlank(value string) bool {
+	return strings.TrimSpace(value) == ""
+}
+
 // UniqueTrimmedStrings trims values, removes blanks, and keeps the first
 // occurrence of each value in stable order.
 func UniqueTrimmedStrings(values []string) []string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,7 @@ func validatePositiveValues(cfg Config) error {
 		{name: "e2b.request_timeout", valid: cfg.E2B.RequestTimeout > 0},
 		{name: "e2b.sandbox_timeout", valid: cfg.E2B.SandboxTimeout > 0},
 		{name: "environment_runner.concurrency", valid: cfg.EnvironmentRunner.Concurrency > 0},
+		{name: "environment_runner.package_provision_timeout", valid: cfg.EnvironmentRunner.PackageProvisionTimeout > 0},
 		{name: "code_session.otlp_log_body_preview_bytes", valid: cfg.CodeSession.OTLPLogBodyPreviewBytes > 0},
 		{name: "webhook.timeout", valid: cfg.Webhook.Timeout > 0},
 		{name: "webhook.max_attempts", valid: cfg.Webhook.MaxAttempts > 0},

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -31,11 +31,12 @@ func defaultConfig() Config {
 			SandboxTimeout: 5 * time.Minute,
 		},
 		EnvironmentRunner: EnvironmentRunnerConfig{
-			Enabled:            true,
-			Concurrency:        2,
-			ManagerPath:        "/usr/local/bin/environment-manager",
-			ClaudeAgentVersion: "2.1.120",
-			ClaudePath:         "/opt/claude-code/bin/claude",
+			Enabled:                 true,
+			Concurrency:             2,
+			PackageProvisionTimeout: 2 * time.Minute,
+			ManagerPath:             "/usr/local/bin/environment-manager",
+			ClaudeAgentVersion:      "2.1.120",
+			ClaudePath:              "/opt/claude-code/bin/claude",
 		},
 		CodeSession: CodeSessionConfig{
 			OTLPLogRoot:             "logs",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -84,11 +84,12 @@ type E2BConfig struct {
 }
 
 type EnvironmentRunnerConfig struct {
-	Enabled            bool   `yaml:"enabled"`
-	Concurrency        int    `yaml:"concurrency"`
-	ManagerPath        string `yaml:"manager_path"`
-	ClaudeAgentVersion string `yaml:"claude_agent_version"`
-	ClaudePath         string `yaml:"claude_path"`
+	Enabled                 bool          `yaml:"enabled"`
+	Concurrency             int           `yaml:"concurrency"`
+	PackageProvisionTimeout time.Duration `yaml:"package_provision_timeout"`
+	ManagerPath             string        `yaml:"manager_path"`
+	ClaudeAgentVersion      string        `yaml:"claude_agent_version"`
+	ClaudePath              string        `yaml:"claude_path"`
 }
 
 type CodeSessionConfig struct {

--- a/internal/environments/handler.go
+++ b/internal/environments/handler.go
@@ -908,16 +908,12 @@ func platformDefaultCloudConfigForResponse() json.RawMessage {
 	return out
 }
 
-func platformPackagesForResponse(raw json.RawMessage) map[string]any {
-	var fields map[string]json.RawMessage
+func platformPackagesForResponse(raw json.RawMessage) *environmentPackages {
+	packages := emptyPackages()
 	if len(raw) > 0 && !isJSONNull(raw) {
-		_ = json.Unmarshal(raw, &fields)
+		_ = json.Unmarshal(raw, packages)
 	}
-	out := emptyPackages()
-	for _, manager := range []string{"apt", "cargo", "gem", "go", "npm", "pip"} {
-		out[manager] = platformStringArrayForResponse(fields[manager])
-	}
-	return out
+	return packages.normalized()
 }
 
 func platformNetworkingForResponse(raw json.RawMessage) map[string]any {
@@ -1190,41 +1186,6 @@ func normalizedCloudValue(raw json.RawMessage) map[string]any {
 	}
 	value["type"] = "cloud"
 	return value
-}
-
-func emptyPackages() map[string]any {
-	return map[string]any{
-		"type":  "packages",
-		"apt":   []string{},
-		"cargo": []string{},
-		"gem":   []string{},
-		"go":    []string{},
-		"npm":   []string{},
-		"pip":   []string{},
-	}
-}
-
-func normalizePackages(raw json.RawMessage) (map[string]any, error) {
-	if len(raw) == 0 || isJSONNull(raw) {
-		return emptyPackages(), nil
-	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &fields); err != nil {
-		return nil, errors.New("config.packages must be an object or null")
-	}
-	out := emptyPackages()
-	for _, manager := range []string{"apt", "cargo", "gem", "go", "npm", "pip"} {
-		rawList, ok := fields[manager]
-		if !ok || isJSONNull(rawList) {
-			continue
-		}
-		values, err := stringArray(rawList, "config.packages."+manager)
-		if err != nil {
-			return nil, err
-		}
-		out[manager] = values
-	}
-	return out, nil
 }
 
 func normalizeNetworking(raw json.RawMessage) (map[string]any, error) {

--- a/internal/environments/package_config.go
+++ b/internal/environments/package_config.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/superduck-ai/open-managed-agents/internal/common/collections"
+
 	"github.com/samber/lo"
 )
 
@@ -120,7 +122,7 @@ func (p *environmentPackages) validate() error {
 // 避免把私有仓库地址或 token 写进 API 错误和日志。
 func validatePackageSpecs(manager string, specs []string) error {
 	switch {
-	case lo.SomeBy(specs, isBlankPackageSpec):
+	case lo.SomeBy(specs, collections.IsBlank):
 		return fmt.Errorf("config.packages.%s entries must be non-empty strings", manager)
 	case lo.SomeBy(specs, isPackageManagerOption):
 		return errors.New(invalidPackageOptionMessage)
@@ -128,10 +130,6 @@ func validatePackageSpecs(manager string, specs []string) error {
 		return fmt.Errorf("config.packages.%s entries must not contain URL credentials", manager)
 	}
 	return nil
-}
-
-func isBlankPackageSpec(spec string) bool {
-	return strings.TrimSpace(spec) == ""
 }
 
 func isPackageManagerOption(spec string) bool {

--- a/internal/environments/package_config.go
+++ b/internal/environments/package_config.go
@@ -1,0 +1,155 @@
+package environments
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/samber/lo"
+)
+
+const (
+	managerPackageType          = "packages"
+	maxPackageManifestBytes     = 1 << 20
+	invalidPackagesTypeMessage  = `config.packages.type must be "packages"`
+	invalidPackageOptionMessage = "config.packages entries must be package specs, not manager options"
+)
+
+var packageCredentialURLPattern = regexp.MustCompile(`(?i)[a-z][a-z0-9+.-]*://[^/@\s]+@`)
+
+type environmentPackages struct {
+	Type  string   `json:"type"`
+	APT   []string `json:"apt"`
+	Cargo []string `json:"cargo"`
+	Gem   []string `json:"gem"`
+	Go    []string `json:"go"`
+	NPM   []string `json:"npm"`
+	PIP   []string `json:"pip"`
+}
+
+// managerSpecs 把一个 Package Manager 的名字和它的 spec 列表绑在一起。specs 是
+// 指针，使 ensureLists 能就地补齐 nil 列表。
+type managerSpecs struct {
+	manager string
+	specs   *[]string
+}
+
+// specsByManager 是 OMA 侧校验、空判断和列表规范化的唯一真相源；这里的顺序与
+// v1 manifest 的规范顺序 apt → cargo → gem → go → npm → pip 一致。实际安装顺序
+// 和首错停止由 Environment Manager 的 provision-packages 合同负责。
+func (p *environmentPackages) specsByManager() []managerSpecs {
+	return []managerSpecs{
+		{manager: "apt", specs: &p.APT},
+		{manager: "cargo", specs: &p.Cargo},
+		{manager: "gem", specs: &p.Gem},
+		{manager: "go", specs: &p.Go},
+		{manager: "npm", specs: &p.NPM},
+		{manager: "pip", specs: &p.PIP},
+	}
+}
+
+func emptyPackages() *environmentPackages {
+	return (&environmentPackages{}).normalized()
+}
+
+// normalized 固定 Claude 兼容响应与 provisioner manifest 的字段形状：把 type 补成
+// managerPackageType，并让每个 manager 序列化成 [] 而非 null。返回自身便于链式调用。
+func (p *environmentPackages) normalized() *environmentPackages {
+	p.Type = managerPackageType
+	p.ensureLists()
+	return p
+}
+
+// normalizePackages 是 config.packages 的 HTTP 边界：它接受任意请求 JSON，
+// 判断结构、校验语义，并返回已补齐空列表的命名 schema。存量配置改走
+// buildPackageManifest 的类型化解码，不再经过这里。
+func normalizePackages(raw json.RawMessage) (*environmentPackages, error) {
+	packages := emptyPackages()
+	if len(raw) == 0 || isJSONNull(raw) {
+		return packages, nil
+	}
+	if err := json.Unmarshal(raw, packages); err != nil {
+		var typeError *json.UnmarshalTypeError
+		if errors.As(err, &typeError) && typeError.Field != "" {
+			if typeError.Field == "type" {
+				return nil, errors.New(invalidPackagesTypeMessage)
+			}
+			return nil, fmt.Errorf("config.packages.%s must be an array of strings", typeError.Field)
+		}
+		return nil, errors.New("config.packages must be an object or null")
+	}
+	if err := packages.validate(); err != nil {
+		return nil, err
+	}
+	packages.ensureLists()
+	if err := packages.checkManifestSize(); err != nil {
+		return nil, err
+	}
+	return packages, nil
+}
+
+// checkManifestSize 在 API 边界拒绝编码后超过 Environment Manager stdin 合同
+// 上限（1 MiB）的 packages。否则 Environment 能创建成功，但之后每个 Session
+// sandbox 都会在装包阶段被 Manager 拒绝而失败。
+func (p *environmentPackages) checkManifestSize() error {
+	encoded, err := json.Marshal(packageManifest{Version: 1, Packages: *p})
+	if err != nil {
+		return err
+	}
+	if len(encoded) > maxPackageManifestBytes {
+		return errors.New("config.packages exceeds the 1 MiB manifest limit")
+	}
+	return nil
+}
+
+func (p *environmentPackages) validate() error {
+	if p.Type != "" && p.Type != managerPackageType {
+		return errors.New(invalidPackagesTypeMessage)
+	}
+	for _, entry := range p.specsByManager() {
+		if err := validatePackageSpecs(entry.manager, *entry.specs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validatePackageSpecs 只报告违规的 manager 和规则，不回显 spec 本身，
+// 避免把私有仓库地址或 token 写进 API 错误和日志。
+func validatePackageSpecs(manager string, specs []string) error {
+	switch {
+	case lo.SomeBy(specs, isBlankPackageSpec):
+		return fmt.Errorf("config.packages.%s entries must be non-empty strings", manager)
+	case lo.SomeBy(specs, isPackageManagerOption):
+		return errors.New(invalidPackageOptionMessage)
+	case lo.SomeBy(specs, packageCredentialURLPattern.MatchString):
+		return fmt.Errorf("config.packages.%s entries must not contain URL credentials", manager)
+	}
+	return nil
+}
+
+func isBlankPackageSpec(spec string) bool {
+	return strings.TrimSpace(spec) == ""
+}
+
+func isPackageManagerOption(spec string) bool {
+	return strings.HasPrefix(strings.TrimSpace(spec), "-")
+}
+
+func (p *environmentPackages) empty() bool {
+	return lo.EveryBy(p.specsByManager(), func(entry managerSpecs) bool {
+		return len(*entry.specs) == 0
+	})
+}
+
+// ensureLists 让每个 manager 都序列化成 []，而不是 null，使 Claude 兼容响应和
+// provisioner manifest 的字段形状保持稳定。
+func (p *environmentPackages) ensureLists() {
+	for _, entry := range p.specsByManager() {
+		if *entry.specs == nil {
+			*entry.specs = []string{}
+		}
+	}
+}

--- a/internal/environments/package_provisioner.go
+++ b/internal/environments/package_provisioner.go
@@ -1,0 +1,182 @@
+package environments
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
+)
+
+const (
+	packageProvisionArgs                 = "provision-packages --protocol v1 --stdin"
+	maxPackageProvisioningResultBytes    = 16 << 10
+	unknownPackageProvisioningDiagnostic = "unknown"
+)
+
+// buildPackageProvisionCommand 用配置的 manager path（与 task-run 相同的
+// firstNonEmpty 兜底与 shell 引用）构造 provision 命令，避免部署把
+// environment_runner.manager_path 指向别处时，无包 session 正常而有包 session
+// 在启动前全部失败。固定 flag 不含任何用户数据，spec 只经由 stdin 传入。
+func buildPackageProvisionCommand(cfg config.Config) string {
+	managerPath := firstNonEmpty(strings.TrimSpace(cfg.EnvironmentRunner.ManagerPath), defaultEnvironmentManagerPath)
+	return shellQuote(managerPath) + " " + packageProvisionArgs
+}
+
+type packageManifest struct {
+	Version  int                 `json:"version"`
+	Packages environmentPackages `json:"packages"`
+}
+
+type cloudEnvironmentPackagesConfig struct {
+	Type     string               `json:"type"`
+	Packages *environmentPackages `json:"packages"`
+}
+
+// packageProvisioningResult is the v1 JSON stdout contract from environment-manager.
+// OMA gates startup on status/exit agreement and only exposes stable diagnostic
+// values; category/stage/manager field combinations stay owned by environment-manager.
+type packageProvisioningResult struct {
+	Version      *int    `json:"version"`
+	Status       *string `json:"status"`
+	Category     *string `json:"category"`
+	Manager      *string `json:"manager"`
+	Stage        *string `json:"stage"`
+	PackageCount *int    `json:"package_count"`
+	DurationMS   *int64  `json:"duration_ms"`
+	ExitCode     *int    `json:"exit_code"`
+}
+
+// buildPackageManifest 从已持久化的 Environment config 生成 provisioner manifest。
+// 存量 config 已经过 HTTP 边界规范化，因此这里直接解码成命名 schema；仍然重新
+// 校验一次，使被直接改写的数据库记录无法把非法 spec 送进 Sandbox。
+func buildPackageManifest(config json.RawMessage) ([]byte, bool, error) {
+	var cloud cloudEnvironmentPackagesConfig
+	if err := json.Unmarshal(config, &cloud); err != nil {
+		return nil, false, fmt.Errorf("decode environment config: %w", err)
+	}
+	if cloud.Type != "cloud" || cloud.Packages == nil {
+		return nil, false, nil
+	}
+	packages := cloud.Packages
+	if err := packages.validate(); err != nil {
+		return nil, false, err
+	}
+	if packages.empty() {
+		return nil, false, nil
+	}
+	packages.normalized()
+	if err := packages.checkManifestSize(); err != nil {
+		return nil, false, err
+	}
+	data, err := json.Marshal(packageManifest{Version: 1, Packages: *packages})
+	if err != nil {
+		return nil, false, fmt.Errorf("encode packages manifest: %w", err)
+	}
+	return data, true, nil
+}
+
+func validatePackageProvisioningResult(commandResult e2bruntime.CommandResult) error {
+	result, err := decodePackageProvisioningResult(commandResult.Stdout)
+	if err != nil {
+		return err
+	}
+	if result.Version == nil || *result.Version != 1 || result.Status == nil || result.DurationMS == nil || *result.DurationMS < 0 {
+		return errors.New("invalid package provisioning result: missing or invalid required field")
+	}
+
+	switch *result.Status {
+	case "succeeded":
+		if commandResult.ExitCode != 0 {
+			return fmt.Errorf("invalid package provisioning result: succeeded status with process exit code %d", commandResult.ExitCode)
+		}
+		if result.PackageCount == nil || *result.PackageCount < 0 || hasPackageProvisioningFailureFields(result) {
+			return errors.New("invalid package provisioning result: inconsistent succeeded fields")
+		}
+		return nil
+	case "failed":
+		if commandResult.ExitCode == 0 {
+			return errors.New("invalid package provisioning result: failed status with process exit code 0")
+		}
+		if result.PackageCount != nil && *result.PackageCount < 0 {
+			return errors.New("invalid package provisioning result: negative package_count")
+		}
+		if result.ExitCode != nil && *result.ExitCode <= 0 {
+			return errors.New("invalid package provisioning result: invalid manager exit_code")
+		}
+		return fmt.Errorf(
+			"provision environment packages: status=failed category=%s manager=%s stage=%s package_count=%s duration_ms=%d exit_code=%s",
+			safePackageProvisioningCategory(result.Category),
+			safePackageProvisioningManager(result.Manager),
+			safePackageProvisioningStage(result.Stage),
+			optionalPackageProvisioningInt(result.PackageCount),
+			*result.DurationMS,
+			optionalPackageProvisioningInt(result.ExitCode),
+		)
+	default:
+		return errors.New("invalid package provisioning result: unknown status")
+	}
+}
+
+func decodePackageProvisioningResult(stdout []byte) (packageProvisioningResult, error) {
+	if len(stdout) > maxPackageProvisioningResultBytes {
+		return packageProvisioningResult{}, errors.New("invalid package provisioning result: exceeds 16 KiB limit")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(stdout))
+	decoder.DisallowUnknownFields()
+	var result packageProvisioningResult
+	if err := decoder.Decode(&result); err != nil {
+		return packageProvisioningResult{}, errors.New("invalid package provisioning result: decode failed")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return packageProvisioningResult{}, errors.New("invalid package provisioning result: multiple JSON values")
+	}
+	return result, nil
+}
+
+func safePackageProvisioningCategory(value *string) string {
+	if value != nil {
+		switch *value {
+		case "invalid_manifest", "package_manager", "execution_environment", "timeout", "cancelled", "internal":
+			return *value
+		}
+	}
+	return unknownPackageProvisioningDiagnostic
+}
+
+func safePackageProvisioningManager(value *string) string {
+	if value != nil {
+		switch *value {
+		case "apt", "cargo", "gem", "go", "npm", "pip":
+			return *value
+		}
+	}
+	return unknownPackageProvisioningDiagnostic
+}
+
+func safePackageProvisioningStage(value *string) string {
+	if value != nil {
+		switch *value {
+		case "decode", "validate", "preflight", "start", "prepare", "update", "install", "finalize":
+			return *value
+		}
+	}
+	return unknownPackageProvisioningDiagnostic
+}
+
+func hasPackageProvisioningFailureFields(result packageProvisioningResult) bool {
+	return result.Category != nil || result.Manager != nil || result.Stage != nil || result.ExitCode != nil
+}
+
+func optionalPackageProvisioningInt(value *int) string {
+	if value == nil {
+		return "unknown"
+	}
+	return strconv.Itoa(*value)
+}

--- a/internal/environments/package_provisioner_test.go
+++ b/internal/environments/package_provisioner_test.go
@@ -1,0 +1,232 @@
+package environments
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
+)
+
+func TestBuildPackageProvisionCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"default", "", "'/usr/local/bin/environment-manager' provision-packages --protocol v1 --stdin"},
+		{"configured path is quoted", "/opt/env manager/bin/environment-manager", "'/opt/env manager/bin/environment-manager' provision-packages --protocol v1 --stdin"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := config.Config{}
+			cfg.EnvironmentRunner.ManagerPath = test.path
+			if got := buildPackageProvisionCommand(cfg); got != test.want {
+				t.Fatalf("buildPackageProvisionCommand() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNormalizePackages(t *testing.T) {
+	t.Run("normalizes representative valid input", func(t *testing.T) {
+		packages, err := normalizePackages(json.RawMessage(`{"type":"packages","apt":[" curl "],"npm":["@scope/pkg@1"],"pip":["requests[socks]"]}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if packages.Type != managerPackageType || !reflect.DeepEqual(packages.APT, []string{" curl "}) ||
+			!reflect.DeepEqual(packages.NPM, []string{"@scope/pkg@1"}) || !reflect.DeepEqual(packages.PIP, []string{"requests[socks]"}) {
+			t.Fatalf("normalizePackages() = %#v", packages)
+		}
+	})
+
+	invalid := []struct {
+		name string
+		raw  json.RawMessage
+		want string
+	}{
+		{"invalid type", json.RawMessage(`{"type":"other","pip":["numpy"]}`), invalidPackagesTypeMessage},
+		{"non-array", json.RawMessage(`{"type":"packages","pip":"numpy"}`), "config.packages.pip must be an array of strings"},
+		{"blank", json.RawMessage(`{"type":"packages","apt":["  "]}`), "entries must be non-empty strings"},
+		{"manager option", json.RawMessage(`{"type":"packages","pip":["--token=secret-value"]}`), invalidPackageOptionMessage},
+		{"credential URL", json.RawMessage(`{"type":"packages","pip":["git+https://user:secret-token@example.test/private.git"]}`), "must not contain URL credentials"},
+	}
+	for _, test := range invalid {
+		t.Run(test.name, func(t *testing.T) {
+			packages, err := normalizePackages(test.raw)
+			if err == nil || packages != nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("normalizePackages() = (%#v, %v), want %q", packages, err, test.want)
+			}
+			if strings.Contains(err.Error(), "secret-value") || strings.Contains(err.Error(), "secret-token") {
+				t.Fatalf("normalization error leaked credentials: %v", err)
+			}
+		})
+	}
+
+	t.Run("API manifest above 1 MiB", func(t *testing.T) {
+		packages, err := normalizePackages(mustPackageJSON(t, map[string]any{
+			"type": managerPackageType,
+			"pip":  []string{strings.Repeat("a", (1<<20)+1)},
+		}))
+		if err == nil || packages != nil || !strings.Contains(err.Error(), "1 MiB manifest limit") {
+			t.Fatalf("normalizePackages() = (%#v, %v), want size error", packages, err)
+		}
+	})
+}
+
+func TestBuildPackageManifest(t *testing.T) {
+	t.Run("malformed root", func(t *testing.T) {
+		manifest, provision, err := buildPackageManifest(json.RawMessage(`{"type":`))
+		if err == nil || provision || manifest != nil || !strings.Contains(err.Error(), "decode environment config") {
+			t.Fatalf("buildPackageManifest() = (%s, %t, %v)", manifest, provision, err)
+		}
+	})
+
+	t.Run("stored dirty validation", func(t *testing.T) {
+		manifest, provision, err := buildPackageManifest(json.RawMessage(`{"type":"cloud","packages":{"type":"packages","pip":["-x=secret-value"]}}`))
+		if err == nil || provision || manifest != nil || !strings.Contains(err.Error(), invalidPackageOptionMessage) || strings.Contains(err.Error(), "secret-value") {
+			t.Fatalf("buildPackageManifest() = (%s, %t, %v)", manifest, provision, err)
+		}
+	})
+
+	for _, test := range []struct {
+		name string
+		raw  string
+	}{
+		{"explicit empty", `{"type":"cloud","packages":{"type":"packages"}}`},
+		{"absent packages", `{"type":"cloud"}`},
+		{"null packages", `{"type":"cloud","packages":null}`},
+		{"non-cloud", `{"type":"local","packages":{"type":"packages","pip":["numpy"]}}`},
+	} {
+		t.Run(test.name+" skips provisioning", func(t *testing.T) {
+			manifest, provision, err := buildPackageManifest(json.RawMessage(test.raw))
+			if err != nil || provision || manifest != nil {
+				t.Fatalf("buildPackageManifest() = (%s, %t, %v)", manifest, provision, err)
+			}
+		})
+	}
+
+	t.Run("exact all-manager special-character JSON stdin", func(t *testing.T) {
+		packages := environmentPackages{
+			Type: managerPackageType,
+			APT:  []string{"libfoo; echo nope"}, Cargo: []string{"crate@1 && false"},
+			Gem: []string{"gem name 'quoted'"}, Go: []string{"example.test/mod@v1.2.3"},
+			NPM: []string{"@scope/package@1.2.3"}, PIP: []string{`requests[socks] ; python_version >= "3.11"`},
+		}
+		manifest, provision, err := buildPackageManifest(mustPackageJSON(t, map[string]any{"type": "cloud", "packages": packages}))
+		if err != nil || !provision {
+			t.Fatalf("buildPackageManifest() provision = %t, error = %v", provision, err)
+		}
+		want := mustPackageJSON(t, packageManifest{Version: 1, Packages: packages})
+		if !bytes.Equal(manifest, want) {
+			t.Fatalf("manifest = %s, want exact JSON stdin %s", manifest, want)
+		}
+	})
+
+	t.Run("stored manifest above 1 MiB", func(t *testing.T) {
+		configJSON := mustPackageJSON(t, map[string]any{"type": "cloud", "packages": map[string]any{
+			"type": managerPackageType, "pip": []string{strings.Repeat("a", (1<<20)+1)},
+		}})
+		manifest, provision, err := buildPackageManifest(configJSON)
+		if err == nil || provision || manifest != nil || !strings.Contains(err.Error(), "1 MiB manifest limit") {
+			t.Fatalf("buildPackageManifest() = (%d bytes, %t, %v)", len(manifest), provision, err)
+		}
+	})
+}
+
+func TestValidatePackageProvisioningResult(t *testing.T) {
+	t.Run("valid success", func(t *testing.T) {
+		err := validatePackageProvisioningResult(e2bruntime.CommandResult{ExitCode: 0, Stdout: []byte(`{"version":1,"status":"succeeded","package_count":6,"duration_ms":12}`)})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("valid structured failure", func(t *testing.T) {
+		err := validatePackageProvisioningResult(e2bruntime.CommandResult{ExitCode: 10, Stdout: []byte(`{"version":1,"status":"failed","category":"package_manager","manager":"npm","stage":"install","package_count":6,"duration_ms":8,"exit_code":17}`)})
+		if err == nil {
+			t.Fatal("failure was accepted")
+		}
+		for _, want := range []string{"category=package_manager", "manager=npm", "stage=install", "package_count=6", "duration_ms=8", "exit_code=17"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error %q does not contain %q", err, want)
+			}
+		}
+	})
+
+	rejected := []struct {
+		name   string
+		exit   int
+		stdout string
+		want   string
+	}{
+		{"failed with exit zero", 0, `{"version":1,"status":"failed","duration_ms":1}`, "process exit code 0"},
+		{"negative duration", 0, `{"version":1,"status":"succeeded","package_count":1,"duration_ms":-1}`, "required field"},
+		{"negative package count", 10, `{"version":1,"status":"failed","package_count":-1,"duration_ms":1}`, "negative package_count"},
+		{"nonpositive manager exit code", 10, `{"version":1,"status":"failed","duration_ms":1,"exit_code":0}`, "manager exit_code"},
+		{"success with failure field", 0, `{"version":1,"status":"succeeded","package_count":1,"duration_ms":1,"manager":"pip"}`, "inconsistent succeeded fields"},
+		{"missing version", 0, `{"status":"succeeded","package_count":1,"duration_ms":1}`, "required field"},
+		{"wrong version", 0, `{"version":2,"status":"succeeded","package_count":1,"duration_ms":1}`, "required field"},
+		{"missing status", 0, `{"version":1,"package_count":1,"duration_ms":1}`, "required field"},
+		{"wrong status type", 0, `{"version":1,"status":2,"package_count":1,"duration_ms":1}`, "decode failed"},
+		{"missing duration", 0, `{"version":1,"status":"succeeded","package_count":1}`, "required field"},
+		{"wrong duration type", 0, `{"version":1,"status":"succeeded","package_count":1,"duration_ms":"1"}`, "decode failed"},
+		{"missing success count", 0, `{"version":1,"status":"succeeded","duration_ms":1}`, "inconsistent succeeded fields"},
+		{"wrong success count type", 0, `{"version":1,"status":"succeeded","package_count":"1","duration_ms":1}`, "decode failed"},
+		{"unknown status", 0, `{"version":1,"status":"pending","duration_ms":1}`, "unknown status"},
+		{"unknown JSON field", 0, `{"version":1,"status":"succeeded","package_count":1,"duration_ms":1,"detail":"nope"}`, "decode failed"},
+		{"multiple JSON values", 0, `{"version":1,"status":"succeeded","package_count":1,"duration_ms":1} {}`, "multiple JSON values"},
+	}
+	for _, test := range rejected {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePackageProvisioningResult(e2bruntime.CommandResult{ExitCode: test.exit, Stdout: []byte(test.stdout)})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+
+	otherInvalid := []struct {
+		name   string
+		result e2bruntime.CommandResult
+		want   string
+	}{
+		{"empty", e2bruntime.CommandResult{}, "decode failed"},
+		{"malformed", e2bruntime.CommandResult{Stdout: []byte(`{"version":`)}, "decode failed"},
+		{"exit status mismatch", e2bruntime.CommandResult{ExitCode: 10, Stdout: []byte(`{"version":1,"status":"succeeded","package_count":1,"duration_ms":2}`)}, "exit code"},
+		{"oversized", e2bruntime.CommandResult{Stdout: bytes.Repeat([]byte("x"), maxPackageProvisioningResultBytes+1)}, "16 KiB limit"},
+	}
+	for _, test := range otherInvalid {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePackageProvisioningResult(test.result)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validatePackageProvisioningResult() = %v, want %q", err, test.want)
+			}
+		})
+	}
+
+	t.Run("unknown diagnostics are sanitized", func(t *testing.T) {
+		const secret = "secret-package-output"
+		err := validatePackageProvisioningResult(e2bruntime.CommandResult{ExitCode: 10, Stdout: []byte(`{"version":1,"status":"failed","category":"` + secret + `","manager":"` + secret + `","stage":"` + secret + `","duration_ms":8}`)})
+		if err == nil || strings.Contains(err.Error(), secret) {
+			t.Fatalf("sanitized diagnostics = %v", err)
+		}
+		for _, field := range []string{"category=unknown", "manager=unknown", "stage=unknown"} {
+			if !strings.Contains(err.Error(), field) {
+				t.Errorf("sanitized diagnostics %q missing %q", err, field)
+			}
+		}
+	})
+}
+
+func mustPackageJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	return data
+}

--- a/internal/environments/package_provisioner_test.go
+++ b/internal/environments/package_provisioner_test.go
@@ -32,17 +32,6 @@ func TestBuildPackageProvisionCommand(t *testing.T) {
 }
 
 func TestNormalizePackages(t *testing.T) {
-	t.Run("normalizes representative valid input", func(t *testing.T) {
-		packages, err := normalizePackages(json.RawMessage(`{"type":"packages","apt":[" curl "],"npm":["@scope/pkg@1"],"pip":["requests[socks]"]}`))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if packages.Type != managerPackageType || !reflect.DeepEqual(packages.APT, []string{" curl "}) ||
-			!reflect.DeepEqual(packages.NPM, []string{"@scope/pkg@1"}) || !reflect.DeepEqual(packages.PIP, []string{"requests[socks]"}) {
-			t.Fatalf("normalizePackages() = %#v", packages)
-		}
-	})
-
 	invalid := []struct {
 		name string
 		raw  json.RawMessage
@@ -73,6 +62,17 @@ func TestNormalizePackages(t *testing.T) {
 		}))
 		if err == nil || packages != nil || !strings.Contains(err.Error(), "1 MiB manifest limit") {
 			t.Fatalf("normalizePackages() = (%#v, %v), want size error", packages, err)
+		}
+	})
+
+	t.Run("normalizes representative valid input", func(t *testing.T) {
+		packages, err := normalizePackages(json.RawMessage(`{"type":"packages","apt":[" curl "],"npm":["@scope/pkg@1"],"pip":["requests[socks]"]}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if packages.Type != managerPackageType || !reflect.DeepEqual(packages.APT, []string{" curl "}) ||
+			!reflect.DeepEqual(packages.NPM, []string{"@scope/pkg@1"}) || !reflect.DeepEqual(packages.PIP, []string{"requests[socks]"}) {
+			t.Fatalf("normalizePackages() = %#v", packages)
 		}
 	})
 }
@@ -138,13 +138,6 @@ func TestBuildPackageManifest(t *testing.T) {
 }
 
 func TestValidatePackageProvisioningResult(t *testing.T) {
-	t.Run("valid success", func(t *testing.T) {
-		err := validatePackageProvisioningResult(e2bruntime.CommandResult{ExitCode: 0, Stdout: []byte(`{"version":1,"status":"succeeded","package_count":6,"duration_ms":12}`)})
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
 	t.Run("valid structured failure", func(t *testing.T) {
 		err := validatePackageProvisioningResult(e2bruntime.CommandResult{ExitCode: 10, Stdout: []byte(`{"version":1,"status":"failed","category":"package_manager","manager":"npm","stage":"install","package_count":6,"duration_ms":8,"exit_code":17}`)})
 		if err == nil {
@@ -218,6 +211,13 @@ func TestValidatePackageProvisioningResult(t *testing.T) {
 			if !strings.Contains(err.Error(), field) {
 				t.Errorf("sanitized diagnostics %q missing %q", err, field)
 			}
+		}
+	})
+
+	t.Run("valid success", func(t *testing.T) {
+		err := validatePackageProvisioningResult(e2bruntime.CommandResult{ExitCode: 0, Stdout: []byte(`{"version":1,"status":"succeeded","package_count":6,"duration_ms":12}`)})
+		if err != nil {
+			t.Fatal(err)
 		}
 	})
 }

--- a/internal/environments/rclone_filestore_test.go
+++ b/internal/environments/rclone_filestore_test.go
@@ -240,18 +240,18 @@ func (p *rcloneTestProvider) FileExists(_ context.Context, _ string, path string
 	return p.ready, nil
 }
 
-func (p *rcloneTestProvider) RunCommand(_ context.Context, _ string, command string, _ time.Duration) error {
-	p.runCommands = append(p.runCommands, command)
+func (p *rcloneTestProvider) RunCommand(_ context.Context, _ string, request e2bruntime.CommandRequest) (e2bruntime.CommandResult, error) {
+	p.runCommands = append(p.runCommands, request.Command)
 	index := len(p.runCommands) - 1
 	if index < len(p.runErrors) {
 		if p.runErrors[index] != nil {
-			return p.runErrors[index]
+			return e2bruntime.CommandResult{}, p.runErrors[index]
 		}
 	}
-	if command == rcloneConfigCleanupCommand() {
+	if request.Command == rcloneConfigCleanupCommand() {
 		p.configExists = false
 	}
-	return nil
+	return e2bruntime.CommandResult{}, nil
 }
 
 func (p *rcloneTestProvider) StartBackgroundCommand(context.Context, string, string, []byte) error {

--- a/internal/environments/rclone_filestore_test.go
+++ b/internal/environments/rclone_filestore_test.go
@@ -97,6 +97,20 @@ func TestRcloneCommandsKeepTokensOutOfCommandText(t *testing.T) {
 	}
 }
 
+func TestRunSandboxCommandReportsBoundedOutput(t *testing.T) {
+	provider := &rcloneTestProvider{runResult: e2bruntime.CommandResult{
+		ExitCode: 17,
+		Stdout:   []byte("readiness probe output"),
+		Stderr:   []byte(strings.Repeat("x", 2049)),
+	}}
+	runner := &Runner{provider: provider}
+	err := runner.runSandboxCommand(context.Background(), "sandbox_test", "probe", time.Second)
+	if err == nil || !strings.Contains(err.Error(), `stdout="readiness probe output"`) ||
+		!strings.Contains(err.Error(), `stderr="`+strings.Repeat("x", 2048)+`...[truncated]"`) {
+		t.Fatalf("runSandboxCommand() error = %v, want bounded stdout and stderr", err)
+	}
+}
+
 func TestStartRcloneFilestoreFailures(t *testing.T) {
 	const secretMarker = "provider-secret-marker"
 	providerFailure := errors.New("provider failed with " + secretMarker)
@@ -198,6 +212,7 @@ type rcloneTestProvider struct {
 	ready           bool
 	readySequence   []bool
 	runErrors       []error
+	runResult       e2bruntime.CommandResult
 	runCommands     []string
 	writePath       string
 	writeData       []byte
@@ -251,7 +266,7 @@ func (p *rcloneTestProvider) RunCommand(_ context.Context, _ string, request e2b
 	if request.Command == rcloneConfigCleanupCommand() {
 		p.configExists = false
 	}
-	return e2bruntime.CommandResult{}, nil
+	return p.runResult, nil
 }
 
 func (p *rcloneTestProvider) StartBackgroundCommand(context.Context, string, string, []byte) error {

--- a/internal/environments/runner.go
+++ b/internal/environments/runner.go
@@ -8,8 +8,10 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
+	"github.com/superduck-ai/open-managed-agents/internal/common/collections"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/filestore"
@@ -363,7 +365,7 @@ func (r *Runner) provisionCreatedSandboxPackages(
 	providerSandboxID string,
 	manifest []byte,
 ) (bool, error) {
-	if strings.TrimSpace(providerSandboxID) == "" {
+	if collections.IsBlank(providerSandboxID) {
 		err := errors.New("provider returned an empty sandbox id for package provisioning")
 		r.failCreatedSandbox(ctx, record, work, providerSandboxID, err)
 		return false, err
@@ -655,12 +657,16 @@ func (r *Runner) runSandboxCommand(ctx context.Context, sandboxID, command strin
 }
 
 func truncateSandboxCommandOutput(value []byte) string {
-	trimmed := strings.TrimSpace(string(value))
+	trimmed := strings.TrimSpace(strings.ToValidUTF8(string(value), "\uFFFD"))
 	const limit = 2048
 	if len(trimmed) <= limit {
 		return trimmed
 	}
-	return trimmed[:limit] + "...[truncated]"
+	end := limit
+	for end > 0 && !utf8.RuneStart(trimmed[end]) {
+		end--
+	}
+	return trimmed[:end] + "...[truncated]"
 }
 
 func (r *Runner) logRcloneStageFailure(ctx context.Context, stage string, publicError, cause error) error {

--- a/internal/environments/runner.go
+++ b/internal/environments/runner.go
@@ -386,7 +386,7 @@ func (r *Runner) provisionCreatedSandboxPackages(
 	if heartbeat.LeaseExtended {
 		return true, nil
 	}
-	r.failCreatedSandbox(ctx, record, work, providerSandboxID, errors.New("environment work stopped during package provisioning"))
+	r.stopCreatedSandbox(ctx, record, work, providerSandboxID)
 	return false, nil
 }
 
@@ -394,7 +394,7 @@ func (r *Runner) provisionPackages(ctx context.Context, sandboxID string, manife
 	result, err := r.provider.RunCommand(ctx, sandboxID, e2bruntime.CommandRequest{
 		Command: buildPackageProvisionCommand(r.cfg),
 		Stdin:   manifest,
-		Timeout: r.cfg.E2B.SandboxTimeout,
+		Timeout: r.cfg.EnvironmentRunner.PackageProvisionTimeout,
 	})
 	if err != nil {
 		return fmt.Errorf("provision environment packages: %w", err)
@@ -429,6 +429,18 @@ func (r *Runner) failCreatedSandbox(ctx context.Context, record db.EnvironmentSa
 	now := time.Now().UTC()
 	message := cause.Error()
 	_ = r.db.UpdateEnvironmentSandboxState(ctx, record.WorkspaceID, record.ExternalID, "failed", &providerSandboxID, &message, &now)
+	_, _ = r.db.StopEnvironmentWork(ctx, work.WorkspaceID, work.EnvironmentExternalID, work.ExternalID, true)
+	if strings.TrimSpace(providerSandboxID) == "" {
+		return
+	}
+	killCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	_ = r.provider.Kill(killCtx, providerSandboxID)
+}
+
+func (r *Runner) stopCreatedSandbox(ctx context.Context, record db.EnvironmentSandbox, work *db.EnvironmentWork, providerSandboxID string) {
+	now := time.Now().UTC()
+	_ = r.db.UpdateEnvironmentSandboxState(ctx, record.WorkspaceID, record.ExternalID, "stopped", &providerSandboxID, nil, &now)
 	_, _ = r.db.StopEnvironmentWork(ctx, work.WorkspaceID, work.EnvironmentExternalID, work.ExternalID, true)
 	if strings.TrimSpace(providerSandboxID) == "" {
 		return
@@ -621,9 +633,23 @@ func (r *Runner) runSandboxCommand(ctx context.Context, sandboxID, command strin
 		return err
 	}
 	if result.ExitCode != 0 {
-		return fmt.Errorf("sandbox command exited with code %d", result.ExitCode)
+		return fmt.Errorf(
+			"sandbox command exited with code %d: stdout=%q stderr=%q",
+			result.ExitCode,
+			truncateSandboxCommandOutput(result.Stdout),
+			truncateSandboxCommandOutput(result.Stderr),
+		)
 	}
 	return nil
+}
+
+func truncateSandboxCommandOutput(value []byte) string {
+	trimmed := strings.TrimSpace(string(value))
+	const limit = 2048
+	if len(trimmed) <= limit {
+		return trimmed
+	}
+	return trimmed[:limit] + "...[truncated]"
 }
 
 func (r *Runner) logRcloneStageFailure(ctx context.Context, stage string, publicError, cause error) error {

--- a/internal/environments/runner.go
+++ b/internal/environments/runner.go
@@ -280,6 +280,21 @@ func (r *Runner) RunOnce(ctx context.Context, workerID string) (bool, error) {
 		*work = updatedWork
 	}
 
+	manifest, provision, err := buildPackageManifest(env.Config)
+	if err != nil {
+		r.failCreatedSandbox(ctx, record, work, providerSandboxID, err)
+		return true, err
+	}
+	if provision {
+		proceed, err := r.provisionCreatedSandboxPackages(ctx, record, work, providerSandboxID, manifest)
+		if err != nil {
+			return true, err
+		}
+		if !proceed {
+			return true, nil
+		}
+	}
+
 	// 只有 Cloud Session Managed Agent 使用固定的四组 Filestore 挂载。
 	// 必须等 rclone ready 后才能继续，确保 Claude 启动时 uploads、outputs、
 	// transcripts 和 tool_results 已经可用。
@@ -339,6 +354,52 @@ func (r *Runner) RunOnce(ctx context.Context, workerID string) (bool, error) {
 
 	// true 表示本轮确实消费了一条 Work；nil 表示所需启动阶段全部完成。
 	return true, nil
+}
+
+func (r *Runner) provisionCreatedSandboxPackages(
+	ctx context.Context,
+	record db.EnvironmentSandbox,
+	work *db.EnvironmentWork,
+	providerSandboxID string,
+	manifest []byte,
+) (bool, error) {
+	if strings.TrimSpace(providerSandboxID) == "" {
+		err := errors.New("provider returned an empty sandbox id for package provisioning")
+		r.failCreatedSandbox(ctx, record, work, providerSandboxID, err)
+		return false, err
+	}
+	// Persist the provider ID before provisioning so a concurrent stop can
+	// find and terminate the sandbox while package installation is running.
+	if err := r.db.UpdateEnvironmentSandboxState(ctx, record.WorkspaceID, record.ExternalID, "creating", &providerSandboxID, nil, nil); err != nil {
+		r.failCreatedSandbox(ctx, record, work, providerSandboxID, err)
+		return false, err
+	}
+	if err := r.provisionPackages(ctx, providerSandboxID, manifest); err != nil {
+		r.failCreatedSandbox(ctx, record, work, providerSandboxID, err)
+		return false, err
+	}
+	heartbeat, err := r.db.HeartbeatEnvironmentWork(ctx, work.WorkspaceID, work.EnvironmentExternalID, work.ExternalID, "", 60, formatTime)
+	if err != nil {
+		r.failCreatedSandbox(ctx, record, work, providerSandboxID, err)
+		return false, err
+	}
+	if heartbeat.LeaseExtended {
+		return true, nil
+	}
+	r.failCreatedSandbox(ctx, record, work, providerSandboxID, errors.New("environment work stopped during package provisioning"))
+	return false, nil
+}
+
+func (r *Runner) provisionPackages(ctx context.Context, sandboxID string, manifest []byte) error {
+	result, err := r.provider.RunCommand(ctx, sandboxID, e2bruntime.CommandRequest{
+		Command: buildPackageProvisionCommand(r.cfg),
+		Stdin:   manifest,
+		Timeout: r.cfg.E2B.SandboxTimeout,
+	})
+	if err != nil {
+		return fmt.Errorf("provision environment packages: %w", err)
+	}
+	return validatePackageProvisioningResult(result)
 }
 
 func (r *Runner) failManagedAgentRuntime(
@@ -497,19 +558,19 @@ func (r *Runner) publishManagedAgentRuntime(
 
 func (r *Runner) startRcloneFilestore(ctx context.Context, sandboxID string, launch rcloneFilestoreLaunch) error {
 	if err := r.provider.WriteFile(ctx, sandboxID, rcloneConfigPath, launch.ConfigPayload); err != nil {
-		_ = r.provider.RunCommand(ctx, sandboxID, rcloneConfigCleanupCommand(), rcloneCommandGraceTimeout)
+		_ = r.runSandboxCommand(ctx, sandboxID, rcloneConfigCleanupCommand(), rcloneCommandGraceTimeout)
 		return r.logRcloneStageFailure(ctx, "config_write", errRcloneConfigWrite, err)
 	}
-	if err := r.provider.RunCommand(ctx, sandboxID, rcloneConfigPermissionsCommand(), rcloneCommandGraceTimeout); err != nil {
-		_ = r.provider.RunCommand(ctx, sandboxID, rcloneConfigCleanupCommand(), rcloneCommandGraceTimeout)
+	if err := r.runSandboxCommand(ctx, sandboxID, rcloneConfigPermissionsCommand(), rcloneCommandGraceTimeout); err != nil {
+		_ = r.runSandboxCommand(ctx, sandboxID, rcloneConfigCleanupCommand(), rcloneCommandGraceTimeout)
 		return r.logRcloneStageFailure(ctx, "config_permissions", errRcloneConfigPermissions, err)
 	}
 	if err := r.provider.StartBackgroundCommand(ctx, sandboxID, rcloneStartCommand(), nil); err != nil {
-		_ = r.provider.RunCommand(ctx, sandboxID, rcloneConfigCleanupCommand(), rcloneCommandGraceTimeout)
+		_ = r.runSandboxCommand(ctx, sandboxID, rcloneConfigCleanupCommand(), rcloneCommandGraceTimeout)
 		return r.logRcloneStageFailure(ctx, "process_start", errRcloneProcessStart, err)
 	}
 	if err := r.waitForRcloneReady(ctx, sandboxID, rcloneReadyPollInterval, rcloneReadyTimeout); err != nil {
-		_ = r.provider.RunCommand(ctx, sandboxID, rcloneConfigCleanupCommand(), rcloneCommandGraceTimeout)
+		_ = r.runSandboxCommand(ctx, sandboxID, rcloneConfigCleanupCommand(), rcloneCommandGraceTimeout)
 		return r.logRcloneStageFailure(ctx, "readiness", errRcloneReadiness, err)
 	}
 	r.removeRcloneConfig(ctx, sandboxID)
@@ -518,7 +579,7 @@ func (r *Runner) startRcloneFilestore(ctx context.Context, sandboxID string, lau
 
 func (r *Runner) removeRcloneConfig(ctx context.Context, sandboxID string) {
 	for attempt := 1; attempt <= rcloneConfigCleanupTries; attempt++ {
-		cleanupErr := r.provider.RunCommand(
+		cleanupErr := r.runSandboxCommand(
 			ctx,
 			sandboxID,
 			rcloneConfigCleanupCommand(),
@@ -552,6 +613,17 @@ func (r *Runner) removeRcloneConfig(ctx context.Context, sandboxID string) {
 		"attempts", rcloneConfigCleanupTries,
 		"config_may_remain", true,
 	)
+}
+
+func (r *Runner) runSandboxCommand(ctx context.Context, sandboxID, command string, timeout time.Duration) error {
+	result, err := r.provider.RunCommand(ctx, sandboxID, e2bruntime.CommandRequest{Command: command, Timeout: timeout})
+	if err != nil {
+		return err
+	}
+	if result.ExitCode != 0 {
+		return fmt.Errorf("sandbox command exited with code %d", result.ExitCode)
+	}
+	return nil
 }
 
 func (r *Runner) logRcloneStageFailure(ctx context.Context, stage string, publicError, cause error) error {

--- a/internal/environments/runner.go
+++ b/internal/environments/runner.go
@@ -375,6 +375,12 @@ func (r *Runner) provisionCreatedSandboxPackages(
 		return false, err
 	}
 	if err := r.provisionPackages(ctx, providerSandboxID, manifest); err != nil {
+		currentWork, lookupErr := r.db.GetEnvironmentWork(ctx, work.WorkspaceID, work.EnvironmentExternalID, work.ExternalID)
+		if lookupErr == nil && (currentWork.State == "stopping" || currentWork.State == "stopped") {
+			*work = currentWork
+			r.stopCreatedSandbox(ctx, record, work, providerSandboxID)
+			return false, nil
+		}
 		r.failCreatedSandbox(ctx, record, work, providerSandboxID, err)
 		return false, err
 	}

--- a/internal/environments/runner.go
+++ b/internal/environments/runner.go
@@ -375,13 +375,9 @@ func (r *Runner) provisionCreatedSandboxPackages(
 		return false, err
 	}
 	if err := r.provisionPackages(ctx, providerSandboxID, manifest); err != nil {
-		currentWork, lookupErr := r.db.GetEnvironmentWork(ctx, work.WorkspaceID, work.EnvironmentExternalID, work.ExternalID)
-		if lookupErr == nil && (currentWork.State == "stopping" || currentWork.State == "stopped") {
-			*work = currentWork
-			r.stopCreatedSandbox(ctx, record, work, providerSandboxID)
+		if r.failCreatedSandbox(ctx, record, work, providerSandboxID, err) {
 			return false, nil
 		}
-		r.failCreatedSandbox(ctx, record, work, providerSandboxID, err)
 		return false, err
 	}
 	heartbeat, err := r.db.HeartbeatEnvironmentWork(ctx, work.WorkspaceID, work.EnvironmentExternalID, work.ExternalID, "", 60, formatTime)
@@ -431,17 +427,26 @@ func (r *Runner) failManagedAgentRuntime(
 	r.failCreatedSandbox(ctx, record, work, providerSandboxID, cause)
 }
 
-func (r *Runner) failCreatedSandbox(ctx context.Context, record db.EnvironmentSandbox, work *db.EnvironmentWork, providerSandboxID string, cause error) {
+// failCreatedSandbox returns true when a concurrent user stop already won and
+// the sandbox was kept stopped instead of being rewritten as failed.
+func (r *Runner) failCreatedSandbox(ctx context.Context, record db.EnvironmentSandbox, work *db.EnvironmentWork, providerSandboxID string, cause error) bool {
+	currentWork, err := r.db.GetEnvironmentWork(ctx, work.WorkspaceID, work.EnvironmentExternalID, work.ExternalID)
+	if err == nil && (currentWork.State == "stopping" || currentWork.State == "stopped") {
+		*work = currentWork
+		r.stopCreatedSandbox(ctx, record, work, providerSandboxID)
+		return true
+	}
 	now := time.Now().UTC()
 	message := cause.Error()
 	_ = r.db.UpdateEnvironmentSandboxState(ctx, record.WorkspaceID, record.ExternalID, "failed", &providerSandboxID, &message, &now)
 	_, _ = r.db.StopEnvironmentWork(ctx, work.WorkspaceID, work.EnvironmentExternalID, work.ExternalID, true)
 	if strings.TrimSpace(providerSandboxID) == "" {
-		return
+		return false
 	}
 	killCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	_ = r.provider.Kill(killCtx, providerSandboxID)
+	return false
 }
 
 func (r *Runner) stopCreatedSandbox(ctx context.Context, record db.EnvironmentSandbox, work *db.EnvironmentWork, providerSandboxID string) {

--- a/internal/runtime/e2bruntime/runtime.go
+++ b/internal/runtime/e2bruntime/runtime.go
@@ -36,13 +36,25 @@ type Sandbox struct {
 	ID string
 }
 
+type CommandRequest struct {
+	Command string
+	Stdin   []byte
+	Timeout time.Duration
+}
+
+type CommandResult struct {
+	ExitCode int
+	Stdout   []byte
+	Stderr   []byte
+}
+
 type Provider interface {
 	Create(ctx context.Context, env db.Environment, work *db.EnvironmentWork, resolution Resolution) (Sandbox, error)
 	Kill(ctx context.Context, sandboxID string) error
 	Resolve(env db.Environment, work *db.EnvironmentWork) (Resolution, error)
 	WriteFile(ctx context.Context, sandboxID string, path string, data []byte) error
 	FileExists(ctx context.Context, sandboxID string, path string) (bool, error)
-	RunCommand(ctx context.Context, sandboxID string, command string, timeout time.Duration) error
+	RunCommand(ctx context.Context, sandboxID string, request CommandRequest) (CommandResult, error)
 	StartBackgroundCommand(ctx context.Context, sandboxID string, command string, stdin []byte) error
 }
 
@@ -162,6 +174,167 @@ func (p *E2BProvider) WriteFile(ctx context.Context, sandboxID string, filePath 
 	return err
 }
 
+func (p *E2BProvider) RunCommand(ctx context.Context, sandboxID string, request CommandRequest) (CommandResult, error) {
+	if strings.TrimSpace(sandboxID) == "" {
+		return CommandResult{}, errors.New("sandbox id is required")
+	}
+	if strings.TrimSpace(request.Command) == "" {
+		return CommandResult{}, errors.New("sandbox command is required")
+	}
+	sandbox, err := p.connect(ctx, sandboxID)
+	if err != nil {
+		return CommandResult{}, err
+	}
+	if request.Timeout <= 0 {
+		request.Timeout = p.cfg.RequestTimeout
+	}
+	return executeCommand(ctx, request, startE2BCommand(sandbox.Commands))
+}
+
+type commandProcess interface {
+	SendStdin(context.Context, []byte) error
+	CloseStdin(context.Context) error
+	Wait() (CommandResult, error)
+	Kill(context.Context) error
+	Disconnect()
+}
+
+type commandStarter func(context.Context, CommandRequest) (commandProcess, error)
+
+type commandWaitOutcome struct {
+	result CommandResult
+	err    error
+}
+
+func executeCommand(ctx context.Context, request CommandRequest, start commandStarter) (CommandResult, error) {
+	timeout := request.Timeout
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	commandCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	process, err := start(commandCtx, request)
+	if err != nil {
+		return CommandResult{}, fmt.Errorf("start sandbox command: %w", err)
+	}
+	if process == nil {
+		return CommandResult{}, errors.New("start sandbox command: missing process handle")
+	}
+	defer process.Disconnect()
+	if len(request.Stdin) != 0 {
+		if err := sendCommandStdin(commandCtx, process, request.Stdin); err != nil {
+			return CommandResult{}, err
+		}
+	}
+
+	waited := make(chan commandWaitOutcome, 1)
+	go func() {
+		result, err := process.Wait()
+		waited <- commandWaitOutcome{result: result, err: err}
+	}()
+
+	select {
+	case outcome := <-waited:
+		if outcome.err != nil {
+			return CommandResult{}, errors.Join(
+				fmt.Errorf("wait for sandbox command: %w", outcome.err),
+				killCommandProcess(process),
+			)
+		}
+		return outcome.result, nil
+	case <-commandCtx.Done():
+		return CommandResult{}, errors.Join(
+			fmt.Errorf("sandbox command: %w", commandCtx.Err()),
+			killCommandProcess(process),
+		)
+	}
+}
+
+func killCommandProcess(process commandProcess) error {
+	killCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := process.Kill(killCtx); err != nil {
+		return fmt.Errorf("kill sandbox command: %w", err)
+	}
+	return nil
+}
+
+func sendCommandStdin(ctx context.Context, process commandProcess, stdin []byte) error {
+	if err := process.SendStdin(ctx, stdin); err != nil {
+		return errors.Join(fmt.Errorf("send sandbox command stdin: %w", err), killCommandProcess(process))
+	}
+	if err := process.CloseStdin(ctx); err != nil {
+		return errors.Join(fmt.Errorf("close sandbox command stdin: %w", err), killCommandProcess(process))
+	}
+	return nil
+}
+
+type e2bCommandProcess struct {
+	commands *e2b.Commands
+	handle   *e2b.CommandHandle
+}
+
+func startE2BCommand(commands *e2b.Commands) commandStarter {
+	return func(ctx context.Context, request CommandRequest) (commandProcess, error) {
+		opts := &e2b.CommandStartOpts{Background: true}
+		if len(request.Stdin) != 0 {
+			stdinEnabled := true
+			opts.Stdin = &stdinEnabled
+		}
+		if request.Timeout > 0 {
+			timeoutMs := int(request.Timeout / time.Millisecond)
+			opts.TimeoutMs = &timeoutMs
+		}
+		execution, err := commands.Run(ctx, request.Command, opts)
+		if err != nil {
+			return nil, err
+		}
+		handle, ok := execution.(*e2b.CommandHandle)
+		if !ok {
+			return nil, fmt.Errorf("sandbox command execution type = %T, want *e2b.CommandHandle", execution)
+		}
+		if handle.Pid == 0 {
+			handle.Disconnect()
+			return nil, errors.New("sandbox background command returned an invalid PID")
+		}
+		return &e2bCommandProcess{commands: commands, handle: handle}, nil
+	}
+}
+
+func (p *e2bCommandProcess) SendStdin(ctx context.Context, stdin []byte) error {
+	return p.commands.SendStdin(ctx, p.handle.Pid, stdin, nil)
+}
+
+func (p *e2bCommandProcess) CloseStdin(ctx context.Context) error {
+	return p.commands.CloseStdin(ctx, p.handle.Pid, nil)
+}
+
+func (p *e2bCommandProcess) Wait() (CommandResult, error) {
+	result, err := p.handle.Wait()
+	if err != nil {
+		var exitErr *e2b.CommandExitError
+		if !errors.As(err, &exitErr) {
+			return CommandResult{}, err
+		}
+		result = &exitErr.CommandResult
+	}
+	return CommandResult{
+		ExitCode: result.ExitCode,
+		Stdout:   []byte(result.Stdout),
+		Stderr:   []byte(result.Stderr),
+	}, nil
+}
+
+func (p *e2bCommandProcess) Kill(ctx context.Context) error {
+	_, err := p.commands.Kill(ctx, p.handle.Pid, nil)
+	return err
+}
+
+func (p *e2bCommandProcess) Disconnect() {
+	p.handle.Disconnect()
+}
+
 func (p *E2BProvider) FileExists(ctx context.Context, sandboxID string, filePath string) (bool, error) {
 	if strings.TrimSpace(sandboxID) == "" {
 		return false, errors.New("sandbox id is required")
@@ -176,40 +349,11 @@ func (p *E2BProvider) FileExists(ctx context.Context, sandboxID string, filePath
 	return sandbox.Files.Exists(ctx, filePath, nil)
 }
 
-func (p *E2BProvider) RunCommand(ctx context.Context, sandboxID string, command string, timeout time.Duration) error {
-	if strings.TrimSpace(sandboxID) == "" {
-		return errors.New("sandbox id is required")
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
 	}
-	if strings.TrimSpace(command) == "" {
-		return errors.New("sandbox command is required")
-	}
-	sandbox, err := p.connect(ctx, sandboxID)
-	if err != nil {
-		return err
-	}
-	timeoutMs := int(timeout / time.Millisecond)
-	if timeoutMs <= 0 {
-		timeoutMs = int(p.cfg.RequestTimeout / time.Millisecond)
-	}
-	if timeoutMs <= 0 {
-		timeoutMs = int((60 * time.Second) / time.Millisecond)
-	}
-	execution, err := sandbox.Commands.Run(ctx, command, &e2b.CommandStartOpts{TimeoutMs: &timeoutMs})
-	if err != nil {
-		var exitErr *e2b.CommandExitError
-		if errors.As(err, &exitErr) {
-			return fmt.Errorf("sandbox command exited with code %d: %s stdout=%q stderr=%q", exitErr.ExitCode, strings.TrimSpace(exitErr.Message), truncateCommandOutput(exitErr.Stdout), truncateCommandOutput(exitErr.Stderr))
-		}
-		return err
-	}
-	result, ok := execution.(*e2b.CommandResult)
-	if !ok {
-		return fmt.Errorf("sandbox command execution type = %T, want *e2b.CommandResult", execution)
-	}
-	if result.ExitCode != 0 {
-		return fmt.Errorf("sandbox command exited with code %d: %s stdout=%q stderr=%q", result.ExitCode, strings.TrimSpace(result.Error), truncateCommandOutput(result.Stdout), truncateCommandOutput(result.Stderr))
-	}
-	return nil
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 // StartBackgroundCommand 通过 E2B 进程 API 启动后台命令。
@@ -300,22 +444,6 @@ func mcpAllowedHostsFromWork(work *db.EnvironmentWork) ([]string, error) {
 		return nil, nil
 	}
 	return networkpolicy.ParseWorkMetadataMCPAllowedHosts(work.Metadata)
-}
-
-func shellQuote(value string) string {
-	if value == "" {
-		return "''"
-	}
-	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
-}
-
-func truncateCommandOutput(value string) string {
-	value = strings.TrimSpace(value)
-	const limit = 2048
-	if len(value) <= limit {
-		return value
-	}
-	return value[:limit] + "...[truncated]"
 }
 
 func (p *E2BProvider) sandboxVolumeMounts(_ *db.EnvironmentWork) map[string]any {

--- a/internal/runtime/e2bruntime/runtime.go
+++ b/internal/runtime/e2bruntime/runtime.go
@@ -181,14 +181,16 @@ func (p *E2BProvider) RunCommand(ctx context.Context, sandboxID string, request 
 	if strings.TrimSpace(request.Command) == "" {
 		return CommandResult{}, errors.New("sandbox command is required")
 	}
-	sandbox, err := p.connect(ctx, sandboxID)
-	if err != nil {
-		return CommandResult{}, err
-	}
 	if request.Timeout <= 0 {
 		request.Timeout = p.cfg.RequestTimeout
 	}
-	return executeCommand(ctx, request, startE2BCommand(sandbox.Commands))
+	return runConnectedCommand(ctx, request, func(connectCtx context.Context) (commandStarter, error) {
+		sandbox, err := p.connect(connectCtx, sandboxID)
+		if err != nil {
+			return nil, err
+		}
+		return startE2BCommand(sandbox.Commands), nil
+	})
 }
 
 type commandProcess interface {
@@ -201,9 +203,26 @@ type commandProcess interface {
 
 type commandStarter func(context.Context, CommandRequest) (commandProcess, error)
 
+type commandConnector func(context.Context) (commandStarter, error)
+
 type commandWaitOutcome struct {
 	result CommandResult
 	err    error
+}
+
+func runConnectedCommand(ctx context.Context, request CommandRequest, connect commandConnector) (CommandResult, error) {
+	timeout := request.Timeout
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+		request.Timeout = timeout
+	}
+	commandCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	start, err := connect(commandCtx)
+	if err != nil {
+		return CommandResult{}, err
+	}
+	return executeCommand(commandCtx, request, start)
 }
 
 func executeCommand(ctx context.Context, request CommandRequest, start commandStarter) (CommandResult, error) {

--- a/internal/runtime/e2bruntime/runtime_test.go
+++ b/internal/runtime/e2bruntime/runtime_test.go
@@ -1,8 +1,11 @@
 package e2bruntime
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,6 +35,121 @@ func TestConnectionOptsFromConfigMapsAllFields(t *testing.T) {
 	if got.RequestTimeoutMs == nil || *got.RequestTimeoutMs != wantTimeoutMs {
 		t.Fatalf("ConnectionOptsFromConfig().RequestTimeoutMs = %v, want %d", got.RequestTimeoutMs, wantTimeoutMs)
 	}
+}
+
+func TestExecuteCommandTransport(t *testing.T) {
+	stdin := []byte(`{"version":1}`)
+	results := []struct {
+		name   string
+		result CommandResult
+	}{
+		{"success", CommandResult{Stdout: []byte(`{"status":"succeeded"}`)}},
+		{"nonzero exit", CommandResult{ExitCode: 10, Stderr: []byte("diagnostic")}},
+	}
+	for _, tt := range results {
+		t.Run(tt.name, func(t *testing.T) {
+			process := newRecordingCommandProcess()
+			process.result = tt.result
+			got, err := executeCommand(context.Background(), CommandRequest{Command: "provision --stdin", Stdin: stdin, Timeout: time.Second}, process.start)
+			if err != nil || !reflect.DeepEqual(got, tt.result) {
+				t.Fatalf("executeCommand() = (%#v, %v), want (%#v, nil)", got, err, tt.result)
+			}
+			if !reflect.DeepEqual(process.stdin, stdin) || process.sendOrder > process.waitOrder || process.closeOrder > process.waitOrder {
+				t.Fatalf("stdin/order = (%q, %d, %d, %d), want send and close before wait", process.stdin, process.sendOrder, process.closeOrder, process.waitOrder)
+			}
+		})
+	}
+
+	for _, tt := range []struct {
+		name, want string
+		configure  func(*recordingCommandProcess)
+	}{
+		{"send failure", "send sandbox command stdin", func(p *recordingCommandProcess) { p.sendErr = errors.New("send") }},
+		{"close failure", "close sandbox command stdin", func(p *recordingCommandProcess) { p.closeErr = errors.New("close") }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			process := newRecordingCommandProcess()
+			tt.configure(process)
+			_, err := executeCommand(context.Background(), CommandRequest{Command: "provision --stdin", Stdin: stdin, Timeout: time.Second}, process.start)
+			if err == nil || !strings.Contains(err.Error(), tt.want) || process.kills != 1 {
+				t.Fatalf("error/kills = (%v, %d), want %q and one kill", err, process.kills, tt.want)
+			}
+		})
+	}
+
+	t.Run("timeout returns and attempts kill", func(t *testing.T) {
+		process := newRecordingCommandProcess()
+		process.blockWait = true
+		started := time.Now()
+		_, err := executeCommand(context.Background(), CommandRequest{Command: "provision --stdin", Stdin: stdin, Timeout: 10 * time.Millisecond}, process.start)
+		if err == nil || !strings.Contains(err.Error(), "deadline exceeded") || process.kills != 1 {
+			t.Fatalf("error/kills = (%v, %d), want deadline and one kill", err, process.kills)
+		}
+		if time.Since(started) > 500*time.Millisecond {
+			t.Fatal("executeCommand blocked after timeout")
+		}
+	})
+}
+
+type recordingCommandProcess struct {
+	sequence, sendOrder, closeOrder, waitOrder, kills int
+	stdin                                             []byte
+	result                                            CommandResult
+	sendErr, closeErr                                 error
+	blockWait                                         bool
+	waitDone                                          chan struct{}
+}
+
+func newRecordingCommandProcess() *recordingCommandProcess {
+	return &recordingCommandProcess{waitDone: make(chan struct{})}
+}
+
+func (p *recordingCommandProcess) start(_ context.Context, _ CommandRequest) (commandProcess, error) {
+	return p, nil
+}
+
+func (p *recordingCommandProcess) SendStdin(_ context.Context, stdin []byte) error {
+	p.sendOrder = p.record(false)
+	p.stdin = append([]byte(nil), stdin...)
+	return p.sendErr
+}
+
+func (p *recordingCommandProcess) CloseStdin(_ context.Context) error {
+	p.closeOrder = p.record(false)
+	return p.closeErr
+}
+
+func (p *recordingCommandProcess) Wait() (CommandResult, error) {
+	p.waitOrder = p.record(false)
+	if p.blockWait {
+		<-p.waitDone
+	}
+	return p.result, nil
+}
+
+func (p *recordingCommandProcess) Kill(context.Context) error {
+	p.record(true)
+	return nil
+}
+
+func (p *recordingCommandProcess) Disconnect() {
+	p.releaseWait()
+}
+
+func (p *recordingCommandProcess) releaseWait() {
+	select {
+	case <-p.waitDone:
+	default:
+		close(p.waitDone)
+	}
+}
+
+func (p *recordingCommandProcess) record(kill bool) int {
+	p.sequence++
+	if kill {
+		p.kills++
+	}
+	return p.sequence
 }
 
 func TestSandboxVolumeMountsOnlyIncludeUserData(t *testing.T) {

--- a/internal/runtime/e2bruntime/runtime_test.go
+++ b/internal/runtime/e2bruntime/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -92,6 +93,7 @@ func TestExecuteCommandTransport(t *testing.T) {
 }
 
 type recordingCommandProcess struct {
+	mu                                                sync.Mutex
 	sequence, sendOrder, closeOrder, waitOrder, kills int
 	stdin                                             []byte
 	result                                            CommandResult
@@ -145,6 +147,8 @@ func (p *recordingCommandProcess) releaseWait() {
 }
 
 func (p *recordingCommandProcess) record(kill bool) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.sequence++
 	if kill {
 		p.kills++

--- a/internal/runtime/e2bruntime/runtime_test.go
+++ b/internal/runtime/e2bruntime/runtime_test.go
@@ -92,6 +92,24 @@ func TestExecuteCommandTransport(t *testing.T) {
 	})
 }
 
+func TestRunConnectedCommandAppliesDeadlineBeforeConnect(t *testing.T) {
+	started := time.Now()
+	_, err := runConnectedCommand(
+		context.Background(),
+		CommandRequest{Command: "provision", Timeout: 10 * time.Millisecond},
+		func(ctx context.Context) (commandStarter, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runConnectedCommand() error = %v, want deadline exceeded", err)
+	}
+	if time.Since(started) > 500*time.Millisecond {
+		t.Fatal("runConnectedCommand did not apply timeout to connect")
+	}
+}
+
 type recordingCommandProcess struct {
 	mu                                                sync.Mutex
 	sequence, sendOrder, closeOrder, waitOrder, kills int

--- a/tests/environments_api_test.go
+++ b/tests/environments_api_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
 
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/google/uuid"
 )
 
@@ -96,6 +98,12 @@ func TestEnvironmentsAPI(t *testing.T) {
 
 	t.Run("failure invalid limited host", func(t *testing.T) {
 		body := `{"name":"bad-host","config":{"type":"cloud","networking":{"type":"limited","allowed_hosts":["https://example.com"]}}}`
+		resp := doEnvironmentRequest(t, app, http.MethodPost, "/v1/environments?beta=true", strings.NewReader(body), defaultTestKey, true)
+		assertError(t, resp, http.StatusBadRequest, "invalid_request_error")
+	})
+
+	t.Run("failure package URL credentials", func(t *testing.T) {
+		body := `{"name":"bad-package-credentials","config":{"type":"cloud","packages":{"pip":["pkg @ https://user:secret-token@example.test/private.whl"]}}}`
 		resp := doEnvironmentRequest(t, app, http.MethodPost, "/v1/environments?beta=true", strings.NewReader(body), defaultTestKey, true)
 		assertError(t, resp, http.StatusBadRequest, "invalid_request_error")
 	})
@@ -228,6 +236,52 @@ func TestEnvironmentsAPI(t *testing.T) {
 
 		deleteEnvironment(t, app, configured.ID)
 	})
+}
+
+func TestOfficialSDKEnvironmentPackagesRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	app := newTestAppWithStore(t, nil, newFakeStore("environment-sdk-packages-bucket"))
+	defer app.close()
+	client := anthropic.NewClient(option.WithBaseURL(app.baseURL), option.WithAPIKey(defaultTestKey))
+	createdPackages := anthropic.BetaPackagesParams{
+		Type: anthropic.BetaPackagesParamsTypePackages, Apt: []string{"ffmpeg"}, Cargo: []string{"ripgrep@14.1.1"},
+		Gem: []string{"rake:13.2.1"}, Go: []string{"golang.org/x/tools/cmd/goimports@v0.35.0"},
+		Npm: []string{"typescript@5.9.3"}, Pip: []string{"numpy==2.3.5"},
+	}
+	created, err := client.Beta.Environments.New(ctx, anthropic.BetaEnvironmentNewParams{
+		Name: "sdk-packages-" + strings.ReplaceAll(time.Now().Format("150405.000000000"), ".", ""),
+		Config: anthropic.BetaEnvironmentNewParamsConfigUnion{OfCloud: &anthropic.BetaCloudConfigParams{
+			Packages: createdPackages,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SDK create environment: %v", err)
+	}
+	defer cleanupEnvironmentRows(t, app.db, created.ID)
+
+	updatedPackages := anthropic.BetaPackagesParams{
+		Type: anthropic.BetaPackagesParamsTypePackages, Apt: []string{"jq"}, Pip: []string{"httpx==0.28.1"},
+	}
+	_, err = client.Beta.Environments.Update(ctx, created.ID, anthropic.BetaEnvironmentUpdateParams{
+		Config: anthropic.BetaEnvironmentUpdateParamsConfigUnion{OfCloud: &anthropic.BetaCloudConfigParams{
+			Packages: updatedPackages,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SDK update environment: %v", err)
+	}
+
+	got, err := client.Beta.Environments.Get(ctx, created.ID, anthropic.BetaEnvironmentGetParams{})
+	if err != nil {
+		t.Fatalf("SDK get environment: %v", err)
+	}
+	packages := got.Config.Packages
+	if packages.Type != anthropic.BetaPackagesTypePackages ||
+		len(packages.Apt) != 1 || packages.Apt[0] != "jq" ||
+		len(packages.Pip) != 1 || packages.Pip[0] != "httpx==0.28.1" ||
+		len(packages.Cargo) != 0 || len(packages.Gem) != 0 || len(packages.Go) != 0 || len(packages.Npm) != 0 {
+		t.Fatalf("SDK packages = %#v, want normalized jq/httpx packages", packages)
+	}
 }
 
 func TestEnvironmentsSchemaHasNoForeignKeys(t *testing.T) {

--- a/tests/environments_runner_cloud_test.go
+++ b/tests/environments_runner_cloud_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -315,6 +316,192 @@ func TestEnvironmentRunnerLaunchesManagedAgentCloudSession(t *testing.T) {
 	if metadata["claude_code_session_id"] != codeSession.ExternalID || metadata["claude_code_sdk_url_path"] != "/v1/code/sessions/"+codeSession.ExternalID || metadata["runtime"] != "claude_code_local" {
 		t.Fatalf("session metadata was not patched: %#v", metadata)
 	}
+}
+
+func TestEnvironmentRunnerPackageProvisioning(t *testing.T) {
+	t.Run("failure terminates sandbox before manager startup", func(t *testing.T) {
+		provider, processed, err := runPackageEnvironment(t, packageRunnerCase{commandErr: errors.New("gem install failed")})
+		if !processed || err == nil || !strings.Contains(err.Error(), "provision environment packages") {
+			t.Fatalf("RunOnce() = (%t, %v), want processed provisioning failure", processed, err)
+		}
+		if len(provider.commands) == 0 || len(provider.launches) != 0 {
+			t.Fatalf("failure commands/launches = %d/%d, want provisioning and no manager launch", len(provider.commands), len(provider.launches))
+		}
+		if strings.Contains(provider.commands[0].request.Command, "@scope/package") || strings.Contains(provider.commands[0].request.Command, "touch /tmp") {
+			t.Fatalf("provision command contains package data: %q", provider.commands[0].request.Command)
+		}
+		if !reflect.DeepEqual(provider.kills, []string{provider.sandboxID}) {
+			t.Fatalf("killed sandboxes = %#v, want failed sandbox", provider.kills)
+		}
+		if provider.codeSessionCreated {
+			t.Fatal("provisioning failure created an active code session")
+		}
+	})
+
+	t.Run("stop requested during provisioning terminates sandbox before manager startup", func(t *testing.T) {
+		provider, processed, err := runPackageEnvironment(t, packageRunnerCase{stopAfterProvision: true})
+		if err != nil || !processed {
+			t.Fatalf("RunOnce() = (%t, %v), want graceful stop", processed, err)
+		}
+		if len(provider.commands) == 0 || len(provider.launches) != 0 {
+			t.Fatalf("stop commands/launches = %d/%d, want provisioning and no manager launch", len(provider.commands), len(provider.launches))
+		}
+		if !reflect.DeepEqual(provider.kills, []string{provider.sandboxID}) {
+			t.Fatalf("killed sandboxes = %#v, want stopped sandbox", provider.kills)
+		}
+		if provider.codeSessionCreated {
+			t.Fatal("graceful stop during provisioning created an active code session")
+		}
+	})
+
+	t.Run("success starts manager after fixed provisioner", func(t *testing.T) {
+		provider, processed, err := runPackageEnvironment(t, packageRunnerCase{})
+		if err != nil || !processed {
+			t.Fatalf("RunOnce() = (%t, %v), want success", processed, err)
+		}
+		if len(provider.commands) == 0 || len(provider.launches) != 1 {
+			t.Fatalf("success commands/launches = %d/%d, want provisioning and one manager launch", len(provider.commands), len(provider.launches))
+		}
+		if provider.commands[0].request.Command != "'/usr/local/bin/environment-manager' provision-packages --protocol v1 --stdin" || !strings.Contains(provider.launches[0].command, "task-run") {
+			t.Fatalf("sandbox provision command/manager command = %q/%q", provider.commands[0].request.Command, provider.launches[0].command)
+		}
+		provisionAt := slices.Index(provider.operations, "command:provision")
+		rcloneAt := slices.Index(provider.operations, "rclone-start")
+		managerAt := slices.Index(provider.operations, "environment-manager")
+		if provisionAt < 0 || provisionAt >= rcloneAt || rcloneAt >= managerAt {
+			t.Fatalf("provision/rclone/manager operation order = %#v", provider.operations)
+		}
+		var manifest struct {
+			Version  int `json:"version"`
+			Packages struct {
+				APT   []string `json:"apt"`
+				Cargo []string `json:"cargo"`
+				Gem   []string `json:"gem"`
+				Go    []string `json:"go"`
+				NPM   []string `json:"npm"`
+				PIP   []string `json:"pip"`
+			} `json:"packages"`
+		}
+		if err := json.Unmarshal(provider.commands[0].request.Stdin, &manifest); err != nil {
+			t.Fatalf("decode package manifest: %v", err)
+		}
+		if manifest.Version != 1 ||
+			!reflect.DeepEqual(manifest.Packages.APT, []string{"ffmpeg"}) ||
+			!reflect.DeepEqual(manifest.Packages.Cargo, []string{"ripgrep@14.1.1"}) ||
+			!reflect.DeepEqual(manifest.Packages.Gem, []string{"rake:13.2.1"}) ||
+			!reflect.DeepEqual(manifest.Packages.Go, []string{"golang.org/x/tools/cmd/goimports@v0.35.0"}) ||
+			!reflect.DeepEqual(manifest.Packages.NPM, []string{"@scope/package@5.9.3"}) ||
+			!reflect.DeepEqual(manifest.Packages.PIP, []string{`requests[socks] @ https://example.test/a.whl ; python_version >= "3.11"`, "name; touch /tmp/oma-package-shell"}) {
+			t.Fatalf("package manifest changed specs: %#v", manifest)
+		}
+		if len(provider.kills) != 0 {
+			t.Fatalf("successful sandbox was killed: %#v", provider.kills)
+		}
+		if !provider.codeSessionCreated {
+			t.Fatal("successful provisioning did not create a code session")
+		}
+		if !provider.sessionHasRuntimeMetadata || !provider.workHasRuntimeMetadata {
+			t.Fatalf("successful provisioning session/work runtime metadata = %t/%t, want true/true", provider.sessionHasRuntimeMetadata, provider.workHasRuntimeMetadata)
+		}
+	})
+}
+
+type packageRunnerCase struct {
+	commandErr         error
+	stopAfterProvision bool
+}
+
+func requestPackageEnvironmentStop(t *testing.T, ctx context.Context, database *db.DB, environmentID string) {
+	t.Helper()
+	ids := getDefaultDBIDs(t, database)
+	works, _, err := database.ListEnvironmentWorkPage(ctx, db.ListEnvironmentWorkPageParams{
+		WorkspaceID:           ids.WorkspaceID,
+		EnvironmentExternalID: environmentID,
+		Limit:                 10,
+	})
+	if err != nil || len(works) != 1 {
+		t.Fatalf("list environment work count/error = %d/%v, want one work", len(works), err)
+	}
+	if _, err := database.StopEnvironmentWork(ctx, ids.WorkspaceID, environmentID, works[0].ExternalID, false); err != nil {
+		t.Fatalf("request environment work stop: %v", err)
+	}
+}
+
+func runPackageEnvironment(t *testing.T, testCase packageRunnerCase) (*recordingRunnerProvider, bool, error) {
+	t.Helper()
+	runCtx := context.Background()
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	cfg.CodeSession.SandboxAPIBaseURL = "http://code-session-sandbox.example.test"
+	cfg.EnvironmentRunner.ManagerPath = "/usr/local/bin/environment-manager"
+	cfg.EnvironmentRunner.ClaudePath = "/opt/claude-code/bin/claude"
+	cfg.EnvironmentRunner.ClaudeAgentVersion = "2.1.120"
+	cfg.E2B.Template = "fake-template"
+	app := newTestAppWithStore(t, &cfg, newFakeStore("runner-package-bucket"))
+	t.Cleanup(app.close)
+	agent := createAgent(t, app, `{
+		"model":"claude-opus-4-8",
+		"name":"Runner Package Agent"
+	}`)
+	t.Cleanup(func() { archiveAgent(t, app, agent.ID) })
+	environment := createEnvironment(t, app, `{
+		"name":"runner-packages-`+strings.ReplaceAll(time.Now().Format("150405.000000000"), ".", "")+`",
+		"config":{"type":"cloud","networking":{"type":"unrestricted"},"packages":{
+			"type":"packages","apt":["ffmpeg"],"cargo":["ripgrep@14.1.1"],"gem":["rake:13.2.1"],
+			"go":["golang.org/x/tools/cmd/goimports@v0.35.0"],"npm":["@scope/package@5.9.3"],
+			"pip":["requests[socks] @ https://example.test/a.whl ; python_version >= \"3.11\"","name; touch /tmp/oma-package-shell"]
+		}}
+	}`)
+	t.Cleanup(func() { cleanupEnvironmentRows(t, app.db, environment.ID) })
+	client := anthropic.NewClient(option.WithBaseURL(app.baseURL), option.WithAPIKey(defaultTestKey))
+	session, err := client.Beta.Sessions.New(runCtx, anthropic.BetaSessionNewParams{
+		Agent: anthropic.BetaSessionNewParamsAgentUnion{OfString: anthropic.String(agent.ID)}, EnvironmentID: environment.ID,
+		Title: anthropic.String("Runner package session"),
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = client.Beta.Sessions.Delete(context.Background(), session.ID, anthropic.BetaSessionDeleteParams{})
+	})
+	provider := &recordingRunnerProvider{
+		sandboxID:  "sandbox-runner-packages",
+		commandErr: testCase.commandErr,
+	}
+	if testCase.stopAfterProvision {
+		provider.afterCommand = func() {
+			if testCase.stopAfterProvision {
+				requestPackageEnvironmentStop(t, runCtx, app.db, environment.ID)
+			}
+		}
+	}
+	runner := newManagedAgentRunner(t, app, provider, cfg)
+	processed, runErr := runner.RunOnce(runCtx, "runner-package-test")
+	inspectionCtx := context.Background()
+	ids := getDefaultDBIDs(t, app.db)
+	_, codeSessionErr := app.db.GetCodeSessionBySessionExternalID(inspectionCtx, ids.WorkspaceID, session.ID)
+	switch {
+	case codeSessionErr == nil:
+		provider.codeSessionCreated = true
+	case errors.Is(codeSessionErr, db.ErrNotFound):
+	default:
+		t.Fatalf("look up package runner code session: %v", codeSessionErr)
+	}
+	works, _, workErr := app.db.ListEnvironmentWorkPage(inspectionCtx, db.ListEnvironmentWorkPageParams{
+		WorkspaceID: ids.WorkspaceID, EnvironmentExternalID: environment.ID, Limit: 10,
+	})
+	if workErr != nil || len(works) != 1 {
+		t.Fatalf("list package runner work count/error = %d/%v, want one work", len(works), workErr)
+	}
+	provider.workHasRuntimeMetadata = hasJSONKey(works[0].Metadata, "claude_code_session_id")
+	storedSession, sessionErr := app.db.GetSession(inspectionCtx, ids.WorkspaceID, session.ID)
+	if sessionErr != nil {
+		t.Fatalf("load package runner session: %v", sessionErr)
+	}
+	provider.sessionHasRuntimeMetadata = hasJSONKey(storedSession.Metadata, "claude_code_session_id")
+	return provider, processed, runErr
 }
 
 func TestEnvironmentRunnerKillsSandboxWhenRcloneReadyFails(t *testing.T) {
@@ -894,19 +1081,24 @@ func TestEnvironmentRunnerDoesNotCreateCodeSessionWhenResolveFails(t *testing.T)
 }
 
 type recordingRunnerProvider struct {
-	sandboxID         string
-	resolveErr        error
-	failOperation     string
-	runCommandFailure error
-	beforeCreate      func()
-	resolves          []recordedSandboxResolve
-	commands          []string
-	launches          []recordedSandboxLaunch
-	rcloneLaunches    []recordedSandboxLaunch
-	writes            []recordedSandboxWrite
-	operations        []string
-	kills             []string
-	creates           []recordedSandboxCreate
+	sandboxID                 string
+	resolveErr                error
+	commandErr                error
+	afterCommand              func()
+	failOperation             string
+	runCommandFailure         error
+	beforeCreate              func()
+	resolves                  []recordedSandboxResolve
+	commands                  []recordedSandboxCommand
+	launches                  []recordedSandboxLaunch
+	rcloneLaunches            []recordedSandboxLaunch
+	writes                    []recordedSandboxWrite
+	operations                []string
+	creates                   []recordedSandboxCreate
+	kills                     []string
+	codeSessionCreated        bool
+	sessionHasRuntimeMetadata bool
+	workHasRuntimeMetadata    bool
 }
 
 type recordedSandboxResolve struct {
@@ -918,6 +1110,11 @@ type recordedSandboxLaunch struct {
 	sandboxID string
 	command   string
 	stdin     []byte
+}
+
+type recordedSandboxCommand struct {
+	sandboxID string
+	request   e2bruntime.CommandRequest
 }
 
 type recordedSandboxWrite struct {
@@ -1020,24 +1217,39 @@ func (p *recordingRunnerProvider) FileExists(_ context.Context, sandboxID, path 
 	return true, nil
 }
 
-func (p *recordingRunnerProvider) RunCommand(_ context.Context, sandboxID string, command string, _ time.Duration) error {
+func (p *recordingRunnerProvider) RunCommand(_ context.Context, sandboxID string, request e2bruntime.CommandRequest) (e2bruntime.CommandResult, error) {
 	if sandboxID != p.sandboxID {
-		p.commands = append(p.commands, "wrong sandbox: "+sandboxID)
-		return nil
+		p.commands = append(p.commands, recordedSandboxCommand{sandboxID: sandboxID, request: request})
+		return e2bruntime.CommandResult{}, nil
 	}
-	p.commands = append(p.commands, command)
-	operation := "command"
+	request.Stdin = append([]byte(nil), request.Stdin...)
+	p.commands = append(p.commands, recordedSandboxCommand{sandboxID: sandboxID, request: request})
+	operation := "command:other"
 	switch {
-	case strings.HasPrefix(command, "chmod 0600 "):
+	case request.Command == "'/usr/local/bin/environment-manager' provision-packages --protocol v1 --stdin":
+		operation = "command:provision"
+	case strings.HasPrefix(request.Command, "chmod 0600 "):
 		operation = "rclone-config-chmod"
-	case strings.HasPrefix(command, "rm -f ") && strings.Contains(command, "rclone-mount-config.json"):
+	case strings.HasPrefix(request.Command, "rm -f ") && strings.Contains(request.Command, "rclone-mount-config.json"):
 		operation = "rclone-config-cleanup"
 	}
 	p.operations = append(p.operations, operation)
-	if operation == p.failOperation {
-		return p.runCommandFailure
+	if operation == "command:provision" {
+		if p.commandErr != nil {
+			return e2bruntime.CommandResult{}, p.commandErr
+		}
+		if p.afterCommand != nil {
+			p.afterCommand()
+		}
+		return e2bruntime.CommandResult{
+			ExitCode: 0,
+			Stdout:   []byte(`{"version":1,"status":"succeeded","package_count":7,"duration_ms":1}`),
+		}, nil
 	}
-	return nil
+	if operation == p.failOperation {
+		return e2bruntime.CommandResult{}, p.runCommandFailure
+	}
+	return e2bruntime.CommandResult{}, nil
 }
 
 func (p *recordingRunnerProvider) StartBackgroundCommand(_ context.Context, sandboxID string, command string, stdin []byte) error {

--- a/tests/environments_runner_cloud_test.go
+++ b/tests/environments_runner_cloud_test.go
@@ -352,6 +352,9 @@ func TestEnvironmentRunnerPackageProvisioning(t *testing.T) {
 		if provider.codeSessionCreated {
 			t.Fatal("graceful stop during provisioning created an active code session")
 		}
+		if provider.sandboxState != "stopped" || provider.sandboxError != nil {
+			t.Fatalf("graceful stop sandbox = state %q error %v, want stopped without error", provider.sandboxState, provider.sandboxError)
+		}
 	})
 
 	t.Run("success starts manager after fixed provisioner", func(t *testing.T) {
@@ -364,6 +367,9 @@ func TestEnvironmentRunnerPackageProvisioning(t *testing.T) {
 		}
 		if provider.commands[0].request.Command != "'/usr/local/bin/environment-manager' provision-packages --protocol v1 --stdin" || !strings.Contains(provider.launches[0].command, "task-run") {
 			t.Fatalf("sandbox provision command/manager command = %q/%q", provider.commands[0].request.Command, provider.launches[0].command)
+		}
+		if provider.commands[0].request.Timeout != cfgPackageProvisionTimeoutForTest {
+			t.Fatalf("package provision timeout = %s, want dedicated runner timeout %s", provider.commands[0].request.Timeout, cfgPackageProvisionTimeoutForTest)
 		}
 		provisionAt := slices.Index(provider.operations, "command:provision")
 		rcloneAt := slices.Index(provider.operations, "rclone-start")
@@ -411,6 +417,8 @@ type packageRunnerCase struct {
 	stopAfterProvision bool
 }
 
+const cfgPackageProvisionTimeoutForTest = 37 * time.Second
+
 func requestPackageEnvironmentStop(t *testing.T, ctx context.Context, database *db.DB, environmentID string) {
 	t.Helper()
 	ids := getDefaultDBIDs(t, database)
@@ -438,6 +446,7 @@ func runPackageEnvironment(t *testing.T, testCase packageRunnerCase) (*recording
 	cfg.EnvironmentRunner.ManagerPath = "/usr/local/bin/environment-manager"
 	cfg.EnvironmentRunner.ClaudePath = "/opt/claude-code/bin/claude"
 	cfg.EnvironmentRunner.ClaudeAgentVersion = "2.1.120"
+	cfg.EnvironmentRunner.PackageProvisionTimeout = cfgPackageProvisionTimeoutForTest
 	cfg.E2B.Template = "fake-template"
 	app := newTestAppWithStore(t, &cfg, newFakeStore("runner-package-bucket"))
 	t.Cleanup(app.close)
@@ -472,9 +481,7 @@ func runPackageEnvironment(t *testing.T, testCase packageRunnerCase) (*recording
 	}
 	if testCase.stopAfterProvision {
 		provider.afterCommand = func() {
-			if testCase.stopAfterProvision {
-				requestPackageEnvironmentStop(t, runCtx, app.db, environment.ID)
-			}
+			requestPackageEnvironmentStop(t, runCtx, app.db, environment.ID)
 		}
 	}
 	runner := newManagedAgentRunner(t, app, provider, cfg)
@@ -501,6 +508,15 @@ func runPackageEnvironment(t *testing.T, testCase packageRunnerCase) (*recording
 		t.Fatalf("load package runner session: %v", sessionErr)
 	}
 	provider.sessionHasRuntimeMetadata = hasJSONKey(storedSession.Metadata, "claude_code_session_id")
+	if err := app.db.Pool.QueryRow(inspectionCtx, `
+		select state, last_error
+		from environment_sandboxes
+		where work_id = $1
+		order by id desc
+		limit 1
+	`, works[0].ID).Scan(&provider.sandboxState, &provider.sandboxError); err != nil {
+		t.Fatalf("load package runner sandbox: %v", err)
+	}
 	return provider, processed, runErr
 }
 
@@ -1099,6 +1115,8 @@ type recordingRunnerProvider struct {
 	codeSessionCreated        bool
 	sessionHasRuntimeMetadata bool
 	workHasRuntimeMetadata    bool
+	sandboxState              string
+	sandboxError              *string
 }
 
 type recordedSandboxResolve struct {

--- a/tests/environments_runner_cloud_test.go
+++ b/tests/environments_runner_cloud_test.go
@@ -357,6 +357,23 @@ func TestEnvironmentRunnerPackageProvisioning(t *testing.T) {
 		}
 	})
 
+	t.Run("force stop during rclone startup preserves stopped sandbox", func(t *testing.T) {
+		provider, processed, err := runPackageEnvironment(t, packageRunnerCase{
+			failOperation:          "rclone-ready",
+			runCommandFailure:      context.Canceled,
+			forceStopBeforeFailure: true,
+		})
+		if err == nil || !processed {
+			t.Fatalf("RunOnce() = (%t, %v), want rclone cancellation after force stop", processed, err)
+		}
+		if provider.sandboxState != "stopped" || provider.sandboxError != nil {
+			t.Fatalf("force-stopped sandbox = state %q error %v, want stopped without error", provider.sandboxState, provider.sandboxError)
+		}
+		if provider.codeSessionCreated || len(provider.launches) != 0 {
+			t.Fatal("force stop during rclone startup started the managed-agent runtime")
+		}
+	})
+
 	t.Run("stop requested during provisioning terminates sandbox before manager startup", func(t *testing.T) {
 		provider, processed, err := runPackageEnvironment(t, packageRunnerCase{stopAfterProvision: true})
 		if err != nil || !processed {
@@ -433,8 +450,11 @@ func TestEnvironmentRunnerPackageProvisioning(t *testing.T) {
 
 type packageRunnerCase struct {
 	commandErr              error
+	failOperation           string
+	runCommandFailure       error
 	stopAfterProvision      bool
 	forceStopAfterProvision bool
+	forceStopBeforeFailure  bool
 }
 
 const cfgPackageProvisionTimeoutForTest = 37 * time.Second
@@ -496,8 +516,10 @@ func runPackageEnvironment(t *testing.T, testCase packageRunnerCase) (*recording
 		_, _ = client.Beta.Sessions.Delete(context.Background(), session.ID, anthropic.BetaSessionDeleteParams{})
 	})
 	provider := &recordingRunnerProvider{
-		sandboxID:  "sandbox-runner-packages",
-		commandErr: testCase.commandErr,
+		sandboxID:         "sandbox-runner-packages",
+		commandErr:        testCase.commandErr,
+		failOperation:     testCase.failOperation,
+		runCommandFailure: testCase.runCommandFailure,
 	}
 	if testCase.stopAfterProvision || testCase.forceStopAfterProvision {
 		provider.afterCommand = func() {
@@ -505,6 +527,12 @@ func runPackageEnvironment(t *testing.T, testCase packageRunnerCase) (*recording
 			if testCase.forceStopAfterProvision {
 				provider.Kill(runCtx, provider.sandboxID)
 			}
+		}
+	}
+	if testCase.forceStopBeforeFailure {
+		provider.beforeRunFailure = func() {
+			requestPackageEnvironmentStop(t, runCtx, app.db, environment.ID, true)
+			provider.Kill(runCtx, provider.sandboxID)
 		}
 	}
 	runner := newManagedAgentRunner(t, app, provider, cfg)
@@ -1127,6 +1155,7 @@ type recordingRunnerProvider struct {
 	failOperation             string
 	runCommandFailure         error
 	beforeCreate              func()
+	beforeRunFailure          func()
 	resolves                  []recordedSandboxResolve
 	commands                  []recordedSandboxCommand
 	launches                  []recordedSandboxLaunch
@@ -1253,6 +1282,9 @@ func (p *recordingRunnerProvider) FileExists(_ context.Context, sandboxID, path 
 	}
 	p.operations = append(p.operations, "rclone-ready")
 	if p.failOperation == "rclone-ready" {
+		if p.beforeRunFailure != nil {
+			p.beforeRunFailure()
+		}
 		return false, p.runCommandFailure
 	}
 	return true, nil

--- a/tests/environments_runner_cloud_test.go
+++ b/tests/environments_runner_cloud_test.go
@@ -338,6 +338,25 @@ func TestEnvironmentRunnerPackageProvisioning(t *testing.T) {
 		}
 	})
 
+	t.Run("force stop during failed provisioning preserves stopped sandbox", func(t *testing.T) {
+		provider, processed, err := runPackageEnvironment(t, packageRunnerCase{
+			commandErr:              context.Canceled,
+			forceStopAfterProvision: true,
+		})
+		if err != nil || !processed {
+			t.Fatalf("RunOnce() = (%t, %v), want force stop to win over command cancellation", processed, err)
+		}
+		if !reflect.DeepEqual(provider.kills, []string{provider.sandboxID, provider.sandboxID}) {
+			t.Fatalf("killed sandboxes = %#v, want stop handler and runner cleanup", provider.kills)
+		}
+		if provider.sandboxState != "stopped" || provider.sandboxError != nil {
+			t.Fatalf("force-stopped sandbox = state %q error %v, want stopped without error", provider.sandboxState, provider.sandboxError)
+		}
+		if provider.codeSessionCreated || len(provider.launches) != 0 {
+			t.Fatal("force stop during provisioning started the managed-agent runtime")
+		}
+	})
+
 	t.Run("stop requested during provisioning terminates sandbox before manager startup", func(t *testing.T) {
 		provider, processed, err := runPackageEnvironment(t, packageRunnerCase{stopAfterProvision: true})
 		if err != nil || !processed {
@@ -413,13 +432,14 @@ func TestEnvironmentRunnerPackageProvisioning(t *testing.T) {
 }
 
 type packageRunnerCase struct {
-	commandErr         error
-	stopAfterProvision bool
+	commandErr              error
+	stopAfterProvision      bool
+	forceStopAfterProvision bool
 }
 
 const cfgPackageProvisionTimeoutForTest = 37 * time.Second
 
-func requestPackageEnvironmentStop(t *testing.T, ctx context.Context, database *db.DB, environmentID string) {
+func requestPackageEnvironmentStop(t *testing.T, ctx context.Context, database *db.DB, environmentID string, force bool) {
 	t.Helper()
 	ids := getDefaultDBIDs(t, database)
 	works, _, err := database.ListEnvironmentWorkPage(ctx, db.ListEnvironmentWorkPageParams{
@@ -430,7 +450,7 @@ func requestPackageEnvironmentStop(t *testing.T, ctx context.Context, database *
 	if err != nil || len(works) != 1 {
 		t.Fatalf("list environment work count/error = %d/%v, want one work", len(works), err)
 	}
-	if _, err := database.StopEnvironmentWork(ctx, ids.WorkspaceID, environmentID, works[0].ExternalID, false); err != nil {
+	if _, err := database.StopEnvironmentWork(ctx, ids.WorkspaceID, environmentID, works[0].ExternalID, force); err != nil {
 		t.Fatalf("request environment work stop: %v", err)
 	}
 }
@@ -479,9 +499,12 @@ func runPackageEnvironment(t *testing.T, testCase packageRunnerCase) (*recording
 		sandboxID:  "sandbox-runner-packages",
 		commandErr: testCase.commandErr,
 	}
-	if testCase.stopAfterProvision {
+	if testCase.stopAfterProvision || testCase.forceStopAfterProvision {
 		provider.afterCommand = func() {
-			requestPackageEnvironmentStop(t, runCtx, app.db, environment.ID)
+			requestPackageEnvironmentStop(t, runCtx, app.db, environment.ID, testCase.forceStopAfterProvision)
+			if testCase.forceStopAfterProvision {
+				provider.Kill(runCtx, provider.sandboxID)
+			}
 		}
 	}
 	runner := newManagedAgentRunner(t, app, provider, cfg)
@@ -1253,11 +1276,11 @@ func (p *recordingRunnerProvider) RunCommand(_ context.Context, sandboxID string
 	}
 	p.operations = append(p.operations, operation)
 	if operation == "command:provision" {
-		if p.commandErr != nil {
-			return e2bruntime.CommandResult{}, p.commandErr
-		}
 		if p.afterCommand != nil {
 			p.afterCommand()
+		}
+		if p.commandErr != nil {
+			return e2bruntime.CommandResult{}, p.commandErr
 		}
 		return e2bruntime.CommandResult{
 			ExitCode: 0,


### PR DESCRIPTION
## 背景

Environment API 已支持声明 npm、PyPI、APT 等 package，但 Runner 创建 Sandbox 后此前不会实际安装这些依赖。本 PR 聚焦补齐 Environment package provisioning，不包含数据库迁移、Filestore、网络策略或其他无关重构。

## 改动内容

- 解析并校验 Environment package 配置，生成稳定的 provisioning manifest。
- 扩展 E2B command 执行能力，支持 stdin、结构化执行结果和超时控制。
- Runner 在启动 Environment Manager 前执行 package provisioning。
- provisioning 失败或收到停止请求时终止 Sandbox，避免启动半初始化的运行环境。
- package provisioning 使用独立的 Runner 超时预算；未配置 packages 的 Environment 保持原有启动行为。
- 补充 package 配置、manifest、E2B runtime 和 Runner provisioning 测试。
- 增加中文设计文档，说明执行顺序、失败语义和兼容边界。

## 范围控制

本 PR 不包含：

- 历史 Environment 的数据库迁移；
- Filestore 或挂载逻辑调整；
- Compose/FUSE 修改；
- 网络策略修改；
- package provisioning 之外的数据库访问重构。

当前仍处于开发阶段，已有 Environment 如需 packages，可直接新建或更新 Environment，不在本 PR 中引入一次性数据迁移。

## 验证

- `go test ./internal/environments ./internal/runtime/e2bruntime ./internal/codesessions ./internal/db -count=1`
- `go test ./tests -run 'TestOfficialSDKEnvironmentPackagesRoundTrip|TestEnvironmentRunnerPackageProvisioning' -count=1 -v`
- `just lint`
- `just dead-code`
- `just duplicates`
- `just complexity`
- pre-commit hooks 全部通过
- 真实链路验证通过：Agent → Environment（npm 6.0.0 更新为 7.0.0）→ Session → Runner → e2b-local → Sandbox，Sandbox 内实际读取到更新后的 `is-number@7.0.0`，Environment Manager 成功注册。

说明：完整 `go test ./...` 在默认本地配置下受既有数据库 migration 33 状态影响；使用 E2E 配置运行后，剩余失败为配置中的模型映射、SSRF 规则和共享测试数据相互影响，与本 PR 的 package provisioning 无关。上述聚焦测试及真实链路均已通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `environment_runner.package_provision_timeout` (default 2 minutes) for environment package provisioning.
  * Packages from `config.packages` are now installed in a dedicated pre-start step for `apt`, `cargo`, `gem`, `go`, `npm`, and `pip`, with size-limited manifests and strict provisioning output validation.
  * Updated API responses to return normalized package configuration consistently.

* **Bug Fixes**
  * Improved sandbox command execution/cleanup with bounded stdout/stderr and safer stop behavior during provisioning.
  * Enhanced handling of concurrent stop/termination to avoid overwriting outcomes.

* **Tests**
  * Added focused unit and integration coverage for normalization, validation, provisioning, and command execution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->