### PR TITLE
Renew E2B sandbox timeouts from running worker heartbeats

### DIFF
--- a/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
+++ b/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
@@ -2,19 +2,24 @@
 
 ## 概述
 
-`POST /v1/code/sessions/{id}/worker/heartbeat` 已实现为“当前 worker epoch 的租约续期”接口。强一致状态来源是 PostgreSQL 的 `code_sessions` 行；本接口不引入 Redis、不新增 `session_heartbeats` 表，也不通过后台清理任务驱动活性判断。
+`POST /v1/code/sessions/{id}/worker/heartbeat` 已实现为“当前 worker epoch 的租约续期”接口，并只为 `worker_status=running` 的 Code Session 续期对应 E2B Sandbox。worker 强一致状态来源是 PostgreSQL 的 `code_sessions` 行；本接口不引入 Redis、不新增 `session_heartbeats` 表，也不通过后台清理任务驱动活性判断。Provider Sandbox 是外部资源，数据库 worker 续租成功且 worker 正在运行时通过 E2B `SetTimeout` 续期。
 
 核心目标：
 
 - 只允许当前 `current_worker_epoch` 的 worker 续约。
 - 使用固定 `60s` TTL 和固定 `10s` grace 处理边界延迟。
 - 在 epoch 冲突或租约超过 grace 后拒绝心跳，并且不更新任何 session 状态。
+- 只有通过当前 epoch 与 lease 校验、且 `worker_status=running` 的 heartbeat 才能续期对应的 E2B Sandbox。
+- E2B 续期时长复用 `e2b.sandbox_timeout`，不维护另一套 Sandbox TTL 配置。
+- `idle` 和 `requires_action` heartbeat 仍续 worker lease，但不续 E2B Sandbox，避免常驻 CCRv2 heartbeat 让空闲 Sandbox 永不过期。
 - 使用 OMA 签发的 Ed25519 session-ingress JWT，并将签名 `session_id` 与请求路径绑定；session 与 lease 状态由 heartbeat 数据库状态机判断。
 
 相关实现文件：
 
 - `internal/codesessions/ingress.go`
 - `internal/db/code_sessions.go`
+- `internal/db/environments.go`
+- `internal/runtime/e2bruntime/runtime.go`
 - `internal/db/db.go`
 - `tests/sessions_api_test.go`
 
@@ -66,6 +71,7 @@ Content-Type: application/json
 | `worker_epoch` 不等于当前 epoch | `409` | `conflict_error` | 无 |
 | 当前 epoch 租约超过 grace | `410` | `session_expired` | 无 |
 | DB 或系统异常 | `500` | `api_error` | 无 |
+| running worker 已关联活动 Sandbox，但续期依赖缺失或 E2B `SetTimeout` 失败 | `503` | `api_error` | worker lease 已续期，Sandbox 续期失败 |
 
 ## 鉴权
 
@@ -81,20 +87,22 @@ handler 的调用顺序为：
 
 1. 先完成 ingress 鉴权。
 2. 再解析 heartbeat body。
-3. 最后进入 DB 租约续期逻辑。
+3. 进入 DB worker 租约续期逻辑。
+4. DB 续期成功后，仅为 running worker 解析活动 Sandbox 并调用 E2B `SetTimeout`。
 
 ## 数据模型
 
-心跳状态直接使用 `code_sessions` 现有列：
+worker 心跳状态直接使用 `code_sessions` 现有列：
 
 - `current_worker_epoch`
 - `worker_lease_expires_at`
 - `worker_last_heartbeat_at`
+- `worker_status`
 - `last_worker_activity_at`
 - `connection_status`
 - `updated_at`
 
-不新增 migration。worker 是否已注册由以下条件判断：
+不新增 migration。Code Session 通过受信任的 Session Work 数据关联 `environment_work`，再通过 `work_id` 定位 `environment_sandboxes` 中最新的 `running` Sandbox；查询同时约束 organization、workspace 和 environment，且要求 Code Session 的 `worker_status=running`、`provider_sandbox_id` 非空。未关联活动 Sandbox 的独立 Code Session，以及 `idle`/`requires_action` Code Session，只续 worker lease，不调用 Provider。worker 是否已注册由以下条件判断：
 
 - `current_worker_epoch > 0`
 - `worker_lease_expires_at is not null`
@@ -110,7 +118,9 @@ handler 的调用顺序为：
 3. 调用 `decodeCodeSessionWorkerHeartbeatBody` 严格解析 body。
 4. 调用 `RecordCodeSessionWorkerHeartbeat(ctx, codeSessionID, epoch, 60s, 10s)`。
 5. 根据 DB sentinel error 映射 HTTP 响应。
-6. 成功时返回 `ok` 和新的 `worker_lease_expires_at`。
+6. DB 续租成功后调用 `GetRenewableEnvironmentSandboxForCodeSession`；只有 running worker 能返回 Sandbox。
+7. running worker 使用 `e2b.sandbox_timeout` 调用 Provider `SetTimeout`。
+8. `idle`、`requires_action` 或未关联活动 Sandbox 时直接返回 worker 续租结果；running worker 已关联 Sandbox 时，两层续租均成功才返回 `ok` 和新的 `worker_lease_expires_at`，续期依赖缺失或 Provider 续期失败时返回 `503`。
 
 body 解析与 `PUT /worker`、events、diagnostics 等路径分开，避免复用旧的 `ValidateCodeSessionWorkerEpoch` 路径把“未注册 worker”“租约过期”和“epoch mismatch”混在一起。
 
@@ -195,6 +205,10 @@ heartbeat 使用 `SELECT ... FOR UPDATE` 锁定目标 `code_sessions` 行，因�
 - heartbeat 先提交时，只会续当前 epoch 的租约；后续 register 仍会 bump 到下一 epoch。
 - 多个当前 epoch heartbeat 并发时按行锁顺序依次续约，最终租约以最后提交的 heartbeat 为准。
 
+E2B 网络调用不在 PostgreSQL 事务中执行，避免远端延迟占用 `code_sessions` 行锁。worker lease 先提交，再按提交后的 worker 状态解析可续期 Sandbox，因此 running worker 遇到 Provider 临时失败时接口返回 `503`，但已经观测到的 worker heartbeat 仍保留；客户端下一次 heartbeat 会重新尝试 `SetTimeout`。`SetTimeout` 是幂等的相对 TTL 更新，并发成功调用以 E2B 最后处理的请求为准。
+
+E2B SDK 的 `Connect` 也会携带 timeout。Provider 所有 connect 操作显式使用 `e2b.sandbox_timeout`，避免 SDK 默认值覆盖项目配置；running heartbeat 随后显式调用 `SetTimeout`，把 Sandbox 生命周期从本次请求重新延长相同配置时长。worker 切换到 `idle` 或 `requires_action` 后，后续 heartbeat 不再连接 Provider；如果没有其他 Provider 操作，Sandbox 会在最后一次 running 续期后的 `e2b.sandbox_timeout` 内自然过期。`last_worker_activity_at` 会被 heartbeat 自身刷新，不能作为 Sandbox idle 计时来源。
+
 ## 日志
 
 epoch mismatch 和 lease expired 会记录结构化文本日志，字段包括：
@@ -229,6 +243,10 @@ epoch mismatch 和 lease expired 会记录结构化文本日志，字段包括�
 - session 不存在返回 `404 not_found_error`。
 - 旧 epoch 和未知未来 epoch 返回 `409 conflict_error`，并断言租约和 activity 字段不变。
 - 当前 epoch 未过期 heartbeat 返回 `200` 并续到 `now + 60s`。
+- running heartbeat 使用对应 `provider_sandbox_id` 和 `e2b.sandbox_timeout` 调用 Sandbox 续期。
+- idle 和 requires-action heartbeat 续 worker lease，但不调用 Sandbox 续期。
+- running heartbeat 的 E2B Sandbox 续期失败返回 `503`。
+- 旧 epoch、未来 epoch 和超过 grace 的 heartbeat 不调用 Sandbox 续期。
 - 刚过期但在 `10s` grace 内 heartbeat 返回 `200`。
 - 超过 grace 返回 `410 session_expired`，并断言状态不更新。
 - 过期 heartbeat 不 bump epoch，下一次 register 继续递增到下一 epoch。
@@ -258,6 +276,7 @@ go test ./... -count=1
 - nonce 防重放。
 - 真实 JWT 签名验证。
 - 独立后台任务清理 heartbeat 状态。
+- Sandbox 续期合并、节流或异步后台续期。
 - 跨区域一致性协议。
 
 这些能力需要独立认证、限流或部署设计。当前接口的强一致边界是单行 PostgreSQL 事务。

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -75,6 +75,7 @@ type ServerDeps struct {
 	Logger                 *slog.Logger
 	PlatformStore          platformsession.Store
 	CodeSessionCredentials *codesessions.SessionCredentials
+	SandboxTimeoutExtender codesessions.SandboxTimeoutExtender
 	FilestoreCredentials   *filestoreapi.TokenCredentials
 	FilestoreService       *filestoreapi.Service
 }
@@ -110,7 +111,7 @@ func NewServer(deps ServerDeps) *Server {
 		admin:                adminapi.NewHandler(deps.Config, deps.DB, componentLogger("admin")),
 		agents:               agents.NewHandler(deps.Config, deps.DB, componentLogger("agents")),
 		batch:                batches.NewHandler(deps.Config, deps.DB, deps.ObjectStore, componentLogger("batches")),
-		codeSessions:         codesessions.NewHandler(deps.Config, codeSessionService, codeSessionLogger),
+		codeSessions:         codesessions.NewHandler(deps.Config, codeSessionService, deps.SandboxTimeoutExtender, codeSessionLogger),
 		deployments:          deploymentsapi.NewHandler(deps.Config, deps.DB, webhookEnqueuer, componentLogger("deployments")),
 		deploymentRuns:       deploymentsapi.NewRunsHandler(deps.Config, deps.DB, componentLogger("deployment_runs")),
 		envs:                 environments.NewHandler(deps.Config, deps.DB, componentLogger("environments")),

--- a/internal/codesessions/handler.go
+++ b/internal/codesessions/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
@@ -13,29 +14,37 @@ import (
 // Handler 是 code-session 的 HTTP transport 边界。
 // 它持有协议相关的鉴权、代理连接和日志状态；业务状态与业务编排统一委托给 Service。
 type Handler struct {
-	cfg           config.Config
-	db            *db.DB
-	service       *Service
-	logger        *slog.Logger
-	upstreamProxy upstreamProxyRuntime
+	cfg                    config.Config
+	db                     *db.DB
+	service                *Service
+	logger                 *slog.Logger
+	sandboxTimeoutExtender SandboxTimeoutExtender
+	upstreamProxy          upstreamProxyRuntime
 	// loadPolicyContext 解析 CONNECT 授权所需的策略上下文；测试可替换为 fixture。
 	loadPolicyContext func(ctx context.Context, identity upstreamProxyIdentity) (upstreamProxyPolicyContext, error)
 	otlpLogMu         sync.Mutex
 }
 
+// SandboxTimeoutExtender renews the provider-side lifetime of a managed-agent
+// sandbox after its current worker proves liveness.
+type SandboxTimeoutExtender interface {
+	SetTimeout(ctx context.Context, sandboxID string, timeout time.Duration) error
+}
+
 // NewHandler 创建长生命周期的 HTTP handler。Handler 直接复用 Service 的数据库依赖，
 // 避免 HTTP 路由和跨资源业务服务意外连接到不同的数据源。
-func NewHandler(cfg config.Config, service *Service, logger *slog.Logger) *Handler {
+func NewHandler(cfg config.Config, service *Service, sandboxTimeoutExtender SandboxTimeoutExtender, logger *slog.Logger) *Handler {
 	if service == nil {
 		panic("codesessions: service is required")
 	}
 	logger = logging.LoggerOrDefault(logger)
 	handler := &Handler{
-		cfg:           cfg,
-		db:            service.db,
-		service:       service,
-		logger:        logger,
-		upstreamProxy: newUpstreamProxyRuntime(),
+		cfg:                    cfg,
+		db:                     service.db,
+		service:                service,
+		logger:                 logger,
+		sandboxTimeoutExtender: sandboxTimeoutExtender,
+		upstreamProxy:          newUpstreamProxyRuntime(),
 	}
 	handler.loadPolicyContext = handler.loadUpstreamProxyPolicyContext
 	// 只有 MITM 开启时才在构造阶段读取稳定私钥并签发一年期根证书，使配置错误在启动期失败。

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -476,7 +476,32 @@ func (h *Handler) handleCodeSessionWorkerHeartbeat(w http.ResponseWriter, r *htt
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusInternalServerError, "api_error", "Could not record code session worker heartbeat"))
 		return
 	}
+	if err := h.extendCodeSessionSandboxTimeout(r.Context(), codeSessionID); err != nil {
+		h.logger.ErrorContext(r.Context(), "extend code session sandbox timeout", "code_session_id", codeSessionID, "error", err)
+		httpapi.WriteError(w, r, httpapi.NewError(http.StatusServiceUnavailable, "api_error", "Could not extend code session sandbox timeout"))
+		return
+	}
 	httpapi.WriteJSON(w, http.StatusOK, map[string]any{"ok": true, "worker_lease_expires_at": expiresAt.Format(time.RFC3339Nano)})
+}
+
+func (h *Handler) extendCodeSessionSandboxTimeout(ctx context.Context, codeSessionID string) error {
+	sandbox, err := h.db.GetRenewableEnvironmentSandboxForCodeSession(ctx, codeSessionID)
+	if errors.Is(err, db.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("resolve active sandbox: %w", err)
+	}
+	if h.sandboxTimeoutExtender == nil {
+		return errors.New("sandbox timeout extender is not configured")
+	}
+	if sandbox.ProviderSandboxID == nil || strings.TrimSpace(*sandbox.ProviderSandboxID) == "" {
+		return errors.New("active sandbox is missing provider sandbox id")
+	}
+	if err := h.sandboxTimeoutExtender.SetTimeout(ctx, *sandbox.ProviderSandboxID, h.cfg.E2B.SandboxTimeout); err != nil {
+		return fmt.Errorf("set provider sandbox timeout: %w", err)
+	}
+	return nil
 }
 
 func (h *Handler) handleCodeSessionWorkerOTLP(w http.ResponseWriter, r *http.Request) {

--- a/internal/codesessions/otlp_file_log_test.go
+++ b/internal/codesessions/otlp_file_log_test.go
@@ -39,7 +39,7 @@ func TestRecordCodeSessionWorkerOTLPFileLogRecordsDecodeErrors(t *testing.T) {
 			OTLPFileLogEnabled: true,
 			OTLPLogRoot:        root,
 		},
-	}, newTestService(t, nil), nil)
+	}, newTestService(t, nil), nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/v1/code/sessions/cse_bad/worker/otlp/logs", bytes.NewReader([]byte(`{"resourceLogs":[`)))
 	req.Header.Set("Content-Type", "application/json")
 
@@ -151,7 +151,7 @@ func TestRecordCodeSessionWorkerOTLPFileLogWritesRequestAndExpandedRecords(t *te
 			OTLPLogRoot:             root,
 			OTLPLogBodyPreviewBytes: 8,
 		},
-	}, newTestService(t, nil), nil)
+	}, newTestService(t, nil), nil, nil)
 
 	metricsBody, err := proto.Marshal(testOTLPMetricsRequest())
 	if err != nil {

--- a/internal/codesessions/upstream_proxy_mitm_test.go
+++ b/internal/codesessions/upstream_proxy_mitm_test.go
@@ -66,7 +66,7 @@ func TestUpstreamProxyCertificateAuthorityIgnoresDormantPrivateKey(t *testing.T)
 	missingKeyFile := filepath.Join(t.TempDir(), "missing-key.pem")
 	handler := NewHandler(config.Config{
 		CodeSession: config.CodeSessionConfig{UpstreamProxyCAKeyFile: missingKeyFile},
-	}, newTestService(t, nil), nil)
+	}, newTestService(t, nil), nil, nil)
 	authority, err := handler.loadUpstreamProxyCA()
 	if err != nil {
 		t.Fatalf("loadUpstreamProxyCA() error = %v", err)
@@ -245,7 +245,7 @@ func TestUpstreamProxyCACertificateHandlerReturnsGeneratedCertificate(t *testing
 	t.Parallel()
 
 	files := writeTestUpstreamProxyCA(t, "handler")
-	handler := NewHandler(files.config(), newTestService(t, nil), nil)
+	handler := NewHandler(files.config(), newTestService(t, nil), nil, nil)
 	authority, err := handler.loadUpstreamProxyCA()
 	if err != nil {
 		t.Fatalf("load generated handler CA: %v", err)
@@ -281,7 +281,7 @@ func TestUpstreamProxyMITMDecryptsAndForwardsHTTPRequest(t *testing.T) {
 	files := writeTestUpstreamProxyCA(t, "tunnel")
 	upstreamRequests := make(chan *http.Request, 1)
 	dialTargets := make(chan string, 1)
-	handler := NewHandler(files.config(), newTestService(t, nil), nil)
+	handler := NewHandler(files.config(), newTestService(t, nil), nil, nil)
 	stubUnrestrictedPolicyContext(t, handler)
 	authority, err := handler.loadUpstreamProxyCA()
 	if err != nil {

--- a/internal/codesessions/upstream_proxy_policy_test.go
+++ b/internal/codesessions/upstream_proxy_policy_test.go
@@ -89,7 +89,7 @@ func stubUnrestrictedPolicyContext(t *testing.T, handler *Handler) {
 
 func policyTestHandler(t *testing.T, policy networkpolicy.Policy, err error) *Handler {
 	t.Helper()
-	handler := NewHandler(config.Config{}, newTestService(t, nil), nil)
+	handler := NewHandler(config.Config{}, newTestService(t, nil), nil, nil)
 	handler.loadPolicyContext = func(context.Context, upstreamProxyIdentity) (upstreamProxyPolicyContext, error) {
 		return upstreamProxyPolicyContext{
 			policy:                policy,

--- a/internal/codesessions/upstream_proxy_test.go
+++ b/internal/codesessions/upstream_proxy_test.go
@@ -184,7 +184,7 @@ func TestUpstreamProxyTunnelForwardsBinaryChunks(t *testing.T) {
 
 	targetConnections := make(chan net.Conn, 1)
 	dialTargets := make(chan string, 1)
-	handler := NewHandler(config.Config{}, newTestService(t, nil), nil)
+	handler := NewHandler(config.Config{}, newTestService(t, nil), nil, nil)
 	stubUnrestrictedPolicyContext(t, handler)
 	handler.upstreamProxy = upstreamProxyRuntime{
 		dial: func(_ context.Context, target string) (net.Conn, error) {

--- a/internal/db/environments.go
+++ b/internal/db/environments.go
@@ -712,6 +712,42 @@ func (d *DB) GetActiveEnvironmentSandboxForWork(ctx context.Context, workspaceID
 	`, environmentWorkLookupArguments(workspaceID, environmentExternalID, workExternalID))
 }
 
+// GetRenewableEnvironmentSandboxForCodeSession resolves the provider sandbox
+// owned by a running managed-agent Code Session. Idle and requires-action
+// workers intentionally return ErrNotFound so their heartbeats cannot keep the
+// sandbox alive indefinitely.
+func (d *DB) GetRenewableEnvironmentSandboxForCodeSession(ctx context.Context, codeSessionExternalID string) (EnvironmentSandbox, error) {
+	return getEnvironmentSandboxSQLX(ctx, d.sql, `
+		select `+environmentSandboxSQLXColumns+`
+		from environment_sandboxes
+		where id = (
+			select sandbox.id
+			from code_sessions code_session
+			join environment_work work
+				on work.organization_id = code_session.organization_id
+				and work.workspace_id = code_session.workspace_id
+				and work.environment_id = code_session.environment_id
+				and work.environment_external_id = code_session.environment_external_id
+				and work.data->>'type' = 'session'
+				and work.data->>'id' = code_session.session_external_id
+				and work.deleted_at is null
+			join environment_sandboxes sandbox
+				on sandbox.organization_id = code_session.organization_id
+				and sandbox.workspace_id = code_session.workspace_id
+				and sandbox.environment_id = code_session.environment_id
+				and sandbox.work_id = work.id
+				and sandbox.provider_sandbox_id is not null
+				and sandbox.state = 'running'
+			where code_session.external_id = :code_session_external_id
+				and code_session.status = 'active'
+				and code_session.worker_status = 'running'
+				and code_session.deleted_at is null
+			order by sandbox.created_at desc, sandbox.id desc
+			limit 1
+		)
+	`, map[string]any{"code_session_external_id": codeSessionExternalID})
+}
+
 const (
 	environmentSQLXColumns = `id, CAST(uuid AS text) AS uuid, external_id, organization_id,
 		workspace_id, created_by_api_key_id, name, description, config, metadata, scope,

--- a/internal/runtime/e2bruntime/runtime.go
+++ b/internal/runtime/e2bruntime/runtime.go
@@ -62,6 +62,8 @@ type E2BProvider struct {
 	cfg config.E2BConfig
 }
 
+const defaultSandboxTimeout = 5 * time.Minute
+
 func NewProvider(cfg config.E2BConfig) *E2BProvider {
 	return &E2BProvider{cfg: cfg}
 }
@@ -122,7 +124,7 @@ func (p *E2BProvider) Create(ctx context.Context, env db.Environment, work *db.E
 	}
 	timeoutMs := int(resolved.Timeout / time.Millisecond)
 	if timeoutMs <= 0 {
-		timeoutMs = int((5 * time.Minute) / time.Millisecond)
+		timeoutMs = int(defaultSandboxTimeout / time.Millisecond)
 	}
 	allowInternet := resolved.AllowInternetAccess
 	opts := &e2b.SandboxOpts{
@@ -152,6 +154,23 @@ func (p *E2BProvider) Kill(ctx context.Context, sandboxID string) error {
 		return err
 	}
 	return sandbox.Kill(ctx, nil)
+}
+
+// SetTimeout renews the provider-side sandbox lifetime from the time of this
+// request. The heartbeat caller passes the configured sandbox lifetime rather
+// than an absolute expiration timestamp.
+func (p *E2BProvider) SetTimeout(ctx context.Context, sandboxID string, timeout time.Duration) error {
+	if strings.TrimSpace(sandboxID) == "" {
+		return errors.New("sandbox id is required")
+	}
+	if timeout <= 0 {
+		timeout = p.sandboxTimeout()
+	}
+	sandbox, err := p.connect(ctx, sandboxID)
+	if err != nil {
+		return err
+	}
+	return sandbox.SetTimeout(ctx, int(timeout/time.Millisecond), nil)
 }
 
 func (p *E2BProvider) WriteFile(ctx context.Context, sandboxID string, filePath string, data []byte) error {
@@ -420,13 +439,22 @@ func (p *E2BProvider) StartBackgroundCommand(ctx context.Context, sandboxID stri
 }
 
 func (p *E2BProvider) connect(ctx context.Context, sandboxID string) (*e2b.Sandbox, error) {
+	timeoutMs := int(p.sandboxTimeout() / time.Millisecond)
 	sandbox, err := e2b.Connect(ctx, sandboxID, &e2b.SandboxConnectOpts{
 		ConnectionOpts: ConnectionOptsFromConfig(p.cfg),
+		TimeoutMs:      &timeoutMs,
 	})
 	if err != nil {
 		return nil, err
 	}
 	return sandbox, nil
+}
+
+func (p *E2BProvider) sandboxTimeout() time.Duration {
+	if p.cfg.SandboxTimeout > 0 {
+		return p.cfg.SandboxTimeout
+	}
+	return defaultSandboxTimeout
 }
 
 func resolveNetwork(raw json.RawMessage, work *db.EnvironmentWork) (*e2b.SandboxNetworkOpts, bool, error) {

--- a/internal/runtime/e2bruntime/runtime_test.go
+++ b/internal/runtime/e2bruntime/runtime_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"sync"
@@ -35,6 +38,52 @@ func TestConnectionOptsFromConfigMapsAllFields(t *testing.T) {
 	wantTimeoutMs := int(cfg.RequestTimeout / time.Millisecond)
 	if got.RequestTimeoutMs == nil || *got.RequestTimeoutMs != wantTimeoutMs {
 		t.Fatalf("ConnectionOptsFromConfig().RequestTimeoutMs = %v, want %d", got.RequestTimeoutMs, wantTimeoutMs)
+	}
+}
+
+func TestSetTimeoutUsesConfiguredConnectTimeoutAndRequestedRenewal(t *testing.T) {
+	var paths []string
+	var timeouts []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		var body struct {
+			Timeout int `json:"timeout"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode %s request: %v", r.URL.Path, err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		timeouts = append(timeouts, body.Timeout)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/sandboxes/sbx_timeout/connect" {
+			_, _ = fmt.Fprint(w, `{"sandboxID":"sbx_timeout","envdURL":"http://127.0.0.1:1"}`)
+			return
+		}
+		if r.URL.Path == "/sandboxes/sbx_timeout/timeout" {
+			_, _ = fmt.Fprint(w, `{}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	provider := NewProvider(config.E2BConfig{
+		APIKey:         "e2b_0000000000000000000000000000000000000000",
+		APIURL:         server.URL,
+		SandboxURL:     server.URL,
+		RequestTimeout: time.Second,
+		SandboxTimeout: 7 * time.Minute,
+	})
+	if err := provider.SetTimeout(context.Background(), "sbx_timeout", 3*time.Minute); err != nil {
+		t.Fatalf("SetTimeout() error = %v", err)
+	}
+	wantPaths := []string{"/sandboxes/sbx_timeout/connect", "/sandboxes/sbx_timeout/timeout"}
+	if !reflect.DeepEqual(paths, wantPaths) {
+		t.Fatalf("request paths = %#v, want %#v", paths, wantPaths)
+	}
+	if want := []int{420, 180}; !reflect.DeepEqual(timeouts, want) {
+		t.Fatalf("request timeouts = %#v, want %#v", timeouts, want)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -102,9 +102,10 @@ func run(logger *slog.Logger) error {
 		logger.With("component", "batches"),
 	).Start(ctx)
 	environmentLogger := logger.With("component", "environment_runner")
+	sandboxProvider := e2bruntime.NewProvider(cfg.E2B)
 	environmentRunner, err := environments.NewRunner(environments.RunnerDependencies{
 		DB:              database,
-		Provider:        e2bruntime.NewProvider(cfg.E2B),
+		Provider:        sandboxProvider,
 		Config:          cfg,
 		CodeSessions:    codesessions.NewServiceWithCredentials(database, codeSessionCredentials, environmentLogger),
 		Skills:          skillsapi.NewRuntimeResolver(database),
@@ -126,6 +127,7 @@ func run(logger *slog.Logger) error {
 			Logger:                 logger,
 			PlatformStore:          platformSessions,
 			CodeSessionCredentials: codeSessionCredentials,
+			SandboxTimeoutExtender: sandboxProvider,
 			FilestoreCredentials:   filestoreCredentials,
 			FilestoreService:       filestoreService,
 		}),

--- a/tests/files_api_test.go
+++ b/tests/files_api_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http/httptest"
 	"net/textproto"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -46,9 +47,40 @@ type testApp struct {
 	sessions             *platformsession.MemoryStore
 	credentials          *codesessions.SessionCredentials
 	filestoreCredentials *filestore.TokenCredentials
+	sandboxTimeouts      *recordingSandboxTimeoutExtender
 	server               *httptest.Server
 	baseURL              string
 	client               *http.Client
+}
+
+type sandboxTimeoutCall struct {
+	sandboxID string
+	timeout   time.Duration
+}
+
+type recordingSandboxTimeoutExtender struct {
+	mu    sync.Mutex
+	calls []sandboxTimeoutCall
+	err   error
+}
+
+func (e *recordingSandboxTimeoutExtender) SetTimeout(_ context.Context, sandboxID string, timeout time.Duration) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.calls = append(e.calls, sandboxTimeoutCall{sandboxID: sandboxID, timeout: timeout})
+	return e.err
+}
+
+func (e *recordingSandboxTimeoutExtender) setError(err error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.err = err
+}
+
+func (e *recordingSandboxTimeoutExtender) snapshotCalls() []sandboxTimeoutCall {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]sandboxTimeoutCall(nil), e.calls...)
 }
 
 type errorResponse struct {
@@ -1023,6 +1055,7 @@ func newTestAppWithStoreAndLogger(t *testing.T, override *config.Config, store s
 		database.Close()
 		t.Fatalf("ensure object store bucket: %v", err)
 	}
+	sandboxTimeouts := &recordingSandboxTimeoutExtender{}
 	server := httptest.NewServer(api.NewServer(api.ServerDeps{
 		Config:                 cfg,
 		DB:                     database,
@@ -1030,6 +1063,7 @@ func newTestAppWithStoreAndLogger(t *testing.T, override *config.Config, store s
 		Logger:                 logger,
 		PlatformStore:          platformSessions,
 		CodeSessionCredentials: credentials,
+		SandboxTimeoutExtender: sandboxTimeouts,
 		FilestoreCredentials:   filestoreCredentials,
 	}))
 	return &testApp{
@@ -1039,6 +1073,7 @@ func newTestAppWithStoreAndLogger(t *testing.T, override *config.Config, store s
 		sessions:             platformSessions,
 		credentials:          credentials,
 		filestoreCredentials: filestoreCredentials,
+		sandboxTimeouts:      sandboxTimeouts,
 		server:               server,
 		baseURL:              server.URL,
 		client:               server.Client(),

--- a/tests/sessions_api_test.go
+++ b/tests/sessions_api_test.go
@@ -2575,6 +2575,64 @@ func TestCodeSessionWorkerHeartbeatRejectsInvalidRequests(t *testing.T) {
 	assertError(t, resp, http.StatusUnauthorized, "authentication_error")
 }
 
+func TestCodeSessionWorkerHeartbeatReportsSandboxTimeoutFailure(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("sessions-code-worker-heartbeat-timeout-failure-bucket"))
+	defer app.close()
+
+	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"sessions-worker-heartbeat-timeout-failure-agent"}`)
+	defer cleanupAgentRows(t, app.db, agent.ID)
+	env := createEnvironment(t, app, `{"name":"sessions-worker-heartbeat-timeout-failure-env"}`)
+	defer cleanupEnvironmentRows(t, app.db, env.ID)
+	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
+	codeSessionID := launchLocalCodeSession(t, app, session.ID)
+	workerEpoch := registerCodeSessionWorker(t, app, codeSessionID)
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(workerEpoch)+`,"worker_status":"running"}`)
+	app.sandboxTimeouts.setError(errors.New("provider unavailable"))
+
+	resp := doCodeSessionWorkerRequest(t, app, codeSessionID, "heartbeat", workerHeartbeatBody(codeSessionID, workerEpoch))
+	assertError(t, resp, http.StatusServiceUnavailable, "api_error")
+	calls := app.sandboxTimeouts.snapshotCalls()
+	if len(calls) != 1 {
+		t.Fatalf("sandbox timeout calls = %d, want 1", len(calls))
+	}
+}
+
+func TestCodeSessionWorkerHeartbeatSkipsSandboxTimeoutWhenNotRunning(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("sessions-code-worker-heartbeat-idle-bucket"))
+	defer app.close()
+
+	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"sessions-worker-heartbeat-idle-agent"}`)
+	defer cleanupAgentRows(t, app.db, agent.ID)
+	env := createEnvironment(t, app, `{"name":"sessions-worker-heartbeat-idle-env"}`)
+	defer cleanupEnvironmentRows(t, app.db, env.ID)
+	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
+	codeSessionID := launchLocalCodeSession(t, app, session.ID)
+	workerEpoch := registerCodeSessionWorker(t, app, codeSessionID)
+
+	beforeIdle, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	if err != nil {
+		t.Fatalf("load before idle heartbeat: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	idleExpiresAt := assertCodeSessionWorkerHeartbeat(t, app, codeSessionID, workerEpoch)
+	if beforeIdle.WorkerLeaseExpiresAt == nil || !idleExpiresAt.After(*beforeIdle.WorkerLeaseExpiresAt) {
+		t.Fatalf("idle heartbeat lease expiry = %s, want after %v", idleExpiresAt, beforeIdle.WorkerLeaseExpiresAt)
+	}
+	if calls := app.sandboxTimeouts.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("idle heartbeat sandbox timeout calls = %d, want 0", len(calls))
+	}
+
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(workerEpoch)+`,"worker_status":"requires_action"}`)
+	time.Sleep(5 * time.Millisecond)
+	requiresActionExpiresAt := assertCodeSessionWorkerHeartbeat(t, app, codeSessionID, workerEpoch)
+	if !requiresActionExpiresAt.After(idleExpiresAt) {
+		t.Fatalf("requires-action heartbeat lease expiry = %s, want after %s", requiresActionExpiresAt, idleExpiresAt)
+	}
+	if calls := app.sandboxTimeouts.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("requires-action heartbeat sandbox timeout calls = %d, want 0", len(calls))
+	}
+}
+
 func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	app := newTestAppWithStore(t, nil, newFakeStore("sessions-code-worker-heartbeat-lease-bucket"))
 	defer app.close()
@@ -2587,6 +2645,7 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	codeSessionID := launchLocalCodeSession(t, app, session.ID)
 
 	epoch1 := registerCodeSessionWorker(t, app, codeSessionID)
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(epoch1)+`,"worker_status":"running"}`)
 	before, err := app.db.GetCodeSession(context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load before heartbeat: %v", err)
@@ -2603,6 +2662,22 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	numberExpiresAt := assertCodeSessionWorkerHeartbeatBody(t, app, codeSessionID, `{"session_id":`+quoteJSON(codeSessionID)+`,"worker_epoch":`+epoch1+`}`)
 	if !numberExpiresAt.After(stringExpiresAt) {
 		t.Fatalf("number heartbeat lease expiry = %s, want after %s", numberExpiresAt, stringExpiresAt)
+	}
+	timeoutCalls := app.sandboxTimeouts.snapshotCalls()
+	if len(timeoutCalls) != 2 {
+		t.Fatalf("sandbox timeout calls = %d, want 2", len(timeoutCalls))
+	}
+	sandbox, err := app.db.GetRenewableEnvironmentSandboxForCodeSession(context.Background(), codeSessionID)
+	if err != nil {
+		t.Fatalf("load active sandbox for code session: %v", err)
+	}
+	if sandbox.ProviderSandboxID == nil {
+		t.Fatal("active sandbox provider id = nil")
+	}
+	for _, call := range timeoutCalls {
+		if call.sandboxID != *sandbox.ProviderSandboxID || call.timeout != app.cfg.E2B.SandboxTimeout {
+			t.Fatalf("sandbox timeout call = %+v, want sandbox %q timeout %s", call, *sandbox.ProviderSandboxID, app.cfg.E2B.SandboxTimeout)
+		}
 	}
 	after, err := app.db.GetCodeSession(context.Background(), codeSessionID)
 	if err != nil {
@@ -2621,6 +2696,9 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	}
 	resp := doCodeSessionWorkerRequest(t, app, codeSessionID, "heartbeat", workerHeartbeatBody(codeSessionID, "999"))
 	assertError(t, resp, http.StatusConflict, "conflict_error")
+	if calls := app.sandboxTimeouts.snapshotCalls(); len(calls) != 2 {
+		t.Fatalf("future epoch sandbox timeout calls = %d, want 2", len(calls))
+	}
 	afterFutureMismatch, err := app.db.GetCodeSession(context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load after future mismatch heartbeat: %v", err)
@@ -2637,6 +2715,9 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	}
 	resp = doCodeSessionWorkerRequest(t, app, codeSessionID, "heartbeat", workerHeartbeatBody(codeSessionID, epoch1))
 	assertError(t, resp, http.StatusConflict, "conflict_error")
+	if calls := app.sandboxTimeouts.snapshotCalls(); len(calls) != 2 {
+		t.Fatalf("stale epoch sandbox timeout calls = %d, want 2", len(calls))
+	}
 	afterMismatch, err := app.db.GetCodeSession(context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load after mismatch heartbeat: %v", err)
@@ -2651,6 +2732,9 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 		t.Fatalf("load grace lease record: %v", err)
 	}
 	assertCodeSessionWorkerHeartbeat(t, app, codeSessionID, epoch2)
+	if calls := app.sandboxTimeouts.snapshotCalls(); len(calls) != 3 {
+		t.Fatalf("grace heartbeat sandbox timeout calls = %d, want 3", len(calls))
+	}
 	graceAfter, err := app.db.GetCodeSession(context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load after grace heartbeat: %v", err)
@@ -2671,6 +2755,9 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	}
 	resp = doCodeSessionWorkerRequest(t, app, codeSessionID, "heartbeat", workerHeartbeatBody(codeSessionID, epoch2))
 	assertError(t, resp, http.StatusGone, "session_expired")
+	if calls := app.sandboxTimeouts.snapshotCalls(); len(calls) != 3 {
+		t.Fatalf("expired heartbeat sandbox timeout calls = %d, want 3", len(calls))
+	}
 	resp = doCodeSessionWorkerOTLPRequest(t, app, codeSessionID, "metrics", epoch2, "application/x-protobuf", nil)
 	assertError(t, resp, http.StatusGone, "session_expired")
 	afterExpiredHeartbeat, err := app.db.GetCodeSession(context.Background(), codeSessionID)


### PR DESCRIPTION
## Summary

- Extend the E2B Sandbox timeout when a valid running worker heartbeat renews its lease.
- Skip provider renewal for idle, requires-action, or unassociated sessions.
- Propagate provider renewal failures as `503` while preserving the worker lease.
- Reuse the configured sandbox timeout for E2B connections and renewals.
- Add design documentation and integration/runtime coverage for the new behavior.

## Testing

- Added runtime tests for E2B timeout configuration and renewal requests.
- Added integration tests for provider failure handling and non-running worker behavior.
- Existing test suite updates cover the new handler dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker heartbeats now renew the associated sandbox timeout when the worker is running.
  * Heartbeats from idle or action-required workers renew only the worker lease.
  * Sandbox renewal failures now return a clear service-unavailable response while preserving the lease renewal result.

* **Bug Fixes**
  * Improved sandbox lifecycle handling and timeout configuration during heartbeat processing.

* **Tests**
  * Added coverage for successful renewal, skipped renewal, and sandbox renewal failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->