### PR TITLE
Remove internal registry references

### DIFF
--- a/docs/design/be/e2b-sandbox-image-contract.md
+++ b/docs/design/be/e2b-sandbox-image-contract.md
@@ -67,7 +67,7 @@ File resource 与 `/uploads` entry 的一致性由 resource 写事务负责，Ru
 ## 镜像验收
 
 仓库中的真实 E2E 固定使用
-`registry.gz.cvte.cn/oma/managed-agent-sandbox:latest`，避免测试配置静默回退到不含
+`ghcr.io/superduck-ai/managed-agent-sandbox:latest`，避免测试配置静默回退到不含
 `rclone-filestore` 的通用 template。部署前仍应将通过验收的镜像 digest 固化到发布系统，
 不能把可变的 `latest` 当作生产可复现性边界。
 

--- a/tests/environments_full_e2b_bridge_integration_test.go
+++ b/tests/environments_full_e2b_bridge_integration_test.go
@@ -18,7 +18,7 @@ import (
 	e2b "github.com/superduck-ai/e2b-go-sdk"
 )
 
-const fullE2BManagedAgentSandboxImage = "registry.gz.cvte.cn/oma/managed-agent-sandbox:latest"
+const fullE2BManagedAgentSandboxImage = "ghcr.io/superduck-ai/managed-agent-sandbox:latest"
 
 func TestE2BManagedAgentBridgeEnvironmentManagerIntegration(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
## Summary

- replace the hard-coded managed-agent sandbox image reference with the GitHub Container Registry location
- keep the E2E sandbox image contract documentation aligned with the test fixture

## Why

The real E2E fixture and its design documentation referenced a private registry hostname. That exposed internal infrastructure metadata in the repository.

## Impact

The repository no longer contains the private registry hostname. The real E2E fixture now points to `ghcr.io/superduck-ai/managed-agent-sandbox:latest`; image availability was intentionally not validated as part of this change.

## Validation

- `just lint`
- `go test -tags=e2e ./tests -run '^$' -count=1`
- `just dead-code`
- `just large-files`
- staged pre-commit hooks
- repository-wide search confirming the private registry hostname is absent

`just hooks-run` passed all formatting, lint, dead-code, complexity, duplication, naming, and large-file checks. Its repository-wide private-key scan still reports the pre-existing fixtures in `scripts/tests/generate-upstream-proxy-ca-key_test.sh` and `scripts/tests/generate-code-session-jwt-key_test.sh`, neither of which is modified by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end sandbox integration checks to validate the managed-agent sandbox image from the new container registry.
  * Added coverage to ensure tests do not silently fall back to an alternative `rclone-filestore` template.

* **Documentation**
  * Updated the sandbox image acceptance contract to reflect the new required image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->