### PR TITLE
Migrate workspace and organization references to UUIDs

### DIFF
--- a/docs/configuration-reference.yaml
+++ b/docs/configuration-reference.yaml
@@ -100,7 +100,6 @@ bootstrap:
       key: sk-ant-local-default
   workspace_name: default
   organization_name: default
-  organization_external_id: org_default
   workspace_external_id: workspace_default
   user_external_id: user_default
   api_key_external_id: api_key_default

--- a/docs/design/be/database-identifier-references.md
+++ b/docs/design/be/database-identifier-references.md
@@ -1,0 +1,72 @@
+# 数据库稳定引用
+
+## 标识符分工
+
+多数核心业务表继续保留三类标识符：
+
+- `id bigint generated always as identity` 是当前数据库内的内部主键，可用于事务内定位和锁；
+- `uuid uuid` 是备份恢复、租户搬迁、跨库合并和部分数据导入后仍保持稳定的业务标识；
+- `external_id text` 是 Anthropic API 或其他外部协议的兼容标识，不替代内部稳定 UUID。
+
+`organizations` 是明确的例外：组织没有必须兼容的 Anthropic 前缀 ID，迁移
+`00037_drop_organization_external_id.sql` 删除 `organizations.external_id`，此后组织在数据库、
+HTTP 路由、Admin 响应、Platform session 和 webhook payload 中统一使用原始 UUID。迁移不修改
+任何已有 `organizations.uuid`，因此已保存的组织引用保持稳定。`organizations.id` 继续作为
+数据库内部 identity，但不会进入 Admin Organization 业务模型；Organization 查询直接按 UUID
+定位。
+
+跨表持久化引用应保存目标资源的 UUID。应用仍可在查询边界把 UUID 解析为当前数据库的 bigint identity，但不能把另一个表的 identity 作为需要跨数据库保持含义的权威引用。数据库不创建 PostgreSQL 外键，引用完整性由写入查询、migration 校验和集成测试维护。
+
+## Workspace 的 Organization 引用
+
+迁移 `00036_use_uuid_workspace_organization_reference.sql` 将：
+
+```text
+workspaces.organization_id bigint
+```
+
+替换为：
+
+```text
+workspaces.organization_uuid uuid
+```
+
+`workspaces.id` 仍是 bigint identity，`workspaces.uuid` 和 `workspaces.external_id` 的值保持不变。原有组织内名称唯一性 `(organization_id, name)` 相应改为 `(organization_uuid, name)`。
+
+迁移前会把每条旧 `organization_id` 与 `organizations.id` 关联；存在无法解析的孤立引用时直接失败。表按最终字段顺序重建，复制时保留 workspace identity，并在重建后校准 identity sequence。回滚同样要求每个 `organization_uuid` 都能解析为当前库的 organization identity，不能把无法解析的引用静默写成空值。
+
+```mermaid
+flowchart LR
+    O["organizations.id bigint"] -->|"迁移前"| WI["workspaces.organization_id bigint"]
+    O2["organizations.uuid uuid"] -->|"迁移后"| WU["workspaces.organization_uuid uuid"]
+    WU --> R["Workspace 查询直接使用 organization UUID 分区"]
+```
+
+## 应用查询边界
+
+鉴权边界提供 organization identity 和 UUID，不再提供 organization external ID。其中 Organization Admin、Workspace Admin、Workspace API Key Admin 和 External Key 的 workspace 引用计数直接传递可信 `organization_uuid`，写入和租户过滤均使用：
+
+```sql
+workspaces.organization_uuid = CAST(:organization_uuid AS uuid)
+```
+
+这些路径不需要返回 organization 的其他字段，因此不得仅为 bigint identity 与 UUID 互转而 JOIN `organizations`。普通 workspace API key 鉴权仍需解析 organization identity 和 UUID；该查询保留 JOIN，并把 UUID 提供给后续 Workspace 查询。
+
+仍需 organization 设置，或需要校验其他 bigint 租户引用的查询继续 JOIN `organizations`。删除 JOIN 的判断依据是查询语义，而不是仅依据 `workspaces` 已保存 UUID。
+
+Console 和 Platform 的组织路由只接受 UUID，不再用 `org_...` 或任意文本值回退查询。
+`GET /v1/organizations/me` 的 `id` 以及 webhook `data.organization_id` 都直接返回相同的
+organization UUID。默认 seed 不再依赖 `org_default`：升级已有数据库时，通过
+`workspace_default.organization_uuid` 找回原组织；全新数据库才创建组织，因此不会因为删除
+external ID 而替换已有 UUID。
+
+## 验收
+
+- `workspaces` 不再包含 `organization_id`；
+- `organization_uuid` 是第 4 列且 PostgreSQL 类型为 `uuid`；
+- `organizations` 不再包含 `external_id`，已有 `uuid` 值不变；
+- Admin Organization 模型和查询不读取或传递 `organizations.id`；
+- Admin organization ID 和 webhook `organization_id` 返回原始 UUID；
+- 默认 seed、Platform 登录、Console Workspace、Admin Workspace、API Key 鉴权、Filestore 和 Code Session 的租户关联继续通过；
+- schema 仍不包含 PostgreSQL 外键；
+- 全量 Go 测试、lint、死代码、重复代码和复杂度门禁通过。

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -36,11 +36,11 @@ func NewService(cfg config.Config, database *db.DB) *Service {
 }
 
 func (s *Service) GetCurrentOrganization(ctx context.Context, principal auth.Principal) (organizationResponse, error) {
-	org, err := s.db.GetAdminOrganization(ctx, principal.OrganizationID)
+	org, err := s.db.GetAdminOrganization(ctx, principal.OrganizationUUID)
 	if err != nil {
 		return organizationResponse{}, mapAdminDBError(err, "Organization not found")
 	}
-	return organizationResponse{ID: org.ExternalID, Name: org.Name, Type: "organization"}, nil
+	return organizationResponse{ID: org.UUID, Name: org.Name, Type: "organization"}, nil
 }
 
 func (s *Service) CreateInvite(ctx context.Context, principal auth.Principal, req createInviteRequest) (inviteResponse, error) {
@@ -185,16 +185,16 @@ func (s *Service) CreateWorkspace(ctx context.Context, principal auth.Principal,
 	}
 	now := time.Now().UTC()
 	record, err := s.db.CreateAdminWorkspace(ctx, db.AdminWorkspace{
-		UUID:           uuid.NewString(),
-		ExternalID:     workspaceID,
-		OrganizationID: principal.OrganizationID,
-		Name:           name,
-		CreatedAt:      now,
-		CompartmentID:  uuid.NewString(),
-		DisplayColor:   "#6C5BB9",
-		DataResidency:  residencyJSON,
-		ExternalKeyID:  normalizedOptionalString(req.ExternalKeyID),
-		Tags:           tagsJSON,
+		UUID:             uuid.NewString(),
+		ExternalID:       workspaceID,
+		OrganizationUUID: principal.OrganizationUUID,
+		Name:             name,
+		CreatedAt:        now,
+		CompartmentID:    uuid.NewString(),
+		DisplayColor:     "#6C5BB9",
+		DataResidency:    residencyJSON,
+		ExternalKeyID:    normalizedOptionalString(req.ExternalKeyID),
+		Tags:             tagsJSON,
 	})
 	if err != nil {
 		return workspaceResponse{}, mapAdminDBError(err, "Could not create workspace")
@@ -203,7 +203,7 @@ func (s *Service) CreateWorkspace(ctx context.Context, principal auth.Principal,
 }
 
 func (s *Service) GetWorkspace(ctx context.Context, principal auth.Principal, workspaceID string) (workspaceResponse, error) {
-	workspace, err := s.db.GetAdminWorkspace(ctx, principal.OrganizationID, workspaceID)
+	workspace, err := s.db.GetAdminWorkspace(ctx, principal.OrganizationUUID, workspaceID)
 	if err != nil {
 		return workspaceResponse{}, mapAdminDBError(err, "Workspace not found")
 	}
@@ -212,11 +212,11 @@ func (s *Service) GetWorkspace(ctx context.Context, principal auth.Principal, wo
 
 func (s *Service) ListWorkspaces(ctx context.Context, principal auth.Principal, includeArchived bool, afterID, beforeID string, limit int) (cursorPageResponse[workspaceResponse], error) {
 	records, hasMore, err := s.db.ListAdminWorkspacesPage(ctx, db.ListAdminWorkspacesParams{
-		OrganizationID:  principal.OrganizationID,
-		IncludeArchived: includeArchived,
-		AfterID:         afterID,
-		BeforeID:        beforeID,
-		Limit:           limit,
+		OrganizationUUID: principal.OrganizationUUID,
+		IncludeArchived:  includeArchived,
+		AfterID:          afterID,
+		BeforeID:         beforeID,
+		Limit:            limit,
 	})
 	if err != nil {
 		return cursorPageResponse[workspaceResponse]{}, err
@@ -229,7 +229,7 @@ func (s *Service) ListWorkspaces(ctx context.Context, principal auth.Principal, 
 }
 
 func (s *Service) UpdateWorkspace(ctx context.Context, principal auth.Principal, workspaceID string, req updateWorkspaceRequest) (workspaceResponse, error) {
-	current, err := s.db.GetAdminWorkspace(ctx, principal.OrganizationID, workspaceID)
+	current, err := s.db.GetAdminWorkspace(ctx, principal.OrganizationUUID, workspaceID)
 	if err != nil {
 		return workspaceResponse{}, mapAdminDBError(err, "Workspace not found")
 	}
@@ -283,7 +283,7 @@ func (s *Service) UpdateWorkspace(ctx context.Context, principal auth.Principal,
 		}
 		externalKeyID = &nextExternalKeyID
 	}
-	updated, err := s.db.UpdateAdminWorkspace(ctx, principal.OrganizationID, workspaceID, db.AdminWorkspace{
+	updated, err := s.db.UpdateAdminWorkspace(ctx, principal.OrganizationUUID, workspaceID, db.AdminWorkspace{
 		Name:          name,
 		DataResidency: residencyJSON,
 		ExternalKeyID: externalKeyID,
@@ -297,7 +297,7 @@ func (s *Service) UpdateWorkspace(ctx context.Context, principal auth.Principal,
 }
 
 func (s *Service) ArchiveWorkspace(ctx context.Context, principal auth.Principal, workspaceID string) (workspaceResponse, error) {
-	workspace, err := s.db.ArchiveAdminWorkspace(ctx, principal.OrganizationID, workspaceID)
+	workspace, err := s.db.ArchiveAdminWorkspace(ctx, principal.OrganizationUUID, workspaceID)
 	if err != nil {
 		return workspaceResponse{}, mapAdminDBError(err, "Workspace not found")
 	}
@@ -308,7 +308,7 @@ func (s *Service) CreateWorkspaceMember(ctx context.Context, principal auth.Prin
 	if err := validateWorkspaceRole(req.WorkspaceRole, false); err != nil {
 		return workspaceMemberResponse{}, invalidRequest(err.Error())
 	}
-	workspace, err := s.db.GetAdminWorkspace(ctx, principal.OrganizationID, workspaceID)
+	workspace, err := s.db.GetAdminWorkspace(ctx, principal.OrganizationUUID, workspaceID)
 	if err != nil {
 		return workspaceMemberResponse{}, mapAdminDBError(err, "Workspace not found")
 	}
@@ -345,7 +345,7 @@ func (s *Service) GetWorkspaceMember(ctx context.Context, principal auth.Princip
 }
 
 func (s *Service) ListWorkspaceMembers(ctx context.Context, principal auth.Principal, workspaceID, afterID, beforeID string, limit int) (cursorPageResponse[workspaceMemberResponse], error) {
-	workspace, err := s.db.GetAdminWorkspace(ctx, principal.OrganizationID, workspaceID)
+	workspace, err := s.db.GetAdminWorkspace(ctx, principal.OrganizationUUID, workspaceID)
 	if err != nil {
 		return cursorPageResponse[workspaceMemberResponse]{}, mapAdminDBError(err, "Workspace not found")
 	}
@@ -386,7 +386,7 @@ func (s *Service) DeleteWorkspaceMember(ctx context.Context, principal auth.Prin
 }
 
 func (s *Service) GetAPIKey(ctx context.Context, principal auth.Principal, apiKeyID string) (apiKeyResponse, error) {
-	key, err := s.db.GetAdminAPIKey(ctx, principal.OrganizationID, apiKeyID)
+	key, err := s.db.GetAdminAPIKey(ctx, principal.OrganizationUUID, apiKeyID)
 	if err != nil {
 		return apiKeyResponse{}, mapAdminDBError(err, "API key not found")
 	}
@@ -400,13 +400,13 @@ func (s *Service) ListAPIKeys(ctx context.Context, principal auth.Principal, wor
 		}
 	}
 	records, hasMore, err := s.db.ListAdminAPIKeysPage(ctx, db.ListAdminAPIKeysParams{
-		OrganizationID:  principal.OrganizationID,
-		WorkspaceID:     workspaceID,
-		CreatedByUserID: createdByUserID,
-		Status:          status,
-		AfterID:         afterID,
-		BeforeID:        beforeID,
-		Limit:           limit,
+		OrganizationUUID: principal.OrganizationUUID,
+		WorkspaceID:      workspaceID,
+		CreatedByUserID:  createdByUserID,
+		Status:           status,
+		AfterID:          afterID,
+		BeforeID:         beforeID,
+		Limit:            limit,
 	})
 	if err != nil {
 		return cursorPageResponse[apiKeyResponse]{}, err
@@ -433,7 +433,7 @@ func (s *Service) UpdateAPIKey(ctx context.Context, principal auth.Principal, ap
 			return apiKeyResponse{}, invalidRequest("name must be non-empty")
 		}
 	}
-	key, err := s.db.UpdateAdminAPIKey(ctx, principal.OrganizationID, apiKeyID, req.Name != nil, name, req.Status != nil, status)
+	key, err := s.db.UpdateAdminAPIKey(ctx, principal.OrganizationUUID, apiKeyID, req.Name != nil, name, req.Status != nil, status)
 	if err != nil {
 		return apiKeyResponse{}, mapAdminDBError(err, "API key not found")
 	}
@@ -524,7 +524,7 @@ func (s *Service) UpdateExternalKey(ctx context.Context, principal auth.Principa
 		}
 		next.ProviderConfig = normalized
 	}
-	refs, err := s.db.CountAdminExternalKeyWorkspaceRefs(ctx, principal.OrganizationID, externalKeyID)
+	refs, err := s.db.CountAdminExternalKeyWorkspaceRefs(ctx, principal.OrganizationUUID, externalKeyID)
 	if err != nil {
 		return externalKeyResponse{}, err
 	}
@@ -540,7 +540,7 @@ func (s *Service) UpdateExternalKey(ctx context.Context, principal auth.Principa
 }
 
 func (s *Service) DeleteExternalKey(ctx context.Context, principal auth.Principal, externalKeyID string) (map[string]string, error) {
-	refs, err := s.db.CountAdminExternalKeyWorkspaceRefs(ctx, principal.OrganizationID, externalKeyID)
+	refs, err := s.db.CountAdminExternalKeyWorkspaceRefs(ctx, principal.OrganizationUUID, externalKeyID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/filestore_auth_test.go
+++ b/internal/api/filestore_auth_test.go
@@ -385,7 +385,7 @@ func TestFilestoreJWTAuthentication(t *testing.T) {
 	t.Run("failure database workspace cmek change revokes existing token", func(t *testing.T) {
 		workspace, getErr := database.GetAdminWorkspace(
 			context.Background(),
-			fixture.organizationID,
+			fixture.tokenIdentity.OrgUUID,
 			fixture.tokenIdentity.WorkspaceTaggedID,
 		)
 		if getErr != nil {
@@ -396,7 +396,7 @@ func TestFilestoreJWTAuthentication(t *testing.T) {
 		next.UpdatedAt = time.Now().UTC()
 		if _, updateErr := database.UpdateAdminWorkspace(
 			context.Background(),
-			fixture.organizationID,
+			fixture.tokenIdentity.OrgUUID,
 			workspace.ExternalID,
 			next,
 		); updateErr != nil {
@@ -406,7 +406,7 @@ func TestFilestoreJWTAuthentication(t *testing.T) {
 			workspace.UpdatedAt = time.Now().UTC()
 			if _, restoreErr := database.UpdateAdminWorkspace(
 				context.Background(),
-				fixture.organizationID,
+				fixture.tokenIdentity.OrgUUID,
 				workspace.ExternalID,
 				workspace,
 			); restoreErr != nil {
@@ -453,8 +453,10 @@ func TestFilestoreJWTAuthentication(t *testing.T) {
 			t.Fatalf("load fixture organization: %v", err)
 		}
 		if err := database.Pool.QueryRow(context.Background(), `
-			insert into workspaces (uuid, external_id, organization_id, name)
-			values ($1, $2, $3, $4)
+			insert into workspaces (uuid, external_id, organization_uuid, name)
+			select $1, $2, uuid, $4
+			from organizations
+			where id = $3
 			returning id
 		`, otherWorkspaceUUID, otherWorkspaceExternalID, organizationID, "Filestore cross-workspace test").Scan(&otherWorkspaceID); err != nil {
 			t.Fatalf("insert other workspace: %v", err)
@@ -580,7 +582,6 @@ func newFilestoreAuthDatabaseFixture(t *testing.T) (*db.DB, config.Config, files
 
 	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
 	organizationUUID := uuid.NewString()
-	organizationExternalID := "org_filestore_auth_" + suffix
 	workspaceUUID := uuid.NewString()
 	workspaceExternalID := "workspace_filestore_auth_" + suffix
 	accountUUID := uuid.NewString()
@@ -602,22 +603,24 @@ func newFilestoreAuthDatabaseFixture(t *testing.T) (*db.DB, config.Config, files
 		_, _ = database.Pool.Exec(ctx, `delete from api_keys where key_hash = $1`, auth.HashAPIKey(workspaceAPIKey))
 		_, _ = database.Pool.Exec(ctx, `delete from users where external_id = $1`, accountExternalID)
 		_, _ = database.Pool.Exec(ctx, `delete from workspaces where external_id = $1`, workspaceExternalID)
-		_, _ = database.Pool.Exec(ctx, `delete from organizations where external_id = $1`, organizationExternalID)
+		_, _ = database.Pool.Exec(ctx, `delete from organizations where uuid = $1`, organizationUUID)
 		database.Close()
 	})
 
 	var organizationID int64
 	if err := database.Pool.QueryRow(context.Background(), `
-		insert into organizations (uuid, external_id, name, settings)
-		values ($1, $2, $3, '{"org_taints":["restricted","compliance"]}'::jsonb)
+		insert into organizations (uuid, name, settings)
+		values ($1, $2, '{"org_taints":["restricted","compliance"]}'::jsonb)
 		returning id
-	`, organizationUUID, organizationExternalID, "Filestore auth test").Scan(&organizationID); err != nil {
+	`, organizationUUID, "Filestore auth test").Scan(&organizationID); err != nil {
 		t.Fatalf("insert filestore auth organization: %v", err)
 	}
 	var workspaceID int64
 	if err := database.Pool.QueryRow(context.Background(), `
-		insert into workspaces (uuid, external_id, organization_id, name, external_key_id)
-		values ($1, $2, $3, $4, 'key_filestore_auth')
+		insert into workspaces (uuid, external_id, organization_uuid, name, external_key_id)
+		select $1, $2, uuid, $4, 'key_filestore_auth'
+		from organizations
+		where id = $3
 		returning id
 	`, workspaceUUID, workspaceExternalID, organizationID, "Filestore auth test").Scan(&workspaceID); err != nil {
 		t.Fatalf("insert filestore auth workspace: %v", err)

--- a/internal/api/platform_mcp_vault_auth.go
+++ b/internal/api/platform_mcp_vault_auth.go
@@ -119,7 +119,7 @@ func (s *Server) handlePlatformMCPVaultAuthStart(w http.ResponseWriter, r *http.
 		return
 	}
 	orgUUID := strings.TrimSpace(chi.URLParam(r, "orgUuid"))
-	if orgUUID == "" || (orgUUID != principal.OrganizationUUID && orgUUID != principal.OrganizationExternalID) {
+	if orgUUID == "" || orgUUID != principal.OrganizationUUID {
 		writePlatformMCPVaultAuthError(w, http.StatusNotFound, platformMCPVaultAuthVerificationRequestFailed, "")
 		return
 	}
@@ -151,7 +151,7 @@ func (s *Server) handlePlatformMCPVaultAuthStart(w http.ResponseWriter, r *http.
 	if workspaceID == "default" {
 		workspaceID = principal.WorkspaceExternalID
 	}
-	workspace, err := s.db.GetAdminWorkspace(r.Context(), principal.OrganizationID, workspaceID)
+	workspace, err := s.db.GetAdminWorkspace(r.Context(), principal.OrganizationUUID, workspaceID)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			writePlatformMCPVaultAuthError(w, http.StatusNotFound, platformMCPVaultAuthVerificationRequestFailed, "")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -405,11 +405,6 @@ func (s *Server) authenticatePlatformSession(r *http.Request) (auth.Principal, *
 		s.logger.ErrorContext(r.Context(), "authenticate platform session", "error", err)
 		return auth.Principal{}, httpapi.NewError(http.StatusInternalServerError, "api_error", "Authentication failed")
 	}
-	if strings.TrimSpace(session.OrganizationUUID) == "" && strings.TrimSpace(session.OrganizationExternalID) != "" {
-		if org, orgErr := s.db.GetPlatformOrganization(r.Context(), session.OrganizationExternalID); orgErr == nil && org != nil {
-			session.OrganizationUUID = org.UUID
-		}
-	}
 	principal := session.Principal()
 	principal, orgErr := s.applyPlatformOrganizationOverride(r, principal)
 	if orgErr != nil {
@@ -419,7 +414,7 @@ func (s *Server) authenticatePlatformSession(r *http.Request) (auth.Principal, *
 	if workspaceID == "" || workspaceID == "default" || workspaceID == principal.WorkspaceExternalID || workspaceID == principal.WorkspaceUUID {
 		return principal, nil
 	}
-	workspace, err := s.db.GetAdminWorkspace(r.Context(), principal.OrganizationID, workspaceID)
+	workspace, err := s.db.GetAdminWorkspace(r.Context(), principal.OrganizationUUID, workspaceID)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			return auth.Principal{}, httpapi.NewError(http.StatusForbidden, "permission_error", "Workspace not found")
@@ -489,7 +484,7 @@ func (s *Server) recoverPlatformMirrorSession(r *http.Request) (auth.Principal, 
 
 func (s *Server) applyPlatformOrganizationOverride(r *http.Request, principal auth.Principal) (auth.Principal, *httpapi.Error) {
 	orgID := platformOrganizationOverrideID(r)
-	if orgID == "" || orgID == principal.OrganizationUUID || orgID == principal.OrganizationExternalID {
+	if orgID == "" || orgID == principal.OrganizationUUID {
 		return principal, nil
 	}
 	org, err := s.db.GetPlatformOrganization(r.Context(), orgID)
@@ -500,11 +495,10 @@ func (s *Server) applyPlatformOrganizationOverride(r *http.Request, principal au
 		s.logger.ErrorContext(r.Context(), "load platform organization override", "error", err)
 		return auth.Principal{}, httpapi.NewError(http.StatusInternalServerError, "api_error", "Authentication failed")
 	}
-	if org.UUID != principal.OrganizationUUID && org.ExternalID != principal.OrganizationExternalID {
+	if org.UUID != principal.OrganizationUUID {
 		return auth.Principal{}, httpapi.NewError(http.StatusForbidden, "permission_error", "Organization not allowed")
 	}
 	principal.OrganizationUUID = org.UUID
-	principal.OrganizationExternalID = org.ExternalID
 	return principal, nil
 }
 
@@ -513,12 +507,12 @@ func (s *Server) platformMirrorOrganizationAlias(r *http.Request, principal auth
 		return ""
 	}
 	orgID := platformAPIPathOrganizationID(r.URL.Path)
-	if orgID == "" || orgID == principal.OrganizationUUID || orgID == principal.OrganizationExternalID {
+	if orgID == "" || orgID == principal.OrganizationUUID {
 		return ""
 	}
 	org, err := s.db.GetPlatformOrganization(r.Context(), orgID)
 	if err == nil {
-		if org.UUID == principal.OrganizationUUID || org.ExternalID == principal.OrganizationExternalID {
+		if org.UUID == principal.OrganizationUUID {
 			return ""
 		}
 		return ""

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -71,14 +71,14 @@ func (s *Server) authenticateWorkspaceAPIKey(r *http.Request, apiKey string) (au
 		return auth.Principal{}, false, httpapi.NewError(http.StatusInternalServerError, "api_error", "Authentication failed")
 	}
 	return auth.Principal{
-		CredentialType:         auth.CredentialTypeAPIKey,
-		APIKeyID:               key.ID,
-		APIKeyExternalID:       key.ExternalID,
-		OrganizationID:         key.OrganizationID,
-		OrganizationExternalID: key.OrganizationExternalID,
-		WorkspaceID:            key.WorkspaceID,
-		WorkspaceUUID:          key.WorkspaceUUID,
-		WorkspaceExternalID:    key.WorkspaceExternalID,
+		CredentialType:      auth.CredentialTypeAPIKey,
+		APIKeyID:            key.ID,
+		APIKeyExternalID:    key.ExternalID,
+		OrganizationID:      key.OrganizationID,
+		OrganizationUUID:    key.OrganizationUUID,
+		WorkspaceID:         key.WorkspaceID,
+		WorkspaceUUID:       key.WorkspaceUUID,
+		WorkspaceExternalID: key.WorkspaceExternalID,
 	}, true, nil
 }
 
@@ -100,15 +100,15 @@ func (s *Server) authenticateEnvironmentCredential(r *http.Request, apiKey strin
 	envKey, err := s.db.GetEnvironmentKey(r.Context(), auth.HashAPIKey(apiKey))
 	if err == nil {
 		return auth.Principal{
-			CredentialType:         auth.CredentialTypeEnvironmentKey,
-			EnvironmentKeyID:       envKey.ID,
-			OrganizationID:         envKey.OrganizationID,
-			OrganizationExternalID: envKey.OrganizationExternalID,
-			WorkspaceID:            envKey.WorkspaceID,
-			WorkspaceUUID:          envKey.WorkspaceUUID,
-			WorkspaceExternalID:    envKey.WorkspaceExternalID,
-			EnvironmentID:          envKey.EnvironmentID,
-			EnvironmentExternalID:  envKey.EnvironmentExternalID,
+			CredentialType:        auth.CredentialTypeEnvironmentKey,
+			EnvironmentKeyID:      envKey.ID,
+			OrganizationID:        envKey.OrganizationID,
+			OrganizationUUID:      envKey.OrganizationUUID,
+			WorkspaceID:           envKey.WorkspaceID,
+			WorkspaceUUID:         envKey.WorkspaceUUID,
+			WorkspaceExternalID:   envKey.WorkspaceExternalID,
+			EnvironmentID:         envKey.EnvironmentID,
+			EnvironmentExternalID: envKey.EnvironmentExternalID,
 		}, true, nil
 	}
 	if errors.Is(err, db.ErrNotFound) {
@@ -165,22 +165,21 @@ func (s *Server) authenticateFilestoreToken(r *http.Request, rawToken string) (f
 	}
 	readonly := claims.Readonly != nil && *claims.Readonly
 	return filestoreapi.Principal{
-		Subject:                claims.Subject,
-		OrganizationID:         scope.OrganizationID,
-		OrganizationUUID:       scope.OrganizationUUID,
-		OrganizationExternalID: scope.OrganizationExternalID,
-		WorkspaceID:            scope.WorkspaceID,
-		WorkspaceUUID:          scope.WorkspaceUUID,
-		WorkspaceExternalID:    scope.WorkspaceExternalID,
-		AccountID:              scope.AccountID,
-		AccountUUID:            scope.AccountUUID,
-		AccountExternalID:      scope.AccountExternalID,
-		FilesystemInternalID:   scope.FilesystemID,
-		FilesystemUUID:         scope.FilesystemUUID,
-		FilesystemExternalID:   scope.FilesystemExternalID,
-		Readonly:               readonly,
-		OrganizationTaints:     append([]string(nil), claims.OrgTaints...),
-		WorkspaceCMEKEnabled:   claims.WorkspaceCMEKEnabled,
+		Subject:              claims.Subject,
+		OrganizationID:       scope.OrganizationID,
+		OrganizationUUID:     scope.OrganizationUUID,
+		WorkspaceID:          scope.WorkspaceID,
+		WorkspaceUUID:        scope.WorkspaceUUID,
+		WorkspaceExternalID:  scope.WorkspaceExternalID,
+		AccountID:            scope.AccountID,
+		AccountUUID:          scope.AccountUUID,
+		AccountExternalID:    scope.AccountExternalID,
+		FilesystemInternalID: scope.FilesystemID,
+		FilesystemUUID:       scope.FilesystemUUID,
+		FilesystemExternalID: scope.FilesystemExternalID,
+		Readonly:             readonly,
+		OrganizationTaints:   append([]string(nil), claims.OrgTaints...),
+		WorkspaceCMEKEnabled: claims.WorkspaceCMEKEnabled,
 	}, nil
 }
 
@@ -189,7 +188,6 @@ func principalFromCodeSessionCredential(codeSession db.CodeSessionCredentialCont
 		CredentialType:          credentialType,
 		OrganizationID:          codeSession.OrganizationID,
 		OrganizationUUID:        codeSession.OrganizationUUID,
-		OrganizationExternalID:  codeSession.OrganizationExternalID,
 		WorkspaceID:             codeSession.WorkspaceID,
 		WorkspaceUUID:           codeSession.WorkspaceUUID,
 		WorkspaceExternalID:     codeSession.WorkspaceExternalID,

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -24,7 +24,6 @@ type Principal struct {
 	APIKeyExternalID          string
 	OrganizationID            int64
 	OrganizationUUID          string
-	OrganizationExternalID    string
 	WorkspaceID               int64
 	WorkspaceUUID             string
 	WorkspaceExternalID       string

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -50,12 +50,11 @@ func defaultConfig() Config {
 			MaxAttempts: 10,
 		},
 		Bootstrap: BootstrapConfig{
-			WorkspaceName:          "default",
-			OrganizationName:       "default",
-			OrganizationExternalID: "org_default",
-			WorkspaceExternalID:    "workspace_default",
-			UserExternalID:         "user_default",
-			APIKeyExternalID:       "api_key_default",
+			WorkspaceName:       "default",
+			OrganizationName:    "default",
+			WorkspaceExternalID: "workspace_default",
+			UserExternalID:      "user_default",
+			APIKeyExternalID:    "api_key_default",
 		},
 		SDKFixtures: SDKFixtureConfig{
 			FileID:            "file_id",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -118,13 +118,12 @@ type WebhookConfig struct {
 }
 
 type BootstrapConfig struct {
-	SeedAPIKeys            []SeedAPIKey `yaml:"seed_api_keys"`
-	WorkspaceName          string       `yaml:"workspace_name"`
-	OrganizationName       string       `yaml:"organization_name"`
-	OrganizationExternalID string       `yaml:"organization_external_id"`
-	WorkspaceExternalID    string       `yaml:"workspace_external_id"`
-	UserExternalID         string       `yaml:"user_external_id"`
-	APIKeyExternalID       string       `yaml:"api_key_external_id"`
+	SeedAPIKeys         []SeedAPIKey `yaml:"seed_api_keys"`
+	WorkspaceName       string       `yaml:"workspace_name"`
+	OrganizationName    string       `yaml:"organization_name"`
+	WorkspaceExternalID string       `yaml:"workspace_external_id"`
+	UserExternalID      string       `yaml:"user_external_id"`
+	APIKeyExternalID    string       `yaml:"api_key_external_id"`
 }
 
 type SDKFixtureConfig struct {

--- a/internal/config/yaml_types.go
+++ b/internal/config/yaml_types.go
@@ -77,13 +77,12 @@ type yamlWebhookConfig struct {
 }
 
 type yamlBootstrapConfig struct {
-	SeedAPIKeys            optional[[]SeedAPIKey] `yaml:"seed_api_keys"`
-	WorkspaceName          string                 `yaml:"workspace_name"`
-	OrganizationName       string                 `yaml:"organization_name"`
-	OrganizationExternalID string                 `yaml:"organization_external_id"`
-	WorkspaceExternalID    string                 `yaml:"workspace_external_id"`
-	UserExternalID         string                 `yaml:"user_external_id"`
-	APIKeyExternalID       string                 `yaml:"api_key_external_id"`
+	SeedAPIKeys         optional[[]SeedAPIKey] `yaml:"seed_api_keys"`
+	WorkspaceName       string                 `yaml:"workspace_name"`
+	OrganizationName    string                 `yaml:"organization_name"`
+	WorkspaceExternalID string                 `yaml:"workspace_external_id"`
+	UserExternalID      string                 `yaml:"user_external_id"`
+	APIKeyExternalID    string                 `yaml:"api_key_external_id"`
 }
 
 func newYAMLConfig() yamlConfig {
@@ -116,12 +115,11 @@ func newYAMLConfig() yamlConfig {
 			AllowInsecure: defaults.Webhook.AllowInsecure,
 		},
 		Bootstrap: yamlBootstrapConfig{
-			WorkspaceName:          defaults.Bootstrap.WorkspaceName,
-			OrganizationName:       defaults.Bootstrap.OrganizationName,
-			OrganizationExternalID: defaults.Bootstrap.OrganizationExternalID,
-			WorkspaceExternalID:    defaults.Bootstrap.WorkspaceExternalID,
-			UserExternalID:         defaults.Bootstrap.UserExternalID,
-			APIKeyExternalID:       defaults.Bootstrap.APIKeyExternalID,
+			WorkspaceName:       defaults.Bootstrap.WorkspaceName,
+			OrganizationName:    defaults.Bootstrap.OrganizationName,
+			WorkspaceExternalID: defaults.Bootstrap.WorkspaceExternalID,
+			UserExternalID:      defaults.Bootstrap.UserExternalID,
+			APIKeyExternalID:    defaults.Bootstrap.APIKeyExternalID,
 		},
 		SDKFixtures: defaults.SDKFixtures,
 	}
@@ -156,12 +154,11 @@ func (input yamlConfig) resolve() Config {
 			AllowInsecure: input.Webhook.AllowInsecure,
 		},
 		Bootstrap: BootstrapConfig{
-			WorkspaceName:          input.Bootstrap.WorkspaceName,
-			OrganizationName:       input.Bootstrap.OrganizationName,
-			OrganizationExternalID: input.Bootstrap.OrganizationExternalID,
-			WorkspaceExternalID:    input.Bootstrap.WorkspaceExternalID,
-			UserExternalID:         input.Bootstrap.UserExternalID,
-			APIKeyExternalID:       input.Bootstrap.APIKeyExternalID,
+			WorkspaceName:       input.Bootstrap.WorkspaceName,
+			OrganizationName:    input.Bootstrap.OrganizationName,
+			WorkspaceExternalID: input.Bootstrap.WorkspaceExternalID,
+			UserExternalID:      input.Bootstrap.UserExternalID,
+			APIKeyExternalID:    input.Bootstrap.APIKeyExternalID,
 		},
 		SDKFixtures: input.SDKFixtures,
 	}

--- a/internal/db/admin.go
+++ b/internal/db/admin.go
@@ -11,10 +11,9 @@ import (
 )
 
 type AdminOrganization struct {
-	ID         int64     `db:"id"`
-	ExternalID string    `db:"external_id"`
-	Name       string    `db:"name"`
-	CreatedAt  time.Time `db:"created_at"`
+	UUID      string    `db:"uuid"`
+	Name      string    `db:"name"`
+	CreatedAt time.Time `db:"created_at"`
 }
 
 type AdminInvite struct {
@@ -39,19 +38,19 @@ type AdminUser struct {
 }
 
 type AdminWorkspace struct {
-	ID             int64           `db:"id"`
-	UUID           string          `db:"uuid"`
-	ExternalID     string          `db:"external_id"`
-	OrganizationID int64           `db:"organization_id"`
-	Name           string          `db:"name"`
-	CreatedAt      time.Time       `db:"created_at"`
-	UpdatedAt      time.Time       `db:"updated_at"`
-	ArchivedAt     *time.Time      `db:"archived_at"`
-	CompartmentID  string          `db:"compartment_id"`
-	DisplayColor   string          `db:"display_color"`
-	DataResidency  json.RawMessage `db:"data_residency"`
-	ExternalKeyID  *string         `db:"external_key_id"`
-	Tags           json.RawMessage `db:"tags"`
+	ID               int64           `db:"id"`
+	UUID             string          `db:"uuid"`
+	ExternalID       string          `db:"external_id"`
+	OrganizationUUID string          `db:"organization_uuid"`
+	Name             string          `db:"name"`
+	CreatedAt        time.Time       `db:"created_at"`
+	UpdatedAt        time.Time       `db:"updated_at"`
+	ArchivedAt       *time.Time      `db:"archived_at"`
+	CompartmentID    string          `db:"compartment_id"`
+	DisplayColor     string          `db:"display_color"`
+	DataResidency    json.RawMessage `db:"data_residency"`
+	ExternalKeyID    *string         `db:"external_key_id"`
+	Tags             json.RawMessage `db:"tags"`
 }
 
 type AdminWorkspaceMember struct {
@@ -70,7 +69,6 @@ type AdminWorkspaceMember struct {
 type AdminAPIKey struct {
 	ID                      int64      `db:"id"`
 	ExternalID              string     `db:"external_id"`
-	OrganizationID          int64      `db:"organization_id"`
 	WorkspaceID             int64      `db:"workspace_id"`
 	WorkspaceExternalID     string     `db:"workspace_external_id"`
 	CreatedByUserExternalID *string    `db:"created_by_user_external_id"`
@@ -142,11 +140,11 @@ type ListAdminUsersParams struct {
 }
 
 type ListAdminWorkspacesParams struct {
-	OrganizationID  int64
-	IncludeArchived bool
-	AfterID         string
-	BeforeID        string
-	Limit           int
+	OrganizationUUID string
+	IncludeArchived  bool
+	AfterID          string
+	BeforeID         string
+	Limit            int
 }
 
 type ListAdminMembersParams struct {
@@ -158,13 +156,13 @@ type ListAdminMembersParams struct {
 }
 
 type ListAdminAPIKeysParams struct {
-	OrganizationID  int64
-	WorkspaceID     string
-	CreatedByUserID string
-	Status          string
-	AfterID         string
-	BeforeID        string
-	Limit           int
+	OrganizationUUID string
+	WorkspaceID      string
+	CreatedByUserID  string
+	Status           string
+	AfterID          string
+	BeforeID         string
+	Limit            int
 }
 
 type ListAdminOffsetParams struct {
@@ -189,12 +187,24 @@ type ListAdminTunnelCertificatesParams struct {
 	Offset          int
 }
 
-func (d *DB) GetAdminOrganization(ctx context.Context, organizationID int64) (AdminOrganization, error) {
-	return getAdminRow[AdminOrganization](ctx, d.sql, `
-		select id, external_id, name, created_at
+const (
+	getAdminOrganizationQuery = `
+		select CAST(uuid AS text) as uuid, name, created_at
 		from organizations
-		where id = :organization_id
-	`, map[string]any{"organization_id": organizationID})
+		where uuid = CAST(:organization_uuid AS uuid)
+	`
+	countAdminExternalKeyWorkspaceRefsQuery = `
+		select count(*)
+		from workspaces
+		where organization_uuid = CAST(:organization_uuid AS uuid)
+			and external_key_id = :external_id
+	`
+)
+
+func (d *DB) GetAdminOrganization(ctx context.Context, organizationUUID string) (AdminOrganization, error) {
+	return getAdminRow[AdminOrganization](ctx, d.sql, getAdminOrganizationQuery, map[string]any{
+		"organization_uuid": organizationUUID,
+	})
 }
 
 func (d *DB) CreateAdminInvite(ctx context.Context, invite AdminInvite) (AdminInvite, error) {
@@ -335,14 +345,15 @@ func (d *DB) DeleteAdminUser(ctx context.Context, organizationID int64, external
 func (d *DB) CreateAdminWorkspace(ctx context.Context, workspace AdminWorkspace) (AdminWorkspace, error) {
 	created, err := getAdminRow[AdminWorkspace](ctx, d.sql, `
 		insert into workspaces (
-			uuid, external_id, organization_id, name, created_at, updated_at,
+			uuid, external_id, organization_uuid, name, created_at, updated_at,
 			compartment_id, display_color, data_residency, external_key_id, tags
 		)
 		values (
-			:uuid, :external_id, :organization_id, :name, :created_at, :created_at,
+			:uuid, :external_id, CAST(:organization_uuid AS uuid), :name, :created_at, :created_at,
 			:compartment_id, :display_color, CAST(:data_residency AS jsonb), :external_key_id, CAST(:tags AS jsonb)
 		)
-		returning id, CAST(uuid AS text) as uuid, external_id, organization_id, name, created_at, updated_at,
+		returning id, CAST(uuid AS text) as uuid, external_id,
+			CAST(organization_uuid AS text) as organization_uuid, name, created_at, updated_at,
 			archived_at, compartment_id, display_color, data_residency, external_key_id, tags
 	`, adminWorkspaceArguments(workspace))
 	if isUniqueViolation(err) {
@@ -351,11 +362,11 @@ func (d *DB) CreateAdminWorkspace(ctx context.Context, workspace AdminWorkspace)
 	return created, err
 }
 
-func (d *DB) GetAdminWorkspace(ctx context.Context, organizationID int64, externalID string) (AdminWorkspace, error) {
+func (d *DB) GetAdminWorkspace(ctx context.Context, organizationUUID, externalID string) (AdminWorkspace, error) {
 	return getAdminRow[AdminWorkspace](ctx, d.sql, adminWorkspaceSelectSQL()+`
-		where organization_id = :organization_id
-			and (external_id = :external_id or CAST(uuid AS text) = :external_id)
-	`, map[string]any{"organization_id": organizationID, "external_id": externalID})
+		where w.organization_uuid = CAST(:organization_uuid AS uuid)
+			and (w.external_id = :external_id or CAST(w.uuid AS text) = :external_id)
+	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
 }
 
 func (d *DB) ListAdminWorkspacesPage(ctx context.Context, params ListAdminWorkspacesParams) ([]AdminWorkspace, bool, error) {
@@ -364,8 +375,8 @@ func (d *DB) ListAdminWorkspacesPage(ctx context.Context, params ListAdminWorksp
 		ctx,
 		"workspaces",
 		"created_at",
-		"organization_id = :organization_id and external_id = :cursor_external_id",
-		map[string]any{"organization_id": params.OrganizationID, "cursor_external_id": cursorID},
+		"organization_uuid = CAST(:organization_uuid AS uuid) and external_id = :cursor_external_id",
+		map[string]any{"organization_uuid": params.OrganizationUUID, "cursor_external_id": cursorID},
 		cursorID,
 	)
 	if err != nil {
@@ -374,13 +385,13 @@ func (d *DB) ListAdminWorkspacesPage(ctx context.Context, params ListAdminWorksp
 	if (params.AfterID != "" || params.BeforeID != "") && !cursorOK {
 		return nil, false, nil
 	}
-	query := adminWorkspaceSelectSQL() + ` where organization_id = :organization_id`
-	args := map[string]any{"organization_id": params.OrganizationID, "limit": params.Limit + 1}
+	query := adminWorkspaceSelectSQL() + ` where w.organization_uuid = CAST(:organization_uuid AS uuid)`
+	args := map[string]any{"organization_uuid": params.OrganizationUUID, "limit": params.Limit + 1}
 	if !params.IncludeArchived {
-		query += " and archived_at is null"
+		query += " and w.archived_at is null"
 	}
-	query = appendCursorFilter(query, args, "created_at", params.AfterID, params.BeforeID, cursor)
-	query += " order by created_at desc, id desc limit :limit"
+	query = appendCursorFilter(query, args, "w.created_at", params.AfterID, params.BeforeID, cursor)
+	query += " order by w.created_at desc, w.id desc limit :limit"
 	workspaces, err := selectAdminRows[AdminWorkspace](ctx, d.sql, query, args)
 	if err != nil {
 		return nil, false, err
@@ -388,9 +399,9 @@ func (d *DB) ListAdminWorkspacesPage(ctx context.Context, params ListAdminWorksp
 	return trimAdminPage(workspaces, params.Limit), len(workspaces) > params.Limit, nil
 }
 
-func (d *DB) UpdateAdminWorkspace(ctx context.Context, organizationID int64, externalID string, next AdminWorkspace) (AdminWorkspace, error) {
+func (d *DB) UpdateAdminWorkspace(ctx context.Context, organizationUUID, externalID string, next AdminWorkspace) (AdminWorkspace, error) {
 	args := adminWorkspaceArguments(next)
-	args["organization_id"] = organizationID
+	args["organization_uuid"] = organizationUUID
 	args["external_id"] = externalID
 	updated, err := getAdminRow[AdminWorkspace](ctx, d.sql, `
 		update workspaces
@@ -399,8 +410,10 @@ func (d *DB) UpdateAdminWorkspace(ctx context.Context, organizationID int64, ext
 			external_key_id = :external_key_id,
 			tags = CAST(:tags AS jsonb),
 			updated_at = :updated_at
-		where organization_id = :organization_id and external_id = :external_id
-		returning id, CAST(uuid AS text) as uuid, external_id, organization_id, name, created_at, updated_at,
+		where organization_uuid = CAST(:organization_uuid AS uuid)
+			and external_id = :external_id
+		returning id, CAST(uuid AS text) as uuid, external_id,
+			CAST(organization_uuid AS text) as organization_uuid, name, created_at, updated_at,
 			archived_at, compartment_id, display_color, data_residency, external_key_id, tags
 	`, args)
 	if isUniqueViolation(err) {
@@ -409,15 +422,17 @@ func (d *DB) UpdateAdminWorkspace(ctx context.Context, organizationID int64, ext
 	return updated, err
 }
 
-func (d *DB) ArchiveAdminWorkspace(ctx context.Context, organizationID int64, externalID string) (AdminWorkspace, error) {
+func (d *DB) ArchiveAdminWorkspace(ctx context.Context, organizationUUID, externalID string) (AdminWorkspace, error) {
 	return getAdminRow[AdminWorkspace](ctx, d.sql, `
 		update workspaces
 		set archived_at = coalesce(archived_at, now()),
 			updated_at = now()
-		where organization_id = :organization_id and external_id = :external_id
-		returning id, CAST(uuid AS text) as uuid, external_id, organization_id, name, created_at, updated_at,
+		where organization_uuid = CAST(:organization_uuid AS uuid)
+			and external_id = :external_id
+		returning id, CAST(uuid AS text) as uuid, external_id,
+			CAST(organization_uuid AS text) as organization_uuid, name, created_at, updated_at,
 			archived_at, compartment_id, display_color, data_residency, external_key_id, tags
-	`, map[string]any{"organization_id": organizationID, "external_id": externalID})
+	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
 }
 
 func (d *DB) CreateAdminWorkspaceMember(ctx context.Context, member AdminWorkspaceMember) (AdminWorkspaceMember, error) {
@@ -522,10 +537,11 @@ func (d *DB) DeleteAdminWorkspaceMember(ctx context.Context, organizationID int6
 	})
 }
 
-func (d *DB) GetAdminAPIKey(ctx context.Context, organizationID int64, externalID string) (AdminAPIKey, error) {
+func (d *DB) GetAdminAPIKey(ctx context.Context, organizationUUID, externalID string) (AdminAPIKey, error) {
 	return getAdminRow[AdminAPIKey](ctx, d.sql, adminAPIKeySelectSQL()+`
-		where w.organization_id = :organization_id and ak.external_id = :external_id
-	`, map[string]any{"organization_id": organizationID, "external_id": externalID})
+		where w.organization_uuid = CAST(:organization_uuid AS uuid)
+			and ak.external_id = :external_id
+	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
 }
 
 func (d *DB) ListAdminAPIKeysPage(ctx context.Context, params ListAdminAPIKeysParams) ([]AdminAPIKey, bool, error) {
@@ -544,8 +560,8 @@ func (d *DB) ListAdminAPIKeysPage(ctx context.Context, params ListAdminAPIKeysPa
 	if (params.AfterID != "" || params.BeforeID != "") && !cursorOK {
 		return nil, false, nil
 	}
-	query := adminAPIKeySelectSQL() + ` where w.organization_id = :organization_id`
-	args := map[string]any{"organization_id": params.OrganizationID, "limit": params.Limit + 1}
+	query := adminAPIKeySelectSQL() + ` where w.organization_uuid = CAST(:organization_uuid AS uuid)`
+	args := map[string]any{"organization_uuid": params.OrganizationUUID, "limit": params.Limit + 1}
 	if params.WorkspaceID != "" {
 		query += " and w.external_id = :workspace_external_id"
 		args["workspace_external_id"] = params.WorkspaceID
@@ -567,7 +583,7 @@ func (d *DB) ListAdminAPIKeysPage(ctx context.Context, params ListAdminAPIKeysPa
 	return trimAdminPage(keys, params.Limit), len(keys) > params.Limit, nil
 }
 
-func (d *DB) UpdateAdminAPIKey(ctx context.Context, organizationID int64, externalID string, setName bool, name string, setStatus bool, status string) (AdminAPIKey, error) {
+func (d *DB) UpdateAdminAPIKey(ctx context.Context, organizationUUID, externalID string, setName bool, name string, setStatus bool, status string) (AdminAPIKey, error) {
 	return getAdminRow[AdminAPIKey](ctx, d.sql, `
 		with updated as (
 			update api_keys ak
@@ -576,12 +592,12 @@ func (d *DB) UpdateAdminAPIKey(ctx context.Context, organizationID int64, extern
 				updated_at = now()
 			from workspaces w
 			where ak.workspace_id = w.id
-				and w.organization_id = :organization_id
+				and w.organization_uuid = CAST(:organization_uuid AS uuid)
 				and ak.external_id = :external_id
 			returning ak.id, ak.external_id, ak.workspace_id, ak.created_by_user_id,
 				ak.name, ak.partial_key_hint, ak.status, ak.created_at, ak.updated_at, ak.expires_at
 		)
-		select ak.id, ak.external_id, w.organization_id, ak.workspace_id,
+		select ak.id, ak.external_id, ak.workspace_id,
 			w.external_id as workspace_external_id,
 			u.external_id as created_by_user_external_id,
 			ak.name, ak.partial_key_hint, ak.status, ak.created_at, ak.updated_at, ak.expires_at
@@ -589,12 +605,12 @@ func (d *DB) UpdateAdminAPIKey(ctx context.Context, organizationID int64, extern
 		join workspaces w on w.id = ak.workspace_id
 		left join users u on u.id = ak.created_by_user_id
 	`, map[string]any{
-		"organization_id": organizationID,
-		"external_id":     externalID,
-		"set_name":        setName,
-		"name":            name,
-		"set_status":      setStatus,
-		"status":          status,
+		"organization_uuid": organizationUUID,
+		"external_id":       externalID,
+		"set_name":          setName,
+		"name":              name,
+		"set_status":        setStatus,
+		"status":            status,
 	})
 }
 
@@ -668,13 +684,12 @@ func (d *DB) DeleteAdminExternalKey(ctx context.Context, organizationID int64, e
 	return nil
 }
 
-func (d *DB) CountAdminExternalKeyWorkspaceRefs(ctx context.Context, organizationID int64, externalID string) (int, error) {
+func (d *DB) CountAdminExternalKeyWorkspaceRefs(ctx context.Context, organizationUUID, externalID string) (int, error) {
 	var count int
-	err := namedGetContext(ctx, d.sql, &count, `
-		select count(*)
-		from workspaces
-		where organization_id = :organization_id and external_key_id = :external_id
-	`, map[string]any{"organization_id": organizationID, "external_id": externalID})
+	err := namedGetContext(ctx, d.sql, &count, countAdminExternalKeyWorkspaceRefsQuery, map[string]any{
+		"organization_uuid": organizationUUID,
+		"external_id":       externalID,
+	})
 	return count, err
 }
 
@@ -906,9 +921,11 @@ func adminUserSelectSQL() string {
 
 func adminWorkspaceSelectSQL() string {
 	return `
-		select id, CAST(uuid AS text) as uuid, external_id, organization_id, name, created_at, updated_at,
-			archived_at, compartment_id, display_color, data_residency, external_key_id, tags
-		from workspaces
+		select w.id, CAST(w.uuid AS text) as uuid, w.external_id,
+			CAST(w.organization_uuid AS text) as organization_uuid, w.name,
+			w.created_at, w.updated_at, w.archived_at, w.compartment_id,
+			w.display_color, w.data_residency, w.external_key_id, w.tags
+		from workspaces w
 	`
 }
 
@@ -922,7 +939,7 @@ func adminWorkspaceMemberSelectSQL() string {
 
 func adminAPIKeySelectSQL() string {
 	return `
-		select ak.id, ak.external_id, w.organization_id, ak.workspace_id,
+		select ak.id, ak.external_id, ak.workspace_id,
 			w.external_id as workspace_external_id,
 			u.external_id as created_by_user_external_id,
 			ak.name, ak.partial_key_hint, ak.status, ak.created_at, ak.updated_at, ak.expires_at
@@ -994,17 +1011,17 @@ func adminInviteArguments(invite AdminInvite) map[string]any {
 
 func adminWorkspaceArguments(workspace AdminWorkspace) map[string]any {
 	return map[string]any{
-		"uuid":            workspace.UUID,
-		"external_id":     workspace.ExternalID,
-		"organization_id": workspace.OrganizationID,
-		"name":            workspace.Name,
-		"created_at":      workspace.CreatedAt,
-		"updated_at":      workspace.UpdatedAt,
-		"compartment_id":  workspace.CompartmentID,
-		"display_color":   workspace.DisplayColor,
-		"data_residency":  jsonArg(workspace.DataResidency),
-		"external_key_id": workspace.ExternalKeyID,
-		"tags":            jsonArg(workspace.Tags),
+		"uuid":              workspace.UUID,
+		"external_id":       workspace.ExternalID,
+		"organization_uuid": workspace.OrganizationUUID,
+		"name":              workspace.Name,
+		"created_at":        workspace.CreatedAt,
+		"updated_at":        workspace.UpdatedAt,
+		"compartment_id":    workspace.CompartmentID,
+		"display_color":     workspace.DisplayColor,
+		"data_residency":    jsonArg(workspace.DataResidency),
+		"external_key_id":   workspace.ExternalKeyID,
+		"tags":              jsonArg(workspace.Tags),
 	}
 }
 

--- a/internal/db/admin_requests.go
+++ b/internal/db/admin_requests.go
@@ -27,7 +27,6 @@ const listAdminRequestsSQL = `
 	from admin_requests ar
 	left join organizations o
 	  on CAST(o.uuid AS text) = CAST(ar.org_uuid AS text)
-	  or o.external_id = CAST(ar.org_uuid AS text)
 	left join users u
 	  on CAST(u.uuid AS text) = CAST(ar.requester_uuid AS text)
 	 and u.organization_id = o.id

--- a/internal/db/admin_requests_test.go
+++ b/internal/db/admin_requests_test.go
@@ -72,8 +72,7 @@ func TestListAdminRequestsSQLXScansPostgreSQLRows(t *testing.T) {
 	if _, err := tx.ExecContext(ctx, `
 		create temporary table organizations (
 			id bigint generated always as identity,
-			uuid uuid not null,
-			external_id text not null
+			uuid uuid not null
 		) on commit drop;
 		create temporary table users (
 			id bigint generated always as identity,
@@ -107,8 +106,8 @@ func TestListAdminRequestsSQLXScansPostgreSQLRows(t *testing.T) {
 	)
 	createdAt := time.Date(2026, time.July, 23, 9, 30, 0, 0, time.UTC)
 	if _, err := tx.ExecContext(ctx, `
-		insert into organizations (uuid, external_id)
-		values ($1, 'org_external')
+		insert into organizations (uuid)
+		values ($1)
 	`, orgUUID); err != nil {
 		t.Fatalf("seed temporary organization: %v", err)
 	}

--- a/internal/db/admin_sqlx_test.go
+++ b/internal/db/admin_sqlx_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -9,11 +10,11 @@ import (
 func TestAppendAdminCursorFilterBindsNamedParameters(t *testing.T) {
 	cursorTime := time.Date(2026, time.July, 23, 10, 30, 0, 0, time.UTC)
 	arguments := map[string]any{
-		"organization_id": int64(42),
-		"limit":           11,
+		"organization_uuid": "22222222-2222-4222-8222-222222222222",
+		"limit":             11,
 	}
 	query := appendCursorFilter(
-		adminAPIKeySelectSQL()+` where w.organization_id = :organization_id`,
+		adminAPIKeySelectSQL()+` where w.organization_uuid = CAST(:organization_uuid AS uuid)`,
 		arguments,
 		"ak.created_at",
 		"apikey_after",
@@ -26,13 +27,13 @@ func TestAppendAdminCursorFilterBindsNamedParameters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bindNamed() error = %v", err)
 	}
-	wantQuery := adminAPIKeySelectSQL() + ` where w.organization_id = $1` +
+	wantQuery := adminAPIKeySelectSQL() + ` where w.organization_uuid = CAST($1 AS uuid)` +
 		" and (ak.created_at < $2 or (ak.created_at = $3 and ak.id < $4))" +
 		" order by ak.created_at desc, ak.id desc limit $5"
 	if boundQuery != wantQuery {
 		t.Fatalf("bindNamed() query = %q, want %q", boundQuery, wantQuery)
 	}
-	wantValues := []any{int64(42), cursorTime, cursorTime, int64(99), 11}
+	wantValues := []any{"22222222-2222-4222-8222-222222222222", cursorTime, cursorTime, int64(99), 11}
 	if !reflect.DeepEqual(values, wantValues) {
 		t.Fatalf("bindNamed() values = %#v, want %#v", values, wantValues)
 	}
@@ -63,5 +64,21 @@ func TestAppendAdminCursorFilterBuildsBeforeCondition(t *testing.T) {
 	wantValues := []any{int64(9), cursorTime, cursorTime, int64(7)}
 	if !reflect.DeepEqual(values, wantValues) {
 		t.Fatalf("bindNamed() values = %#v, want %#v", values, wantValues)
+	}
+}
+
+func TestGetAdminOrganizationQueryUsesUUID(t *testing.T) {
+	organizationUUID := "22222222-2222-4222-8222-222222222222"
+	query, arguments, err := bindNamed(postgresRebinder{}, getAdminOrganizationQuery, map[string]any{
+		"organization_uuid": organizationUUID,
+	})
+	if err != nil {
+		t.Fatalf("bindNamed() error = %v", err)
+	}
+	if len(arguments) != 1 || arguments[0] != organizationUUID {
+		t.Fatalf("bindNamed() arguments = %#v, want organization UUID", arguments)
+	}
+	if want := "where uuid = CAST($1 AS uuid)"; !strings.Contains(query, want) {
+		t.Fatalf("bound query = %q, want %q", query, want)
 	}
 }

--- a/internal/db/bootstrap.go
+++ b/internal/db/bootstrap.go
@@ -29,7 +29,6 @@ type bootstrapUserRow struct {
 
 type bootstrapOrganizationRow struct {
 	UUID                   string    `db:"uuid"`
-	ExternalID             string    `db:"external_id"`
 	Name                   string    `db:"name"`
 	Domain                 *string   `db:"domain"`
 	ParentOrganizationUUID *string   `db:"parent_organization_uuid"`
@@ -55,7 +54,7 @@ func (d *DB) FindBootstrapUserContext(ctx context.Context, preferredOrgUUID stri
 	`
 	arguments := map[string]any{}
 	if trimmedPreferredOrgUUID := strings.TrimSpace(preferredOrgUUID); trimmedPreferredOrgUUID != "" {
-		query += ` and (cast(o.uuid as text) = :preferred_org_uuid or o.external_id = :preferred_org_uuid)`
+		query += ` and cast(o.uuid as text) = :preferred_org_uuid`
 		arguments["preferred_org_uuid"] = trimmedPreferredOrgUUID
 	}
 	query += `
@@ -165,10 +164,9 @@ func (d *DB) UpdatePlatformOrganization(ctx context.Context, orgUUID string, pat
 		set name = coalesce(CAST(:name AS text), name),
 		    settings = coalesce(CAST(:settings AS jsonb), settings),
 		    updated_at = current_timestamp
-		where cast(uuid as text) = :org_uuid or external_id = :org_uuid
+		where cast(uuid as text) = :org_uuid
 		returning
 			cast(uuid as text) as uuid,
-			external_id,
 			name,
 			CAST(NULL AS text) as domain,
 			CAST(NULL AS text) as parent_organization_uuid,
@@ -204,7 +202,6 @@ func (d *DB) ListBootstrapUserOrganizations(ctx context.Context, userExternalID 
 	err := namedSelectContext(ctx, d.sql, &rows, `
 		select
 			cast(o.uuid as text) as uuid,
-			o.external_id,
 			o.name,
 			CAST(NULL AS text) as domain,
 			CAST(NULL AS text) as parent_organization_uuid,
@@ -222,7 +219,7 @@ func (d *DB) ListBootstrapUserOrganizations(ctx context.Context, userExternalID 
 			or 'user_' || left(replace(cast(u.uuid as text), '-', ''), 24) = :user_external_id
 		  )
 		order by
-			case when cast(o.uuid as text) = :preferred_org_uuid or o.external_id = :preferred_org_uuid then 0 else 1 end,
+			case when cast(o.uuid as text) = :preferred_org_uuid then 0 else 1 end,
 			u.added_at asc,
 			u.id asc
 	`, map[string]any{
@@ -252,7 +249,7 @@ func (d *DB) GetOrganizationProfile(ctx context.Context, orgUUID string) (platfo
 	err := namedGetContext(ctx, d.sql, &profileBytes, `
 		select coalesce(profile, CAST('{}' AS jsonb))
 		from organizations
-		where cast(uuid as text) = :org_uuid or external_id = :org_uuid
+		where cast(uuid as text) = :org_uuid
 		limit 1
 	`, map[string]any{"org_uuid": strings.TrimSpace(orgUUID)})
 	if errors.Is(err, sql.ErrNoRows) {
@@ -277,7 +274,7 @@ func (d *DB) UpdateOrganizationProfile(ctx context.Context, orgUUID string, prof
 		update organizations
 		set profile = CAST(:profile AS jsonb),
 		    updated_at = current_timestamp
-		where cast(uuid as text) = :org_uuid or external_id = :org_uuid
+		where cast(uuid as text) = :org_uuid
 		returning coalesce(profile, CAST('{}' AS jsonb))
 	`, map[string]any{
 		"org_uuid": strings.TrimSpace(orgUUID),
@@ -297,7 +294,6 @@ func getBootstrapOrganizationRow(ctx context.Context, database sqlxNamedQueryer,
 	err := namedGetContext(ctx, database, &row, `
 		select
 			cast(o.uuid as text) as uuid,
-			o.external_id,
 			o.name,
 			CAST(NULL AS text) as domain,
 			CAST(NULL AS text) as parent_organization_uuid,
@@ -307,7 +303,7 @@ func getBootstrapOrganizationRow(ctx context.Context, database sqlxNamedQueryer,
 			'' as role,
 			o.created_at as added_at
 		from organizations o
-		where cast(o.uuid as text) = :org_uuid or o.external_id = :org_uuid
+		where cast(o.uuid as text) = :org_uuid
 		limit 1
 	`, map[string]any{"org_uuid": orgUUID})
 	if errors.Is(err, sql.ErrNoRows) {
@@ -326,7 +322,6 @@ func (row bootstrapOrganizationRow) organizationRecord() (*platform.Organization
 	}
 	return &platform.OrganizationRecord{
 		UUID:                   row.UUID,
-		ExternalID:             row.ExternalID,
 		Name:                   row.Name,
 		Domain:                 row.Domain,
 		ParentOrganizationUUID: row.ParentOrganizationUUID,

--- a/internal/db/bootstrap_sqlx_test.go
+++ b/internal/db/bootstrap_sqlx_test.go
@@ -10,21 +10,21 @@ func TestBootstrapQueriesUseNamedParametersAndCasts(t *testing.T) {
 			cast(o.uuid as text) as uuid,
 			coalesce(o.settings, CAST('{}' AS jsonb)) as settings
 		from organizations o
-		where cast(o.uuid as text) = :org_uuid or o.external_id = :org_uuid
+		where cast(o.uuid as text) = :org_uuid
 		limit 1
 	`, map[string]any{"org_uuid": "org_123"})
 	if err != nil {
 		t.Fatalf("bindNamed() error = %v", err)
 	}
-	if len(arguments) != 2 {
-		t.Fatalf("bindNamed() arguments len = %d, want 2", len(arguments))
+	if len(arguments) != 1 {
+		t.Fatalf("bindNamed() arguments len = %d, want 1", len(arguments))
 	}
 	wantQuery := `
 		select
 			cast(o.uuid as text) as uuid,
 			coalesce(o.settings, CAST('{}' AS jsonb)) as settings
 		from organizations o
-		where cast(o.uuid as text) = $1 or o.external_id = $2
+		where cast(o.uuid as text) = $1
 		limit 1
 	`
 	if query != wantQuery {

--- a/internal/db/code_sessions.go
+++ b/internal/db/code_sessions.go
@@ -70,7 +70,6 @@ type CodeSessionCredentialContext struct {
 	CodeSessionExternalID   string
 	OrganizationID          int64
 	OrganizationUUID        string
-	OrganizationExternalID  string
 	WorkspaceID             int64
 	WorkspaceUUID           string
 	WorkspaceExternalID     string
@@ -289,7 +288,6 @@ func (d *DB) CreateCodeSession(ctx context.Context, input CreateCodeSessionInput
 const codeSessionCredentialContextSelect = `
 	select cs.id AS code_session_id, cs.external_id AS code_session_external_id,
 		cs.organization_id, CAST(o.uuid AS text) AS organization_uuid,
-		o.external_id AS organization_external_id,
 		cs.workspace_id, CAST(w.uuid AS text) AS workspace_uuid,
 		w.external_id AS workspace_external_id,
 		s.id AS public_session_id, s.external_id AS public_session_external_id,
@@ -297,7 +295,7 @@ const codeSessionCredentialContextSelect = `
 		coalesce(u.email, '') AS account_email
 	from code_sessions cs
 	join organizations o on o.id = cs.organization_id
-	join workspaces w on w.id = cs.workspace_id and w.organization_id = cs.organization_id
+	join workspaces w on w.id = cs.workspace_id and w.organization_uuid = o.uuid
 	join sessions s on s.id = cs.session_id
 		and s.workspace_id = cs.workspace_id
 		and s.organization_id = cs.organization_id
@@ -363,7 +361,7 @@ func (d *DB) GetCodeSessionNetworkPolicyContext(
 			on o.id = cs.organization_id
 		join workspaces w
 			on w.id = cs.workspace_id
-			and w.organization_id = cs.organization_id
+			and w.organization_uuid = o.uuid
 		join environments e
 			on e.id = cs.environment_id
 			and e.external_id = cs.environment_external_id

--- a/internal/db/code_sessions_sqlx.go
+++ b/internal/db/code_sessions_sqlx.go
@@ -102,7 +102,6 @@ type codeSessionCredentialContextRow struct {
 	CodeSessionExternalID   string `db:"code_session_external_id"`
 	OrganizationID          int64  `db:"organization_id"`
 	OrganizationUUID        string `db:"organization_uuid"`
-	OrganizationExternalID  string `db:"organization_external_id"`
 	WorkspaceID             int64  `db:"workspace_id"`
 	WorkspaceUUID           string `db:"workspace_uuid"`
 	WorkspaceExternalID     string `db:"workspace_external_id"`
@@ -331,7 +330,6 @@ func (r codeSessionCredentialContextRow) context() CodeSessionCredentialContext 
 		CodeSessionExternalID:   r.CodeSessionExternalID,
 		OrganizationID:          r.OrganizationID,
 		OrganizationUUID:        r.OrganizationUUID,
-		OrganizationExternalID:  r.OrganizationExternalID,
 		WorkspaceID:             r.WorkspaceID,
 		WorkspaceUUID:           r.WorkspaceUUID,
 		WorkspaceExternalID:     r.WorkspaceExternalID,

--- a/internal/db/console_api_keys.go
+++ b/internal/db/console_api_keys.go
@@ -215,7 +215,7 @@ func (d *DB) resolveConsoleAPIKeyCoreRefs(
 			join lateral (
 				select id
 				from workspaces
-				where organization_id = o.id
+				where organization_uuid = o.uuid
 				  and archived_at is null
 				order by
 					case
@@ -227,7 +227,7 @@ func (d *DB) resolveConsoleAPIKeyCoreRefs(
 					id asc
 				limit 1
 			) w on true
-			where CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid
+			where CAST(o.uuid AS text) = :org_uuid
 			limit 1
 		`, map[string]any{"org_uuid": orgUUID})
 		if err != nil {
@@ -237,8 +237,8 @@ func (d *DB) resolveConsoleAPIKeyCoreRefs(
 		err := namedGetContext(ctx, database, &coreWorkspaceID, `
 			select w.id
 			from workspaces w
-			join organizations o on o.id = w.organization_id
-			where (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
+			join organizations o on o.uuid = w.organization_uuid
+			where CAST(o.uuid AS text) = :org_uuid
 			  and (w.external_id = :workspace_id or CAST(w.uuid AS text) = :workspace_id)
 			  and w.archived_at is null
 			limit 1
@@ -255,7 +255,7 @@ func (d *DB) resolveConsoleAPIKeyCoreRefs(
 			select u.id
 			from users u
 			join organizations o on o.id = u.organization_id
-			where (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
+			where CAST(o.uuid AS text) = :org_uuid
 			  and u.deleted_at is null
 			  and (
 				u.external_id = :user_uuid
@@ -306,25 +306,25 @@ func (d *DB) CreateConsoleWorkspace(ctx context.Context, input platform.CreateCo
 	}
 	workspace, err := getConsoleWorkspaceSQLX(ctx, d.sql, `
 		with org as (
-			select id, CAST(uuid AS text) as org_uuid
+			select uuid, CAST(uuid AS text) as org_uuid
 			from organizations
-			where CAST(uuid AS text) = :org_uuid or external_id = :org_uuid
+			where CAST(uuid AS text) = :org_uuid
 			limit 1
 		)
 		insert into workspaces (
 			uuid,
 			external_id,
-			organization_id,
+			organization_uuid,
 			name,
 			compartment_id,
 			display_color,
 			data_residency,
 			tags
 		)
-		select :uuid, :external_id, org.id, :name, :external_id, :display_color,
+		select :uuid, :external_id, org.uuid, :name, :external_id, :display_color,
 			CAST(:data_residency AS jsonb), CAST('{}' AS jsonb)
 		from org
-		on conflict (organization_id, name) do update set
+		on conflict (organization_uuid, name) do update set
 			display_color = excluded.display_color,
 			data_residency = excluded.data_residency,
 			archived_at = null,
@@ -389,8 +389,8 @@ func listConsoleWorkspacesQuery(orgUUID string, includeArchived bool) (string, m
 			w.created_at,
 			w.updated_at
 		from workspaces w
-		join organizations o on o.id = w.organization_id
-		where (o.external_id = :org_uuid or CAST(o.uuid AS text) = :org_uuid)
+		join organizations o on o.uuid = w.organization_uuid
+		where CAST(o.uuid AS text) = :org_uuid
 		` + archivedFilter + `
 		order by w.name asc, w.id asc
 	`

--- a/internal/db/console_api_keys_sqlx_test.go
+++ b/internal/db/console_api_keys_sqlx_test.go
@@ -34,7 +34,7 @@ func TestConsoleAPIKeyQueriesUseSQLXNamedParameters(t *testing.T) {
 			name:         "list workspaces",
 			query:        workspaceQuery,
 			arguments:    workspaceArguments,
-			wantArgCount: 2,
+			wantArgCount: 1,
 		},
 	}
 

--- a/internal/db/console_invites.go
+++ b/internal/db/console_invites.go
@@ -22,7 +22,7 @@ const (
 		with org as (
 			select id
 			from organizations
-			where CAST(uuid AS text) = :org_uuid or external_id = :org_uuid
+			where CAST(uuid AS text) = :org_uuid
 			limit 1
 		)
 		insert into organization_invites (
@@ -45,7 +45,7 @@ const (
 			expires_at = :expires_at
 		from organizations o
 		where i.organization_id = o.id
-			and (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
+			and CAST(o.uuid AS text) = :org_uuid
 			and i.external_id = :invite_id
 			and i.deleted_at is null
 		returning ` + consoleInviteColumns + `
@@ -56,7 +56,7 @@ const (
 			deleted_at = coalesce(i.deleted_at, now())
 		from organizations o
 		where i.organization_id = o.id
-			and (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
+			and CAST(o.uuid AS text) = :org_uuid
 			and i.external_id = :invite_id
 		returning ` + consoleInviteColumns + `
 	`
@@ -82,7 +82,7 @@ func (d *DB) ListConsoleInvites(ctx context.Context, orgUUID string, status stri
 		select ` + consoleInviteColumns + `
 		from organization_invites i
 		join organizations o on o.id = i.organization_id
-		where (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
+		where CAST(o.uuid AS text) = :org_uuid
 	`
 	switch strings.TrimSpace(strings.ToLower(status)) {
 	case "":

--- a/internal/db/console_invites_sqlx_test.go
+++ b/internal/db/console_invites_sqlx_test.go
@@ -12,7 +12,7 @@ func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
 		select ` + consoleInviteColumns + `
 		from organization_invites i
 		join organizations o on o.id = i.organization_id
-		where (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
+		where CAST(o.uuid AS text) = :org_uuid
 			and i.deleted_at is null
 		order by i.invited_at desc, i.id desc
 		limit :limit
@@ -30,7 +30,7 @@ func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
 				"org_uuid": "org_test",
 				"limit":    100,
 			},
-			wantArgCount: 3,
+			wantArgCount: 2,
 		},
 		{
 			name:  "create",
@@ -43,7 +43,7 @@ func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
 				"invited_at":  now,
 				"expires_at":  now.Add(21 * 24 * time.Hour),
 			},
-			wantArgCount: 7,
+			wantArgCount: 6,
 		},
 		{
 			name:  "resend",
@@ -54,7 +54,7 @@ func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
 				"invited_at": now,
 				"expires_at": now.Add(21 * 24 * time.Hour),
 			},
-			wantArgCount: 5,
+			wantArgCount: 4,
 		},
 		{
 			name:  "delete",
@@ -63,7 +63,7 @@ func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
 				"org_uuid":  "org_test",
 				"invite_id": "invite_test",
 			},
-			wantArgCount: 3,
+			wantArgCount: 2,
 		},
 	}
 

--- a/internal/db/console_members.go
+++ b/internal/db/console_members.go
@@ -19,7 +19,7 @@ const (
 			u.added_at
 		from users u
 		join organizations o on o.id = u.organization_id
-		where (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
+		where CAST(o.uuid AS text) = :org_uuid
 			and u.deleted_at is null
 		order by u.added_at asc, u.id asc
 		limit :limit
@@ -28,7 +28,7 @@ const (
 		with target_org as (
 			select id
 			from organizations
-			where CAST(uuid AS text) = :org_uuid or external_id = :org_uuid
+			where CAST(uuid AS text) = :org_uuid
 			limit 1
 		)
 		update users u
@@ -53,7 +53,7 @@ const (
 		with target_org as (
 			select id
 			from organizations
-			where CAST(uuid AS text) = :org_uuid or external_id = :org_uuid
+			where CAST(uuid AS text) = :org_uuid
 			limit 1
 		)
 		update users u
@@ -73,7 +73,7 @@ const (
 		set deleted_at = coalesce(wm.deleted_at, now()),
 			updated_at = now()
 		from organizations o, users u
-		where (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
+		where CAST(o.uuid AS text) = :org_uuid
 			and wm.organization_id = o.id
 			and u.organization_id = o.id
 			and wm.user_id = u.id

--- a/internal/db/console_members_sqlx_test.go
+++ b/internal/db/console_members_sqlx_test.go
@@ -19,7 +19,7 @@ func TestConsoleMemberQueriesUseSQLXNamedParameters(t *testing.T) {
 				"org_uuid": "org_test",
 				"limit":    100,
 			},
-			wantArgCount: 3,
+			wantArgCount: 2,
 		},
 		{
 			name:  "update role",
@@ -29,7 +29,7 @@ func TestConsoleMemberQueriesUseSQLXNamedParameters(t *testing.T) {
 				"user_id":  "user_test",
 				"role":     "developer",
 			},
-			wantArgCount: 6,
+			wantArgCount: 5,
 		},
 		{
 			name:  "remove user",
@@ -38,7 +38,7 @@ func TestConsoleMemberQueriesUseSQLXNamedParameters(t *testing.T) {
 				"org_uuid": "org_test",
 				"user_id":  "user_test",
 			},
-			wantArgCount: 5,
+			wantArgCount: 4,
 		},
 		{
 			name:  "remove workspace memberships",
@@ -47,7 +47,7 @@ func TestConsoleMemberQueriesUseSQLXNamedParameters(t *testing.T) {
 				"org_uuid": "org_test",
 				"user_id":  "user_test",
 			},
-			wantArgCount: 5,
+			wantArgCount: 4,
 		},
 	}
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -41,13 +41,13 @@ type DB struct {
 }
 
 type APIKey struct {
-	ID                     int64
-	ExternalID             string
-	OrganizationID         int64
-	OrganizationExternalID string
-	WorkspaceID            int64
-	WorkspaceUUID          string
-	WorkspaceExternalID    string
+	ID                  int64
+	ExternalID          string
+	OrganizationID      int64
+	OrganizationUUID    string
+	WorkspaceID         int64
+	WorkspaceUUID       string
+	WorkspaceExternalID string
 }
 
 type foreignKeyRow struct {
@@ -56,13 +56,13 @@ type foreignKeyRow struct {
 }
 
 type apiKeyRow struct {
-	ID                     int64  `db:"id"`
-	ExternalID             string `db:"external_id"`
-	OrganizationID         int64  `db:"organization_id"`
-	OrganizationExternalID string `db:"organization_external_id"`
-	WorkspaceID            int64  `db:"workspace_id"`
-	WorkspaceUUID          string `db:"workspace_uuid"`
-	WorkspaceExternalID    string `db:"workspace_external_id"`
+	ID                  int64  `db:"id"`
+	ExternalID          string `db:"external_id"`
+	OrganizationID      int64  `db:"organization_id"`
+	OrganizationUUID    string `db:"organization_uuid"`
+	WorkspaceID         int64  `db:"workspace_id"`
+	WorkspaceUUID       string `db:"workspace_uuid"`
+	WorkspaceExternalID string `db:"workspace_external_id"`
 }
 
 const (
@@ -81,16 +81,40 @@ const (
 	`
 	legacyTableExistsQuery = `select to_regclass(:table_name) is not null`
 	seedOrganizationQuery  = `
-		insert into organizations (external_id, name)
-		values (:external_id, :name)
-		on conflict (external_id) do update set name = excluded.name
-		returning id
+		with existing as (
+			select o.id
+			from organizations o
+			join workspaces w on w.organization_uuid = o.uuid
+			where w.external_id = :workspace_external_id
+			limit 1
+		),
+		updated as (
+			update organizations o
+			set name = :name,
+				updated_at = now()
+			from existing
+			where o.id = existing.id
+			returning o.id
+		),
+		inserted as (
+			insert into organizations (name)
+			select :name
+			where not exists (select 1 from existing)
+			returning id
+		)
+		select id from updated
+		union all
+		select id from inserted
+		limit 1
 	`
-	seedWorkspaceQuery = `
-		insert into workspaces (external_id, organization_id, name)
-		values (:external_id, :organization_id, :name)
+	seedOrganizationLockQuery = `select pg_advisory_xact_lock(704611533427849228)`
+	seedWorkspaceQuery        = `
+		insert into workspaces (external_id, organization_uuid, name)
+		select :external_id, uuid, :name
+		from organizations
+		where id = :organization_id
 		on conflict (external_id) do update set
-			organization_id = excluded.organization_id,
+			organization_uuid = excluded.organization_uuid,
 			name = excluded.name
 		returning id
 	`
@@ -142,12 +166,12 @@ const (
 	`
 	getAPIKeyQuery = `
 		select ak.id, ak.external_id,
-			o.id as organization_id, o.external_id as organization_external_id,
+			o.id as organization_id, CAST(o.uuid AS text) as organization_uuid,
 			w.id as workspace_id, CAST(w.uuid AS text) as workspace_uuid,
 			w.external_id as workspace_external_id
 		from api_keys ak
 		join workspaces w on w.id = ak.workspace_id
-		join organizations o on o.id = w.organization_id
+		join organizations o on o.uuid = w.organization_uuid
 		where ak.key_hash = :key_hash
 			and ak.status = 'active'
 			and (ak.expires_at is null or ak.expires_at > now())
@@ -475,10 +499,13 @@ func (d *DB) Seed(ctx context.Context, seedAPIKeys []config.SeedAPIKey) error {
 	}
 	defer tx.Rollback()
 
+	if _, err := tx.ExecContext(ctx, seedOrganizationLockQuery); err != nil {
+		return err
+	}
 	var organizationID int64
 	if err := namedGetContext(ctx, tx, &organizationID, seedOrganizationQuery, map[string]any{
-		"external_id": "org_default",
-		"name":        "default",
+		"workspace_external_id": "workspace_default",
+		"name":                  "default",
 	}); err != nil {
 		return err
 	}
@@ -542,13 +569,13 @@ func (d *DB) GetAPIKey(ctx context.Context, keyHash string) (APIKey, error) {
 
 func (r apiKeyRow) apiKey() APIKey {
 	return APIKey{
-		ID:                     r.ID,
-		ExternalID:             r.ExternalID,
-		OrganizationID:         r.OrganizationID,
-		OrganizationExternalID: r.OrganizationExternalID,
-		WorkspaceID:            r.WorkspaceID,
-		WorkspaceUUID:          r.WorkspaceUUID,
-		WorkspaceExternalID:    r.WorkspaceExternalID,
+		ID:                  r.ID,
+		ExternalID:          r.ExternalID,
+		OrganizationID:      r.OrganizationID,
+		OrganizationUUID:    r.OrganizationUUID,
+		WorkspaceID:         r.WorkspaceID,
+		WorkspaceUUID:       r.WorkspaceUUID,
+		WorkspaceExternalID: r.WorkspaceExternalID,
 	}
 }
 

--- a/internal/db/db_sqlx_test.go
+++ b/internal/db/db_sqlx_test.go
@@ -40,10 +40,10 @@ func TestDatabaseQueriesUseSQLXNamedParameters(t *testing.T) {
 			name:  "seed organization",
 			query: seedOrganizationQuery,
 			arguments: map[string]any{
-				"external_id": "org_default",
-				"name":        "default",
+				"workspace_external_id": "workspace_default",
+				"name":                  "default",
 			},
-			wantArgCount: 2,
+			wantArgCount: 3,
 		},
 		{
 			name:  "seed workspace",
@@ -121,18 +121,18 @@ func TestDatabaseQueriesUseSQLXNamedParameters(t *testing.T) {
 
 func TestAPIKeyRowMapsDatabaseColumns(t *testing.T) {
 	row := apiKeyRow{
-		ID:                     1,
-		ExternalID:             "sk_default",
-		OrganizationID:         2,
-		OrganizationExternalID: "org_default",
-		WorkspaceID:            3,
-		WorkspaceUUID:          "11111111-1111-4111-8111-111111111111",
-		WorkspaceExternalID:    "workspace_default",
+		ID:                  1,
+		ExternalID:          "sk_default",
+		OrganizationID:      2,
+		OrganizationUUID:    "22222222-2222-4222-8222-222222222222",
+		WorkspaceID:         3,
+		WorkspaceUUID:       "11111111-1111-4111-8111-111111111111",
+		WorkspaceExternalID: "workspace_default",
 	}
 
 	key := row.apiKey()
 	if key.ExternalID != row.ExternalID ||
-		key.OrganizationExternalID != row.OrganizationExternalID ||
+		key.OrganizationUUID != row.OrganizationUUID ||
 		key.WorkspaceUUID != row.WorkspaceUUID {
 		t.Fatalf("apiKeyRow.apiKey() = %#v, want values from %#v", key, row)
 	}

--- a/internal/db/environments.go
+++ b/internal/db/environments.go
@@ -41,15 +41,15 @@ type ListEnvironmentsPageParams struct {
 }
 
 type EnvironmentKey struct {
-	ID                     int64
-	ExternalID             string
-	OrganizationID         int64
-	OrganizationExternalID string
-	WorkspaceID            int64
-	WorkspaceUUID          string
-	WorkspaceExternalID    string
-	EnvironmentID          int64
-	EnvironmentExternalID  string
+	ID                    int64
+	ExternalID            string
+	OrganizationID        int64
+	OrganizationUUID      string
+	WorkspaceID           int64
+	WorkspaceUUID         string
+	WorkspaceExternalID   string
+	EnvironmentID         int64
+	EnvironmentExternalID string
 }
 
 type EnvironmentWork struct {
@@ -299,7 +299,7 @@ func (d *DB) GetEnvironmentKey(ctx context.Context, keyHash string) (Environment
 			returning id, external_id, organization_id, workspace_id, environment_id, environment_external_id
 		)
 		select updated.id, updated.external_id, updated.organization_id,
-			organizations.external_id AS organization_external_id,
+			CAST(organizations.uuid AS text) AS organization_uuid,
 			updated.workspace_id, CAST(workspaces.uuid AS text) AS workspace_uuid,
 			workspaces.external_id AS workspace_external_id,
 			updated.environment_id, updated.environment_external_id
@@ -743,15 +743,15 @@ type environmentRow struct {
 }
 
 type environmentKeyRow struct {
-	ID                     int64  `db:"id"`
-	ExternalID             string `db:"external_id"`
-	OrganizationID         int64  `db:"organization_id"`
-	OrganizationExternalID string `db:"organization_external_id"`
-	WorkspaceID            int64  `db:"workspace_id"`
-	WorkspaceUUID          string `db:"workspace_uuid"`
-	WorkspaceExternalID    string `db:"workspace_external_id"`
-	EnvironmentID          int64  `db:"environment_id"`
-	EnvironmentExternalID  string `db:"environment_external_id"`
+	ID                    int64  `db:"id"`
+	ExternalID            string `db:"external_id"`
+	OrganizationID        int64  `db:"organization_id"`
+	OrganizationUUID      string `db:"organization_uuid"`
+	WorkspaceID           int64  `db:"workspace_id"`
+	WorkspaceUUID         string `db:"workspace_uuid"`
+	WorkspaceExternalID   string `db:"workspace_external_id"`
+	EnvironmentID         int64  `db:"environment_id"`
+	EnvironmentExternalID string `db:"environment_external_id"`
 }
 
 type environmentWorkStatsRow struct {
@@ -951,15 +951,15 @@ func (r environmentRow) environment() Environment {
 
 func (r environmentKeyRow) key() EnvironmentKey {
 	return EnvironmentKey{
-		ID:                     r.ID,
-		ExternalID:             r.ExternalID,
-		OrganizationID:         r.OrganizationID,
-		OrganizationExternalID: r.OrganizationExternalID,
-		WorkspaceID:            r.WorkspaceID,
-		WorkspaceUUID:          r.WorkspaceUUID,
-		WorkspaceExternalID:    r.WorkspaceExternalID,
-		EnvironmentID:          r.EnvironmentID,
-		EnvironmentExternalID:  r.EnvironmentExternalID,
+		ID:                    r.ID,
+		ExternalID:            r.ExternalID,
+		OrganizationID:        r.OrganizationID,
+		OrganizationUUID:      r.OrganizationUUID,
+		WorkspaceID:           r.WorkspaceID,
+		WorkspaceUUID:         r.WorkspaceUUID,
+		WorkspaceExternalID:   r.WorkspaceExternalID,
+		EnvironmentID:         r.EnvironmentID,
+		EnvironmentExternalID: r.EnvironmentExternalID,
 	}
 }
 

--- a/internal/db/files_sqlx.go
+++ b/internal/db/files_sqlx.go
@@ -34,7 +34,9 @@ const (
 			f.downloadable, f.scope_type, f.scope_id, f.created_by_api_key_id, f.created_at
 		from files f
 		join workspaces w on w.id = f.workspace_id
-		where w.organization_id = :organization_id
+		where w.organization_uuid = (
+				select uuid from organizations where id = :organization_id
+			)
 			and cast(f.uuid as text) = :file_uuid
 			and f.deleted_at is null
 	`

--- a/internal/db/filestore.go
+++ b/internal/db/filestore.go
@@ -47,18 +47,17 @@ type FilestoreFilesystem struct {
 // FilestoreTokenScope 是 Filestore JWT 通过数据库回查后得到的完整授权边界。
 // UUID 与 external ID 同时保留，以便 API 层既能校验 claim，又能向下游传递内部主键。
 type FilestoreTokenScope struct {
-	OrganizationID         int64
-	OrganizationUUID       string
-	OrganizationExternalID string
-	WorkspaceID            int64
-	WorkspaceUUID          string
-	WorkspaceExternalID    string
-	AccountID              int64
-	AccountUUID            string
-	AccountExternalID      string
-	FilesystemID           int64
-	FilesystemUUID         string
-	FilesystemExternalID   string
+	OrganizationID       int64
+	OrganizationUUID     string
+	WorkspaceID          int64
+	WorkspaceUUID        string
+	WorkspaceExternalID  string
+	AccountID            int64
+	AccountUUID          string
+	AccountExternalID    string
+	FilesystemID         int64
+	FilesystemUUID       string
+	FilesystemExternalID string
 	// OrgTaints 是 organizations.settings 中的当前组织策略标签。
 	OrgTaints []string
 	// WorkspaceCMEKEnabled 由 workspace.external_key_id 是否非空推导，

--- a/internal/db/filestore_filesystems.go
+++ b/internal/db/filestore_filesystems.go
@@ -28,7 +28,7 @@ var (
 			from workspaces w, organizations o
 			where w.id = :workspace_id
 				and o.id = :organization_id
-				and w.organization_id = o.id
+				and w.organization_uuid = o.uuid
 				and fs.workspace_uuid = w.uuid
 				and fs.organization_uuid = o.uuid
 				and fs.session_uuid = :session_uuid
@@ -56,11 +56,11 @@ var (
 	validateFilestoreSessionBindingQuery = `
 		select w.id as workspace_id
 		from sessions s
-		join workspaces w
-			on w.id = s.workspace_id
-			and w.organization_id = s.organization_id
 		join organizations o
 			on o.id = s.organization_id
+		join workspaces w
+			on w.id = s.workspace_id
+			and w.organization_uuid = o.uuid
 		where s.uuid = CAST(:session_uuid AS uuid)
 			and o.uuid = CAST(:organization_uuid AS uuid)
 			and w.uuid = CAST(:workspace_uuid AS uuid)
@@ -144,7 +144,6 @@ type filestoreSessionBindingRow struct {
 const filestoreSessionTokenScopeQuery = `
 	select o.id as organization_id,
 		cast(o.uuid as text) as organization_uuid,
-		o.external_id as organization_external_id,
 		w.id as workspace_id,
 		cast(w.uuid as text) as workspace_uuid,
 		w.external_id as workspace_external_id,
@@ -161,7 +160,7 @@ const filestoreSessionTokenScopeQuery = `
 		on o.id = s.organization_id
 	join workspaces w
 		on w.id = s.workspace_id
-		and w.organization_id = s.organization_id
+		and w.organization_uuid = o.uuid
 	join api_keys ak
 		on ak.id = s.created_by_api_key_id
 		and ak.workspace_id = s.workspace_id
@@ -200,7 +199,6 @@ func (d *DB) ResolveFilestoreTokenScope(
 	return getFilestoreTokenScopeSQLX(ctx, d.sql, `
 		select o.id as organization_id,
 			cast(o.uuid as text) as organization_uuid,
-			o.external_id as organization_external_id,
 			w.id as workspace_id,
 			cast(w.uuid as text) as workspace_uuid,
 			w.external_id as workspace_external_id,
@@ -214,7 +212,7 @@ func (d *DB) ResolveFilestoreTokenScope(
 			(nullif(trim(w.external_key_id), '') is not null) as workspace_cmek_enabled
 		from organizations o
 		join workspaces w
-			on w.organization_id = o.id
+			on w.organization_uuid = o.uuid
 		join users u
 			on u.organization_id = o.id
 			and u.deleted_at is null

--- a/internal/db/filestore_session_sqlx.go
+++ b/internal/db/filestore_session_sqlx.go
@@ -21,7 +21,7 @@ var insertSessionFilesystemSQLXQuery = `
 		from organizations o
 		join workspaces w
 			on w.id = :workspace_id
-			and w.organization_id = o.id
+			and w.organization_uuid = o.uuid
 		join api_keys ak
 			on ak.id = :created_by_api_key_id
 			and ak.workspace_id = w.id

--- a/internal/db/filestore_sqlx.go
+++ b/internal/db/filestore_sqlx.go
@@ -24,20 +24,19 @@ type filestoreFilesystemRow struct {
 }
 
 type filestoreTokenScopeRow struct {
-	OrganizationID         int64  `db:"organization_id"`
-	OrganizationUUID       string `db:"organization_uuid"`
-	OrganizationExternalID string `db:"organization_external_id"`
-	WorkspaceID            int64  `db:"workspace_id"`
-	WorkspaceUUID          string `db:"workspace_uuid"`
-	WorkspaceExternalID    string `db:"workspace_external_id"`
-	AccountID              int64  `db:"account_id"`
-	AccountUUID            string `db:"account_uuid"`
-	AccountExternalID      string `db:"account_external_id"`
-	FilesystemID           int64  `db:"filesystem_id"`
-	FilesystemUUID         string `db:"filesystem_uuid"`
-	FilesystemExternalID   string `db:"filesystem_external_id"`
-	OrgTaintsJSON          []byte `db:"org_taints_json"`
-	WorkspaceCMEKEnabled   bool   `db:"workspace_cmek_enabled"`
+	OrganizationID       int64  `db:"organization_id"`
+	OrganizationUUID     string `db:"organization_uuid"`
+	WorkspaceID          int64  `db:"workspace_id"`
+	WorkspaceUUID        string `db:"workspace_uuid"`
+	WorkspaceExternalID  string `db:"workspace_external_id"`
+	AccountID            int64  `db:"account_id"`
+	AccountUUID          string `db:"account_uuid"`
+	AccountExternalID    string `db:"account_external_id"`
+	FilesystemID         int64  `db:"filesystem_id"`
+	FilesystemUUID       string `db:"filesystem_uuid"`
+	FilesystemExternalID string `db:"filesystem_external_id"`
+	OrgTaintsJSON        []byte `db:"org_taints_json"`
+	WorkspaceCMEKEnabled bool   `db:"workspace_cmek_enabled"`
 }
 
 type filestoreEntryRow struct {
@@ -217,20 +216,19 @@ func (row filestoreTokenScopeRow) scope() (FilestoreTokenScope, error) {
 		orgTaints = []string{}
 	}
 	return FilestoreTokenScope{
-		OrganizationID:         row.OrganizationID,
-		OrganizationUUID:       row.OrganizationUUID,
-		OrganizationExternalID: row.OrganizationExternalID,
-		WorkspaceID:            row.WorkspaceID,
-		WorkspaceUUID:          row.WorkspaceUUID,
-		WorkspaceExternalID:    row.WorkspaceExternalID,
-		AccountID:              row.AccountID,
-		AccountUUID:            row.AccountUUID,
-		AccountExternalID:      row.AccountExternalID,
-		FilesystemID:           row.FilesystemID,
-		FilesystemUUID:         row.FilesystemUUID,
-		FilesystemExternalID:   row.FilesystemExternalID,
-		OrgTaints:              orgTaints,
-		WorkspaceCMEKEnabled:   row.WorkspaceCMEKEnabled,
+		OrganizationID:       row.OrganizationID,
+		OrganizationUUID:     row.OrganizationUUID,
+		WorkspaceID:          row.WorkspaceID,
+		WorkspaceUUID:        row.WorkspaceUUID,
+		WorkspaceExternalID:  row.WorkspaceExternalID,
+		AccountID:            row.AccountID,
+		AccountUUID:          row.AccountUUID,
+		AccountExternalID:    row.AccountExternalID,
+		FilesystemID:         row.FilesystemID,
+		FilesystemUUID:       row.FilesystemUUID,
+		FilesystemExternalID: row.FilesystemExternalID,
+		OrgTaints:            orgTaints,
+		WorkspaceCMEKEnabled: row.WorkspaceCMEKEnabled,
 	}, nil
 }
 

--- a/internal/db/migrations/00036_use_uuid_workspace_organization_reference.sql
+++ b/internal/db/migrations/00036_use_uuid_workspace_organization_reference.sql
@@ -1,0 +1,133 @@
+-- +goose Up
+
+-- Workspace 的组织归属需要在整库恢复、租户搬迁和跨库合并后保持稳定，
+-- 不能依赖源数据库可重新生成的 organization identity。
+-- PostgreSQL 不能原地调整列顺序，因此按最终结构重建表并保留 workspace identity。
+-- +goose StatementBegin
+do $$
+begin
+	if exists (
+		select 1
+		from workspaces w
+		left join organizations o on o.id = w.organization_id
+		where o.id is null
+	) then
+		raise exception 'cannot migrate workspace organization references to UUID';
+	end if;
+end $$;
+-- +goose StatementEnd
+
+create table workspaces_uuid_refs (
+	id bigint generated always as identity,
+	uuid uuid not null default gen_random_uuid(),
+	external_id text not null,
+	organization_uuid uuid not null,
+	name text not null,
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	archived_at timestamptz,
+	compartment_id text not null default gen_random_uuid()::text,
+	display_color text not null default '#6C5BB9',
+	data_residency jsonb not null default '{"workspace_geo":"us","allowed_inference_geos":"unrestricted","default_inference_geo":"global"}'::jsonb,
+	external_key_id text,
+	tags jsonb not null default '{}'::jsonb,
+	constraint workspaces_uuid_refs_id_pk primary key (id),
+	constraint workspaces_uuid_refs_uuid_key unique (uuid),
+	constraint workspaces_uuid_refs_external_id_key unique (external_id),
+	constraint workspaces_uuid_refs_organization_name_key unique (organization_uuid, name)
+);
+
+insert into workspaces_uuid_refs (
+	id, uuid, external_id, organization_uuid, name, created_at, updated_at,
+	archived_at, compartment_id, display_color, data_residency, external_key_id, tags
+)
+overriding system value
+select
+	w.id, w.uuid, w.external_id, o.uuid, w.name, w.created_at, w.updated_at,
+	w.archived_at, w.compartment_id, w.display_color, w.data_residency, w.external_key_id, w.tags
+from workspaces w
+join organizations o on o.id = w.organization_id;
+
+drop table workspaces;
+alter table workspaces_uuid_refs rename to workspaces;
+
+alter table workspaces
+	rename constraint workspaces_uuid_refs_id_pk to workspaces_id_pk;
+alter table workspaces
+	rename constraint workspaces_uuid_refs_uuid_key to workspaces_uuid_key;
+alter table workspaces
+	rename constraint workspaces_uuid_refs_external_id_key to workspaces_external_id_key;
+alter table workspaces
+	rename constraint workspaces_uuid_refs_organization_name_key to workspaces_organization_uuid_name_key;
+
+select setval(
+	pg_get_serial_sequence('workspaces', 'id'),
+	coalesce((select max(id) from workspaces), 1),
+	exists (select 1 from workspaces)
+);
+
+-- +goose Down
+
+-- 回滚时仅在每条稳定 UUID 都能解析为当前库 organization identity 时恢复旧结构。
+-- +goose StatementBegin
+do $$
+begin
+	if exists (
+		select 1
+		from workspaces w
+		left join organizations o on o.uuid = w.organization_uuid
+		where o.uuid is null
+	) then
+		raise exception 'cannot restore workspace organization internal references';
+	end if;
+end $$;
+-- +goose StatementEnd
+
+create table workspaces_internal_refs (
+	id bigint generated always as identity,
+	uuid uuid not null default gen_random_uuid(),
+	external_id text not null,
+	organization_id bigint not null,
+	name text not null,
+	created_at timestamptz not null default now(),
+	updated_at timestamptz not null default now(),
+	archived_at timestamptz,
+	compartment_id text not null default gen_random_uuid()::text,
+	display_color text not null default '#6C5BB9',
+	data_residency jsonb not null default '{"workspace_geo":"us","allowed_inference_geos":"unrestricted","default_inference_geo":"global"}'::jsonb,
+	external_key_id text,
+	tags jsonb not null default '{}'::jsonb,
+	constraint workspaces_internal_refs_id_pk primary key (id),
+	constraint workspaces_internal_refs_uuid_key unique (uuid),
+	constraint workspaces_internal_refs_external_id_key unique (external_id),
+	constraint workspaces_internal_refs_organization_name_key unique (organization_id, name)
+);
+
+insert into workspaces_internal_refs (
+	id, uuid, external_id, organization_id, name, created_at, updated_at,
+	archived_at, compartment_id, display_color, data_residency, external_key_id, tags
+)
+overriding system value
+select
+	w.id, w.uuid, w.external_id, o.id, w.name, w.created_at, w.updated_at,
+	w.archived_at, w.compartment_id, w.display_color, w.data_residency, w.external_key_id, w.tags
+from workspaces w
+join organizations o on o.uuid = w.organization_uuid;
+
+drop table workspaces;
+alter table workspaces_internal_refs rename to workspaces;
+
+alter table workspaces
+	rename constraint workspaces_internal_refs_id_pk to workspaces_id_pk;
+alter table workspaces
+	rename constraint workspaces_internal_refs_uuid_key to workspaces_uuid_key;
+alter table workspaces
+	rename constraint workspaces_internal_refs_external_id_key to workspaces_external_id_key;
+alter table workspaces
+	rename constraint workspaces_internal_refs_organization_name_key to workspaces_organization_name_key;
+
+select setval(
+	pg_get_serial_sequence('workspaces', 'id'),
+	coalesce((select max(id) from workspaces), 1),
+	exists (select 1 from workspaces)
+);

--- a/internal/db/migrations/00037_drop_organization_external_id.sql
+++ b/internal/db/migrations/00037_drop_organization_external_id.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+
+alter table organizations
+	drop column external_id;
+
+-- +goose Down
+
+alter table organizations
+	add column external_id text;
+
+update organizations
+set external_id = 'org_' || replace(CAST(uuid AS text), '-', '');
+
+alter table organizations
+	alter column external_id set not null,
+	add constraint organizations_external_id_key unique (external_id);

--- a/internal/db/platform_auth.go
+++ b/internal/db/platform_auth.go
@@ -16,8 +16,7 @@ type PlatformAuthUserContext struct {
 }
 
 type PlatformAuthOrganizationInput struct {
-	ExternalID string
-	Name       string
+	Name string
 }
 
 type PlatformAuthOrganizationRef struct {
@@ -89,7 +88,6 @@ const (
 	`
 	resolvePlatformSessionIdentityQuery = `
 		select o.id AS organization_id, CAST(o.uuid AS text) AS organization_uuid,
-			o.external_id AS organization_external_id,
 			w.id AS workspace_id, CAST(w.uuid AS text) AS workspace_uuid,
 			w.external_id AS workspace_external_id,
 			u.id AS user_id, u.external_id AS user_external_id,
@@ -99,7 +97,7 @@ const (
 		join lateral (
 			select id, uuid, external_id
 			from workspaces
-			where organization_id = o.id
+			where organization_uuid = o.uuid
 			  and archived_at is null
 			order by case when external_id = 'workspace_default' then 0 else 1 end,
 				created_at asc, id asc
@@ -115,7 +113,7 @@ const (
 				created_at asc, id asc
 			limit 1
 		) ak on true
-		where (CAST(o.uuid AS text) = :org_uuid or o.external_id = :org_uuid)
+		where CAST(o.uuid AS text) = :org_uuid
 		  and u.deleted_at is null
 		  and (
 			u.external_id = :user_uuid
@@ -187,10 +185,10 @@ func (tx PlatformAuthTx) UpdateEmptyUserName(ctx context.Context, userExternalID
 func (tx PlatformAuthTx) InsertOrganization(ctx context.Context, input PlatformAuthOrganizationInput) (PlatformAuthOrganizationRef, error) {
 	var row platformAuthOrganizationRefRow
 	if err := namedGetContext(ctx, tx.tx, &row, `
-		insert into organizations (external_id, name)
-		values (:external_id, :name)
+		insert into organizations (name)
+		values (:name)
 		returning id, CAST(uuid AS text) AS uuid
-	`, map[string]any{"external_id": input.ExternalID, "name": input.Name}); err != nil {
+	`, map[string]any{"name": input.Name}); err != nil {
 		return PlatformAuthOrganizationRef{}, err
 	}
 	return PlatformAuthOrganizationRef{ID: row.ID, UUID: row.UUID}, nil
@@ -222,8 +220,10 @@ func (tx PlatformAuthTx) InsertUser(ctx context.Context, input PlatformAuthUserI
 func (tx PlatformAuthTx) InsertWorkspace(ctx context.Context, input PlatformAuthWorkspaceInput) (PlatformAuthWorkspaceRef, error) {
 	var out PlatformAuthWorkspaceRef
 	if err := namedGetContext(ctx, tx.tx, &out.ID, `
-		insert into workspaces (uuid, external_id, organization_id, name, compartment_id)
-		values (:uuid, :external_id, :organization_id, :name, :compartment_id)
+		insert into workspaces (uuid, external_id, organization_uuid, name, compartment_id)
+		select :uuid, :external_id, uuid, :name, :compartment_id
+		from organizations
+		where id = :organization_id
 		returning id
 	`, map[string]any{
 		"uuid":            input.UUID,
@@ -323,29 +323,27 @@ type platformAuthOrganizationRefRow struct {
 }
 
 type platformSessionIdentityRow struct {
-	OrganizationID         int64  `db:"organization_id"`
-	OrganizationUUID       string `db:"organization_uuid"`
-	OrganizationExternalID string `db:"organization_external_id"`
-	WorkspaceID            int64  `db:"workspace_id"`
-	WorkspaceUUID          string `db:"workspace_uuid"`
-	WorkspaceExternalID    string `db:"workspace_external_id"`
-	UserID                 int64  `db:"user_id"`
-	UserExternalID         string `db:"user_external_id"`
-	APIKeyID               int64  `db:"api_key_id"`
-	APIKeyExternalID       string `db:"api_key_external_id"`
+	OrganizationID      int64  `db:"organization_id"`
+	OrganizationUUID    string `db:"organization_uuid"`
+	WorkspaceID         int64  `db:"workspace_id"`
+	WorkspaceUUID       string `db:"workspace_uuid"`
+	WorkspaceExternalID string `db:"workspace_external_id"`
+	UserID              int64  `db:"user_id"`
+	UserExternalID      string `db:"user_external_id"`
+	APIKeyID            int64  `db:"api_key_id"`
+	APIKeyExternalID    string `db:"api_key_external_id"`
 }
 
 func (r platformSessionIdentityRow) session() platformsession.Session {
 	return platformsession.Session{
-		OrganizationID:         r.OrganizationID,
-		OrganizationUUID:       r.OrganizationUUID,
-		OrganizationExternalID: r.OrganizationExternalID,
-		WorkspaceID:            r.WorkspaceID,
-		WorkspaceUUID:          r.WorkspaceUUID,
-		WorkspaceExternalID:    r.WorkspaceExternalID,
-		UserID:                 r.UserID,
-		UserExternalID:         r.UserExternalID,
-		APIKeyID:               r.APIKeyID,
-		APIKeyExternalID:       r.APIKeyExternalID,
+		OrganizationID:      r.OrganizationID,
+		OrganizationUUID:    r.OrganizationUUID,
+		WorkspaceID:         r.WorkspaceID,
+		WorkspaceUUID:       r.WorkspaceUUID,
+		WorkspaceExternalID: r.WorkspaceExternalID,
+		UserID:              r.UserID,
+		UserExternalID:      r.UserExternalID,
+		APIKeyID:            r.APIKeyID,
+		APIKeyExternalID:    r.APIKeyExternalID,
 	}
 }

--- a/internal/db/platform_auth_sqlx_test.go
+++ b/internal/db/platform_auth_sqlx_test.go
@@ -33,7 +33,7 @@ func TestPlatformAuthQueriesUseSQLXNamedParameters(t *testing.T) {
 				"org_uuid":  "org_test",
 				"user_uuid": "user_test",
 			},
-			wantArgCount: 5,
+			wantArgCount: 4,
 		},
 	}
 
@@ -58,16 +58,15 @@ func TestPlatformAuthQueriesUseSQLXNamedParameters(t *testing.T) {
 
 func TestPlatformSessionIdentityRowMapping(t *testing.T) {
 	row := platformSessionIdentityRow{
-		OrganizationID:         1,
-		OrganizationUUID:       "org-uuid",
-		OrganizationExternalID: "org_test",
-		WorkspaceID:            2,
-		WorkspaceUUID:          "workspace-uuid",
-		WorkspaceExternalID:    "workspace_test",
-		UserID:                 3,
-		UserExternalID:         "user_test",
-		APIKeyID:               4,
-		APIKeyExternalID:       "api_key_test",
+		OrganizationID:      1,
+		OrganizationUUID:    "org-uuid",
+		WorkspaceID:         2,
+		WorkspaceUUID:       "workspace-uuid",
+		WorkspaceExternalID: "workspace_test",
+		UserID:              3,
+		UserExternalID:      "user_test",
+		APIKeyID:            4,
+		APIKeyExternalID:    "api_key_test",
 	}
 
 	session := row.session()

--- a/internal/db/webhook_endpoints.go
+++ b/internal/db/webhook_endpoints.go
@@ -29,10 +29,10 @@ const (
 	`
 	getWorkspaceIdentifiersQuery = `
 		select
-			o.external_id AS organization_external_id,
+			CAST(o.uuid AS text) AS organization_uuid,
 			w.external_id AS workspace_external_id
 		from workspaces w
-		join organizations o on o.id = w.organization_id
+		join organizations o on o.uuid = w.organization_uuid
 		where w.id = :workspace_id
 	`
 	createWebhookEndpointQuery = `
@@ -132,8 +132,8 @@ const (
 )
 
 type WorkspaceIdentifiers struct {
-	OrganizationExternalID string
-	WorkspaceExternalID    string
+	OrganizationUUID    string
+	WorkspaceExternalID string
 }
 
 type WebhookEndpoint struct {
@@ -157,8 +157,8 @@ type WebhookEndpoint struct {
 }
 
 type workspaceIdentifiersRow struct {
-	OrganizationExternalID string `db:"organization_external_id"`
-	WorkspaceExternalID    string `db:"workspace_external_id"`
+	OrganizationUUID    string `db:"organization_uuid"`
+	WorkspaceExternalID string `db:"workspace_external_id"`
 }
 
 type webhookEndpointRow struct {
@@ -189,8 +189,8 @@ func (d *DB) GetWorkspaceIdentifiers(ctx context.Context, workspaceID int64) (Wo
 		return WorkspaceIdentifiers{}, mapNoRows(err)
 	}
 	return WorkspaceIdentifiers{
-		OrganizationExternalID: row.OrganizationExternalID,
-		WorkspaceExternalID:    row.WorkspaceExternalID,
+		OrganizationUUID:    row.OrganizationUUID,
+		WorkspaceExternalID: row.WorkspaceExternalID,
 	}, nil
 }
 

--- a/internal/deployments/handler.go
+++ b/internal/deployments/handler.go
@@ -652,12 +652,12 @@ func (h *Handler) enqueueWebhook(ctx context.Context, principal auth.Principal, 
 		return
 	}
 	h.webhooks.Enqueue(ctx, webhooks.EnqueueInput{
-		WorkspaceID:            principal.WorkspaceID,
-		OrganizationExternalID: principal.OrganizationExternalID,
-		WorkspaceExternalID:    principal.WorkspaceExternalID,
-		EventType:              eventType,
-		ResourceID:             resourceID,
-		Options:                webhooks.EventOptions{SessionThreadID: sessionThreadID},
+		WorkspaceID:         principal.WorkspaceID,
+		OrganizationUUID:    principal.OrganizationUUID,
+		WorkspaceExternalID: principal.WorkspaceExternalID,
+		EventType:           eventType,
+		ResourceID:          resourceID,
+		Options:             webhooks.EventOptions{SessionThreadID: sessionThreadID},
 	})
 }
 

--- a/internal/files/platform.go
+++ b/internal/files/platform.go
@@ -289,11 +289,8 @@ func (h *Handler) resolvePlatformOrganizationScope(r *http.Request, principal au
 	orgID := strings.TrimSpace(chi.URLParam(r, "orgUuid"))
 	if orgID == "" || orgID == "default" {
 		orgID = principal.OrganizationUUID
-		if orgID == "" {
-			orgID = principal.OrganizationExternalID
-		}
 	}
-	if orgID != principal.OrganizationUUID && orgID != principal.OrganizationExternalID {
+	if orgID != principal.OrganizationUUID {
 		return platformOrganizationScope{}, httpapi.NewError(http.StatusForbidden, "permission_error", "Organization not found")
 	}
 	return platformOrganizationScope{

--- a/internal/filestore/principal.go
+++ b/internal/filestore/principal.go
@@ -9,16 +9,15 @@ type principalContextKey struct{}
 // 所有字段都来自专用 Filestore JWT 及其数据库范围回查；该类型不承载
 // workspace API key 或 code-session 凭证的兼容身份。
 type Principal struct {
-	Subject                string
-	OrganizationID         int64
-	OrganizationUUID       string
-	OrganizationExternalID string
-	WorkspaceID            int64
-	WorkspaceUUID          string
-	WorkspaceExternalID    string
-	AccountID              int64
-	AccountUUID            string
-	AccountExternalID      string
+	Subject             string
+	OrganizationID      int64
+	OrganizationUUID    string
+	WorkspaceID         int64
+	WorkspaceUUID       string
+	WorkspaceExternalID string
+	AccountID           int64
+	AccountUUID         string
+	AccountExternalID   string
 
 	FilesystemInternalID int64
 	FilesystemUUID       string

--- a/internal/mcpcatalogs/handler.go
+++ b/internal/mcpcatalogs/handler.go
@@ -233,7 +233,7 @@ func principalCanSeeOrganization(r *http.Request, principal auth.Principal, valu
 	if value == "" {
 		return false
 	}
-	if value == strings.TrimSpace(principal.OrganizationUUID) || value == strings.TrimSpace(principal.OrganizationExternalID) {
+	if value == strings.TrimSpace(principal.OrganizationUUID) {
 		return true
 	}
 	// platform.claude.com 的镜像 session 恢复后，path 仍携带官方 organization UUID，

--- a/internal/platform/bootstrap.go
+++ b/internal/platform/bootstrap.go
@@ -16,7 +16,6 @@ type UserRecord struct {
 
 type OrganizationRecord struct {
 	UUID                   string
-	ExternalID             string
 	Name                   string
 	Domain                 *string
 	ParentOrganizationUUID *string

--- a/internal/platformapi/platform_bootstrap.go
+++ b/internal/platformapi/platform_bootstrap.go
@@ -24,7 +24,7 @@ func handleBootstrap(store OrganizationStore) http.HandlerFunc {
 		if principal, ok := auth.PrincipalFromContext(r.Context()); ok {
 			userExternalID = strings.TrimSpace(principal.UserExternalID)
 			if orgUUID == "" {
-				orgUUID = firstNonEmpty(principal.OrganizationUUID, principal.OrganizationExternalID)
+				orgUUID = principal.OrganizationUUID
 			}
 		}
 

--- a/internal/platformapi/platform_bootstrap_builders.go
+++ b/internal/platformapi/platform_bootstrap_builders.go
@@ -8,7 +8,7 @@ func buildAccount(user UserRecord, orgs []UserOrganizationRecord, preferredOrgUU
 	memberships := make([]Membership, 0, len(orgs))
 	selectedOrgUUID := orgs[0].UUID
 	for _, org := range orgs {
-		if org.UUID == preferredOrgUUID || org.ExternalID == preferredOrgUUID {
+		if org.UUID == preferredOrgUUID {
 			selectedOrgUUID = org.UUID
 		}
 		createdAt := isoTime(org.AddedAt)

--- a/internal/platformapi/support.go
+++ b/internal/platformapi/support.go
@@ -128,8 +128,7 @@ func principalCanSeeOrg(principal auth.Principal, orgUUID string) bool {
 	if orgUUID == "" {
 		return false
 	}
-	return orgUUID == strings.TrimSpace(principal.OrganizationUUID) ||
-		orgUUID == strings.TrimSpace(principal.OrganizationExternalID)
+	return orgUUID == strings.TrimSpace(principal.OrganizationUUID)
 }
 
 func organizationNotFound(w http.ResponseWriter) {

--- a/internal/platformauth/service.go
+++ b/internal/platformauth/service.go
@@ -68,10 +68,6 @@ func (s *Service) ResolvePlatformSessionIdentity(ctx context.Context, input plat
 }
 
 func createDefaultUserOrganization(ctx context.Context, tx db.PlatformAuthTxStore, email string, defaultName string) (db.PlatformAuthUserContext, error) {
-	orgExternalID, err := ids.New("org_")
-	if err != nil {
-		return db.PlatformAuthUserContext{}, err
-	}
 	workspaceExternalID, err := ids.New("wrkspc_")
 	if err != nil {
 		return db.PlatformAuthUserContext{}, err
@@ -86,8 +82,7 @@ func createDefaultUserOrganization(ctx context.Context, tx db.PlatformAuthTxStor
 	}
 
 	org, err := tx.InsertOrganization(ctx, db.PlatformAuthOrganizationInput{
-		ExternalID: orgExternalID,
-		Name:       defaultPlatformOrganizationName(email),
+		Name: defaultPlatformOrganizationName(email),
 	})
 	if err != nil {
 		return db.PlatformAuthUserContext{}, err

--- a/internal/platformauth/service_test.go
+++ b/internal/platformauth/service_test.go
@@ -52,7 +52,7 @@ func TestServiceFindOrCreateUserContextByEmail(t *testing.T) {
 		if !strings.HasPrefix(userID, "user_") || orgUUID != "created-org-uuid" {
 			t.Fatalf("context = (%q, %q), want created context", userID, orgUUID)
 		}
-		if len(tx.organizations) != 1 || tx.organizations[0].Name != "new user" || !strings.HasPrefix(tx.organizations[0].ExternalID, "org_") {
+		if len(tx.organizations) != 1 || tx.organizations[0].Name != "new user" {
 			t.Fatalf("organizations = %#v, want default organization", tx.organizations)
 		}
 		if len(tx.workspaces) != 1 || tx.workspaces[0].Name != "default" || !strings.HasPrefix(tx.workspaces[0].ExternalID, "wrkspc_") {

--- a/internal/platformsession/session.go
+++ b/internal/platformsession/session.go
@@ -21,18 +21,17 @@ type CreateInput struct {
 }
 
 type Session struct {
-	ExternalID             string     `json:"external_id"`
-	OrganizationID         int64      `json:"organization_id"`
-	OrganizationUUID       string     `json:"organization_uuid"`
-	OrganizationExternalID string     `json:"organization_external_id"`
-	WorkspaceID            int64      `json:"workspace_id"`
-	WorkspaceUUID          string     `json:"workspace_uuid"`
-	WorkspaceExternalID    string     `json:"workspace_external_id"`
-	UserID                 int64      `json:"user_id"`
-	UserExternalID         string     `json:"user_external_id"`
-	APIKeyID               int64      `json:"api_key_id"`
-	APIKeyExternalID       string     `json:"api_key_external_id"`
-	ExpiresAt              *time.Time `json:"expires_at,omitempty"`
+	ExternalID          string     `json:"external_id"`
+	OrganizationID      int64      `json:"organization_id"`
+	OrganizationUUID    string     `json:"organization_uuid"`
+	WorkspaceID         int64      `json:"workspace_id"`
+	WorkspaceUUID       string     `json:"workspace_uuid"`
+	WorkspaceExternalID string     `json:"workspace_external_id"`
+	UserID              int64      `json:"user_id"`
+	UserExternalID      string     `json:"user_external_id"`
+	APIKeyID            int64      `json:"api_key_id"`
+	APIKeyExternalID    string     `json:"api_key_external_id"`
+	ExpiresAt           *time.Time `json:"expires_at,omitempty"`
 }
 
 type Store interface {
@@ -48,7 +47,6 @@ func (s Session) Principal() auth.Principal {
 		APIKeyExternalID:          s.APIKeyExternalID,
 		OrganizationID:            s.OrganizationID,
 		OrganizationUUID:          s.OrganizationUUID,
-		OrganizationExternalID:    s.OrganizationExternalID,
 		WorkspaceID:               s.WorkspaceID,
 		WorkspaceUUID:             s.WorkspaceUUID,
 		WorkspaceExternalID:       s.WorkspaceExternalID,

--- a/internal/sessions/access.go
+++ b/internal/sessions/access.go
@@ -74,9 +74,9 @@ func workspaceIDFromRequest(r *http.Request) int64 {
 	return principal.WorkspaceID
 }
 
-func organizationExternalIDFromRequest(r *http.Request) string {
+func organizationUUIDFromRequest(r *http.Request) string {
 	principal, _ := auth.PrincipalFromContext(r.Context())
-	return principal.OrganizationExternalID
+	return principal.OrganizationUUID
 }
 
 func workspaceExternalIDFromRequest(r *http.Request) string {

--- a/internal/sessions/service.go
+++ b/internal/sessions/service.go
@@ -624,11 +624,11 @@ func (h *Handler) sendEventsRoute(w http.ResponseWriter, r *http.Request) {
 	}
 	if outcomesChanged {
 		h.enqueueWebhook(r.Context(), webhooks.EnqueueInput{
-			WorkspaceID:            session.WorkspaceID,
-			OrganizationExternalID: organizationExternalIDFromRequest(r),
-			WorkspaceExternalID:    workspaceExternalIDFromRequest(r),
-			EventType:              "session.outcome_evaluation_ended",
-			ResourceID:             session.ExternalID,
+			WorkspaceID:         session.WorkspaceID,
+			OrganizationUUID:    organizationUUIDFromRequest(r),
+			WorkspaceExternalID: workspaceExternalIDFromRequest(r),
+			EventType:           "session.outcome_evaluation_ended",
+			ResourceID:          session.ExternalID,
 		})
 	}
 	data := make([]json.RawMessage, 0, len(created))

--- a/internal/sessions/webhook_bridge.go
+++ b/internal/sessions/webhook_bridge.go
@@ -32,12 +32,12 @@ func (h *Handler) enqueueWebhooksForSessionEvents(ctx context.Context, workspace
 			}
 			seen[key] = struct{}{}
 			h.enqueueWebhook(ctx, webhooks.EnqueueInput{
-				WorkspaceID:            workspaceID,
-				OrganizationExternalID: workspaceIDs.OrganizationExternalID,
-				WorkspaceExternalID:    workspaceIDs.WorkspaceExternalID,
-				EventType:              webhookEvent.EventType,
-				ResourceID:             sessionID,
-				Options:                webhooks.EventOptions{SessionThreadID: webhookEvent.ThreadID},
+				WorkspaceID:         workspaceID,
+				OrganizationUUID:    workspaceIDs.OrganizationUUID,
+				WorkspaceExternalID: workspaceIDs.WorkspaceExternalID,
+				EventType:           webhookEvent.EventType,
+				ResourceID:          sessionID,
+				Options:             webhooks.EventOptions{SessionThreadID: webhookEvent.ThreadID},
 			})
 		}
 	}
@@ -51,12 +51,12 @@ func (h *Handler) enqueueWebhook(ctx context.Context, input webhooks.EnqueueInpu
 
 func (h *Handler) enqueuePrincipalWebhook(ctx context.Context, principal auth.Principal, eventType, resourceID string, sessionThreadID *string) {
 	h.enqueueWebhook(ctx, webhooks.EnqueueInput{
-		WorkspaceID:            principal.WorkspaceID,
-		OrganizationExternalID: principal.OrganizationExternalID,
-		WorkspaceExternalID:    principal.WorkspaceExternalID,
-		EventType:              eventType,
-		ResourceID:             resourceID,
-		Options:                webhooks.EventOptions{SessionThreadID: sessionThreadID},
+		WorkspaceID:         principal.WorkspaceID,
+		OrganizationUUID:    principal.OrganizationUUID,
+		WorkspaceExternalID: principal.WorkspaceExternalID,
+		EventType:           eventType,
+		ResourceID:          resourceID,
+		Options:             webhooks.EventOptions{SessionThreadID: sessionThreadID},
 	})
 }
 

--- a/internal/vaults/handler.go
+++ b/internal/vaults/handler.go
@@ -627,12 +627,12 @@ func (h *Handler) enqueueWebhookWithOptions(r *http.Request, principal auth.Prin
 		return
 	}
 	h.webhooks.Enqueue(r.Context(), webhooks.EnqueueInput{
-		WorkspaceID:            principal.WorkspaceID,
-		OrganizationExternalID: principal.OrganizationExternalID,
-		WorkspaceExternalID:    principal.WorkspaceExternalID,
-		EventType:              eventType,
-		ResourceID:             resourceID,
-		Options:                options,
+		WorkspaceID:         principal.WorkspaceID,
+		OrganizationUUID:    principal.OrganizationUUID,
+		WorkspaceExternalID: principal.WorkspaceExternalID,
+		EventType:           eventType,
+		ResourceID:          resourceID,
+		Options:             options,
 	})
 }
 

--- a/internal/webhooks/enqueuer.go
+++ b/internal/webhooks/enqueuer.go
@@ -15,12 +15,12 @@ import (
 // EnqueueInput contains event-specific values while Enqueuer owns the stable
 // database, configuration, and logger dependencies.
 type EnqueueInput struct {
-	WorkspaceID            int64
-	OrganizationExternalID string
-	WorkspaceExternalID    string
-	EventType              string
-	ResourceID             string
-	Options                EventOptions
+	WorkspaceID         int64
+	OrganizationUUID    string
+	WorkspaceExternalID string
+	EventType           string
+	ResourceID          string
+	Options             EventOptions
 }
 
 type enqueueStore interface {
@@ -65,7 +65,7 @@ func (e *Enqueuer) Enqueue(ctx context.Context, input EnqueueInput) {
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
 		Data: EventData{
 			ID:              input.ResourceID,
-			OrganizationID:  input.OrganizationExternalID,
+			OrganizationID:  input.OrganizationUUID,
 			Type:            input.EventType,
 			WorkspaceID:     input.WorkspaceExternalID,
 			SessionThreadID: input.Options.SessionThreadID,

--- a/internal/webhooks/enqueuer_test.go
+++ b/internal/webhooks/enqueuer_test.go
@@ -36,11 +36,11 @@ func TestEnqueuerUsesOwnedLogger(t *testing.T) {
 	enqueuer := newEnqueuer(failingEnqueueStore{}, config.WebhookConfig{}, logger)
 
 	enqueuer.Enqueue(context.Background(), EnqueueInput{
-		WorkspaceID:            42,
-		OrganizationExternalID: "org_test",
-		WorkspaceExternalID:    "wrk_test",
-		EventType:              "session.created",
-		ResourceID:             "session_test",
+		WorkspaceID:         42,
+		OrganizationUUID:    "11111111-1111-4111-8111-111111111111",
+		WorkspaceExternalID: "wrk_test",
+		EventType:           "session.created",
+		ResourceID:          "session_test",
 	})
 
 	var record map[string]any

--- a/internal/workbench/workbench_support.go
+++ b/internal/workbench/workbench_support.go
@@ -143,8 +143,7 @@ func principalCanSeeOrg(principal auth.Principal, orgUUID string) bool {
 	if orgUUID == "" {
 		return false
 	}
-	return orgUUID == strings.TrimSpace(principal.OrganizationUUID) ||
-		orgUUID == strings.TrimSpace(principal.OrganizationExternalID)
+	return orgUUID == strings.TrimSpace(principal.OrganizationUUID)
 }
 
 func organizationNotFound(w http.ResponseWriter) {

--- a/tests/admin_api_test.go
+++ b/tests/admin_api_test.go
@@ -69,6 +69,97 @@ type adminDefaultIDs struct {
 	UserID         int64
 }
 
+func TestWorkspaceOrganizationReferenceUsesUUID(t *testing.T) {
+	app := newTestApp(t, nil)
+	defer app.close()
+
+	var legacyColumnCount int
+	if err := app.db.Pool.QueryRow(context.Background(), `
+		select count(*)
+		from information_schema.columns
+		where table_schema = current_schema()
+			and table_name = 'workspaces'
+			and column_name = 'organization_id'
+	`).Scan(&legacyColumnCount); err != nil {
+		t.Fatalf("query legacy workspace organization column: %v", err)
+	}
+	if legacyColumnCount != 0 {
+		t.Fatalf("workspace organization_id column count = %d, want 0", legacyColumnCount)
+	}
+	if err := app.db.Pool.QueryRow(context.Background(), `
+		select count(*)
+		from information_schema.columns
+		where table_schema = current_schema()
+			and table_name = 'organizations'
+			and column_name = 'external_id'
+	`).Scan(&legacyColumnCount); err != nil {
+		t.Fatalf("query legacy organization external ID column: %v", err)
+	}
+	if legacyColumnCount != 0 {
+		t.Fatalf("organization external_id column count = %d, want 0", legacyColumnCount)
+	}
+	var dataType string
+	var ordinalPosition int
+	if err := app.db.Pool.QueryRow(context.Background(), `
+		select data_type, ordinal_position
+		from information_schema.columns
+		where table_schema = current_schema()
+			and table_name = 'workspaces'
+			and column_name = 'organization_uuid'
+	`).Scan(&dataType, &ordinalPosition); err != nil {
+		t.Fatalf("query workspace organization UUID column: %v", err)
+	}
+	if dataType != "uuid" || ordinalPosition != 4 {
+		t.Fatalf("workspace organization_uuid = type %s ordinal %d, want uuid at 4", dataType, ordinalPosition)
+	}
+
+	var referenceMatches bool
+	if err := app.db.Pool.QueryRow(context.Background(), `
+		select w.organization_uuid = o.uuid
+		from workspaces w
+		join organizations o on o.uuid = w.organization_uuid
+		where w.external_id = 'workspace_default'
+	`).Scan(&referenceMatches); err != nil {
+		t.Fatalf("query default workspace organization UUID: %v", err)
+	}
+	if !referenceMatches {
+		t.Fatal("default workspace organization_uuid does not match organization uuid")
+	}
+
+	var originalOrganizationUUID string
+	var organizationCount int
+	if err := app.db.Pool.QueryRow(context.Background(), `
+		select o.uuid::text, (select count(*) from organizations)
+		from organizations o
+		join workspaces w on w.organization_uuid = o.uuid
+		where w.external_id = 'workspace_default'
+	`).Scan(&originalOrganizationUUID, &organizationCount); err != nil {
+		t.Fatalf("load organization state before repeated seed: %v", err)
+	}
+	if err := app.db.Seed(context.Background(), app.cfg.Bootstrap.SeedAPIKeys); err != nil {
+		t.Fatalf("repeat default seed: %v", err)
+	}
+	var seededOrganizationUUID string
+	var seededOrganizationCount int
+	if err := app.db.Pool.QueryRow(context.Background(), `
+		select o.uuid::text, (select count(*) from organizations)
+		from organizations o
+		join workspaces w on w.organization_uuid = o.uuid
+		where w.external_id = 'workspace_default'
+	`).Scan(&seededOrganizationUUID, &seededOrganizationCount); err != nil {
+		t.Fatalf("load organization state after repeated seed: %v", err)
+	}
+	if seededOrganizationUUID != originalOrganizationUUID || seededOrganizationCount != organizationCount {
+		t.Fatalf(
+			"repeated seed changed organization state: UUID %s -> %s, count %d -> %d",
+			originalOrganizationUUID,
+			seededOrganizationUUID,
+			organizationCount,
+			seededOrganizationCount,
+		)
+	}
+}
+
 func TestAdminAPI(t *testing.T) {
 	app := newTestApp(t, nil)
 	defer app.close()
@@ -136,10 +227,14 @@ func TestAdminAPI(t *testing.T) {
 	})
 
 	t.Run("success organization me", func(t *testing.T) {
+		apiKey, err := app.db.GetAPIKey(context.Background(), auth.HashAPIKey(defaultTestKey))
+		if err != nil {
+			t.Fatalf("load default API key: %v", err)
+		}
 		var org adminObject
 		adminDecodeOK(t, adminDo(t, app, http.MethodGet, "/v1/organizations/me", nil, defaultTestKey, ""), &org)
-		if org.ID != "org_default" || org.Type != "organization" {
-			t.Fatalf("organization = %+v, want org_default organization", org)
+		if org.ID != apiKey.OrganizationUUID || org.Type != "organization" {
+			t.Fatalf("organization = %+v, want UUID %s organization", org, apiKey.OrganizationUUID)
 		}
 	})
 
@@ -554,7 +649,8 @@ func seedAdminTunnel(t *testing.T, database *db.DB, tunnelID, domain string, wor
 		if err := database.Pool.QueryRow(context.Background(), `
 			select id
 			from workspaces
-			where external_id = $1 and organization_id = $2
+			where external_id = $1
+				and organization_uuid = (select uuid from organizations where id = $2)
 		`, *workspaceExternalID, ids.OrganizationID).Scan(&loadedWorkspaceID); err != nil {
 			t.Fatalf("load tunnel workspace: %v", err)
 		}
@@ -579,9 +675,8 @@ func getAdminDefaultIDs(t *testing.T, database *db.DB) adminDefaultIDs {
 	if err := database.Pool.QueryRow(context.Background(), `
 		select o.id, w.id, u.id
 		from organizations o
-		join workspaces w on w.organization_id = o.id and w.external_id = 'workspace_default'
+		join workspaces w on w.organization_uuid = o.uuid and w.external_id = 'workspace_default'
 		join users u on u.organization_id = o.id and u.external_id = 'user_default'
-		where o.external_id = 'org_default'
 	`).Scan(&ids.OrganizationID, &ids.WorkspaceID, &ids.UserID); err != nil {
 		t.Fatalf("load admin default ids: %v", err)
 	}

--- a/tests/console_invites_api_test.go
+++ b/tests/console_invites_api_test.go
@@ -18,7 +18,8 @@ func TestConsoleInvitesAPI(t *testing.T) {
 	if err := app.db.Pool.QueryRow(context.Background(), `
 		select o.uuid::text, o.id
 		from organizations o
-		where o.external_id = 'org_default'
+		join workspaces w on w.organization_uuid = o.uuid
+		where w.external_id = 'workspace_default'
 	`).Scan(&orgUUID, &orgID); err != nil {
 		t.Fatalf("load default organization ids: %v", err)
 	}

--- a/tests/console_members_api_test.go
+++ b/tests/console_members_api_test.go
@@ -19,7 +19,8 @@ func TestConsoleMembersAPI(t *testing.T) {
 	if err := app.db.Pool.QueryRow(context.Background(), `
 		select o.uuid::text, o.id
 		from organizations o
-		where o.external_id = 'org_default'
+		join workspaces w on w.organization_uuid = o.uuid
+		where w.external_id = 'workspace_default'
 	`).Scan(&orgUUID, &orgID); err != nil {
 		t.Fatalf("load default organization ids: %v", err)
 	}

--- a/tests/files_api_test.go
+++ b/tests/files_api_test.go
@@ -1052,10 +1052,14 @@ func (a *testApp) close() {
 
 func (a *testApp) seedPlatformSession(t *testing.T, sessionKey string) {
 	t.Helper()
+	userExternalID, orgUUID, err := a.db.FindBootstrapUserContext(context.Background(), "")
+	if err != nil {
+		t.Fatalf("find bootstrap user context: %v", err)
+	}
 	session, err := a.db.ResolvePlatformSessionIdentity(context.Background(), platformsession.CreateInput{
 		SessionKey: sessionKey,
-		UserUUID:   a.cfg.Bootstrap.UserExternalID,
-		OrgUUID:    a.cfg.Bootstrap.OrganizationExternalID,
+		UserUUID:   userExternalID,
+		OrgUUID:    orgUUID,
 	})
 	if err != nil {
 		t.Fatalf("resolve platform session identity: %v", err)
@@ -1222,24 +1226,25 @@ func containsFile(files []metadataResponse, id string) bool {
 	return false
 }
 
-func seedWorkspaceKey(t *testing.T, database *db.DB, orgID, workspaceID, keyID, apiKey string) {
+func seedWorkspaceKey(t *testing.T, database *db.DB, organizationName, workspaceID, keyID, apiKey string) {
 	t.Helper()
 	ctx := context.Background()
 	var organizationRowID int64
 	if err := database.Pool.QueryRow(ctx, `
-		insert into organizations (external_id, name)
-		values ($1, $1)
-		on conflict (external_id) do update set name = excluded.name
+		insert into organizations (name)
+		values ($1)
 		returning id
-	`, orgID).Scan(&organizationRowID); err != nil {
+	`, organizationName).Scan(&organizationRowID); err != nil {
 		t.Fatalf("seed org: %v", err)
 	}
 	var workspaceRowID int64
 	if err := database.Pool.QueryRow(ctx, `
-		insert into workspaces (external_id, organization_id, name)
-		values ($1, $2, $1)
+		insert into workspaces (external_id, organization_uuid, name)
+		select $1, uuid, $1
+		from organizations
+		where id = $2
 		on conflict (external_id) do update set
-			organization_id = excluded.organization_id,
+			organization_uuid = excluded.organization_uuid,
 			name = excluded.name
 		returning id
 	`, workspaceID, organizationRowID).Scan(&workspaceRowID); err != nil {
@@ -1347,7 +1352,7 @@ func getDefaultDBIDs(t *testing.T, database *db.DB) defaultDBIDs {
 	if err := database.Pool.QueryRow(context.Background(), `
 		select o.uuid::text, w.id, w.uuid::text, ak.id
 		from workspaces w
-		join organizations o on o.id = w.organization_id
+		join organizations o on o.uuid = w.organization_uuid
 		join api_keys ak on ak.workspace_id = w.id
 		where w.external_id = 'workspace_default'
 			and ak.external_id = 'api_key_default'

--- a/tests/filestore_db_test.go
+++ b/tests/filestore_db_test.go
@@ -1126,15 +1126,17 @@ func seedFilestoreLookupScope(t *testing.T, app *testApp) (int64, int64, string,
 		}
 	})
 	if err := app.db.Pool.QueryRow(ctx, `
-		insert into organizations (external_id, name)
-		values ($1, $2)
+		insert into organizations (name)
+		values ($1)
 		returning id, uuid::text
-	`, "org_filestore_lookup_"+suffix, "Filestore lookup "+suffix).Scan(&organizationID, &organizationUUID); err != nil {
+	`, "Filestore lookup "+suffix).Scan(&organizationID, &organizationUUID); err != nil {
 		t.Fatalf("insert lookup organization: %v", err)
 	}
 	if err := app.db.Pool.QueryRow(ctx, `
-		insert into workspaces (external_id, organization_id, name)
-		values ($1, $2, $3)
+		insert into workspaces (external_id, organization_uuid, name)
+		select $1, uuid, $3
+		from organizations
+		where id = $2
 		returning id, uuid::text
 	`, "wrkspc_filestore_lookup_"+suffix, organizationID, "Filestore lookup "+suffix).Scan(&workspaceID, &workspaceUUID); err != nil {
 		t.Fatalf("insert lookup workspace: %v", err)

--- a/tests/platform_console_backend_api_test.go
+++ b/tests/platform_console_backend_api_test.go
@@ -1029,30 +1029,32 @@ func loadDefaultOrganizationUUID(t *testing.T, app *testApp) string {
 	if err := app.db.Pool.QueryRow(context.Background(), `
 		select o.uuid::text
 		from organizations o
-		where o.external_id = 'org_default'
+		join workspaces w on w.organization_uuid = o.uuid
+		where w.external_id = 'workspace_default'
 	`).Scan(&orgUUID); err != nil {
 		t.Fatalf("load default organization uuid: %v", err)
 	}
 	return orgUUID
 }
 
-func seedConsoleDefaultWorkspace(t *testing.T, app *testApp, orgExternalID string, workspaceExternalID string) string {
+func seedConsoleDefaultWorkspace(t *testing.T, app *testApp, organizationName string, workspaceExternalID string) string {
 	t.Helper()
 	var organizationID int64
 	var orgUUID string
 	if err := app.db.Pool.QueryRow(context.Background(), `
-		insert into organizations (external_id, name)
-		values ($1, $1)
-		on conflict (external_id) do update set name = excluded.name
+		insert into organizations (name)
+		values ($1)
 		returning id, uuid::text
-	`, orgExternalID).Scan(&organizationID, &orgUUID); err != nil {
+	`, organizationName).Scan(&organizationID, &orgUUID); err != nil {
 		t.Fatalf("seed console org: %v", err)
 	}
 	if _, err := app.db.Pool.Exec(context.Background(), `
-		insert into workspaces (external_id, organization_id, name)
-		values ($1, $2, 'default')
+		insert into workspaces (external_id, organization_uuid, name)
+		select $1, uuid, 'default'
+		from organizations
+		where id = $2
 		on conflict (external_id) do update set
-			organization_id = excluded.organization_id,
+			organization_uuid = excluded.organization_uuid,
 			name = excluded.name,
 			archived_at = null,
 			updated_at = now()

--- a/tests/platform_email_login_api_test.go
+++ b/tests/platform_email_login_api_test.go
@@ -108,7 +108,7 @@ func TestPlatformEmailLoginRoutes(t *testing.T) {
 	if err := app.db.Pool.QueryRow(context.Background(), `
 		select count(*)
 		from organizations o
-		join workspaces w on w.organization_id = o.id
+		join workspaces w on w.organization_uuid = o.uuid
 		where o.uuid::text = $1
 		  and lower(w.name) = 'default'
 		  and w.archived_at is null
@@ -348,8 +348,7 @@ func (a *testApp) ensureDefaultPlatformUser(t *testing.T, email string) {
 		with refs as (
 			select o.id as organization_id, w.id as workspace_id, w.external_id as workspace_external_id
 			from organizations o
-			join workspaces w on w.organization_id = o.id and w.external_id = 'workspace_default'
-			where o.external_id = 'org_default'
+			join workspaces w on w.organization_uuid = o.uuid and w.external_id = 'workspace_default'
 			limit 1
 		),
 		existing_user as (

--- a/tests/webhooks_api_test.go
+++ b/tests/webhooks_api_test.go
@@ -181,11 +181,11 @@ func TestWebhookEndpointDelivery(t *testing.T) {
 	enqueuer := webhooks.NewEnqueuer(app.db, app.cfg.Webhook, nil)
 	enqueue := func(eventType, resourceID string) {
 		enqueuer.Enqueue(ctx, webhooks.EnqueueInput{
-			WorkspaceID:            apiKey.WorkspaceID,
-			OrganizationExternalID: apiKey.OrganizationExternalID,
-			WorkspaceExternalID:    apiKey.WorkspaceExternalID,
-			EventType:              eventType,
-			ResourceID:             resourceID,
+			WorkspaceID:         apiKey.WorkspaceID,
+			OrganizationUUID:    apiKey.OrganizationUUID,
+			WorkspaceExternalID: apiKey.WorkspaceExternalID,
+			EventType:           eventType,
+			ResourceID:          resourceID,
 		})
 	}
 	sessionID := "sesn_webhook_endpoint_delivery"
@@ -214,14 +214,19 @@ func TestWebhookEndpointDelivery(t *testing.T) {
 	var payload struct {
 		Type string `json:"type"`
 		Data struct {
-			ID   string `json:"id"`
-			Type string `json:"type"`
+			ID             string `json:"id"`
+			OrganizationID string `json:"organization_id"`
+			Type           string `json:"type"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(delivered.Body, &payload); err != nil {
 		t.Fatalf("unmarshal delivered webhook: %v", err)
 	}
-	if event.Type != "event" || payload.Type != "event" || payload.Data.Type != "session.status_idled" || payload.Data.ID != sessionID {
+	if event.Type != "event" ||
+		payload.Type != "event" ||
+		payload.Data.Type != "session.status_idled" ||
+		payload.Data.ID != sessionID ||
+		payload.Data.OrganizationID != apiKey.OrganizationUUID {
 		t.Fatalf("unexpected webhook event=%+v payload=%+v body=%s", event, payload, delivered.Body)
 	}
 


### PR DESCRIPTION
## Summary

- Migrate workspace and organization reference handling from external IDs to UUIDs
- Add database migrations to update reference columns and remove `organization_external_id`
- Update authentication, platform services, filestore, sessions, webhooks, admin APIs, and related tests
- Expand SQLx coverage and refresh configuration and design documentation

## Testing

- Updated unit, integration, database, API, and end-to-end test coverage across affected components
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization references now consistently use stable UUIDs across administration, authentication, workspaces, sessions, and webhooks.
  * Workspace associations remain stable during database migrations.
* **Bug Fixes**
  * Improved organization scoping and authorization consistency across platform, console, filestore, and API workflows.
  * Prevented ambiguous organization matching through legacy identifiers.
* **Documentation**
  * Added guidance on stable database identifiers, migration behavior, and cross-resource references.
* **Breaking Changes**
  * Removed organization external IDs from bootstrap configuration and related API payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->