### PR TITLE
Migrate database access to sqlx and enforce UUID boundary references

### DIFF
--- a/docs/design/be/database-identifier-references.md
+++ b/docs/design/be/database-identifier-references.md
@@ -116,8 +116,29 @@ identity 静默带入新结构。PostgreSQL schema 仍不创建外键约束。
 鉴权边界只提供资源 UUID 与协议所需 external ID，不再提供 organization/workspace/API key 等资源的 bigint identity。其中 Organization Admin、Workspace Admin、Workspace API Key Admin、External Key 和 Tunnel 直接传递可信 `organization_uuid`，写入和租户过滤均使用：
 
 ```sql
-workspaces.organization_uuid = CAST(:organization_uuid AS uuid)
+workspaces.organization_uuid = :organization_uuid
 ```
+
+DB 方法需要在查询前复用、比较或序列化 UUID 时，应在方法入口通过 `parseDBUUID` 或
+`parseDBNullableUUID` 转换成 `uuid.UUID`/`uuid.NullUUID`。对于仍由兼容模型承载的字符串
+UUID，参数映射只区分 `dbUUID(value)` 和 `dbNullableUUID(pointer)` 两种 SQL 语义；统一的
+`bindNamed` 边界在调用 `sqlx.Named` 前将它们转换成标准
+`uuid.UUID`/`uuid.NullUUID`。自定义参数类型不实现 `driver.Valuer`，PostgreSQL driver
+只接收标准 typed UUID，校验错误也在 SQL 绑定前返回。
+
+sqlx 行结构同样使用 `uuid.UUID`/`uuid.NullUUID` 扫描 `uuid` 列，只有映射到 HTTP、SDK、
+事件或其他文本协议 DTO 时才调用 `String()`。因此普通查询不得通过
+`CAST(:..._uuid AS uuid)` 修复字符串输入，也不得通过 `CAST(uuid AS text) AS uuid`
+把数据库输出降级成字符串。
+
+同时兼容 external ID 与 UUID 的查询使用两个参数：原始 external ID 文本，以及由
+`tryParseDBUUIDIdentifier` 解析出的 nullable UUID；SQL 分别比较 `external_id` 和 `uuid`，
+不再对 UUID 列做文本 CAST。JSON job payload 在 Go 边界序列化，UUID 关联优先使用同一查询中
+已有的 typed UUID 参数或 PostgreSQL `to_jsonb(uuid)`。
+
+少量 UUID 到文本的转换仍属于业务表达式本身，而不是数据库类型补丁，包括：生成带前缀的
+external ID、为 advisory lock 构造稳定文本哈希、生成历史兼容的合成 user ID，以及读取 JSON
+协议字段。这些表达式不得扩散到普通 UUID 行定位、租户过滤、分页游标或行扫描。
 
 这些路径不需要返回 organization 的其他字段，因此不得仅为 bigint identity 与 UUID 互转而 JOIN `organizations`。普通 workspace API key 鉴权直接从 Workspace 的 `organization_uuid` 建立租户范围，不再 JOIN Organization 读取 identity。
 
@@ -180,6 +201,13 @@ Console 与 Workbench 的 workspace 路由仍需兼容协议 external ID 和 `de
 - deployments/session、Code Session/runtime、jobs/statistics、Console/Workbench 的跨表引用均为 UUID；
 - 目标表的应用模型、过滤条件、父子关联与稳定排序不读取 bigint identity；
 - nullable UUID 引用保留原有可空语义，必填或已有非空引用无法映射时 migration 失败；
+- DB 输入参数在 sqlx 边界校验为 typed UUID，UUID/nullable UUID 列使用
+  `uuid.UUID`/`uuid.NullUUID` 扫描，普通 SQL 不包含 UUID 输入或输出修复 CAST；
+- “external ID 或 UUID”兼容查询使用独立 nullable typed UUID 参数，不对 UUID 列转文本；
+- Auth/Admin、Admin/Console/Workbench、资源目录、Sessions/runtime、Files/Filestore 五组路径
+  都有真实 PostgreSQL 集成测试，覆盖 named binding、nullable UUID、结构体扫描、事务和分页；
+- 生产 DB 源码的回归测试拒绝重新引入 `CAST(:..._uuid AS uuid)`、UUID 输出列文本 CAST 或
+  UUID 标识符列侧文本 CAST；
 - Platform session 持久化 API key UUID，并兼容升级前缺少该字段的已登录 session；
 - 鉴权 Principal 与 Filestore Principal 不携带 bigint identity；
 - Filestore 查询不再通过 Workspace identity 反查 UUID，目录分页使用 UUID；

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -35,15 +35,24 @@ func NewService(cfg config.Config, database *db.DB) *Service {
 	return &Service{cfg: cfg, db: database}
 }
 
+func principalOrganizationUUID(principal auth.Principal) (uuid.UUID, error) {
+	organizationUUID, err := uuid.Parse(strings.TrimSpace(principal.OrganizationUUID))
+	if err != nil || organizationUUID == uuid.Nil {
+		return uuid.Nil, db.ErrNotFound
+	}
+	return organizationUUID, nil
+}
+
 func (s *Service) GetCurrentOrganization(ctx context.Context, principal auth.Principal) (organizationResponse, error) {
-	if strings.TrimSpace(principal.OrganizationUUID) == "" {
+	organizationUUID, err := principalOrganizationUUID(principal)
+	if err != nil {
 		return organizationResponse{}, mapAdminDBError(db.ErrNotFound, "Organization not found")
 	}
-	org, err := s.db.GetAdminOrganization(ctx, principal.OrganizationUUID)
+	org, err := s.db.GetAdminOrganization(ctx, organizationUUID)
 	if err != nil {
 		return organizationResponse{}, mapAdminDBError(err, "Organization not found")
 	}
-	return organizationResponse{ID: org.UUID, Name: org.Name, Type: "organization"}, nil
+	return organizationResponse{ID: org.UUID.String(), Name: org.Name, Type: "organization"}, nil
 }
 
 func (s *Service) CreateInvite(ctx context.Context, principal auth.Principal, req createInviteRequest) (inviteResponse, error) {
@@ -59,9 +68,13 @@ func (s *Service) CreateInvite(ctx context.Context, principal auth.Principal, re
 		return inviteResponse{}, err
 	}
 	now := time.Now().UTC()
+	organizationUUID, err := principalOrganizationUUID(principal)
+	if err != nil {
+		return inviteResponse{}, mapAdminDBError(db.ErrNotFound, "Organization not found")
+	}
 	invite, err := s.db.CreateAdminInvite(ctx, db.AdminInvite{
 		ExternalID:       externalID,
-		OrganizationUUID: principal.OrganizationUUID,
+		OrganizationUUID: organizationUUID,
 		Email:            email,
 		Role:             req.Role,
 		Status:           "pending",
@@ -187,10 +200,14 @@ func (s *Service) CreateWorkspace(ctx context.Context, principal auth.Principal,
 		return workspaceResponse{}, err
 	}
 	now := time.Now().UTC()
+	organizationUUID, err := principalOrganizationUUID(principal)
+	if err != nil {
+		return workspaceResponse{}, mapAdminDBError(db.ErrNotFound, "Organization not found")
+	}
 	record, err := s.db.CreateAdminWorkspace(ctx, db.AdminWorkspace{
-		UUID:             uuid.NewString(),
+		UUID:             uuid.New(),
 		ExternalID:       workspaceID,
-		OrganizationUUID: principal.OrganizationUUID,
+		OrganizationUUID: organizationUUID,
 		Name:             name,
 		CreatedAt:        now,
 		CompartmentID:    uuid.NewString(),
@@ -325,7 +342,7 @@ func (s *Service) CreateWorkspaceMember(ctx context.Context, principal auth.Prin
 	}
 	member, err := s.db.CreateAdminWorkspaceMember(ctx, db.AdminWorkspaceMember{
 		ExternalID:          memberID,
-		OrganizationUUID:    principal.OrganizationUUID,
+		OrganizationUUID:    workspace.OrganizationUUID,
 		WorkspaceUUID:       workspace.UUID,
 		WorkspaceExternalID: workspace.ExternalID,
 		UserUUID:            user.UUID,
@@ -354,7 +371,7 @@ func (s *Service) ListWorkspaceMembers(ctx context.Context, principal auth.Princ
 	}
 	records, hasMore, err := s.db.ListAdminWorkspaceMembersPage(ctx, db.ListAdminMembersParams{
 		OrganizationUUID: principal.OrganizationUUID,
-		WorkspaceUUID:    workspace.UUID,
+		WorkspaceUUID:    workspace.UUID.String(),
 		AfterID:          afterID,
 		BeforeID:         beforeID,
 		Limit:            limit,
@@ -464,9 +481,13 @@ func (s *Service) CreateExternalKey(ctx context.Context, principal auth.Principa
 		return externalKeyResponse{}, err
 	}
 	now := time.Now().UTC()
+	organizationUUID, err := principalOrganizationUUID(principal)
+	if err != nil {
+		return externalKeyResponse{}, mapAdminDBError(db.ErrNotFound, "Organization not found")
+	}
 	key, err := s.db.CreateAdminExternalKey(ctx, db.AdminExternalKey{
 		ExternalID:       externalID,
-		OrganizationUUID: principal.OrganizationUUID,
+		OrganizationUUID: organizationUUID,
 		DisplayName:      displayName,
 		Geo:              geo,
 		ProviderConfig:   providerConfig,
@@ -677,7 +698,7 @@ func (s *Service) CreateTunnelCertificate(ctx context.Context, principal auth.Pr
 	if tunnel.ArchivedAt != nil {
 		return tunnelCertificateResponse{}, conflict("Tunnel is archived")
 	}
-	count, err := s.db.CountActiveAdminTunnelCertificates(ctx, principal.OrganizationUUID, tunnel.UUID)
+	count, err := s.db.CountActiveAdminTunnelCertificates(ctx, principal.OrganizationUUID, tunnel.UUID.String())
 	if err != nil {
 		return tunnelCertificateResponse{}, err
 	}
@@ -694,7 +715,7 @@ func (s *Service) CreateTunnelCertificate(ctx context.Context, principal auth.Pr
 	}
 	cert, err := s.db.CreateAdminTunnelCertificate(ctx, db.AdminTunnelCertificate{
 		ExternalID:       certID,
-		OrganizationUUID: principal.OrganizationUUID,
+		OrganizationUUID: tunnel.OrganizationUUID,
 		TunnelUUID:       tunnel.UUID,
 		TunnelExternalID: tunnel.ExternalID,
 		CACertificatePEM: req.CACertificatePEM,
@@ -723,7 +744,7 @@ func (s *Service) ListTunnelCertificates(ctx context.Context, principal auth.Pri
 	}
 	records, hasMore, err := s.db.ListAdminTunnelCertificatesPage(ctx, db.ListAdminTunnelCertificatesParams{
 		OrganizationUUID: principal.OrganizationUUID,
-		TunnelUUID:       tunnel.UUID,
+		TunnelUUID:       tunnel.UUID.String(),
 		IncludeArchived:  includeArchived,
 		Limit:            limit,
 		Offset:           offset,

--- a/internal/api/platform_mcp_vault_auth.go
+++ b/internal/api/platform_mcp_vault_auth.go
@@ -166,7 +166,7 @@ func (s *Server) handlePlatformMCPVaultAuthStart(w http.ResponseWriter, r *http.
 		return
 	}
 
-	vault, err := s.db.GetVaultByExternalIDOrUUID(r.Context(), workspace.UUID, req.VaultID)
+	vault, err := s.db.GetVaultByExternalIDOrUUID(r.Context(), workspace.UUID.String(), req.VaultID)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			writePlatformMCPVaultAuthError(w, http.StatusNotFound, platformMCPVaultAuthVerificationRequestFailed, "")
@@ -182,7 +182,7 @@ func (s *Server) handlePlatformMCPVaultAuthStart(w http.ResponseWriter, r *http.
 	}
 
 	credentials, _, err := s.db.ListVaultCredentialsPage(r.Context(), db.ListVaultCredentialsPageParams{
-		WorkspaceUUID:   workspace.UUID,
+		WorkspaceUUID:   workspace.UUID.String(),
 		VaultExternalID: vault.ExternalID,
 		Limit:           50,
 		IncludeArchived: false,
@@ -241,7 +241,7 @@ func (s *Server) handlePlatformMCPVaultAuthStart(w http.ResponseWriter, r *http.
 		UUID:                      uuid.NewString(),
 		ExternalID:                flowID,
 		OrganizationUUID:          principal.OrganizationUUID,
-		WorkspaceUUID:             workspace.UUID,
+		WorkspaceUUID:             workspace.UUID.String(),
 		VaultUUID:                 vault.UUID,
 		VaultExternalID:           vault.ExternalID,
 		UserUUID:                  principal.UserUUID,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -447,7 +447,7 @@ func (s *Server) authenticatePlatformSession(r *http.Request) (auth.Principal, *
 	if workspace.ArchivedAt != nil {
 		return auth.Principal{}, httpapi.NewError(http.StatusForbidden, "permission_error", "Workspace is archived")
 	}
-	principal.WorkspaceUUID = workspace.UUID
+	principal.WorkspaceUUID = workspace.UUID.String()
 	principal.WorkspaceExternalID = workspace.ExternalID
 	return principal, nil
 }

--- a/internal/api/service_auth.go
+++ b/internal/api/service_auth.go
@@ -72,10 +72,10 @@ func (s *Server) authenticateWorkspaceAPIKey(r *http.Request, apiKey string) (au
 	}
 	return auth.Principal{
 		CredentialType:      auth.CredentialTypeAPIKey,
-		APIKeyUUID:          key.UUID,
+		APIKeyUUID:          key.UUID.String(),
 		APIKeyExternalID:    key.ExternalID,
-		OrganizationUUID:    key.OrganizationUUID,
-		WorkspaceUUID:       key.WorkspaceUUID,
+		OrganizationUUID:    key.OrganizationUUID.String(),
+		WorkspaceUUID:       key.WorkspaceUUID.String(),
 		WorkspaceExternalID: key.WorkspaceExternalID,
 	}, true, nil
 }

--- a/internal/db/admin.go
+++ b/internal/db/admin.go
@@ -8,18 +8,20 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type AdminOrganization struct {
-	UUID      string    `db:"uuid"`
+	UUID      uuid.UUID `db:"uuid"`
 	Name      string    `db:"name"`
 	CreatedAt time.Time `db:"created_at"`
 }
 
 type AdminInvite struct {
-	UUID             string    `db:"uuid"`
+	UUID             uuid.UUID `db:"uuid"`
 	ExternalID       string    `db:"external_id"`
-	OrganizationUUID string    `db:"organization_uuid"`
+	OrganizationUUID uuid.UUID `db:"organization_uuid"`
 	Email            string    `db:"email"`
 	Role             string    `db:"role"`
 	Status           string    `db:"status"`
@@ -28,9 +30,9 @@ type AdminInvite struct {
 }
 
 type AdminUser struct {
-	UUID             string    `db:"uuid"`
+	UUID             uuid.UUID `db:"uuid"`
 	ExternalID       string    `db:"external_id"`
-	OrganizationUUID string    `db:"organization_uuid"`
+	OrganizationUUID uuid.UUID `db:"organization_uuid"`
 	Email            string    `db:"email"`
 	Name             string    `db:"name"`
 	Role             string    `db:"role"`
@@ -38,9 +40,9 @@ type AdminUser struct {
 }
 
 type AdminWorkspace struct {
-	UUID             string          `db:"uuid"`
+	UUID             uuid.UUID       `db:"uuid"`
 	ExternalID       string          `db:"external_id"`
-	OrganizationUUID string          `db:"organization_uuid"`
+	OrganizationUUID uuid.UUID       `db:"organization_uuid"`
 	Name             string          `db:"name"`
 	CreatedAt        time.Time       `db:"created_at"`
 	UpdatedAt        time.Time       `db:"updated_at"`
@@ -53,12 +55,12 @@ type AdminWorkspace struct {
 }
 
 type AdminWorkspaceMember struct {
-	UUID                string    `db:"uuid"`
+	UUID                uuid.UUID `db:"uuid"`
 	ExternalID          string    `db:"external_id"`
-	OrganizationUUID    string    `db:"organization_uuid"`
-	WorkspaceUUID       string    `db:"workspace_uuid"`
+	OrganizationUUID    uuid.UUID `db:"organization_uuid"`
+	WorkspaceUUID       uuid.UUID `db:"workspace_uuid"`
 	WorkspaceExternalID string    `db:"workspace_external_id"`
-	UserUUID            string    `db:"user_uuid"`
+	UserUUID            uuid.UUID `db:"user_uuid"`
 	UserExternalID      string    `db:"user_external_id"`
 	WorkspaceRole       string    `db:"workspace_role"`
 	CreatedAt           time.Time `db:"created_at"`
@@ -66,24 +68,24 @@ type AdminWorkspaceMember struct {
 }
 
 type AdminAPIKey struct {
-	UUID                    string     `db:"uuid"`
-	ExternalID              string     `db:"external_id"`
-	WorkspaceUUID           string     `db:"workspace_uuid"`
-	WorkspaceExternalID     string     `db:"workspace_external_id"`
-	CreatedByUserUUID       *string    `db:"created_by_user_uuid"`
-	CreatedByUserExternalID *string    `db:"created_by_user_external_id"`
-	Name                    string     `db:"name"`
-	PartialKeyHint          string     `db:"partial_key_hint"`
-	Status                  string     `db:"status"`
-	CreatedAt               time.Time  `db:"created_at"`
-	UpdatedAt               time.Time  `db:"updated_at"`
-	ExpiresAt               *time.Time `db:"expires_at"`
+	UUID                    uuid.UUID     `db:"uuid"`
+	ExternalID              string        `db:"external_id"`
+	WorkspaceUUID           uuid.UUID     `db:"workspace_uuid"`
+	WorkspaceExternalID     string        `db:"workspace_external_id"`
+	CreatedByUserUUID       uuid.NullUUID `db:"created_by_user_uuid"`
+	CreatedByUserExternalID *string       `db:"created_by_user_external_id"`
+	Name                    string        `db:"name"`
+	PartialKeyHint          string        `db:"partial_key_hint"`
+	Status                  string        `db:"status"`
+	CreatedAt               time.Time     `db:"created_at"`
+	UpdatedAt               time.Time     `db:"updated_at"`
+	ExpiresAt               *time.Time    `db:"expires_at"`
 }
 
 type AdminExternalKey struct {
-	UUID             string          `db:"uuid"`
+	UUID             uuid.UUID       `db:"uuid"`
 	ExternalID       string          `db:"external_id"`
-	OrganizationUUID string          `db:"organization_uuid"`
+	OrganizationUUID uuid.UUID       `db:"organization_uuid"`
 	DisplayName      string          `db:"display_name"`
 	Geo              string          `db:"geo"`
 	ProviderConfig   json.RawMessage `db:"provider_config"`
@@ -92,25 +94,25 @@ type AdminExternalKey struct {
 }
 
 type AdminTunnel struct {
-	UUID                string     `db:"uuid"`
-	ExternalID          string     `db:"external_id"`
-	OrganizationUUID    string     `db:"organization_uuid"`
-	WorkspaceUUID       *string    `db:"workspace_uuid"`
-	WorkspaceExternalID *string    `db:"workspace_external_id"`
-	DisplayName         *string    `db:"display_name"`
-	Domain              string     `db:"domain"`
-	TokenID             *string    `db:"token_id"`
-	TunnelToken         *string    `db:"tunnel_token"`
-	CreatedAt           time.Time  `db:"created_at"`
-	UpdatedAt           time.Time  `db:"updated_at"`
-	ArchivedAt          *time.Time `db:"archived_at"`
+	UUID                uuid.UUID     `db:"uuid"`
+	ExternalID          string        `db:"external_id"`
+	OrganizationUUID    uuid.UUID     `db:"organization_uuid"`
+	WorkspaceUUID       uuid.NullUUID `db:"workspace_uuid"`
+	WorkspaceExternalID *string       `db:"workspace_external_id"`
+	DisplayName         *string       `db:"display_name"`
+	Domain              string        `db:"domain"`
+	TokenID             *string       `db:"token_id"`
+	TunnelToken         *string       `db:"tunnel_token"`
+	CreatedAt           time.Time     `db:"created_at"`
+	UpdatedAt           time.Time     `db:"updated_at"`
+	ArchivedAt          *time.Time    `db:"archived_at"`
 }
 
 type AdminTunnelCertificate struct {
-	UUID             string     `db:"uuid"`
+	UUID             uuid.UUID  `db:"uuid"`
 	ExternalID       string     `db:"external_id"`
-	OrganizationUUID string     `db:"organization_uuid"`
-	TunnelUUID       string     `db:"tunnel_uuid"`
+	OrganizationUUID uuid.UUID  `db:"organization_uuid"`
+	TunnelUUID       uuid.UUID  `db:"tunnel_uuid"`
 	TunnelExternalID string     `db:"tunnel_external_id"`
 	CACertificatePEM string     `db:"ca_certificate_pem"`
 	Fingerprint      string     `db:"fingerprint"`
@@ -121,7 +123,7 @@ type AdminTunnelCertificate struct {
 
 type AdminCursor struct {
 	CreatedAt time.Time `db:"created_at"`
-	UUID      string    `db:"uuid"`
+	UUID      uuid.UUID `db:"uuid"`
 }
 
 type ListAdminInvitesParams struct {
@@ -189,19 +191,19 @@ type ListAdminTunnelCertificatesParams struct {
 
 const (
 	getAdminOrganizationQuery = `
-		select CAST(uuid AS text) as uuid, name, created_at
+		select uuid, name, created_at
 		from organizations
-		where uuid = CAST(:organization_uuid AS uuid)
+		where uuid = :organization_uuid
 	`
 	countAdminExternalKeyWorkspaceRefsQuery = `
 		select count(*)
 		from workspaces
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and external_key_id = :external_id
 	`
 )
 
-func (d *DB) GetAdminOrganization(ctx context.Context, organizationUUID string) (AdminOrganization, error) {
+func (d *DB) GetAdminOrganization(ctx context.Context, organizationUUID uuid.UUID) (AdminOrganization, error) {
 	return getAdminRow[AdminOrganization](ctx, d.sql, getAdminOrganizationQuery, map[string]any{
 		"organization_uuid": organizationUUID,
 	})
@@ -213,10 +215,10 @@ func (d *DB) CreateAdminInvite(ctx context.Context, invite AdminInvite) (AdminIn
 			external_id, organization_uuid, email, role, status, invited_at, expires_at
 		)
 		values (
-			:external_id, CAST(:organization_uuid AS uuid), :email, :role, :status, :invited_at, :expires_at
+			:external_id, :organization_uuid, :email, :role, :status, :invited_at, :expires_at
 		)
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
+		returning uuid, external_id,
+			organization_uuid,
 			email, role, status, invited_at, expires_at
 	`, adminInviteArguments(invite))
 	if isUniqueViolation(err) {
@@ -227,8 +229,8 @@ func (d *DB) CreateAdminInvite(ctx context.Context, invite AdminInvite) (AdminIn
 
 func (d *DB) GetAdminInvite(ctx context.Context, organizationUUID, externalID string) (AdminInvite, error) {
 	return getAdminRow[AdminInvite](ctx, d.sql, adminInviteSelectSQL()+`
-		where organization_uuid = CAST(:organization_uuid AS uuid) and external_id = :external_id
-	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
+		where organization_uuid = :organization_uuid and external_id = :external_id
+	`, map[string]any{"organization_uuid": dbUUID(organizationUUID), "external_id": externalID})
 }
 
 func (d *DB) ListAdminInvitesPage(ctx context.Context, params ListAdminInvitesParams) ([]AdminInvite, bool, error) {
@@ -237,8 +239,8 @@ func (d *DB) ListAdminInvitesPage(ctx context.Context, params ListAdminInvitesPa
 		ctx,
 		"organization_invites",
 		"invited_at",
-		"organization_uuid = CAST(:organization_uuid AS uuid) and external_id = :cursor_external_id",
-		map[string]any{"organization_uuid": params.OrganizationUUID, "cursor_external_id": cursorID},
+		"organization_uuid = :organization_uuid and external_id = :cursor_external_id",
+		map[string]any{"organization_uuid": dbUUID(params.OrganizationUUID), "cursor_external_id": cursorID},
 		cursorID,
 	)
 	if err != nil {
@@ -247,8 +249,8 @@ func (d *DB) ListAdminInvitesPage(ctx context.Context, params ListAdminInvitesPa
 	if (params.AfterID != "" || params.BeforeID != "") && !cursorOK {
 		return nil, false, nil
 	}
-	query := adminInviteSelectSQL() + ` where organization_uuid = CAST(:organization_uuid AS uuid)`
-	args := map[string]any{"organization_uuid": params.OrganizationUUID, "limit": params.Limit + 1}
+	query := adminInviteSelectSQL() + ` where organization_uuid = :organization_uuid`
+	args := map[string]any{"organization_uuid": dbUUID(params.OrganizationUUID), "limit": params.Limit + 1}
 	query = appendCursorFilter(query, args, "invited_at", params.AfterID, params.BeforeID, cursor)
 	query += " order by invited_at desc, uuid desc limit :limit"
 	invites, err := selectAdminRows[AdminInvite](ctx, d.sql, query, args)
@@ -263,18 +265,18 @@ func (d *DB) DeleteAdminInvite(ctx context.Context, organizationUUID, externalID
 		update organization_invites
 		set status = 'deleted',
 			deleted_at = coalesce(deleted_at, now())
-		where organization_uuid = CAST(:organization_uuid AS uuid) and external_id = :external_id
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
+		where organization_uuid = :organization_uuid and external_id = :external_id
+		returning uuid, external_id,
+			organization_uuid,
 			email, role, status, invited_at, expires_at
-	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
+	`, map[string]any{"organization_uuid": dbUUID(organizationUUID), "external_id": externalID})
 }
 
 func (d *DB) GetAdminUser(ctx context.Context, organizationUUID, externalID string) (AdminUser, error) {
 	return getAdminRow[AdminUser](ctx, d.sql, adminUserSelectSQL()+`
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and external_id = :external_id and deleted_at is null
-	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
+	`, map[string]any{"organization_uuid": dbUUID(organizationUUID), "external_id": externalID})
 }
 
 func (d *DB) ListAdminUsersPage(ctx context.Context, params ListAdminUsersParams) ([]AdminUser, bool, error) {
@@ -283,8 +285,8 @@ func (d *DB) ListAdminUsersPage(ctx context.Context, params ListAdminUsersParams
 		ctx,
 		"users",
 		"added_at",
-		"organization_uuid = CAST(:organization_uuid AS uuid) and external_id = :cursor_external_id and deleted_at is null",
-		map[string]any{"organization_uuid": params.OrganizationUUID, "cursor_external_id": cursorID},
+		"organization_uuid = :organization_uuid and external_id = :cursor_external_id and deleted_at is null",
+		map[string]any{"organization_uuid": dbUUID(params.OrganizationUUID), "cursor_external_id": cursorID},
 		cursorID,
 	)
 	if err != nil {
@@ -294,9 +296,9 @@ func (d *DB) ListAdminUsersPage(ctx context.Context, params ListAdminUsersParams
 		return nil, false, nil
 	}
 	query := adminUserSelectSQL() + `
-		where organization_uuid = CAST(:organization_uuid AS uuid) and deleted_at is null
+		where organization_uuid = :organization_uuid and deleted_at is null
 	`
-	args := map[string]any{"organization_uuid": params.OrganizationUUID, "limit": params.Limit + 1}
+	args := map[string]any{"organization_uuid": dbUUID(params.OrganizationUUID), "limit": params.Limit + 1}
 	if params.Email != "" {
 		query += " and lower(email) = lower(:email)"
 		args["email"] = params.Email
@@ -315,12 +317,12 @@ func (d *DB) UpdateAdminUserRole(ctx context.Context, organizationUUID, external
 		update users
 		set role = :role,
 			updated_at = now()
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and external_id = :external_id and deleted_at is null
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
+		returning uuid, external_id,
+			organization_uuid,
 			email, name, role, added_at
-	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID, "role": role})
+	`, map[string]any{"organization_uuid": dbUUID(organizationUUID), "external_id": externalID, "role": role})
 }
 
 func (d *DB) DeleteAdminUser(ctx context.Context, organizationUUID, externalID string) (AdminUser, error) {
@@ -329,28 +331,29 @@ func (d *DB) DeleteAdminUser(ctx context.Context, organizationUUID, externalID s
 		return AdminUser{}, err
 	}
 	defer tx.Rollback()
-	args := map[string]any{"organization_uuid": organizationUUID, "external_id": externalID}
+	args := map[string]any{"organization_uuid": dbUUID(organizationUUID), "external_id": externalID}
 	user, err := getAdminRow[AdminUser](ctx, tx, `
 		update users
 		set deleted_at = coalesce(deleted_at, now()),
 			updated_at = now()
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and external_id = :external_id and deleted_at is null
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
+		returning uuid, external_id,
+			organization_uuid,
 			email, name, role, added_at
 	`, args)
 	if err != nil {
 		return AdminUser{}, err
 	}
+	args["user_uuid"] = user.UUID
 	if _, err := namedExecContext(ctx, tx, `
 		update workspace_members
 		set deleted_at = coalesce(deleted_at, now()),
 			updated_at = now()
-		where organization_uuid = CAST(:organization_uuid AS uuid)
-			and user_uuid = CAST(:user_uuid AS uuid)
+		where organization_uuid = :organization_uuid
+			and user_uuid = :user_uuid
 			and deleted_at is null
-	`, map[string]any{"organization_uuid": organizationUUID, "user_uuid": user.UUID}); err != nil {
+	`, args); err != nil {
 		return AdminUser{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -366,11 +369,11 @@ func (d *DB) CreateAdminWorkspace(ctx context.Context, workspace AdminWorkspace)
 			compartment_id, display_color, data_residency, external_key_id, tags
 		)
 		values (
-			:uuid, :external_id, CAST(:organization_uuid AS uuid), :name, :created_at, :created_at,
+			:uuid, :external_id, :organization_uuid, :name, :created_at, :created_at,
 			:compartment_id, :display_color, CAST(:data_residency AS jsonb), :external_key_id, CAST(:tags AS jsonb)
 		)
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid, name, created_at, updated_at,
+		returning uuid, external_id,
+			organization_uuid, name, created_at, updated_at,
 			archived_at, compartment_id, display_color, data_residency, external_key_id, tags
 	`, adminWorkspaceArguments(workspace))
 	if isUniqueViolation(err) {
@@ -381,9 +384,13 @@ func (d *DB) CreateAdminWorkspace(ctx context.Context, workspace AdminWorkspace)
 
 func (d *DB) GetAdminWorkspace(ctx context.Context, organizationUUID, externalID string) (AdminWorkspace, error) {
 	return getAdminRow[AdminWorkspace](ctx, d.sql, adminWorkspaceSelectSQL()+`
-		where w.organization_uuid = CAST(:organization_uuid AS uuid)
-			and (w.external_id = :external_id or CAST(w.uuid AS text) = :external_id)
-	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
+		where w.organization_uuid = :organization_uuid
+			and (w.external_id = :external_id or w.uuid = :workspace_uuid)
+	`, map[string]any{
+		"organization_uuid": dbUUID(organizationUUID),
+		"external_id":       externalID,
+		"workspace_uuid":    tryParseDBUUIDIdentifier(externalID),
+	})
 }
 
 func (d *DB) ListAdminWorkspacesPage(ctx context.Context, params ListAdminWorkspacesParams) ([]AdminWorkspace, bool, error) {
@@ -392,8 +399,8 @@ func (d *DB) ListAdminWorkspacesPage(ctx context.Context, params ListAdminWorksp
 		ctx,
 		"workspaces",
 		"created_at",
-		"organization_uuid = CAST(:organization_uuid AS uuid) and external_id = :cursor_external_id",
-		map[string]any{"organization_uuid": params.OrganizationUUID, "cursor_external_id": cursorID},
+		"organization_uuid = :organization_uuid and external_id = :cursor_external_id",
+		map[string]any{"organization_uuid": dbUUID(params.OrganizationUUID), "cursor_external_id": cursorID},
 		cursorID,
 	)
 	if err != nil {
@@ -402,8 +409,8 @@ func (d *DB) ListAdminWorkspacesPage(ctx context.Context, params ListAdminWorksp
 	if (params.AfterID != "" || params.BeforeID != "") && !cursorOK {
 		return nil, false, nil
 	}
-	query := adminWorkspaceSelectSQL() + ` where w.organization_uuid = CAST(:organization_uuid AS uuid)`
-	args := map[string]any{"organization_uuid": params.OrganizationUUID, "limit": params.Limit + 1}
+	query := adminWorkspaceSelectSQL() + ` where w.organization_uuid = :organization_uuid`
+	args := map[string]any{"organization_uuid": dbUUID(params.OrganizationUUID), "limit": params.Limit + 1}
 	if !params.IncludeArchived {
 		query += " and w.archived_at is null"
 	}
@@ -418,7 +425,7 @@ func (d *DB) ListAdminWorkspacesPage(ctx context.Context, params ListAdminWorksp
 
 func (d *DB) UpdateAdminWorkspace(ctx context.Context, organizationUUID, externalID string, next AdminWorkspace) (AdminWorkspace, error) {
 	args := adminWorkspaceArguments(next)
-	args["organization_uuid"] = organizationUUID
+	args["organization_uuid"] = dbUUID(organizationUUID)
 	args["external_id"] = externalID
 	updated, err := getAdminRow[AdminWorkspace](ctx, d.sql, `
 		update workspaces
@@ -427,10 +434,10 @@ func (d *DB) UpdateAdminWorkspace(ctx context.Context, organizationUUID, externa
 			external_key_id = :external_key_id,
 			tags = CAST(:tags AS jsonb),
 			updated_at = :updated_at
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and external_id = :external_id
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid, name, created_at, updated_at,
+		returning uuid, external_id,
+			organization_uuid, name, created_at, updated_at,
 			archived_at, compartment_id, display_color, data_residency, external_key_id, tags
 	`, args)
 	if isUniqueViolation(err) {
@@ -444,12 +451,12 @@ func (d *DB) ArchiveAdminWorkspace(ctx context.Context, organizationUUID, extern
 		update workspaces
 		set archived_at = coalesce(archived_at, now()),
 			updated_at = now()
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and external_id = :external_id
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid, name, created_at, updated_at,
+		returning uuid, external_id,
+			organization_uuid, name, created_at, updated_at,
 			archived_at, compartment_id, display_color, data_residency, external_key_id, tags
-	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
+	`, map[string]any{"organization_uuid": dbUUID(organizationUUID), "external_id": externalID})
 }
 
 func (d *DB) CreateAdminWorkspaceMember(ctx context.Context, member AdminWorkspaceMember) (AdminWorkspaceMember, error) {
@@ -459,14 +466,14 @@ func (d *DB) CreateAdminWorkspaceMember(ctx context.Context, member AdminWorkspa
 			user_uuid, user_external_id, workspace_role, created_at, updated_at
 		)
 		values (
-			:external_id, CAST(:organization_uuid AS uuid), CAST(:workspace_uuid AS uuid),
-			:workspace_external_id, CAST(:user_uuid AS uuid), :user_external_id,
+			:external_id, :organization_uuid, :workspace_uuid,
+			:workspace_external_id, :user_uuid, :user_external_id,
 			:workspace_role, :created_at, :created_at
 		)
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
-			CAST(workspace_uuid AS text) as workspace_uuid, workspace_external_id,
-			CAST(user_uuid AS text) as user_uuid, user_external_id,
+		returning uuid, external_id,
+			organization_uuid,
+			workspace_uuid, workspace_external_id,
+			user_uuid, user_external_id,
 			workspace_role, created_at, updated_at
 	`, adminWorkspaceMemberArguments(member))
 	if isUniqueViolation(err) {
@@ -477,12 +484,12 @@ func (d *DB) CreateAdminWorkspaceMember(ctx context.Context, member AdminWorkspa
 
 func (d *DB) GetAdminWorkspaceMember(ctx context.Context, organizationUUID, workspaceExternalID, userExternalID string) (AdminWorkspaceMember, error) {
 	return getAdminRow[AdminWorkspaceMember](ctx, d.sql, adminWorkspaceMemberSelectSQL()+`
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and workspace_external_id = :workspace_external_id
 			and user_external_id = :user_external_id
 			and deleted_at is null
 	`, map[string]any{
-		"organization_uuid":     organizationUUID,
+		"organization_uuid":     dbUUID(organizationUUID),
 		"workspace_external_id": workspaceExternalID,
 		"user_external_id":      userExternalID,
 	})
@@ -494,8 +501,8 @@ func (d *DB) ListAdminWorkspaceMembersPage(ctx context.Context, params ListAdmin
 		ctx,
 		"workspace_members",
 		"created_at",
-		"workspace_uuid = CAST(:workspace_uuid AS uuid) and user_external_id = :cursor_external_id and deleted_at is null",
-		map[string]any{"workspace_uuid": params.WorkspaceUUID, "cursor_external_id": cursorID},
+		"workspace_uuid = :workspace_uuid and user_external_id = :cursor_external_id and deleted_at is null",
+		map[string]any{"workspace_uuid": dbUUID(params.WorkspaceUUID), "cursor_external_id": cursorID},
 		cursorID,
 	)
 	if err != nil {
@@ -505,13 +512,13 @@ func (d *DB) ListAdminWorkspaceMembersPage(ctx context.Context, params ListAdmin
 		return nil, false, nil
 	}
 	query := adminWorkspaceMemberSelectSQL() + `
-		where organization_uuid = CAST(:organization_uuid AS uuid)
-			and workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where organization_uuid = :organization_uuid
+			and workspace_uuid = :workspace_uuid
 			and deleted_at is null
 	`
 	args := map[string]any{
-		"organization_uuid": params.OrganizationUUID,
-		"workspace_uuid":    params.WorkspaceUUID,
+		"organization_uuid": dbUUID(params.OrganizationUUID),
+		"workspace_uuid":    dbUUID(params.WorkspaceUUID),
 		"limit":             params.Limit + 1,
 	}
 	query = appendCursorFilter(query, args, "created_at", params.AfterID, params.BeforeID, cursor)
@@ -528,17 +535,17 @@ func (d *DB) UpdateAdminWorkspaceMember(ctx context.Context, organizationUUID, w
 		update workspace_members
 		set workspace_role = :workspace_role,
 			updated_at = now()
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and workspace_external_id = :workspace_external_id
 			and user_external_id = :user_external_id
 			and deleted_at is null
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
-			CAST(workspace_uuid AS text) as workspace_uuid, workspace_external_id,
-			CAST(user_uuid AS text) as user_uuid, user_external_id,
+		returning uuid, external_id,
+			organization_uuid,
+			workspace_uuid, workspace_external_id,
+			user_uuid, user_external_id,
 			workspace_role, created_at, updated_at
 	`, map[string]any{
-		"organization_uuid":     organizationUUID,
+		"organization_uuid":     dbUUID(organizationUUID),
 		"workspace_external_id": workspaceExternalID,
 		"user_external_id":      userExternalID,
 		"workspace_role":        role,
@@ -550,17 +557,17 @@ func (d *DB) DeleteAdminWorkspaceMember(ctx context.Context, organizationUUID, w
 		update workspace_members
 		set deleted_at = coalesce(deleted_at, now()),
 			updated_at = now()
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and workspace_external_id = :workspace_external_id
 			and user_external_id = :user_external_id
 			and deleted_at is null
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
-			CAST(workspace_uuid AS text) as workspace_uuid, workspace_external_id,
-			CAST(user_uuid AS text) as user_uuid, user_external_id,
+		returning uuid, external_id,
+			organization_uuid,
+			workspace_uuid, workspace_external_id,
+			user_uuid, user_external_id,
 			workspace_role, created_at, updated_at
 	`, map[string]any{
-		"organization_uuid":     organizationUUID,
+		"organization_uuid":     dbUUID(organizationUUID),
 		"workspace_external_id": workspaceExternalID,
 		"user_external_id":      userExternalID,
 	})
@@ -568,9 +575,9 @@ func (d *DB) DeleteAdminWorkspaceMember(ctx context.Context, organizationUUID, w
 
 func (d *DB) GetAdminAPIKey(ctx context.Context, organizationUUID, externalID string) (AdminAPIKey, error) {
 	return getAdminRow[AdminAPIKey](ctx, d.sql, adminAPIKeySelectSQL()+`
-		where w.organization_uuid = CAST(:organization_uuid AS uuid)
+		where w.organization_uuid = :organization_uuid
 			and ak.external_id = :external_id
-	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
+	`, map[string]any{"organization_uuid": dbUUID(organizationUUID), "external_id": externalID})
 }
 
 func (d *DB) ListAdminAPIKeysPage(ctx context.Context, params ListAdminAPIKeysParams) ([]AdminAPIKey, bool, error) {
@@ -589,8 +596,8 @@ func (d *DB) ListAdminAPIKeysPage(ctx context.Context, params ListAdminAPIKeysPa
 	if (params.AfterID != "" || params.BeforeID != "") && !cursorOK {
 		return nil, false, nil
 	}
-	query := adminAPIKeySelectSQL() + ` where w.organization_uuid = CAST(:organization_uuid AS uuid)`
-	args := map[string]any{"organization_uuid": params.OrganizationUUID, "limit": params.Limit + 1}
+	query := adminAPIKeySelectSQL() + ` where w.organization_uuid = :organization_uuid`
+	args := map[string]any{"organization_uuid": dbUUID(params.OrganizationUUID), "limit": params.Limit + 1}
 	if params.WorkspaceExternalID != "" {
 		query += " and w.external_id = :workspace_external_id"
 		args["workspace_external_id"] = params.WorkspaceExternalID
@@ -621,11 +628,11 @@ func (d *DB) UpdateAdminAPIKey(ctx context.Context, organizationUUID, externalID
 				updated_at = now()
 			from workspaces w
 			where ak.workspace_uuid = w.uuid
-				and w.organization_uuid = CAST(:organization_uuid AS uuid)
+				and w.organization_uuid = :organization_uuid
 				and ak.external_id = :external_id
-			returning CAST(ak.uuid AS text) as uuid, ak.external_id,
-				CAST(ak.workspace_uuid AS text) as workspace_uuid,
-				CAST(ak.created_by_user_uuid AS text) as created_by_user_uuid,
+			returning ak.uuid, ak.external_id,
+				ak.workspace_uuid,
+				ak.created_by_user_uuid,
 				ak.name, ak.partial_key_hint, ak.status, ak.created_at, ak.updated_at, ak.expires_at
 		)
 		select ak.uuid, ak.external_id, ak.workspace_uuid,
@@ -634,10 +641,10 @@ func (d *DB) UpdateAdminAPIKey(ctx context.Context, organizationUUID, externalID
 			u.external_id as created_by_user_external_id,
 			ak.name, ak.partial_key_hint, ak.status, ak.created_at, ak.updated_at, ak.expires_at
 		from updated ak
-		join workspaces w on CAST(w.uuid AS text) = ak.workspace_uuid
-		left join users u on CAST(u.uuid AS text) = ak.created_by_user_uuid
+		join workspaces w on w.uuid = ak.workspace_uuid
+		left join users u on u.uuid = ak.created_by_user_uuid
 	`, map[string]any{
-		"organization_uuid": organizationUUID,
+		"organization_uuid": dbUUID(organizationUUID),
 		"external_id":       externalID,
 		"set_name":          setName,
 		"name":              name,
@@ -652,11 +659,11 @@ func (d *DB) CreateAdminExternalKey(ctx context.Context, key AdminExternalKey) (
 			external_id, organization_uuid, display_name, geo, provider_config, created_at, updated_at
 		)
 		values (
-			:external_id, CAST(:organization_uuid AS uuid), :display_name, :geo,
+			:external_id, :organization_uuid, :display_name, :geo,
 			CAST(:provider_config AS jsonb), :created_at, :created_at
 		)
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
+		returning uuid, external_id,
+			organization_uuid,
 			display_name, geo, provider_config, created_at, updated_at
 	`, adminExternalKeyArguments(key))
 	if isUniqueViolation(err) {
@@ -667,18 +674,18 @@ func (d *DB) CreateAdminExternalKey(ctx context.Context, key AdminExternalKey) (
 
 func (d *DB) GetAdminExternalKey(ctx context.Context, organizationUUID, externalID string) (AdminExternalKey, error) {
 	return getAdminRow[AdminExternalKey](ctx, d.sql, adminExternalKeySelectSQL()+`
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and external_id = :external_id and deleted_at is null
-	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
+	`, map[string]any{"organization_uuid": dbUUID(organizationUUID), "external_id": externalID})
 }
 
 func (d *DB) ListAdminExternalKeysPage(ctx context.Context, params ListAdminExternalKeysParams) ([]AdminExternalKey, bool, error) {
 	keys, err := selectAdminRows[AdminExternalKey](ctx, d.sql, adminExternalKeySelectSQL()+`
-		where organization_uuid = CAST(:organization_uuid AS uuid) and deleted_at is null
+		where organization_uuid = :organization_uuid and deleted_at is null
 		order by created_at desc, uuid desc
 		limit :limit offset :offset
 	`, map[string]any{
-		"organization_uuid": params.OrganizationUUID,
+		"organization_uuid": dbUUID(params.OrganizationUUID),
 		"limit":             params.Limit + 1,
 		"offset":            params.Offset,
 	})
@@ -690,7 +697,7 @@ func (d *DB) ListAdminExternalKeysPage(ctx context.Context, params ListAdminExte
 
 func (d *DB) UpdateAdminExternalKey(ctx context.Context, organizationUUID, externalID string, next AdminExternalKey) (AdminExternalKey, error) {
 	args := adminExternalKeyArguments(next)
-	args["organization_uuid"] = organizationUUID
+	args["organization_uuid"] = dbUUID(organizationUUID)
 	args["external_id"] = externalID
 	return getAdminRow[AdminExternalKey](ctx, d.sql, `
 		update external_keys
@@ -698,10 +705,10 @@ func (d *DB) UpdateAdminExternalKey(ctx context.Context, organizationUUID, exter
 			geo = :geo,
 			provider_config = CAST(:provider_config AS jsonb),
 			updated_at = :updated_at
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and external_id = :external_id and deleted_at is null
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
+		returning uuid, external_id,
+			organization_uuid,
 			display_name, geo, provider_config, created_at, updated_at
 	`, args)
 }
@@ -711,9 +718,9 @@ func (d *DB) DeleteAdminExternalKey(ctx context.Context, organizationUUID, exter
 		update external_keys
 		set deleted_at = coalesce(deleted_at, now()),
 			updated_at = now()
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and external_id = :external_id and deleted_at is null
-	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
+	`, map[string]any{"organization_uuid": dbUUID(organizationUUID), "external_id": externalID})
 	if err != nil {
 		return err
 	}
@@ -726,7 +733,7 @@ func (d *DB) DeleteAdminExternalKey(ctx context.Context, organizationUUID, exter
 func (d *DB) CountAdminExternalKeyWorkspaceRefs(ctx context.Context, organizationUUID, externalID string) (int, error) {
 	var count int
 	err := namedGetContext(ctx, d.sql, &count, countAdminExternalKeyWorkspaceRefsQuery, map[string]any{
-		"organization_uuid": organizationUUID,
+		"organization_uuid": dbUUID(organizationUUID),
 		"external_id":       externalID,
 	})
 	return count, err
@@ -734,14 +741,14 @@ func (d *DB) CountAdminExternalKeyWorkspaceRefs(ctx context.Context, organizatio
 
 func (d *DB) GetAdminTunnel(ctx context.Context, organizationUUID, externalID string) (AdminTunnel, error) {
 	return getAdminRow[AdminTunnel](ctx, d.sql, adminTunnelSelectSQL()+`
-		where organization_uuid = CAST(:organization_uuid AS uuid) and external_id = :external_id
-	`, map[string]any{"organization_uuid": organizationUUID, "external_id": externalID})
+		where organization_uuid = :organization_uuid and external_id = :external_id
+	`, map[string]any{"organization_uuid": dbUUID(organizationUUID), "external_id": externalID})
 }
 
 func (d *DB) ListAdminTunnelsPage(ctx context.Context, params ListAdminTunnelsParams) ([]AdminTunnel, bool, error) {
-	query := adminTunnelSelectSQL() + ` where organization_uuid = CAST(:organization_uuid AS uuid)`
+	query := adminTunnelSelectSQL() + ` where organization_uuid = :organization_uuid`
 	args := map[string]any{
-		"organization_uuid": params.OrganizationUUID,
+		"organization_uuid": dbUUID(params.OrganizationUUID),
 		"limit":             params.Limit + 1,
 		"offset":            params.Offset,
 	}
@@ -766,13 +773,13 @@ func (d *DB) SetAdminTunnelToken(ctx context.Context, organizationUUID, external
 		set token_id = :token_id,
 			tunnel_token = :tunnel_token,
 			updated_at = now()
-		where organization_uuid = CAST(:organization_uuid AS uuid) and external_id = :external_id and archived_at is null
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
-			CAST(workspace_uuid AS text) as workspace_uuid, workspace_external_id,
+		where organization_uuid = :organization_uuid and external_id = :external_id and archived_at is null
+		returning uuid, external_id,
+			organization_uuid,
+			workspace_uuid, workspace_external_id,
 			display_name, domain, token_id, tunnel_token, created_at, updated_at, archived_at
 	`, map[string]any{
-		"organization_uuid": organizationUUID,
+		"organization_uuid": dbUUID(organizationUUID),
 		"external_id":       externalID,
 		"token_id":          tokenID,
 		"tunnel_token":      token,
@@ -785,17 +792,17 @@ func (d *DB) ArchiveAdminTunnel(ctx context.Context, organizationUUID, externalI
 		return AdminTunnel{}, err
 	}
 	defer tx.Rollback()
-	args := map[string]any{"organization_uuid": organizationUUID, "external_id": externalID}
+	args := map[string]any{"organization_uuid": dbUUID(organizationUUID), "external_id": externalID}
 	tunnel, err := getAdminRow[AdminTunnel](ctx, tx, `
 		update mcp_tunnels
 		set archived_at = coalesce(archived_at, now()),
 			token_id = null,
 			tunnel_token = null,
 			updated_at = now()
-		where organization_uuid = CAST(:organization_uuid AS uuid) and external_id = :external_id
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
-			CAST(workspace_uuid AS text) as workspace_uuid, workspace_external_id,
+		where organization_uuid = :organization_uuid and external_id = :external_id
+		returning uuid, external_id,
+			organization_uuid,
+			workspace_uuid, workspace_external_id,
 			display_name, domain, token_id, tunnel_token, created_at, updated_at, archived_at
 	`, args)
 	if err != nil {
@@ -805,8 +812,8 @@ func (d *DB) ArchiveAdminTunnel(ctx context.Context, organizationUUID, externalI
 	if _, err := namedExecContext(ctx, tx, `
 		update mcp_tunnel_certificates
 		set archived_at = coalesce(archived_at, now())
-		where organization_uuid = CAST(:organization_uuid AS uuid)
-			and tunnel_uuid = CAST(:tunnel_uuid AS uuid)
+		where organization_uuid = :organization_uuid
+			and tunnel_uuid = :tunnel_uuid
 			and archived_at is null
 	`, args); err != nil {
 		return AdminTunnel{}, err
@@ -824,12 +831,12 @@ func (d *DB) CreateAdminTunnelCertificate(ctx context.Context, cert AdminTunnelC
 			ca_certificate_pem, fingerprint, expires_at, created_at
 		)
 		values (
-			:external_id, CAST(:organization_uuid AS uuid), CAST(:tunnel_uuid AS uuid), :tunnel_external_id,
+			:external_id, :organization_uuid, :tunnel_uuid, :tunnel_external_id,
 			:ca_certificate_pem, :fingerprint, :expires_at, :created_at
 		)
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
-			CAST(tunnel_uuid AS text) as tunnel_uuid, tunnel_external_id,
+		returning uuid, external_id,
+			organization_uuid,
+			tunnel_uuid, tunnel_external_id,
 			ca_certificate_pem, fingerprint, expires_at, created_at, archived_at
 	`, adminTunnelCertificateArguments(cert))
 	if isUniqueViolation(err) {
@@ -840,11 +847,11 @@ func (d *DB) CreateAdminTunnelCertificate(ctx context.Context, cert AdminTunnelC
 
 func (d *DB) GetAdminTunnelCertificate(ctx context.Context, organizationUUID, tunnelExternalID, certExternalID string) (AdminTunnelCertificate, error) {
 	return getAdminRow[AdminTunnelCertificate](ctx, d.sql, adminTunnelCertificateSelectSQL()+`
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and tunnel_external_id = :tunnel_external_id
 			and external_id = :external_id
 	`, map[string]any{
-		"organization_uuid":  organizationUUID,
+		"organization_uuid":  dbUUID(organizationUUID),
 		"tunnel_external_id": tunnelExternalID,
 		"external_id":        certExternalID,
 	})
@@ -852,12 +859,12 @@ func (d *DB) GetAdminTunnelCertificate(ctx context.Context, organizationUUID, tu
 
 func (d *DB) ListAdminTunnelCertificatesPage(ctx context.Context, params ListAdminTunnelCertificatesParams) ([]AdminTunnelCertificate, bool, error) {
 	query := adminTunnelCertificateSelectSQL() + `
-		where organization_uuid = CAST(:organization_uuid AS uuid)
-			and tunnel_uuid = CAST(:tunnel_uuid AS uuid)
+		where organization_uuid = :organization_uuid
+			and tunnel_uuid = :tunnel_uuid
 	`
 	args := map[string]any{
-		"organization_uuid": params.OrganizationUUID,
-		"tunnel_uuid":       params.TunnelUUID,
+		"organization_uuid": dbUUID(params.OrganizationUUID),
+		"tunnel_uuid":       dbUUID(params.TunnelUUID),
 		"limit":             params.Limit + 1,
 		"offset":            params.Offset,
 	}
@@ -876,15 +883,15 @@ func (d *DB) ArchiveAdminTunnelCertificate(ctx context.Context, organizationUUID
 	return getAdminRow[AdminTunnelCertificate](ctx, d.sql, `
 		update mcp_tunnel_certificates
 		set archived_at = coalesce(archived_at, now())
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 			and tunnel_external_id = :tunnel_external_id
 			and external_id = :external_id
-		returning CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
-			CAST(tunnel_uuid AS text) as tunnel_uuid, tunnel_external_id,
+		returning uuid, external_id,
+			organization_uuid,
+			tunnel_uuid, tunnel_external_id,
 			ca_certificate_pem, fingerprint, expires_at, created_at, archived_at
 	`, map[string]any{
-		"organization_uuid":  organizationUUID,
+		"organization_uuid":  dbUUID(organizationUUID),
 		"tunnel_external_id": tunnelExternalID,
 		"external_id":        certExternalID,
 	})
@@ -895,10 +902,13 @@ func (d *DB) CountActiveAdminTunnelCertificates(ctx context.Context, organizatio
 	err := namedGetContext(ctx, d.sql, &count, `
 		select count(*)
 		from mcp_tunnel_certificates
-		where organization_uuid = CAST(:organization_uuid AS uuid)
-			and tunnel_uuid = CAST(:tunnel_uuid AS uuid)
+		where organization_uuid = :organization_uuid
+			and tunnel_uuid = :tunnel_uuid
 			and archived_at is null
-	`, map[string]any{"organization_uuid": organizationUUID, "tunnel_uuid": tunnelUUID})
+	`, map[string]any{
+		"organization_uuid": dbUUID(organizationUUID),
+		"tunnel_uuid":       dbUUID(tunnelUUID),
+	})
 	return count, err
 }
 
@@ -912,7 +922,7 @@ func (d *DB) adminCursor(
 		return nil, false, nil
 	}
 	query := fmt.Sprintf(
-		"select CAST(uuid AS text) as uuid, %s as created_at from %s where %s",
+		"select uuid, %s as created_at from %s where %s",
 		timeColumn,
 		table,
 		where,
@@ -944,14 +954,14 @@ func appendCursorFilter(
 	}
 	if afterID != "" {
 		query += fmt.Sprintf(
-			" and (%s < :cursor_created_at or (%s = :cursor_created_at and %s < CAST(:cursor_uuid AS uuid)))",
+			" and (%s < :cursor_created_at or (%s = :cursor_created_at and %s < :cursor_uuid))",
 			column,
 			column,
 			uuidColumn,
 		)
 	} else {
 		query += fmt.Sprintf(
-			" and (%s > :cursor_created_at or (%s = :cursor_created_at and %s > CAST(:cursor_uuid AS uuid)))",
+			" and (%s > :cursor_created_at or (%s = :cursor_created_at and %s > :cursor_uuid))",
 			column,
 			column,
 			uuidColumn,
@@ -964,8 +974,8 @@ func appendCursorFilter(
 
 func adminInviteSelectSQL() string {
 	return `
-		select CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
+		select uuid, external_id,
+			organization_uuid,
 			email, role, status, invited_at, expires_at
 		from organization_invites
 	`
@@ -973,8 +983,8 @@ func adminInviteSelectSQL() string {
 
 func adminUserSelectSQL() string {
 	return `
-		select CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
+		select uuid, external_id,
+			organization_uuid,
 			email, name, role, added_at
 		from users
 	`
@@ -982,8 +992,8 @@ func adminUserSelectSQL() string {
 
 func adminWorkspaceSelectSQL() string {
 	return `
-		select CAST(w.uuid AS text) as uuid, w.external_id,
-			CAST(w.organization_uuid AS text) as organization_uuid, w.name,
+		select w.uuid, w.external_id,
+			w.organization_uuid, w.name,
 			w.created_at, w.updated_at, w.archived_at, w.compartment_id,
 			w.display_color, w.data_residency, w.external_key_id, w.tags
 		from workspaces w
@@ -992,10 +1002,10 @@ func adminWorkspaceSelectSQL() string {
 
 func adminWorkspaceMemberSelectSQL() string {
 	return `
-		select CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
-			CAST(workspace_uuid AS text) as workspace_uuid, workspace_external_id,
-			CAST(user_uuid AS text) as user_uuid, user_external_id,
+		select uuid, external_id,
+			organization_uuid,
+			workspace_uuid, workspace_external_id,
+			user_uuid, user_external_id,
 			workspace_role, created_at, updated_at
 		from workspace_members
 	`
@@ -1003,10 +1013,10 @@ func adminWorkspaceMemberSelectSQL() string {
 
 func adminAPIKeySelectSQL() string {
 	return `
-		select CAST(ak.uuid AS text) as uuid, ak.external_id,
-			CAST(ak.workspace_uuid AS text) as workspace_uuid,
+		select ak.uuid, ak.external_id,
+			ak.workspace_uuid,
 			w.external_id as workspace_external_id,
-			CAST(ak.created_by_user_uuid AS text) as created_by_user_uuid,
+			ak.created_by_user_uuid,
 			u.external_id as created_by_user_external_id,
 			ak.name, ak.partial_key_hint, ak.status, ak.created_at, ak.updated_at, ak.expires_at
 		from api_keys ak
@@ -1017,8 +1027,8 @@ func adminAPIKeySelectSQL() string {
 
 func adminExternalKeySelectSQL() string {
 	return `
-		select CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
+		select uuid, external_id,
+			organization_uuid,
 			display_name, geo, provider_config, created_at, updated_at
 		from external_keys
 	`
@@ -1026,9 +1036,9 @@ func adminExternalKeySelectSQL() string {
 
 func adminTunnelSelectSQL() string {
 	return `
-		select CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
-			CAST(workspace_uuid AS text) as workspace_uuid, workspace_external_id,
+		select uuid, external_id,
+			organization_uuid,
+			workspace_uuid, workspace_external_id,
 			display_name, domain, token_id, tunnel_token, created_at, updated_at, archived_at
 		from mcp_tunnels
 	`
@@ -1036,9 +1046,9 @@ func adminTunnelSelectSQL() string {
 
 func adminTunnelCertificateSelectSQL() string {
 	return `
-		select CAST(uuid AS text) as uuid, external_id,
-			CAST(organization_uuid AS text) as organization_uuid,
-			CAST(tunnel_uuid AS text) as tunnel_uuid, tunnel_external_id,
+		select uuid, external_id,
+			organization_uuid,
+			tunnel_uuid, tunnel_external_id,
 			ca_certificate_pem, fingerprint, expires_at, created_at, archived_at
 		from mcp_tunnel_certificates
 	`

--- a/internal/db/admin_requests.go
+++ b/internal/db/admin_requests.go
@@ -6,15 +6,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
 )
 
 const listAdminRequestsSQL = `
 	select
-		CAST(ar.request_uuid AS text) as request_uuid,
-		CAST(ar.org_uuid AS text) as org_uuid,
+		ar.request_uuid,
+		ar.org_uuid,
 		ar.request_type,
-		CAST(ar.requester_uuid AS text) as requester_uuid,
+		ar.requester_uuid,
 		ar.requested_seat_tier,
 		ar.details,
 		ar.status,
@@ -29,7 +30,7 @@ const listAdminRequestsSQL = `
 	  on u.uuid = ar.requester_uuid
 	 and u.organization_uuid = ar.org_uuid
 	 and u.deleted_at is null
-	where CAST(ar.org_uuid AS text) = :org_uuid
+	where ar.org_uuid = :org_uuid
 	  and ar.request_type = :request_type
 	  and ar.status = :status
 	order by ar.created_at desc, ar.request_uuid desc
@@ -37,27 +38,27 @@ const listAdminRequestsSQL = `
 `
 
 type adminRequestRow struct {
-	UUID              string     `db:"request_uuid"`
-	OrgUUID           string     `db:"org_uuid"`
-	RequestType       string     `db:"request_type"`
-	RequesterUUID     *string    `db:"requester_uuid"`
-	RequestedSeatTier *string    `db:"requested_seat_tier"`
-	Details           []byte     `db:"details"`
-	Status            string     `db:"status"`
-	CreatedAt         time.Time  `db:"created_at"`
-	ResolvedAt        *time.Time `db:"resolved_at"`
-	RequesterEmail    *string    `db:"requester_email"`
-	RequesterName     *string    `db:"requester_name"`
-	RequesterRole     *string    `db:"requester_role"`
-	RequesterSeatTier *string    `db:"requester_seat_tier"`
+	UUID              uuid.UUID     `db:"request_uuid"`
+	OrgUUID           uuid.UUID     `db:"org_uuid"`
+	RequestType       string        `db:"request_type"`
+	RequesterUUID     uuid.NullUUID `db:"requester_uuid"`
+	RequestedSeatTier *string       `db:"requested_seat_tier"`
+	Details           []byte        `db:"details"`
+	Status            string        `db:"status"`
+	CreatedAt         time.Time     `db:"created_at"`
+	ResolvedAt        *time.Time    `db:"resolved_at"`
+	RequesterEmail    *string       `db:"requester_email"`
+	RequesterName     *string       `db:"requester_name"`
+	RequesterRole     *string       `db:"requester_role"`
+	RequesterSeatTier *string       `db:"requester_seat_tier"`
 }
 
 func (r adminRequestRow) toAdminRequest() (platform.AdminRequest, error) {
 	request := platform.AdminRequest{
-		UUID:              r.UUID,
-		OrgUUID:           r.OrgUUID,
+		UUID:              r.UUID.String(),
+		OrgUUID:           r.OrgUUID.String(),
 		RequestType:       r.RequestType,
-		RequesterUUID:     r.RequesterUUID,
+		RequesterUUID:     nullableUUIDString(r.RequesterUUID),
 		RequestedSeatTier: r.RequestedSeatTier,
 		Status:            r.Status,
 		CreatedAt:         r.CreatedAt,
@@ -87,7 +88,7 @@ func listAdminRequestsSQLX(
 ) ([]platform.AdminRequest, error) {
 	var rows []adminRequestRow
 	if err := namedSelectContext(ctx, database, &rows, listAdminRequestsSQL, map[string]any{
-		"org_uuid":     orgUUID,
+		"org_uuid":     dbUUID(orgUUID),
 		"request_type": requestType,
 		"status":       status,
 		"limit":        limit,

--- a/internal/db/admin_requests_test.go
+++ b/internal/db/admin_requests_test.go
@@ -40,7 +40,7 @@ func TestListAdminRequestsQueryUsesNamedPostgreSQLArguments(t *testing.T) {
 		t.Fatalf("bindNamed() query contains PostgreSQL shorthand cast: %q", query)
 	}
 	for _, clause := range []string{
-		"where CAST(ar.org_uuid AS text) = $1",
+		"where ar.org_uuid = $1",
 		"and ar.request_type = $2",
 		"and ar.status = $3",
 		"limit $4",

--- a/internal/db/admin_sqlx_test.go
+++ b/internal/db/admin_sqlx_test.go
@@ -5,21 +5,25 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestAppendAdminCursorFilterBindsNamedParameters(t *testing.T) {
 	cursorTime := time.Date(2026, time.July, 23, 10, 30, 0, 0, time.UTC)
+	organizationUUID := uuid.MustParse("22222222-2222-4222-8222-222222222222")
+	cursorUUID := uuid.MustParse("99999999-9999-4999-8999-999999999999")
 	arguments := map[string]any{
-		"organization_uuid": "22222222-2222-4222-8222-222222222222",
+		"organization_uuid": organizationUUID,
 		"limit":             11,
 	}
 	query := appendCursorFilter(
-		adminAPIKeySelectSQL()+` where w.organization_uuid = CAST(:organization_uuid AS uuid)`,
+		adminAPIKeySelectSQL()+` where w.organization_uuid = :organization_uuid`,
 		arguments,
 		"ak.created_at",
 		"apikey_after",
 		"",
-		&AdminCursor{CreatedAt: cursorTime, UUID: "99999999-9999-4999-8999-999999999999"},
+		&AdminCursor{CreatedAt: cursorTime, UUID: cursorUUID},
 	)
 	query += " order by ak.created_at desc, ak.uuid desc limit :limit"
 
@@ -27,17 +31,17 @@ func TestAppendAdminCursorFilterBindsNamedParameters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bindNamed() error = %v", err)
 	}
-	wantQuery := adminAPIKeySelectSQL() + ` where w.organization_uuid = CAST($1 AS uuid)` +
-		" and (ak.created_at < $2 or (ak.created_at = $3 and ak.uuid < CAST($4 AS uuid)))" +
+	wantQuery := adminAPIKeySelectSQL() + ` where w.organization_uuid = $1` +
+		" and (ak.created_at < $2 or (ak.created_at = $3 and ak.uuid < $4))" +
 		" order by ak.created_at desc, ak.uuid desc limit $5"
 	if boundQuery != wantQuery {
 		t.Fatalf("bindNamed() query = %q, want %q", boundQuery, wantQuery)
 	}
 	wantValues := []any{
-		"22222222-2222-4222-8222-222222222222",
+		organizationUUID,
 		cursorTime,
 		cursorTime,
-		"99999999-9999-4999-8999-999999999999",
+		cursorUUID,
 		11,
 	}
 	if !reflect.DeepEqual(values, wantValues) {
@@ -47,31 +51,33 @@ func TestAppendAdminCursorFilterBindsNamedParameters(t *testing.T) {
 
 func TestAppendAdminCursorFilterBuildsBeforeCondition(t *testing.T) {
 	cursorTime := time.Date(2026, time.July, 23, 11, 0, 0, 0, time.UTC)
+	organizationUUID := uuid.MustParse("99999999-9999-4999-8999-999999999999")
+	cursorUUID := uuid.MustParse("77777777-7777-4777-8777-777777777777")
 	arguments := map[string]any{}
 	query := appendCursorFilter(
-		"select uuid from users where organization_uuid = CAST(:organization_uuid AS uuid)",
+		"select uuid from users where organization_uuid = :organization_uuid",
 		arguments,
 		"added_at",
 		"",
 		"user_before",
-		&AdminCursor{CreatedAt: cursorTime, UUID: "77777777-7777-4777-8777-777777777777"},
+		&AdminCursor{CreatedAt: cursorTime, UUID: cursorUUID},
 	)
-	arguments["organization_uuid"] = "99999999-9999-4999-8999-999999999999"
+	arguments["organization_uuid"] = organizationUUID
 
 	boundQuery, values, err := bindNamed(postgresRebinder{}, query, arguments)
 	if err != nil {
 		t.Fatalf("bindNamed() error = %v", err)
 	}
-	wantQuery := "select uuid from users where organization_uuid = CAST($1 AS uuid)" +
-		" and (added_at > $2 or (added_at = $3 and uuid > CAST($4 AS uuid)))"
+	wantQuery := "select uuid from users where organization_uuid = $1" +
+		" and (added_at > $2 or (added_at = $3 and uuid > $4))"
 	if boundQuery != wantQuery {
 		t.Fatalf("bindNamed() query = %q, want %q", boundQuery, wantQuery)
 	}
 	wantValues := []any{
-		"99999999-9999-4999-8999-999999999999",
+		organizationUUID,
 		cursorTime,
 		cursorTime,
-		"77777777-7777-4777-8777-777777777777",
+		cursorUUID,
 	}
 	if !reflect.DeepEqual(values, wantValues) {
 		t.Fatalf("bindNamed() values = %#v, want %#v", values, wantValues)
@@ -79,7 +85,7 @@ func TestAppendAdminCursorFilterBuildsBeforeCondition(t *testing.T) {
 }
 
 func TestGetAdminOrganizationQueryUsesUUID(t *testing.T) {
-	organizationUUID := "22222222-2222-4222-8222-222222222222"
+	organizationUUID := uuid.MustParse("22222222-2222-4222-8222-222222222222")
 	query, arguments, err := bindNamed(postgresRebinder{}, getAdminOrganizationQuery, map[string]any{
 		"organization_uuid": organizationUUID,
 	})
@@ -89,7 +95,10 @@ func TestGetAdminOrganizationQueryUsesUUID(t *testing.T) {
 	if len(arguments) != 1 || arguments[0] != organizationUUID {
 		t.Fatalf("bindNamed() arguments = %#v, want organization UUID", arguments)
 	}
-	if want := "where uuid = CAST($1 AS uuid)"; !strings.Contains(query, want) {
+	if want := "where uuid = $1"; !strings.Contains(query, want) {
 		t.Fatalf("bound query = %q, want %q", query, want)
+	}
+	if strings.Contains(query, "CAST(") {
+		t.Fatalf("bound query contains UUID cast ceremony: %q", query)
 	}
 }

--- a/internal/db/agents.go
+++ b/internal/db/agents.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -34,24 +35,24 @@ type Agent struct {
 }
 
 type agentRow struct {
-	UUID                string     `db:"uuid"`
-	ExternalID          string     `db:"external_id"`
-	WorkspaceUUID       string     `db:"workspace_uuid"`
-	CreatedByAPIKeyUUID string     `db:"created_by_api_key_uuid"`
-	CurrentVersion      int        `db:"current_version"`
-	Name                string     `db:"name"`
-	Description         *string    `db:"description"`
-	System              *string    `db:"system"`
-	Model               []byte     `db:"model"`
-	MCPServers          []byte     `db:"mcp_servers"`
-	Metadata            []byte     `db:"metadata"`
-	Multiagent          []byte     `db:"multiagent"`
-	Skills              []byte     `db:"skills"`
-	Tools               []byte     `db:"tools"`
-	CreatedAt           time.Time  `db:"created_at"`
-	UpdatedAt           time.Time  `db:"updated_at"`
-	ArchivedAt          *time.Time `db:"archived_at"`
-	DeletedAt           *time.Time `db:"deleted_at"`
+	UUID                uuid.UUID     `db:"uuid"`
+	ExternalID          string        `db:"external_id"`
+	WorkspaceUUID       uuid.UUID     `db:"workspace_uuid"`
+	CreatedByAPIKeyUUID uuid.NullUUID `db:"created_by_api_key_uuid"`
+	CurrentVersion      int           `db:"current_version"`
+	Name                string        `db:"name"`
+	Description         *string       `db:"description"`
+	System              *string       `db:"system"`
+	Model               []byte        `db:"model"`
+	MCPServers          []byte        `db:"mcp_servers"`
+	Metadata            []byte        `db:"metadata"`
+	Multiagent          []byte        `db:"multiagent"`
+	Skills              []byte        `db:"skills"`
+	Tools               []byte        `db:"tools"`
+	CreatedAt           time.Time     `db:"created_at"`
+	UpdatedAt           time.Time     `db:"updated_at"`
+	ArchivedAt          *time.Time    `db:"archived_at"`
+	DeletedAt           *time.Time    `db:"deleted_at"`
 }
 
 type AgentPageCursor struct {
@@ -105,15 +106,15 @@ const createAgentSQL = `
 		skills, tools, created_at, updated_at
 	)
 	values (
-		CAST(:uuid AS uuid), :external_id, CAST(:workspace_uuid AS uuid),
-		CAST(:created_by_api_key_uuid AS uuid), 1,
+		:uuid, :external_id, :workspace_uuid,
+		:created_by_api_key_uuid, 1,
 		:name, :description, :system, CAST(:model AS jsonb), CAST(:mcp_servers AS jsonb),
 		CAST(:metadata AS jsonb), CAST(:multiagent AS jsonb), CAST(:skills AS jsonb),
 		CAST(:tools AS jsonb), :created_at, :created_at
 	)
-	returning CAST(uuid AS text) AS uuid, external_id,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(created_by_api_key_uuid AS text) AS created_by_api_key_uuid,
+	returning uuid, external_id,
+		workspace_uuid,
+		created_by_api_key_uuid,
 		current_version, name, description, system, model,
 		mcp_servers, metadata, multiagent, skills, tools, created_at, updated_at,
 		archived_at, deleted_at
@@ -132,12 +133,12 @@ const updateAgentSQL = `
 		skills = CAST(:skills AS jsonb),
 		tools = CAST(:tools AS jsonb),
 		updated_at = :updated_at
-	where workspace_uuid = CAST(:workspace_uuid AS uuid)
+	where workspace_uuid = :workspace_uuid
 		and external_id = :external_id
 		and deleted_at is null
-	returning CAST(uuid AS text) AS uuid, external_id,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(created_by_api_key_uuid AS text) AS created_by_api_key_uuid,
+	returning uuid, external_id,
+		workspace_uuid,
+		created_by_api_key_uuid,
 		current_version, name, description, system, model,
 		mcp_servers, metadata, multiagent, skills, tools, created_at, updated_at,
 		archived_at, deleted_at
@@ -150,7 +151,7 @@ const insertAgentVersionSQL = `
 		skills, tools, agent_created_at, agent_updated_at, archived_at
 	)
 	values (
-		:version_external_id, CAST(:workspace_uuid AS uuid), CAST(:agent_uuid AS uuid),
+		:version_external_id, :workspace_uuid, :agent_uuid,
 		:agent_external_id, :version,
 		:name, :description, :system, CAST(:model AS jsonb), CAST(:mcp_servers AS jsonb),
 		CAST(:metadata AS jsonb), CAST(:multiagent AS jsonb), CAST(:skills AS jsonb),
@@ -182,11 +183,11 @@ func (d *DB) CreateAgent(ctx context.Context, agent Agent, versionExternalID str
 
 func (d *DB) GetAgent(ctx context.Context, workspaceUUID string, externalID string) (Agent, error) {
 	return getAgentSQLX(ctx, d.sql, agentSelectSQL()+`
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
 			and external_id = :external_id
 			and deleted_at is null
 	`, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 	})
 }
@@ -196,11 +197,11 @@ func (d *DB) GetAgentVersion(ctx context.Context, workspaceUUID string, external
 		return Agent{}, ErrNotFound
 	}
 	return getAgentSQLX(ctx, d.sql, agentVersionSelectSQL()+`
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
 			and agent_external_id = :external_id
 			and version = :version
 	`, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 		"version":        version,
 	})
@@ -216,12 +217,12 @@ func (d *DB) UpdateAgent(ctx context.Context, workspaceUUID string, externalID s
 	}()
 
 	current, err := getAgentSQLX(ctx, tx, agentSelectSQL()+`
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
 			and external_id = :external_id
 			and deleted_at is null
 		for update
 	`, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 	})
 	if err != nil {
@@ -237,10 +238,11 @@ func (d *DB) UpdateAgent(ctx context.Context, workspaceUUID string, externalID s
 		return current, tx.Commit()
 	}
 
-	arguments := agentArguments(next)
-	arguments["workspace_uuid"] = workspaceUUID
+	arguments := agentConfigArguments(next)
+	arguments["workspace_uuid"] = dbUUID(workspaceUUID)
 	arguments["external_id"] = externalID
 	arguments["current_version"] = current.CurrentVersion + 1
+	arguments["updated_at"] = next.UpdatedAt
 	updated, err := getAgentSQLX(ctx, tx, updateAgentSQL, arguments)
 	if err != nil {
 		return Agent{}, err
@@ -304,17 +306,17 @@ func (d *DB) ArchiveAgent(ctx context.Context, workspaceUUID string, externalID 
 		update agents
 		set archived_at = coalesce(archived_at, now()),
 			updated_at = now()
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
 			and external_id = :external_id
 			and deleted_at is null
-		returning CAST(uuid AS text) AS uuid, external_id,
-			CAST(workspace_uuid AS text) AS workspace_uuid,
-			CAST(created_by_api_key_uuid AS text) AS created_by_api_key_uuid,
+		returning uuid, external_id,
+			workspace_uuid,
+			created_by_api_key_uuid,
 			current_version, name, description, system, model,
 			mcp_servers, metadata, multiagent, skills, tools, created_at, updated_at,
 			archived_at, deleted_at
 	`, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 	})
 }
@@ -354,15 +356,15 @@ func (d *DB) SearchAgentsPage(ctx context.Context, params SearchAgentsPageParams
 
 func (d *DB) ListAgentVersionsPage(ctx context.Context, params ListAgentVersionsPageParams) ([]Agent, bool, error) {
 	limit := agentPageLimit(params.Limit)
-	var agentUUID string
+	var agentUUID uuid.UUID
 	err := namedGetContext(ctx, d.sql, &agentUUID, `
-		select CAST(uuid AS text)
+		select uuid
 		from agents
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
 			and external_id = :external_id
 			and deleted_at is null
 	`, map[string]any{
-		"workspace_uuid": params.WorkspaceUUID,
+		"workspace_uuid": dbUUID(params.WorkspaceUUID),
 		"external_id":    params.AgentExternalID,
 	})
 	if errors.Is(err, sql.ErrNoRows) {
@@ -381,9 +383,10 @@ func (d *DB) ListAgentVersionsPage(ctx context.Context, params ListAgentVersions
 }
 
 func insertAgentVersion(ctx context.Context, tx *sqlx.Tx, agent Agent, versionExternalID string) error {
-	arguments := agentArguments(agent)
+	arguments := agentConfigArguments(agent)
 	arguments["version_external_id"] = versionExternalID
-	arguments["agent_uuid"] = agent.UUID
+	arguments["workspace_uuid"] = dbUUID(agent.WorkspaceUUID)
+	arguments["agent_uuid"] = dbUUID(agent.UUID)
 	arguments["agent_external_id"] = agent.ExternalID
 	arguments["version"] = agent.CurrentVersion
 	arguments["agent_created_at"] = agent.CreatedAt
@@ -395,11 +398,11 @@ func insertAgentVersion(ctx context.Context, tx *sqlx.Tx, agent Agent, versionEx
 
 func agentPageQuery(filter agentPageFilter) (string, map[string]any) {
 	query := agentSelectSQL() + `
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
 			and deleted_at is null
 	`
 	arguments := map[string]any{
-		"workspace_uuid": filter.WorkspaceUUID,
+		"workspace_uuid": dbUUID(filter.WorkspaceUUID),
 		"limit":          filter.Limit + 1,
 	}
 	if !filter.IncludeArchived {
@@ -418,26 +421,26 @@ func agentPageQuery(filter agentPageFilter) (string, map[string]any) {
 		arguments["name"] = filter.Name
 	}
 	if filter.Cursor != nil {
-		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < CAST(:cursor_uuid AS uuid)))"
+		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < :cursor_uuid))"
 		arguments["cursor_created_at"] = filter.Cursor.CreatedAt
-		arguments["cursor_uuid"] = filter.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(filter.Cursor.UUID)
 	}
 	query += " order by created_at desc, uuid desc limit :limit"
 	return query, arguments
 }
 
-func agentVersionsPageQuery(agentUUID string, cursor *AgentVersionPageCursor, limit int) (string, map[string]any) {
+func agentVersionsPageQuery(agentUUID uuid.UUID, cursor *AgentVersionPageCursor, limit int) (string, map[string]any) {
 	query := agentVersionSelectSQL() + `
-		where agent_uuid = CAST(:agent_uuid AS uuid)
+		where agent_uuid = :agent_uuid
 	`
 	arguments := map[string]any{
 		"agent_uuid": agentUUID,
 		"limit":      limit + 1,
 	}
 	if cursor != nil {
-		query += " and (version < :cursor_version or (version = :cursor_version and uuid < CAST(:cursor_uuid AS uuid)))"
+		query += " and (version < :cursor_version or (version = :cursor_version and uuid < :cursor_uuid))"
 		arguments["cursor_version"] = cursor.Version
-		arguments["cursor_uuid"] = cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(cursor.UUID)
 	}
 	query += " order by version desc, uuid desc limit :limit"
 	return query, arguments
@@ -445,9 +448,9 @@ func agentVersionsPageQuery(agentUUID string, cursor *AgentVersionPageCursor, li
 
 func agentSelectSQL() string {
 	return `
-		select CAST(uuid AS text) AS uuid, external_id,
-			CAST(workspace_uuid AS text) AS workspace_uuid,
-			CAST(created_by_api_key_uuid AS text) AS created_by_api_key_uuid,
+		select uuid, external_id,
+			workspace_uuid,
+			created_by_api_key_uuid,
 			current_version, name, description, system, model,
 			mcp_servers, metadata, multiagent, skills, tools, created_at, updated_at,
 			archived_at, deleted_at
@@ -457,9 +460,9 @@ func agentSelectSQL() string {
 
 func agentVersionSelectSQL() string {
 	return `
-		select CAST(uuid AS text) AS uuid, agent_external_id AS external_id,
-			CAST(workspace_uuid AS text) AS workspace_uuid,
-			CAST('' AS text) AS created_by_api_key_uuid,
+		select uuid, agent_external_id AS external_id,
+			workspace_uuid,
+			CAST(null AS uuid) AS created_by_api_key_uuid,
 			version AS current_version, name, description, system, model, mcp_servers,
 			metadata, multiagent, skills, tools, agent_created_at AS created_at,
 			agent_updated_at AS updated_at, archived_at,
@@ -494,10 +497,10 @@ func selectAgentsSQLX(ctx context.Context, database sqlxNamedQueryer, query stri
 
 func (row agentRow) agent() Agent {
 	return Agent{
-		UUID:                row.UUID,
+		UUID:                row.UUID.String(),
 		ExternalID:          row.ExternalID,
-		WorkspaceUUID:       row.WorkspaceUUID,
-		CreatedByAPIKeyUUID: row.CreatedByAPIKeyUUID,
+		WorkspaceUUID:       row.WorkspaceUUID.String(),
+		CreatedByAPIKeyUUID: nullableUUIDValue(row.CreatedByAPIKeyUUID),
 		CurrentVersion:      row.CurrentVersion,
 		Name:                row.Name,
 		Description:         row.Description,
@@ -516,22 +519,26 @@ func (row agentRow) agent() Agent {
 }
 
 func agentArguments(agent Agent) map[string]any {
+	arguments := agentConfigArguments(agent)
+	arguments["uuid"] = dbUUID(agent.UUID)
+	arguments["external_id"] = agent.ExternalID
+	arguments["workspace_uuid"] = dbUUID(agent.WorkspaceUUID)
+	arguments["created_by_api_key_uuid"] = dbUUID(agent.CreatedByAPIKeyUUID)
+	arguments["created_at"] = agent.CreatedAt
+	return arguments
+}
+
+func agentConfigArguments(agent Agent) map[string]any {
 	return map[string]any{
-		"uuid":                    agent.UUID,
-		"external_id":             agent.ExternalID,
-		"workspace_uuid":          agent.WorkspaceUUID,
-		"created_by_api_key_uuid": agent.CreatedByAPIKeyUUID,
-		"name":                    agent.Name,
-		"description":             agent.Description,
-		"system":                  agent.System,
-		"model":                   jsonArg(agent.Model),
-		"mcp_servers":             jsonArg(agent.MCPServers),
-		"metadata":                jsonArg(agent.Metadata),
-		"multiagent":              jsonArg(agent.Multiagent),
-		"skills":                  jsonArg(agent.Skills),
-		"tools":                   jsonArg(agent.Tools),
-		"created_at":              agent.CreatedAt,
-		"updated_at":              agent.UpdatedAt,
+		"name":        agent.Name,
+		"description": agent.Description,
+		"system":      agent.System,
+		"model":       jsonArg(agent.Model),
+		"mcp_servers": jsonArg(agent.MCPServers),
+		"metadata":    jsonArg(agent.Metadata),
+		"multiagent":  jsonArg(agent.Multiagent),
+		"skills":      jsonArg(agent.Skills),
+		"tools":       jsonArg(agent.Tools),
 	}
 }
 

--- a/internal/db/agents_test.go
+++ b/internal/db/agents_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestAgentPageQueryBindsNamedParameters(t *testing.T) {
@@ -31,17 +33,20 @@ func TestAgentPageQueryBindsNamedParameters(t *testing.T) {
 		t.Fatalf("bound query still contains named placeholders: %q", boundQuery)
 	}
 	wantValues := []any{
-		"00000000-0000-0000-0000-000000000042",
+		uuid.MustParse("00000000-0000-0000-0000-000000000042"),
 		createdAtGTE,
 		createdAtLTE,
 		"managed",
 		cursorCreatedAt,
 		cursorCreatedAt,
-		"00000000-0000-0000-0000-000000000017",
+		uuid.MustParse("00000000-0000-0000-0000-000000000017"),
 		6,
 	}
 	if !reflect.DeepEqual(values, wantValues) {
 		t.Fatalf("bindNamed() values = %#v, want %#v", values, wantValues)
+	}
+	if strings.Contains(boundQuery, " AS uuid)") {
+		t.Fatalf("bound query contains UUID cast ceremony: %q", boundQuery)
 	}
 }
 
@@ -84,7 +89,7 @@ func TestAgentMutationQueryBindsJSONArguments(t *testing.T) {
 
 func TestAgentRowConversionCopiesJSON(t *testing.T) {
 	row := agentRow{
-		UUID:           "00000000-0000-0000-0000-000000000007",
+		UUID:           uuid.MustParse("00000000-0000-0000-0000-000000000007"),
 		ExternalID:     "agent_row",
 		CurrentVersion: 2,
 		Name:           "row agent",
@@ -101,7 +106,7 @@ func TestAgentRowConversionCopiesJSON(t *testing.T) {
 	if string(agent.Model) != `{"id":"claude-opus-4-6"}` {
 		t.Fatalf("agent.Model = %s, want copied JSON", agent.Model)
 	}
-	if agent.UUID != row.UUID || agent.ExternalID != row.ExternalID || agent.CurrentVersion != row.CurrentVersion {
+	if agent.UUID != row.UUID.String() || agent.ExternalID != row.ExternalID || agent.CurrentVersion != row.CurrentVersion {
 		t.Fatalf("agent identity fields = %+v, want values from row %+v", agent, row)
 	}
 }

--- a/internal/db/batches.go
+++ b/internal/db/batches.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type MessageBatch struct {
@@ -79,11 +81,16 @@ type MessageBatchJob struct {
 	Attempts               int
 }
 
+type messageBatchJobPayload struct {
+	MessageBatchUUID       string `json:"message_batch_uuid"`
+	MessageBatchExternalID string `json:"message_batch_external_id"`
+}
+
 type messageBatchRow struct {
-	UUID                string     `db:"uuid"`
+	UUID                uuid.UUID  `db:"uuid"`
 	ExternalID          string     `db:"external_id"`
-	WorkspaceUUID       string     `db:"workspace_uuid"`
-	CreatedByAPIKeyUUID string     `db:"created_by_api_key_uuid"`
+	WorkspaceUUID       uuid.UUID  `db:"workspace_uuid"`
+	CreatedByAPIKeyUUID uuid.UUID  `db:"created_by_api_key_uuid"`
 	APIVariant          string     `db:"api_variant"`
 	AnthropicVersion    string     `db:"anthropic_version"`
 	BetaHeadersJSON     []byte     `db:"beta_headers"`
@@ -109,9 +116,9 @@ type messageBatchRow struct {
 }
 
 type messageBatchRequestRow struct {
-	UUID              string     `db:"uuid"`
-	WorkspaceUUID     string     `db:"workspace_uuid"`
-	MessageBatchUUID  string     `db:"message_batch_uuid"`
+	UUID              uuid.UUID  `db:"uuid"`
+	WorkspaceUUID     uuid.UUID  `db:"workspace_uuid"`
+	MessageBatchUUID  uuid.UUID  `db:"message_batch_uuid"`
 	RequestIndex      int        `db:"request_index"`
 	ExternalID        string     `db:"external_id"`
 	CustomID          string     `db:"custom_id"`
@@ -127,12 +134,12 @@ type messageBatchRequestRow struct {
 }
 
 type messageBatchJobRow struct {
-	UUID                   string `db:"uuid"`
-	ExternalID             string `db:"external_id"`
-	WorkspaceUUID          string `db:"workspace_uuid"`
-	MessageBatchUUID       string `db:"message_batch_uuid"`
-	MessageBatchExternalID string `db:"message_batch_external_id"`
-	Attempts               int    `db:"attempts"`
+	UUID                   uuid.UUID `db:"uuid"`
+	ExternalID             string    `db:"external_id"`
+	WorkspaceUUID          uuid.UUID `db:"workspace_uuid"`
+	MessageBatchUUID       string    `db:"message_batch_uuid"`
+	MessageBatchExternalID string    `db:"message_batch_external_id"`
+	Attempts               int       `db:"attempts"`
 }
 
 func (d *DB) CreateMessageBatch(ctx context.Context, b MessageBatch, reqs []NewBatchRequest) (MessageBatch, error) {
@@ -150,7 +157,7 @@ func (d *DB) CreateMessageBatch(ctx context.Context, b MessageBatch, reqs []NewB
 	}()
 
 	var created struct {
-		UUID      string    `db:"uuid"`
+		UUID      uuid.UUID `db:"uuid"`
 		CreatedAt time.Time `db:"created_at"`
 		UpdatedAt time.Time `db:"updated_at"`
 	}
@@ -165,12 +172,12 @@ func (d *DB) CreateMessageBatch(ctx context.Context, b MessageBatch, reqs []NewB
 			:anthropic_version, CAST(:beta_headers AS jsonb), :request_count,
 			:request_count, :created_at, :expires_at
 		)
-		returning CAST(uuid AS text) AS uuid, created_at, updated_at
+		returning uuid, created_at, updated_at
 	`, map[string]any{
-		"uuid":                    b.UUID,
+		"uuid":                    dbUUID(b.UUID),
 		"external_id":             b.ExternalID,
-		"workspace_uuid":          b.WorkspaceUUID,
-		"created_by_api_key_uuid": b.CreatedByAPIKeyUUID,
+		"workspace_uuid":          dbUUID(b.WorkspaceUUID),
+		"created_by_api_key_uuid": dbUUID(b.CreatedByAPIKeyUUID),
 		"api_variant":             b.APIVariant,
 		"anthropic_version":       b.AnthropicVersion,
 		"beta_headers":            string(betaHeaders),
@@ -181,7 +188,7 @@ func (d *DB) CreateMessageBatch(ctx context.Context, b MessageBatch, reqs []NewB
 	if err != nil {
 		return MessageBatch{}, err
 	}
-	b.UUID = created.UUID
+	b.UUID = created.UUID.String()
 	b.CreatedAt = created.CreatedAt
 	b.UpdatedAt = created.UpdatedAt
 	b.RequestCount = len(reqs)
@@ -194,10 +201,14 @@ func (d *DB) CreateMessageBatch(ctx context.Context, b MessageBatch, reqs []NewB
 	}
 	defer requestStatement.Close()
 	for _, req := range reqs {
+		requestWorkspaceUUID, err := parseDBUUID("workspace_uuid", req.WorkspaceUUID)
+		if err != nil {
+			return MessageBatch{}, err
+		}
 		if _, err := requestStatement.ExecContext(ctx, map[string]any{
 			"external_id":        req.ExternalID,
-			"workspace_uuid":     req.WorkspaceUUID,
-			"message_batch_uuid": b.UUID,
+			"workspace_uuid":     requestWorkspaceUUID,
+			"message_batch_uuid": created.UUID,
 			"request_index":      req.RequestIndex,
 			"custom_id":          req.CustomID,
 			"params":             string(req.Params),
@@ -206,6 +217,13 @@ func (d *DB) CreateMessageBatch(ctx context.Context, b MessageBatch, reqs []NewB
 		}
 	}
 
+	jobPayload, err := json.Marshal(messageBatchJobPayload{
+		MessageBatchUUID:       b.UUID,
+		MessageBatchExternalID: b.ExternalID,
+	})
+	if err != nil {
+		return MessageBatch{}, err
+	}
 	if _, err := namedExecContext(ctx, tx, `
 		insert into jobs (external_id, workspace_uuid, type, status, payload)
 		values (
@@ -213,15 +231,11 @@ func (d *DB) CreateMessageBatch(ctx context.Context, b MessageBatch, reqs []NewB
 			:workspace_uuid,
 			'message_batch_process',
 			'pending',
-			jsonb_build_object(
-				'message_batch_uuid', CAST(:message_batch_uuid AS text),
-				'message_batch_external_id', CAST(:message_batch_external_id AS text)
-			)
+			CAST(:payload AS jsonb)
 		)
 	`, map[string]any{
-		"workspace_uuid":            b.WorkspaceUUID,
-		"message_batch_uuid":        b.UUID,
-		"message_batch_external_id": b.ExternalID,
+		"workspace_uuid": dbUUID(b.WorkspaceUUID),
+		"payload":        jobPayload,
 	}); err != nil {
 		return MessageBatch{}, err
 	}
@@ -238,7 +252,7 @@ func (d *DB) GetMessageBatch(ctx context.Context, workspaceUUID, externalID stri
 			and mb.external_id = :external_id
 			and mb.deleted_at is null
 	`, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 	})
 }
@@ -246,7 +260,7 @@ func (d *DB) GetMessageBatch(ctx context.Context, workspaceUUID, externalID stri
 func (d *DB) GetMessageBatchByUUID(ctx context.Context, batchUUID string) (MessageBatch, error) {
 	return getMessageBatchSQLX(ctx, d.sql, messageBatchSelectSQL()+`
 		where mb.uuid = :batch_uuid
-	`, map[string]any{"batch_uuid": batchUUID})
+	`, map[string]any{"batch_uuid": dbUUID(batchUUID)})
 }
 
 func (d *DB) ListMessageBatchesPage(ctx context.Context, params ListMessageBatchesPageParams) ([]MessageBatch, bool, error) {
@@ -258,7 +272,7 @@ func (d *DB) ListMessageBatchesPage(ctx context.Context, params ListMessageBatch
 	}
 
 	var cursor struct {
-		UUID      string    `db:"uuid"`
+		UUID      uuid.UUID `db:"uuid"`
 		CreatedAt time.Time `db:"created_at"`
 	}
 	if params.AfterID != "" || params.BeforeID != "" {
@@ -267,13 +281,13 @@ func (d *DB) ListMessageBatchesPage(ctx context.Context, params ListMessageBatch
 			cursorExternalID = params.BeforeID
 		}
 		err := namedGetContext(ctx, d.sql, &cursor, `
-			select CAST(uuid AS text) AS uuid, created_at
+			select uuid, created_at
 			from message_batches
 			where workspace_uuid = :workspace_uuid
 				and external_id = :external_id
 				and deleted_at is null
 		`, map[string]any{
-			"workspace_uuid": params.WorkspaceUUID,
+			"workspace_uuid": dbUUID(params.WorkspaceUUID),
 			"external_id":    cursorExternalID,
 		})
 		if errors.Is(err, sql.ErrNoRows) {
@@ -288,7 +302,7 @@ func (d *DB) ListMessageBatchesPage(ctx context.Context, params ListMessageBatch
 		where mb.workspace_uuid = :workspace_uuid and mb.deleted_at is null
 	`
 	arguments := map[string]any{
-		"workspace_uuid": params.WorkspaceUUID,
+		"workspace_uuid": dbUUID(params.WorkspaceUUID),
 		"limit":          params.Limit + 1,
 	}
 	if params.AfterID != "" {
@@ -325,7 +339,7 @@ func (d *DB) ListMessageBatchesPage(ctx context.Context, params ListMessageBatch
 
 func (d *DB) CancelMessageBatch(ctx context.Context, workspaceUUID, externalID string) (MessageBatch, error) {
 	arguments := map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 	}
 	rowsAffected, err := namedExecRowsAffected(ctx, d.sql, `
@@ -362,7 +376,7 @@ func (d *DB) CancelMessageBatch(ctx context.Context, workspaceUUID, externalID s
 
 func (d *DB) SoftDeleteMessageBatch(ctx context.Context, workspaceUUID, externalID string) error {
 	arguments := map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 	}
 	rowsAffected, err := namedExecRowsAffected(ctx, d.sql, `
@@ -414,7 +428,7 @@ func (d *DB) FinalizeMessageBatch(ctx context.Context, batchUUID string, process
 			updated_at = now()
 		where uuid = :batch_uuid and processing_status in ('in_progress', 'canceling')
 	`, map[string]any{
-		"batch_uuid":         batchUUID,
+		"batch_uuid":         dbUUID(batchUUID),
 		"ended_at":           endedAt,
 		"processing_count":   processing,
 		"succeeded_count":    succeeded,
@@ -444,7 +458,7 @@ func (d *DB) FinalizePendingRequests(ctx context.Context, batchUUID, finalStatus
 			updated_at = now()
 		where message_batch_uuid = :message_batch_uuid and status = 'queued'
 	`, map[string]any{
-		"message_batch_uuid": batchUUID,
+		"message_batch_uuid": dbUUID(batchUUID),
 		"final_status":       finalStatus,
 		"result":             string(result),
 	})
@@ -462,7 +476,7 @@ func (d *DB) MarkStaleInFlightRequestsErrored(ctx context.Context, batchUUID str
 			and status = 'in_flight'
 			and started_at < :before
 	`, map[string]any{
-		"message_batch_uuid": batchUUID,
+		"message_batch_uuid": dbUUID(batchUUID),
 		"before":             before,
 		"result":             string(result),
 	})
@@ -485,7 +499,7 @@ func (d *DB) CountRequestsByStatus(ctx context.Context, batchUUID string) (proce
 			CAST(count(*) filter (where status = 'expired') AS int) AS expired
 		from message_batch_requests
 		where message_batch_uuid = :message_batch_uuid
-	`, map[string]any{"message_batch_uuid": batchUUID})
+	`, map[string]any{"message_batch_uuid": dbUUID(batchUUID)})
 	processing = counts.Processing
 	succeeded = counts.Succeeded
 	errored = counts.Errored
@@ -519,7 +533,7 @@ func (d *DB) GetMessageBatchRequestByIndex(ctx context.Context, batchUUID string
 	return getMessageBatchRequestSQLX(ctx, d.sql, messageBatchRequestSelectSQL()+`
 		where message_batch_uuid = :message_batch_uuid and request_index = :request_index
 	`, map[string]any{
-		"message_batch_uuid": batchUUID,
+		"message_batch_uuid": dbUUID(batchUUID),
 		"request_index":      index,
 	})
 }
@@ -529,7 +543,7 @@ func (d *DB) ListMessageBatchRequestsOrdered(ctx context.Context, batchUUID stri
 	err := namedSelectContext(ctx, d.sql, &rows, messageBatchRequestSelectSQL()+`
 		where message_batch_uuid = :message_batch_uuid
 		order by request_index
-	`, map[string]any{"message_batch_uuid": batchUUID})
+	`, map[string]any{"message_batch_uuid": dbUUID(batchUUID)})
 	if err != nil {
 		return nil, err
 	}
@@ -549,7 +563,7 @@ func (d *DB) ClaimMessageBatchRequest(ctx context.Context, requestUUID, workerID
 			updated_at = now()
 		where uuid = :request_uuid and status = 'queued'
 	`, map[string]any{
-		"request_uuid": requestUUID,
+		"request_uuid": dbUUID(requestUUID),
 		"worker_id":    workerID,
 		"started_at":   startedAt,
 	})
@@ -569,7 +583,7 @@ func (d *DB) CompleteMessageBatchRequest(ctx context.Context, requestUUID, statu
 			updated_at = now()
 		where uuid = :request_uuid and status = 'in_flight'
 	`, map[string]any{
-		"request_uuid":        requestUUID,
+		"request_uuid":        dbUUID(requestUUID),
 		"status":              status,
 		"result":              string(result),
 		"upstream_request_id": upstreamRequestID,
@@ -582,22 +596,25 @@ func (d *DB) CompleteMessageBatchRequest(ctx context.Context, requestUUID, statu
 }
 
 func (d *DB) EnqueueMessageBatchJob(ctx context.Context, workspaceUUID, batchUUID, batchExternalID string) error {
-	_, err := namedExecContext(ctx, d.sql, `
+	payload, err := json.Marshal(messageBatchJobPayload{
+		MessageBatchUUID:       batchUUID,
+		MessageBatchExternalID: batchExternalID,
+	})
+	if err != nil {
+		return err
+	}
+	_, err = namedExecContext(ctx, d.sql, `
 		insert into jobs (external_id, workspace_uuid, type, status, payload)
 		values (
 			concat('job_', replace(CAST(gen_random_uuid() AS text), '-', '')),
 			:workspace_uuid,
 			'message_batch_process',
 			'pending',
-			jsonb_build_object(
-				'message_batch_uuid', CAST(:message_batch_uuid AS text),
-				'message_batch_external_id', CAST(:message_batch_external_id AS text)
-			)
+			CAST(:payload AS jsonb)
 		)
 	`, map[string]any{
-		"workspace_uuid":            workspaceUUID,
-		"message_batch_uuid":        batchUUID,
-		"message_batch_external_id": batchExternalID,
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"payload":        payload,
 	})
 	return err
 }
@@ -646,8 +663,8 @@ const leaseMessageBatchJobsSQL = `
 			updated_at = now()
 		from next_jobs
 		where j.uuid = next_jobs.uuid
-		returning CAST(j.uuid AS text) AS uuid, j.external_id,
-			CAST(j.workspace_uuid AS text) AS workspace_uuid,
+		returning j.uuid, j.external_id,
+			j.workspace_uuid,
 			j.payload->>'message_batch_uuid' AS message_batch_uuid,
 			coalesce(j.payload->>'message_batch_external_id', '') AS message_batch_external_id,
 			j.attempts
@@ -666,7 +683,7 @@ func (d *DB) ExtendMessageBatchJobLease(ctx context.Context, jobUUID, workerID s
 			and status = 'running'
 			and locked_by = :worker_id
 	`, map[string]any{
-		"job_uuid":           jobUUID,
+		"job_uuid":           dbUUID(jobUUID),
 		"worker_id":          workerID,
 		"lease_microseconds": leaseDuration.Microseconds(),
 	})
@@ -687,7 +704,7 @@ func (d *DB) CompleteMessageBatchJob(ctx context.Context, jobUUID string) error 
 			locked_until = null,
 			updated_at = now()
 		where uuid = :job_uuid and type = 'message_batch_process'
-	`, map[string]any{"job_uuid": jobUUID})
+	`, map[string]any{"job_uuid": dbUUID(jobUUID)})
 	return err
 }
 
@@ -709,7 +726,7 @@ func (d *DB) FailMessageBatchJob(ctx context.Context, jobUUID string, attempts i
 			payload = payload || jsonb_build_object('last_error', CAST(:reason AS text))
 		where uuid = :job_uuid and type = 'message_batch_process'
 	`, map[string]any{
-		"job_uuid":  jobUUID,
+		"job_uuid":  dbUUID(jobUUID),
 		"status":    status,
 		"run_after": runAfter,
 		"reason":    reason,
@@ -720,9 +737,9 @@ func (d *DB) FailMessageBatchJob(ctx context.Context, jobUUID string, attempts i
 
 func messageBatchSelectSQL() string {
 	return `
-		select CAST(mb.uuid AS text) AS uuid, mb.external_id,
-			CAST(mb.workspace_uuid AS text) AS workspace_uuid,
-			CAST(mb.created_by_api_key_uuid AS text) AS created_by_api_key_uuid,
+		select mb.uuid, mb.external_id,
+			mb.workspace_uuid,
+			mb.created_by_api_key_uuid,
 			mb.api_variant, mb.anthropic_version, mb.beta_headers, mb.processing_status,
 			mb.request_count, mb.processing_count, mb.succeeded_count, mb.errored_count,
 			mb.canceled_count, mb.expired_count, mb.results_s3_bucket, mb.results_s3_key,
@@ -765,10 +782,10 @@ func (row messageBatchRow) batch() (MessageBatch, error) {
 		}
 	}
 	return MessageBatch{
-		UUID:                row.UUID,
+		UUID:                row.UUID.String(),
 		ExternalID:          row.ExternalID,
-		WorkspaceUUID:       row.WorkspaceUUID,
-		CreatedByAPIKeyUUID: row.CreatedByAPIKeyUUID,
+		WorkspaceUUID:       row.WorkspaceUUID.String(),
+		CreatedByAPIKeyUUID: row.CreatedByAPIKeyUUID.String(),
 		APIVariant:          row.APIVariant,
 		AnthropicVersion:    row.AnthropicVersion,
 		BetaHeaders:         betaHeaders,
@@ -806,9 +823,9 @@ const insertMessageBatchRequestSQL = `
 
 func messageBatchRequestSelectSQL() string {
 	return `
-		select CAST(uuid AS text) AS uuid,
-			CAST(workspace_uuid AS text) AS workspace_uuid,
-			CAST(message_batch_uuid AS text) AS message_batch_uuid,
+		select uuid,
+			workspace_uuid,
+			message_batch_uuid,
 			request_index, external_id, custom_id,
 			params, status, result, upstream_request_id, started_at, completed_at,
 			in_flight_worker_id, created_at, updated_at
@@ -830,9 +847,9 @@ func getMessageBatchRequestSQLX(ctx context.Context, database sqlxNamedQueryer, 
 
 func (row messageBatchRequestRow) request() MessageBatchRequest {
 	return MessageBatchRequest{
-		UUID:              row.UUID,
-		WorkspaceUUID:     row.WorkspaceUUID,
-		MessageBatchUUID:  row.MessageBatchUUID,
+		UUID:              row.UUID.String(),
+		WorkspaceUUID:     row.WorkspaceUUID.String(),
+		MessageBatchUUID:  row.MessageBatchUUID.String(),
 		RequestIndex:      row.RequestIndex,
 		ExternalID:        row.ExternalID,
 		CustomID:          row.CustomID,
@@ -850,9 +867,9 @@ func (row messageBatchRequestRow) request() MessageBatchRequest {
 
 func (row messageBatchJobRow) job() MessageBatchJob {
 	return MessageBatchJob{
-		UUID:                   row.UUID,
+		UUID:                   row.UUID.String(),
 		ExternalID:             row.ExternalID,
-		WorkspaceUUID:          row.WorkspaceUUID,
+		WorkspaceUUID:          row.WorkspaceUUID.String(),
 		MessageBatchUUID:       row.MessageBatchUUID,
 		MessageBatchExternalID: row.MessageBatchExternalID,
 		Attempts:               row.Attempts,

--- a/internal/db/bootstrap.go
+++ b/internal/db/bootstrap.go
@@ -8,16 +8,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
 )
 
 type bootstrapUserContextRow struct {
-	UserExternalID string `db:"user_external_id"`
-	OrgUUID        string `db:"org_uuid"`
+	UserExternalID string    `db:"user_external_id"`
+	OrgUUID        uuid.UUID `db:"org_uuid"`
 }
 
 type bootstrapUserRow struct {
-	UUID          string    `db:"uuid"`
+	UUID          uuid.UUID `db:"uuid"`
 	ExternalID    string    `db:"external_id"`
 	Email         string    `db:"email"`
 	FullName      *string   `db:"full_name"`
@@ -28,15 +29,15 @@ type bootstrapUserRow struct {
 }
 
 type bootstrapOrganizationRow struct {
-	UUID                   string    `db:"uuid"`
-	Name                   string    `db:"name"`
-	Domain                 *string   `db:"domain"`
-	ParentOrganizationUUID *string   `db:"parent_organization_uuid"`
-	Settings               []byte    `db:"settings"`
-	CreatedAt              time.Time `db:"created_at"`
-	UpdatedAt              time.Time `db:"updated_at"`
-	Role                   string    `db:"role"`
-	AddedAt                time.Time `db:"added_at"`
+	UUID                   uuid.UUID     `db:"uuid"`
+	Name                   string        `db:"name"`
+	Domain                 *string       `db:"domain"`
+	ParentOrganizationUUID uuid.NullUUID `db:"parent_organization_uuid"`
+	Settings               []byte        `db:"settings"`
+	CreatedAt              time.Time     `db:"created_at"`
+	UpdatedAt              time.Time     `db:"updated_at"`
+	Role                   string        `db:"role"`
+	AddedAt                time.Time     `db:"added_at"`
 }
 
 func (d *DB) FindBootstrapUserContext(ctx context.Context, preferredOrgUUID string) (string, string, error) {
@@ -47,14 +48,14 @@ func (d *DB) FindBootstrapUserContext(ctx context.Context, preferredOrgUUID stri
 	query := `
 		select
 			u.external_id as user_external_id,
-			cast(u.organization_uuid as text) as org_uuid
+			u.organization_uuid as org_uuid
 		from users u
 		where u.deleted_at is null
 	`
 	arguments := map[string]any{}
 	if trimmedPreferredOrgUUID := strings.TrimSpace(preferredOrgUUID); trimmedPreferredOrgUUID != "" {
-		query += ` and u.organization_uuid = cast(:preferred_org_uuid as uuid)`
-		arguments["preferred_org_uuid"] = trimmedPreferredOrgUUID
+		query += ` and u.organization_uuid = :preferred_org_uuid`
+		arguments["preferred_org_uuid"] = dbUUID(trimmedPreferredOrgUUID)
 	}
 	query += `
 		order by case when u.external_id = 'user_default' then 0 else 1 end, u.added_at asc, u.uuid asc
@@ -68,7 +69,7 @@ func (d *DB) FindBootstrapUserContext(ctx context.Context, preferredOrgUUID stri
 		}
 		return "", "", mapNoRows(err)
 	}
-	return row.UserExternalID, row.OrgUUID, nil
+	return row.UserExternalID, row.OrgUUID.String(), nil
 }
 
 func (d *DB) GetBootstrapUser(ctx context.Context, userExternalID string) (*platform.UserRecord, error) {
@@ -79,7 +80,7 @@ func (d *DB) GetBootstrapUser(ctx context.Context, userExternalID string) (*plat
 	var row bootstrapUserRow
 	err := namedGetContext(ctx, d.sql, &row, `
 		select
-			cast(u.uuid as text) as uuid,
+			u.uuid,
 			u.external_id,
 			u.email,
 			nullif(u.name, '') as full_name,
@@ -91,12 +92,15 @@ func (d *DB) GetBootstrapUser(ctx context.Context, userExternalID string) (*plat
 		where u.deleted_at is null
 		  and (
 			u.external_id = :user_external_id
-			or cast(u.uuid as text) = :user_external_id
+			or u.uuid = :user_uuid
 			or 'user_' || left(replace(cast(u.uuid as text), '-', ''), 24) = :user_external_id
 		  )
 		order by u.added_at asc, u.uuid asc
 		limit 1
-	`, map[string]any{"user_external_id": strings.TrimSpace(userExternalID)})
+	`, map[string]any{
+		"user_external_id": strings.TrimSpace(userExternalID),
+		"user_uuid":        tryParseDBUUIDIdentifier(userExternalID),
+	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, platform.ErrNotFound
 	}
@@ -105,7 +109,7 @@ func (d *DB) GetBootstrapUser(ctx context.Context, userExternalID string) (*plat
 	}
 
 	user := &platform.UserRecord{
-		UUID:          row.UUID,
+		UUID:          row.UUID.String(),
 		ExternalID:    row.ExternalID,
 		Email:         row.Email,
 		FullName:      row.FullName,
@@ -163,19 +167,19 @@ func (d *DB) UpdatePlatformOrganization(ctx context.Context, orgUUID string, pat
 		set name = coalesce(CAST(:name AS text), name),
 		    settings = coalesce(CAST(:settings AS jsonb), settings),
 		    updated_at = current_timestamp
-		where cast(uuid as text) = :org_uuid
+		where uuid = :org_uuid
 		returning
-			cast(uuid as text) as uuid,
+			uuid,
 			name,
 			CAST(NULL AS text) as domain,
-			CAST(NULL AS text) as parent_organization_uuid,
+			CAST(NULL AS uuid) as parent_organization_uuid,
 			coalesce(settings, CAST('{}' AS jsonb)) as settings,
 			created_at,
 			updated_at,
 			'' as role,
 			created_at as added_at
 	`, map[string]any{
-		"org_uuid": strings.TrimSpace(orgUUID),
+		"org_uuid": dbUUID(orgUUID),
 		"name":     name,
 		"settings": settingsValue,
 	})
@@ -200,10 +204,10 @@ func (d *DB) ListBootstrapUserOrganizations(ctx context.Context, userExternalID 
 	rows := []bootstrapOrganizationRow{}
 	err := namedSelectContext(ctx, d.sql, &rows, `
 		select
-			cast(o.uuid as text) as uuid,
+			o.uuid,
 			o.name,
 			CAST(NULL AS text) as domain,
-			CAST(NULL AS text) as parent_organization_uuid,
+			CAST(NULL AS uuid) as parent_organization_uuid,
 			coalesce(o.settings, CAST('{}' AS jsonb)) as settings,
 			o.created_at,
 			o.updated_at,
@@ -214,16 +218,17 @@ func (d *DB) ListBootstrapUserOrganizations(ctx context.Context, userExternalID 
 		where u.deleted_at is null
 		  and (
 			u.external_id = :user_external_id
-			or cast(u.uuid as text) = :user_external_id
+			or u.uuid = :user_uuid
 			or 'user_' || left(replace(cast(u.uuid as text), '-', ''), 24) = :user_external_id
 		  )
 		order by
-			case when cast(o.uuid as text) = :preferred_org_uuid then 0 else 1 end,
+			case when o.uuid = :preferred_org_uuid then 0 else 1 end,
 			u.added_at asc,
 			u.uuid asc
 	`, map[string]any{
 		"user_external_id":   strings.TrimSpace(userExternalID),
-		"preferred_org_uuid": strings.TrimSpace(preferredOrgUUID),
+		"user_uuid":          tryParseDBUUIDIdentifier(userExternalID),
+		"preferred_org_uuid": tryParseDBUUIDIdentifier(preferredOrgUUID),
 	})
 	if err != nil {
 		return nil, err
@@ -248,9 +253,9 @@ func (d *DB) GetOrganizationProfile(ctx context.Context, orgUUID string) (platfo
 	err := namedGetContext(ctx, d.sql, &profileBytes, `
 		select coalesce(profile, CAST('{}' AS jsonb))
 		from organizations
-		where cast(uuid as text) = :org_uuid
+		where uuid = :org_uuid
 		limit 1
-	`, map[string]any{"org_uuid": strings.TrimSpace(orgUUID)})
+	`, map[string]any{"org_uuid": dbUUID(orgUUID)})
 	if errors.Is(err, sql.ErrNoRows) {
 		return platform.OrganizationProfile{}, platform.ErrNotFound
 	}
@@ -273,10 +278,10 @@ func (d *DB) UpdateOrganizationProfile(ctx context.Context, orgUUID string, prof
 		update organizations
 		set profile = CAST(:profile AS jsonb),
 		    updated_at = current_timestamp
-		where cast(uuid as text) = :org_uuid
+		where uuid = :org_uuid
 		returning coalesce(profile, CAST('{}' AS jsonb))
 	`, map[string]any{
-		"org_uuid": strings.TrimSpace(orgUUID),
+		"org_uuid": dbUUID(orgUUID),
 		"profile":  string(profileBytes),
 	})
 	if errors.Is(err, sql.ErrNoRows) {
@@ -292,19 +297,19 @@ func getBootstrapOrganizationRow(ctx context.Context, database sqlxNamedQueryer,
 	var row bootstrapOrganizationRow
 	err := namedGetContext(ctx, database, &row, `
 		select
-			cast(o.uuid as text) as uuid,
+			o.uuid,
 			o.name,
 			CAST(NULL AS text) as domain,
-			CAST(NULL AS text) as parent_organization_uuid,
+			CAST(NULL AS uuid) as parent_organization_uuid,
 			coalesce(o.settings, CAST('{}' AS jsonb)) as settings,
 			o.created_at,
 			o.updated_at,
 			'' as role,
 			o.created_at as added_at
 		from organizations o
-		where cast(o.uuid as text) = :org_uuid
+		where o.uuid = :org_uuid
 		limit 1
-	`, map[string]any{"org_uuid": orgUUID})
+	`, map[string]any{"org_uuid": dbUUID(orgUUID)})
 	if errors.Is(err, sql.ErrNoRows) {
 		return bootstrapOrganizationRow{}, platform.ErrNotFound
 	}
@@ -320,10 +325,10 @@ func (row bootstrapOrganizationRow) organizationRecord() (*platform.Organization
 		return nil, err
 	}
 	return &platform.OrganizationRecord{
-		UUID:                   row.UUID,
+		UUID:                   row.UUID.String(),
 		Name:                   row.Name,
 		Domain:                 row.Domain,
-		ParentOrganizationUUID: row.ParentOrganizationUUID,
+		ParentOrganizationUUID: nullableUUIDString(row.ParentOrganizationUUID),
 		Settings:               settings,
 		CreatedAt:              row.CreatedAt,
 		UpdatedAt:              row.UpdatedAt,

--- a/internal/db/bootstrap_sqlx_test.go
+++ b/internal/db/bootstrap_sqlx_test.go
@@ -4,15 +4,17 @@ import (
 	"testing"
 )
 
-func TestBootstrapQueriesUseNamedParametersAndCasts(t *testing.T) {
+func TestBootstrapQueriesUseNamedTypedUUIDParameters(t *testing.T) {
 	query, arguments, err := bindNamed(postgresRebinder{}, `
 		select
-		cast(o.uuid as text) as uuid,
+		o.uuid,
 		coalesce(o.settings, CAST('{}' AS jsonb)) as settings
 	from organizations o
-	where o.uuid = CAST(:org_uuid AS uuid)
+	where o.uuid = :org_uuid
 	limit 1
-`, map[string]any{"org_uuid": "00000000-0000-0000-0000-000000000001"})
+`, map[string]any{
+		"org_uuid": dbUUID("00000000-0000-0000-0000-000000000001"),
+	})
 	if err != nil {
 		t.Fatalf("bindNamed() error = %v", err)
 	}
@@ -21,10 +23,10 @@ func TestBootstrapQueriesUseNamedParametersAndCasts(t *testing.T) {
 	}
 	wantQuery := `
 		select
-		cast(o.uuid as text) as uuid,
+		o.uuid,
 		coalesce(o.settings, CAST('{}' AS jsonb)) as settings
 	from organizations o
-	where o.uuid = CAST($1 AS uuid)
+	where o.uuid = $1
 	limit 1
 `
 	if query != wantQuery {

--- a/internal/db/builtin_skills.go
+++ b/internal/db/builtin_skills.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
 	builtinSkillColumns = `
 		id,
-		CAST(uuid AS text) AS uuid,
+		uuid,
 		external_id,
 		display_title,
 		latest_version,
@@ -21,7 +23,7 @@ const (
 	`
 	builtinSkillVersionColumns = `
 		id,
-		CAST(uuid AS text) AS uuid,
+		uuid,
 		external_id,
 		skill_id,
 		skill_external_id,
@@ -185,7 +187,7 @@ type ListBuiltinSkillVersionsPageParams struct {
 
 type builtinSkillRow struct {
 	ID            int64      `db:"id"`
-	UUID          string     `db:"uuid"`
+	UUID          uuid.UUID  `db:"uuid"`
 	ExternalID    string     `db:"external_id"`
 	DisplayTitle  string     `db:"display_title"`
 	LatestVersion *string    `db:"latest_version"`
@@ -196,7 +198,7 @@ type builtinSkillRow struct {
 
 type builtinSkillVersionRow struct {
 	ID              int64      `db:"id"`
-	UUID            string     `db:"uuid"`
+	UUID            uuid.UUID  `db:"uuid"`
 	ExternalID      string     `db:"external_id"`
 	SkillID         int64      `db:"skill_id"`
 	SkillExternalID string     `db:"skill_external_id"`
@@ -465,7 +467,7 @@ func selectBuiltinSkillVersionsSQLX(
 func (r builtinSkillRow) skill() BuiltinSkill {
 	return BuiltinSkill{
 		ID:            r.ID,
-		UUID:          r.UUID,
+		UUID:          r.UUID.String(),
 		ExternalID:    r.ExternalID,
 		DisplayTitle:  r.DisplayTitle,
 		LatestVersion: r.LatestVersion,
@@ -478,7 +480,7 @@ func (r builtinSkillRow) skill() BuiltinSkill {
 func (r builtinSkillVersionRow) skillVersion() BuiltinSkillVersion {
 	return BuiltinSkillVersion{
 		ID:              r.ID,
-		UUID:            r.UUID,
+		UUID:            r.UUID.String(),
 		ExternalID:      r.ExternalID,
 		SkillID:         r.SkillID,
 		SkillExternalID: r.SkillExternalID,

--- a/internal/db/code_sessions.go
+++ b/internal/db/code_sessions.go
@@ -260,11 +260,11 @@ func (d *DB) CreateCodeSession(ctx context.Context, input CreateCodeSessionInput
 		returning `+codeSessionColumns()+`
 	`, map[string]any{
 		"external_id":             input.ExternalID,
-		"organization_uuid":       input.OrganizationUUID,
-		"workspace_uuid":          input.WorkspaceUUID,
-		"session_uuid":            input.SessionUUID,
+		"organization_uuid":       dbUUID(input.OrganizationUUID),
+		"workspace_uuid":          dbUUID(input.WorkspaceUUID),
+		"session_uuid":            dbUUID(input.SessionUUID),
 		"session_external_id":     input.SessionExternalID,
-		"environment_uuid":        input.EnvironmentUUID,
+		"environment_uuid":        dbUUID(input.EnvironmentUUID),
 		"environment_external_id": input.EnvironmentExternalID,
 		"work_dir":                input.WorkDir,
 		"permission_mode":         input.PermissionMode,
@@ -281,12 +281,12 @@ func (d *DB) CreateCodeSession(ctx context.Context, input CreateCodeSessionInput
 // JOIN 中同时校验 organization、workspace 和 session 的归属，防止跨租户查询。
 // worker lease 不在这里校验：OAuth 鉴权要求有效 lease，首次签发 JWT 时还没有 lease。
 const codeSessionCredentialContextSelect = `
-	select CAST(cs.uuid AS text) AS code_session_uuid, cs.external_id AS code_session_external_id,
-		CAST(cs.organization_uuid AS text) AS organization_uuid,
-		CAST(cs.workspace_uuid AS text) AS workspace_uuid,
+	select cs.uuid AS code_session_uuid, cs.external_id AS code_session_external_id,
+		cs.organization_uuid AS organization_uuid,
+		cs.workspace_uuid AS workspace_uuid,
 		w.external_id AS workspace_external_id,
-		CAST(s.uuid AS text) AS public_session_uuid, s.external_id AS public_session_external_id,
-		CAST(s.agent_uuid AS text) AS agent_uuid, s.agent_external_id, s.agent_version,
+		s.uuid AS public_session_uuid, s.external_id AS public_session_external_id,
+		s.agent_uuid AS agent_uuid, s.agent_external_id, s.agent_version,
 		coalesce(u.email, '') AS account_email
 	from code_sessions cs
 	join workspaces w on w.uuid = cs.workspace_uuid
@@ -332,8 +332,8 @@ func (d *DB) GetCodeSessionByOAuthAccessTokenHash(ctx context.Context, tokenHash
 func (d *DB) GetCodeSessionCredentialContextForIssue(ctx context.Context, organizationUUID, workspaceUUID string, codeSessionExternalID string) (CodeSessionCredentialContext, error) {
 	return getCodeSessionCredentialContextSQLX(ctx, d.sql, codeSessionCredentialContextForIssueQuery, map[string]any{
 		"code_session_external_id": strings.TrimSpace(codeSessionExternalID),
-		"organization_uuid":        organizationUUID,
-		"workspace_uuid":           workspaceUUID,
+		"organization_uuid":        dbUUID(organizationUUID),
+		"workspace_uuid":           dbUUID(workspaceUUID),
 	})
 }
 
@@ -348,8 +348,8 @@ func (d *DB) GetCodeSessionNetworkPolicyContext(
 ) (CodeSessionNetworkPolicyContext, error) {
 	var row codeSessionNetworkPolicyContextRow
 	err := namedGetContext(ctx, d.sql, &row, `
-		select CAST(cs.organization_uuid AS text) AS organization_uuid,
-			CAST(cs.workspace_uuid AS text) AS workspace_uuid,
+		select cs.organization_uuid AS organization_uuid,
+			cs.workspace_uuid AS workspace_uuid,
 			e.external_id AS environment_external_id,
 			e.config AS environment_config, s.agent_snapshot
 		from code_sessions cs
@@ -368,13 +368,13 @@ func (d *DB) GetCodeSessionNetworkPolicyContext(
 			and s.environment_external_id = cs.environment_external_id
 			and s.deleted_at is null
 		where cs.external_id = :code_session_external_id
-			and cs.organization_uuid = CAST(:organization_uuid AS uuid)
-			and cs.workspace_uuid = CAST(:workspace_uuid AS uuid)
+			and cs.organization_uuid = :organization_uuid
+			and cs.workspace_uuid = :workspace_uuid
 	`+activeCodeSessionCredentialConditions,
 		map[string]any{
 			"code_session_external_id": strings.TrimSpace(codeSessionExternalID),
-			"organization_uuid":        strings.TrimSpace(organizationUUID),
-			"workspace_uuid":           strings.TrimSpace(workspaceUUID),
+			"organization_uuid":        dbUUID(strings.TrimSpace(organizationUUID)),
+			"workspace_uuid":           dbUUID(strings.TrimSpace(workspaceUUID)),
 		})
 	if errors.Is(err, sql.ErrNoRows) {
 		return CodeSessionNetworkPolicyContext{}, ErrNotFound
@@ -383,8 +383,8 @@ func (d *DB) GetCodeSessionNetworkPolicyContext(
 		return CodeSessionNetworkPolicyContext{}, err
 	}
 	return CodeSessionNetworkPolicyContext{
-		OrganizationUUID:      row.OrganizationUUID,
-		WorkspaceUUID:         row.WorkspaceUUID,
+		OrganizationUUID:      row.OrganizationUUID.String(),
+		WorkspaceUUID:         row.WorkspaceUUID.String(),
 		EnvironmentExternalID: row.EnvironmentExternalID,
 		EnvironmentConfig:     copyRaw(row.EnvironmentConfig),
 		AgentSnapshot:         copyRaw(row.AgentSnapshot),
@@ -408,7 +408,10 @@ func (d *DB) GetCodeSessionBySessionExternalID(ctx context.Context, workspaceUUI
 			and deleted_at is null
 		order by created_at desc, uuid desc
 		limit 1
-	`, map[string]any{"workspace_uuid": workspaceUUID, "session_external_id": sessionExternalID})
+	`, map[string]any{
+		"workspace_uuid":      dbUUID(workspaceUUID),
+		"session_external_id": sessionExternalID,
+	})
 }
 
 func (d *DB) RegisterCodeSessionWorker(ctx context.Context, codeSessionExternalID string, binding CodeSessionWorkerBinding, leaseTTL time.Duration) (int64, time.Time, error) {
@@ -452,7 +455,7 @@ func (d *DB) RegisterCodeSessionWorker(ctx context.Context, codeSessionExternalI
 			last_worker_connected_at = :now,
 			last_worker_activity_at = :now,
 			updated_at = :now
-		where uuid = CAST(:uuid AS uuid)
+		where uuid = :uuid
 		returning current_worker_epoch
 	`, map[string]any{
 		"epoch":                   nextEpoch,
@@ -460,7 +463,7 @@ func (d *DB) RegisterCodeSessionWorker(ctx context.Context, codeSessionExternalI
 		"now":                     now,
 		"worker_token_session_id": nullableWorkerTokenSessionID(binding.TokenSessionID),
 		"worker_binding":          jsonArg(json.RawMessage(bindingJSON)),
-		"uuid":                    session.UUID,
+		"uuid":                    dbUUID(session.UUID),
 	}); err != nil {
 		return 0, time.Time{}, err
 	}
@@ -558,7 +561,7 @@ func (d *DB) RecordCodeSessionWorkerHeartbeat(ctx context.Context, codeSessionEx
 
 	var leaseRow codeSessionWorkerLeaseRow
 	err = namedGetContext(ctx, tx, &leaseRow, `
-		select CAST(uuid AS text) AS uuid, current_worker_epoch, worker_lease_expires_at
+		select uuid, current_worker_epoch, worker_lease_expires_at
 		from code_sessions
 		where external_id = :external_id and deleted_at is null
 		for update
@@ -570,7 +573,7 @@ func (d *DB) RecordCodeSessionWorkerHeartbeat(ctx context.Context, codeSessionEx
 		return time.Time{}, err
 	}
 
-	sessionUUID := leaseRow.UUID
+	sessionUUID := leaseRow.UUID.String()
 	currentEpoch := leaseRow.CurrentWorkerEpoch
 	lease := leaseRow.WorkerLeaseExpiresAt
 	var leaseExpiresAt *time.Time
@@ -613,9 +616,13 @@ func (d *DB) RecordCodeSessionWorkerHeartbeat(ctx context.Context, codeSessionEx
 			last_worker_activity_at = :now,
 			connection_status = 'connected',
 			updated_at = :now
-		where uuid = CAST(:uuid AS uuid)
+		where uuid = :uuid
 		returning worker_lease_expires_at
-	`, map[string]any{"now": now, "expires_at": expiresAt, "uuid": sessionUUID}); err != nil {
+	`, map[string]any{
+		"now":        now,
+		"expires_at": expiresAt,
+		"uuid":       dbUUID(sessionUUID),
+	}); err != nil {
 		return time.Time{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -682,10 +689,10 @@ func (d *DB) UpdateCodeSessionWorkerState(ctx context.Context, codeSessionExtern
 			last_worker_connected_at = :now,
 			last_worker_activity_at = :now,
 			updated_at = :now
-		where uuid = CAST(:uuid AS uuid)
+		where uuid = :uuid
 		returning `+codeSessionColumns()+`
 	`, map[string]any{
-		"uuid":                    current.UUID,
+		"uuid":                    dbUUID(current.UUID),
 		"worker_status":           workerStatus,
 		"requires_action_details": jsonArg(requiresActionDetails),
 		"external_metadata":       jsonArg(externalMetadata),
@@ -756,9 +763,9 @@ func (d *DB) AppendCodeSessionInternalEvents(ctx context.Context, codeSessionExt
 				returning `+codeSessionInternalEventColumns()+`
 			`, map[string]any{
 			"external_id":              input.ExternalID,
-			"organization_uuid":        session.OrganizationUUID,
-			"workspace_uuid":           session.WorkspaceUUID,
-			"code_session_uuid":        session.UUID,
+			"organization_uuid":        dbUUID(session.OrganizationUUID),
+			"workspace_uuid":           dbUUID(session.WorkspaceUUID),
+			"code_session_uuid":        dbUUID(session.UUID),
 			"code_session_external_id": session.ExternalID,
 			"sequence_num":             nextSequence,
 			"event_type":               input.EventType,
@@ -785,8 +792,12 @@ func (d *DB) AppendCodeSessionInternalEvents(ctx context.Context, codeSessionExt
 		if _, err := namedExecContext(ctx, tx, `
 			update code_sessions
 			set last_internal_sequence_num = :sequence_num, updated_at = :now
-			where uuid = CAST(:uuid AS uuid)
-		`, map[string]any{"sequence_num": sequence, "now": now, "uuid": session.UUID}); err != nil {
+			where uuid = :uuid
+		`, map[string]any{
+			"sequence_num": sequence,
+			"now":          now,
+			"uuid":         dbUUID(session.UUID),
+		}); err != nil {
 			return nil, err
 		}
 	}
@@ -846,9 +857,9 @@ func (d *DB) appendCodeSessionEvent(ctx context.Context, direction string, codeS
 	var event CodeSessionEvent
 	eventArguments := map[string]any{
 		"external_id":              input.ExternalID,
-		"organization_uuid":        session.OrganizationUUID,
-		"workspace_uuid":           session.WorkspaceUUID,
-		"code_session_uuid":        session.UUID,
+		"organization_uuid":        dbUUID(session.OrganizationUUID),
+		"workspace_uuid":           dbUUID(session.WorkspaceUUID),
+		"code_session_uuid":        dbUUID(session.UUID),
 		"code_session_external_id": session.ExternalID,
 		"sequence_num":             sequence,
 		"event_type":               input.EventType,
@@ -897,10 +908,10 @@ func (d *DB) appendCodeSessionEvent(ctx context.Context, direction string, codeS
 	if err != nil {
 		return CodeSessionEvent{}, false, err
 	}
-	if _, err := namedExecContext(ctx, tx, `update code_sessions set `+sequenceColumn+` = :sequence_num, updated_at = :now where uuid = CAST(:uuid AS uuid)`, map[string]any{
+	if _, err := namedExecContext(ctx, tx, `update code_sessions set `+sequenceColumn+` = :sequence_num, updated_at = :now where uuid = :uuid`, map[string]any{
 		"sequence_num": sequence,
 		"now":          now,
-		"uuid":         session.UUID,
+		"uuid":         dbUUID(session.UUID),
 	}); err != nil {
 		return CodeSessionEvent{}, false, err
 	}
@@ -911,7 +922,10 @@ func (d *DB) appendCodeSessionEvent(ctx context.Context, direction string, codeS
 }
 
 func (d *DB) getCodeSessionEventTx(ctx context.Context, tx sqlxNamedQueryer, direction string, workspaceUUID string, idempotencyKey string) (CodeSessionEvent, error) {
-	arguments := map[string]any{"workspace_uuid": workspaceUUID, "idempotency_key": idempotencyKey}
+	arguments := map[string]any{
+		"workspace_uuid":  dbUUID(workspaceUUID),
+		"idempotency_key": idempotencyKey,
+	}
 	if direction == "outbound" {
 		return getCodeSessionEventSQLX(ctx, tx, `
 			select `+codeSessionOutboundEventColumns()+`
@@ -937,7 +951,7 @@ func (d *DB) ListCodeSessionInternalEventsPage(ctx context.Context, params ListC
 		params.AfterSequence = 0
 	}
 	arguments := map[string]any{
-		"workspace_uuid":           params.WorkspaceUUID,
+		"workspace_uuid":           dbUUID(params.WorkspaceUUID),
 		"code_session_external_id": params.CodeSessionExternalID,
 		"after_sequence":           params.AfterSequence,
 		"limit":                    limit + 1,
@@ -1236,9 +1250,9 @@ func (d *DB) ApplyCodeSessionWorkerDeliveryUpdates(ctx context.Context, codeSess
 				delivery_worker_epoch = :epoch,
 				last_delivery_update_at = :now,
 				updated_at = :now
-				where uuid = CAST(:uuid AS uuid) and deleted_at is null
+				where uuid = :uuid and deleted_at is null
 			`, map[string]any{
-			"uuid":            event.UUID,
+			"uuid":            dbUUID(event.UUID),
 			"target_status":   targetStatus,
 			"mark_received":   rank >= codeSessionDeliveryStatusRank("received"),
 			"mark_processing": rank >= codeSessionDeliveryStatusRank("processing"),
@@ -1254,8 +1268,11 @@ func (d *DB) ApplyCodeSessionWorkerDeliveryUpdates(ctx context.Context, codeSess
 		if _, err := namedExecContext(ctx, tx, `
 			update code_sessions
 			set last_worker_activity_at = :now, updated_at = :now
-				where uuid = CAST(:uuid AS uuid) and deleted_at is null
-			`, map[string]any{"now": now, "uuid": session.UUID}); err != nil {
+				where uuid = :uuid and deleted_at is null
+			`, map[string]any{
+			"now":  now,
+			"uuid": dbUUID(session.UUID),
+		}); err != nil {
 			return CodeSessionWorkerDeliveryResult{}, err
 		}
 	}
@@ -1266,7 +1283,10 @@ func (d *DB) ApplyCodeSessionWorkerDeliveryUpdates(ctx context.Context, codeSess
 }
 
 func getCodeSessionInboundDeliveryEventTx(ctx context.Context, tx sqlxNamedQueryer, codeSessionUUID string, eventID string) (CodeSessionEvent, error) {
-	arguments := map[string]any{"code_session_uuid": codeSessionUUID, "event_id": eventID}
+	arguments := map[string]any{
+		"code_session_uuid": dbUUID(codeSessionUUID),
+		"event_id":          eventID,
+	}
 	event, err := getCodeSessionEventSQLX(ctx, tx, `
 		select `+codeSessionInboundEventColumns()+`
 		from code_session_inbound_events
@@ -1462,11 +1482,11 @@ func (d *DB) codeSessionWorkerEpochUpdateError(ctx context.Context, codeSessionE
 }
 
 func codeSessionColumns() string {
-	return `CAST(uuid AS text) AS uuid, external_id,
-		CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(session_uuid AS text) AS session_uuid, session_external_id,
-		CAST(environment_uuid AS text) AS environment_uuid,
+	return `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		session_uuid, session_external_id,
+		environment_uuid,
 		environment_external_id, work_dir, permission_mode, model, status, metadata,
 		connection_status, last_inbound_sequence_num, last_outbound_sequence_num, last_internal_sequence_num,
 		last_worker_connected_at, last_worker_activity_at, current_worker_epoch, worker_lease_expires_at,
@@ -1476,10 +1496,10 @@ func codeSessionColumns() string {
 }
 
 func codeSessionInboundEventColumns() string {
-	return `CAST(uuid AS text) AS uuid, external_id,
-		CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(code_session_uuid AS text) AS code_session_uuid, code_session_external_id,
+	return `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		code_session_uuid, code_session_external_id,
 		sequence_num, event_type, event_subtype, payload_uuid, request_id, payload, payload_hash,
 		idempotency_key, delivery_status, source, sent_at, delivery_worker_epoch, received_at, processing_at,
 		processed_at, last_delivery_attempt_at, last_delivery_update_at, delivery_attempts,
@@ -1491,7 +1511,7 @@ func codeSessionInboundEventColumnsWithAlias(alias string) string {
 	if prefix != "" {
 		prefix += "."
 	}
-	return `CAST(` + prefix + `uuid AS text) AS uuid, ` + prefix + `external_id, CAST(` + prefix + `organization_uuid AS text) AS organization_uuid, CAST(` + prefix + `workspace_uuid AS text) AS workspace_uuid, CAST(` + prefix + `code_session_uuid AS text) AS code_session_uuid, ` + prefix + `code_session_external_id,
+	return prefix + `uuid AS uuid, ` + prefix + `external_id, ` + prefix + `organization_uuid AS organization_uuid, ` + prefix + `workspace_uuid AS workspace_uuid, ` + prefix + `code_session_uuid AS code_session_uuid, ` + prefix + `code_session_external_id,
 		` + prefix + `sequence_num, ` + prefix + `event_type, ` + prefix + `event_subtype, ` + prefix + `payload_uuid, ` + prefix + `request_id, ` + prefix + `payload, ` + prefix + `payload_hash,
 		` + prefix + `idempotency_key, ` + prefix + `delivery_status, ` + prefix + `source, ` + prefix + `sent_at, ` + prefix + `delivery_worker_epoch, ` + prefix + `received_at, ` + prefix + `processing_at,
 		` + prefix + `processed_at, ` + prefix + `last_delivery_attempt_at, ` + prefix + `last_delivery_update_at, ` + prefix + `delivery_attempts,
@@ -1499,10 +1519,10 @@ func codeSessionInboundEventColumnsWithAlias(alias string) string {
 }
 
 func codeSessionOutboundEventColumns() string {
-	return `CAST(uuid AS text) AS uuid, external_id,
-		CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(code_session_uuid AS text) AS code_session_uuid, code_session_external_id,
+	return `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		code_session_uuid, code_session_external_id,
 		sequence_num, event_type, event_subtype, payload_uuid, request_id, payload, payload_hash,
 		idempotency_key, CAST('' AS text) AS delivery_status, source, CAST(null AS timestamptz) AS sent_at,
 		CAST(null AS bigint) AS delivery_worker_epoch, CAST(null AS timestamptz) AS received_at, CAST(null AS timestamptz) AS processing_at,
@@ -1512,10 +1532,10 @@ func codeSessionOutboundEventColumns() string {
 }
 
 func codeSessionInternalEventColumns() string {
-	return `CAST(uuid AS text) AS uuid, external_id,
-		CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(code_session_uuid AS text) AS code_session_uuid, code_session_external_id,
+	return `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		code_session_uuid, code_session_external_id,
 		sequence_num, event_type, payload_uuid, agent_id, is_compaction, payload, payload_hash,
 		idempotency_key, event_metadata, created_at, updated_at, deleted_at`
 }
@@ -1525,7 +1545,7 @@ func codeSessionInternalEventColumnsWithAlias(alias string) string {
 	if prefix != "" {
 		prefix += "."
 	}
-	return `CAST(` + prefix + `uuid AS text) AS uuid, ` + prefix + `external_id, CAST(` + prefix + `organization_uuid AS text) AS organization_uuid, CAST(` + prefix + `workspace_uuid AS text) AS workspace_uuid, CAST(` + prefix + `code_session_uuid AS text) AS code_session_uuid, ` + prefix + `code_session_external_id,
+	return prefix + `uuid AS uuid, ` + prefix + `external_id, ` + prefix + `organization_uuid AS organization_uuid, ` + prefix + `workspace_uuid AS workspace_uuid, ` + prefix + `code_session_uuid AS code_session_uuid, ` + prefix + `code_session_external_id,
 		` + prefix + `sequence_num, ` + prefix + `event_type, ` + prefix + `payload_uuid, ` + prefix + `agent_id, ` + prefix + `is_compaction, ` + prefix + `payload, ` + prefix + `payload_hash,
 		` + prefix + `idempotency_key, ` + prefix + `event_metadata, ` + prefix + `created_at, ` + prefix + `updated_at, ` + prefix + `deleted_at`
 }

--- a/internal/db/code_sessions_sqlx.go
+++ b/internal/db/code_sessions_sqlx.go
@@ -6,16 +6,18 @@ import (
 	"encoding/json"
 	"errors"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type codeSessionRow struct {
-	UUID                        string     `db:"uuid"`
+	UUID                        uuid.UUID  `db:"uuid"`
 	ExternalID                  string     `db:"external_id"`
-	OrganizationUUID            string     `db:"organization_uuid"`
-	WorkspaceUUID               string     `db:"workspace_uuid"`
-	SessionUUID                 string     `db:"session_uuid"`
+	OrganizationUUID            uuid.UUID  `db:"organization_uuid"`
+	WorkspaceUUID               uuid.UUID  `db:"workspace_uuid"`
+	SessionUUID                 uuid.UUID  `db:"session_uuid"`
 	SessionExternalID           string     `db:"session_external_id"`
-	EnvironmentUUID             string     `db:"environment_uuid"`
+	EnvironmentUUID             uuid.UUID  `db:"environment_uuid"`
 	EnvironmentExternalID       string     `db:"environment_external_id"`
 	WorkDir                     string     `db:"work_dir"`
 	PermissionMode              string     `db:"permission_mode"`
@@ -43,11 +45,11 @@ type codeSessionRow struct {
 }
 
 type codeSessionEventRow struct {
-	UUID                  string     `db:"uuid"`
+	UUID                  uuid.UUID  `db:"uuid"`
 	ExternalID            string     `db:"external_id"`
-	OrganizationUUID      string     `db:"organization_uuid"`
-	WorkspaceUUID         string     `db:"workspace_uuid"`
-	CodeSessionUUID       string     `db:"code_session_uuid"`
+	OrganizationUUID      uuid.UUID  `db:"organization_uuid"`
+	WorkspaceUUID         uuid.UUID  `db:"workspace_uuid"`
+	CodeSessionUUID       uuid.UUID  `db:"code_session_uuid"`
 	CodeSessionExternalID string     `db:"code_session_external_id"`
 	SequenceNum           int64      `db:"sequence_num"`
 	EventType             string     `db:"event_type"`
@@ -74,11 +76,11 @@ type codeSessionEventRow struct {
 }
 
 type codeSessionInternalEventRow struct {
-	UUID                  string     `db:"uuid"`
+	UUID                  uuid.UUID  `db:"uuid"`
 	ExternalID            string     `db:"external_id"`
-	OrganizationUUID      string     `db:"organization_uuid"`
-	WorkspaceUUID         string     `db:"workspace_uuid"`
-	CodeSessionUUID       string     `db:"code_session_uuid"`
+	OrganizationUUID      uuid.UUID  `db:"organization_uuid"`
+	WorkspaceUUID         uuid.UUID  `db:"workspace_uuid"`
+	CodeSessionUUID       uuid.UUID  `db:"code_session_uuid"`
 	CodeSessionExternalID string     `db:"code_session_external_id"`
 	SequenceNum           int64      `db:"sequence_num"`
 	EventType             string     `db:"event_type"`
@@ -95,29 +97,29 @@ type codeSessionInternalEventRow struct {
 }
 
 type codeSessionCredentialContextRow struct {
-	CodeSessionUUID         string `db:"code_session_uuid"`
-	CodeSessionExternalID   string `db:"code_session_external_id"`
-	OrganizationUUID        string `db:"organization_uuid"`
-	WorkspaceUUID           string `db:"workspace_uuid"`
-	WorkspaceExternalID     string `db:"workspace_external_id"`
-	PublicSessionUUID       string `db:"public_session_uuid"`
-	PublicSessionExternalID string `db:"public_session_external_id"`
-	AgentUUID               string `db:"agent_uuid"`
-	AgentExternalID         string `db:"agent_external_id"`
-	AgentVersion            int    `db:"agent_version"`
-	AccountEmail            string `db:"account_email"`
+	CodeSessionUUID         uuid.UUID `db:"code_session_uuid"`
+	CodeSessionExternalID   string    `db:"code_session_external_id"`
+	OrganizationUUID        uuid.UUID `db:"organization_uuid"`
+	WorkspaceUUID           uuid.UUID `db:"workspace_uuid"`
+	WorkspaceExternalID     string    `db:"workspace_external_id"`
+	PublicSessionUUID       uuid.UUID `db:"public_session_uuid"`
+	PublicSessionExternalID string    `db:"public_session_external_id"`
+	AgentUUID               uuid.UUID `db:"agent_uuid"`
+	AgentExternalID         string    `db:"agent_external_id"`
+	AgentVersion            int       `db:"agent_version"`
+	AccountEmail            string    `db:"account_email"`
 }
 
 type codeSessionNetworkPolicyContextRow struct {
-	OrganizationUUID      string `db:"organization_uuid"`
-	WorkspaceUUID         string `db:"workspace_uuid"`
-	EnvironmentExternalID string `db:"environment_external_id"`
-	EnvironmentConfig     []byte `db:"environment_config"`
-	AgentSnapshot         []byte `db:"agent_snapshot"`
+	OrganizationUUID      uuid.UUID `db:"organization_uuid"`
+	WorkspaceUUID         uuid.UUID `db:"workspace_uuid"`
+	EnvironmentExternalID string    `db:"environment_external_id"`
+	EnvironmentConfig     []byte    `db:"environment_config"`
+	AgentSnapshot         []byte    `db:"agent_snapshot"`
 }
 
 type codeSessionWorkerLeaseRow struct {
-	UUID                 string       `db:"uuid"`
+	UUID                 uuid.UUID    `db:"uuid"`
 	CurrentWorkerEpoch   int64        `db:"current_worker_epoch"`
 	WorkerLeaseExpiresAt sql.NullTime `db:"worker_lease_expires_at"`
 }
@@ -226,13 +228,13 @@ func (r codeSessionRow) session() CodeSession {
 		workerExternalMetadata = json.RawMessage(`{}`)
 	}
 	return CodeSession{
-		UUID:                        r.UUID,
+		UUID:                        r.UUID.String(),
 		ExternalID:                  r.ExternalID,
-		OrganizationUUID:            r.OrganizationUUID,
-		WorkspaceUUID:               r.WorkspaceUUID,
-		SessionUUID:                 r.SessionUUID,
+		OrganizationUUID:            r.OrganizationUUID.String(),
+		WorkspaceUUID:               r.WorkspaceUUID.String(),
+		SessionUUID:                 r.SessionUUID.String(),
 		SessionExternalID:           r.SessionExternalID,
-		EnvironmentUUID:             r.EnvironmentUUID,
+		EnvironmentUUID:             r.EnvironmentUUID.String(),
 		EnvironmentExternalID:       r.EnvironmentExternalID,
 		WorkDir:                     r.WorkDir,
 		PermissionMode:              r.PermissionMode,
@@ -262,11 +264,11 @@ func (r codeSessionRow) session() CodeSession {
 
 func (r codeSessionEventRow) event() CodeSessionEvent {
 	return CodeSessionEvent{
-		UUID:                  r.UUID,
+		UUID:                  r.UUID.String(),
 		ExternalID:            r.ExternalID,
-		OrganizationUUID:      r.OrganizationUUID,
-		WorkspaceUUID:         r.WorkspaceUUID,
-		CodeSessionUUID:       r.CodeSessionUUID,
+		OrganizationUUID:      r.OrganizationUUID.String(),
+		WorkspaceUUID:         r.WorkspaceUUID.String(),
+		CodeSessionUUID:       r.CodeSessionUUID.String(),
 		CodeSessionExternalID: r.CodeSessionExternalID,
 		SequenceNum:           r.SequenceNum,
 		EventType:             r.EventType,
@@ -295,11 +297,11 @@ func (r codeSessionEventRow) event() CodeSessionEvent {
 
 func (r codeSessionInternalEventRow) event() CodeSessionInternalEvent {
 	return CodeSessionInternalEvent{
-		UUID:                  r.UUID,
+		UUID:                  r.UUID.String(),
 		ExternalID:            r.ExternalID,
-		OrganizationUUID:      r.OrganizationUUID,
-		WorkspaceUUID:         r.WorkspaceUUID,
-		CodeSessionUUID:       r.CodeSessionUUID,
+		OrganizationUUID:      r.OrganizationUUID.String(),
+		WorkspaceUUID:         r.WorkspaceUUID.String(),
+		CodeSessionUUID:       r.CodeSessionUUID.String(),
 		CodeSessionExternalID: r.CodeSessionExternalID,
 		SequenceNum:           r.SequenceNum,
 		EventType:             r.EventType,
@@ -318,14 +320,14 @@ func (r codeSessionInternalEventRow) event() CodeSessionInternalEvent {
 
 func (r codeSessionCredentialContextRow) context() CodeSessionCredentialContext {
 	return CodeSessionCredentialContext{
-		CodeSessionUUID:         r.CodeSessionUUID,
+		CodeSessionUUID:         r.CodeSessionUUID.String(),
 		CodeSessionExternalID:   r.CodeSessionExternalID,
-		OrganizationUUID:        r.OrganizationUUID,
-		WorkspaceUUID:           r.WorkspaceUUID,
+		OrganizationUUID:        r.OrganizationUUID.String(),
+		WorkspaceUUID:           r.WorkspaceUUID.String(),
 		WorkspaceExternalID:     r.WorkspaceExternalID,
-		PublicSessionUUID:       r.PublicSessionUUID,
+		PublicSessionUUID:       r.PublicSessionUUID.String(),
 		PublicSessionExternalID: r.PublicSessionExternalID,
-		AgentUUID:               r.AgentUUID,
+		AgentUUID:               r.AgentUUID.String(),
 		AgentExternalID:         r.AgentExternalID,
 		AgentVersion:            r.AgentVersion,
 		AccountEmail:            r.AccountEmail,

--- a/internal/db/console_api_keys.go
+++ b/internal/db/console_api_keys.go
@@ -20,7 +20,15 @@ func (d *DB) ListConsoleAPIKeys(ctx context.Context, orgUUID string, workspaceUU
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" {
 		return []platform.ConsoleAPIKey{}, nil
 	}
-	query, arguments := listConsoleAPIKeysQuery(orgUUID, workspaceUUID)
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return []platform.ConsoleAPIKey{}, nil
+	}
+	typedWorkspaceUUID, err := parseDBNullableUUID("workspace_uuid", workspaceUUID)
+	if err != nil {
+		return []platform.ConsoleAPIKey{}, nil
+	}
+	query, arguments := listConsoleAPIKeysQuery(typedOrgUUID, typedWorkspaceUUID)
 	keys, err := selectConsoleAPIKeysSQLX(ctx, d.sql, query, arguments)
 	if err != nil {
 		if isUndefinedTableError(err) {
@@ -31,17 +39,17 @@ func (d *DB) ListConsoleAPIKeys(ctx context.Context, orgUUID string, workspaceUU
 	return keys, nil
 }
 
-func listConsoleAPIKeysQuery(orgUUID string, workspaceUUID *string) (string, map[string]any) {
+func listConsoleAPIKeysQuery(orgUUID uuid.UUID, workspaceUUID uuid.NullUUID) (string, map[string]any) {
 	query := `
 		select
 			` + consoleAPIKeySQLXColumns + `
 		from console_api_keys
-		where organization_uuid = CAST(:organization_uuid AS uuid)
+		where organization_uuid = :organization_uuid
 	`
-	arguments := map[string]any{"organization_uuid": strings.TrimSpace(orgUUID)}
-	if workspaceUUID != nil {
-		query += ` and workspace_uuid = CAST(:workspace_uuid AS uuid)`
-		arguments["workspace_uuid"] = strings.TrimSpace(*workspaceUUID)
+	arguments := map[string]any{"organization_uuid": orgUUID}
+	if workspaceUUID.Valid {
+		query += ` and workspace_uuid = :workspace_uuid`
+		arguments["workspace_uuid"] = workspaceUUID.UUID
 	}
 	query += ` order by created_at desc, external_id desc`
 	return query, arguments
@@ -51,9 +59,15 @@ func (d *DB) CreateConsoleAPIKey(ctx context.Context, input platform.CreateConso
 	if d == nil || d.sql == nil || strings.TrimSpace(input.OrgUUID) == "" || strings.TrimSpace(input.WorkspaceUUID) == "" {
 		return platform.CreateConsoleAPIKeyResult{}, platform.ErrNotFound
 	}
-	orgUUID := strings.TrimSpace(input.OrgUUID)
-	workspaceUUID := strings.TrimSpace(input.WorkspaceUUID)
-	workspaceDisplayID := firstNonEmpty(strings.TrimSpace(input.WorkspaceDisplayID), workspaceUUID)
+	orgUUID, err := parseDBUUID("organization_uuid", input.OrgUUID)
+	if err != nil {
+		return platform.CreateConsoleAPIKeyResult{}, platform.ErrNotFound
+	}
+	workspaceUUID, err := parseDBUUID("workspace_uuid", input.WorkspaceUUID)
+	if err != nil {
+		return platform.CreateConsoleAPIKeyResult{}, platform.ErrNotFound
+	}
+	workspaceDisplayID := firstNonEmpty(strings.TrimSpace(input.WorkspaceDisplayID), workspaceUUID.String())
 	rawKey := "sk-ant-api03-" + consoleRandomToken(32)
 	keyPrefix := rawKey
 	if len(keyPrefix) > 16 {
@@ -64,7 +78,7 @@ func (d *DB) CreateConsoleAPIKey(ctx context.Context, input platform.CreateConso
 		keySuffix = keySuffix[len(keySuffix)-6:]
 	}
 	externalID := consolePrefixedID("apikey", 18)
-	coreAPIKeyUUID := uuid.NewString()
+	coreAPIKeyUUID := uuid.New()
 	keyHash := auth.HashAPIKey(rawKey)
 
 	tx, err := d.sql.BeginTxx(ctx, nil)
@@ -94,11 +108,11 @@ func (d *DB) CreateConsoleAPIKey(ctx context.Context, input platform.CreateConso
 			expires_at
 		)
 		values (
-			:external_id, CAST(:api_key_ref_uuid AS uuid),
-			CAST(:organization_uuid AS uuid), CAST(:workspace_uuid AS uuid),
+			:external_id, :api_key_ref_uuid,
+			:organization_uuid, :workspace_uuid,
 			:workspace_display_id, :name,
 			:key_prefix, :key_suffix, :key_hash, 'active',
-			CAST(:created_by_user_ref_uuid AS uuid), :expires_at
+			:created_by_user_ref_uuid, :expires_at
 		)
 		returning `+consoleAPIKeySQLXColumns+`
 	`, map[string]any{
@@ -130,8 +144,8 @@ func (d *DB) CreateConsoleAPIKey(ctx context.Context, input platform.CreateConso
 			expires_at
 		)
 		values (
-			CAST(:uuid AS uuid), :external_id, CAST(:workspace_uuid AS uuid), :key_hash, 'active',
-			CAST(:created_by_user_uuid AS uuid),
+			:uuid, :external_id, :workspace_uuid, :key_hash, 'active',
+			:created_by_user_uuid,
 			:name, :partial_key_hint, :expires_at
 		)
 	`, map[string]any{
@@ -163,8 +177,14 @@ func (d *DB) UpdateConsoleAPIKeyStatus(ctx context.Context, input platform.Updat
 		strings.TrimSpace(input.Status) == "" {
 		return platform.ConsoleAPIKey{}, platform.ErrNotFound
 	}
-	orgUUID := strings.TrimSpace(input.OrgUUID)
-	workspaceUUID := strings.TrimSpace(input.WorkspaceUUID)
+	orgUUID, err := parseDBUUID("organization_uuid", input.OrgUUID)
+	if err != nil {
+		return platform.ConsoleAPIKey{}, platform.ErrNotFound
+	}
+	workspaceUUID, err := parseDBUUID("workspace_uuid", input.WorkspaceUUID)
+	if err != nil {
+		return platform.ConsoleAPIKey{}, platform.ErrNotFound
+	}
 	apiKeyID := strings.TrimSpace(input.APIKeyID)
 	status := strings.TrimSpace(input.Status)
 
@@ -182,8 +202,8 @@ func (d *DB) UpdateConsoleAPIKeyStatus(ctx context.Context, input platform.Updat
 				else null
 			end,
 			updated_at = now()
-		where organization_uuid = CAST(:organization_uuid AS uuid)
-		  and workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where organization_uuid = :organization_uuid
+		  and workspace_uuid = :workspace_uuid
 		  and external_id = :api_key_id
 		returning `+consoleAPIKeySQLXColumns+`
 	`, map[string]any{
@@ -213,29 +233,33 @@ func (d *DB) UpdateConsoleAPIKeyStatus(ctx context.Context, input platform.Updat
 func resolveConsoleAPIKeyUserUUID(
 	ctx context.Context,
 	database sqlxNamedQueryer,
-	orgUUID string,
+	orgUUID uuid.UUID,
 	userUUID *string,
-) (*string, error) {
-	var coreUserUUID *string
+) (uuid.NullUUID, error) {
+	var coreUserUUID uuid.NullUUID
 	if userUUID != nil && strings.TrimSpace(*userUUID) != "" {
-		var resolvedUserUUID string
+		var resolvedUserUUID uuid.UUID
 		err := namedGetContext(ctx, database, &resolvedUserUUID, `
-			select CAST(u.uuid AS text)
+			select u.uuid
 			from users u
-			where u.organization_uuid = CAST(:org_uuid AS uuid)
+			where u.organization_uuid = :org_uuid
 			  and u.deleted_at is null
 			  and (
 				u.external_id = :user_uuid
-				or CAST(u.uuid AS text) = :user_uuid
+				or u.uuid = :user_internal_uuid
 				or 'user_' || left(replace(CAST(u.uuid AS text), '-', ''), 24) = :user_uuid
 			  )
 			limit 1
-		`, map[string]any{"org_uuid": orgUUID, "user_uuid": strings.TrimSpace(*userUUID)})
+		`, map[string]any{
+			"org_uuid":           orgUUID,
+			"user_uuid":          strings.TrimSpace(*userUUID),
+			"user_internal_uuid": tryParseDBUUIDIdentifier(*userUUID),
+		})
 		if err != nil && !errors.Is(mapNoRows(err), platform.ErrNotFound) {
-			return nil, err
+			return uuid.NullUUID{}, err
 		}
 		if err == nil {
-			coreUserUUID = &resolvedUserUUID
+			coreUserUUID = uuid.NullUUID{UUID: resolvedUserUUID, Valid: true}
 		}
 	}
 	return coreUserUUID, nil
@@ -245,16 +269,24 @@ func (d *DB) CountConsoleAPIKeys(ctx context.Context, orgUUID string, workspaceU
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(workspaceUUID) == "" {
 		return 0, nil
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return 0, nil
+	}
+	typedWorkspaceUUID, err := parseDBUUID("workspace_uuid", workspaceUUID)
+	if err != nil {
+		return 0, nil
+	}
 	var count int
-	err := namedGetContext(ctx, d.sql, &count, `
+	err = namedGetContext(ctx, d.sql, &count, `
 		select count(*)
 		from console_api_keys
-		where organization_uuid = CAST(:organization_uuid AS uuid)
-		  and workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where organization_uuid = :organization_uuid
+		  and workspace_uuid = :workspace_uuid
 		  and archived_at is null
 	`, map[string]any{
-		"organization_uuid": strings.TrimSpace(orgUUID),
-		"workspace_uuid":    strings.TrimSpace(workspaceUUID),
+		"organization_uuid": typedOrgUUID,
+		"workspace_uuid":    typedWorkspaceUUID,
 	})
 	if isUndefinedTableError(err) {
 		return 0, nil
@@ -271,11 +303,15 @@ func (d *DB) CreateConsoleWorkspace(ctx context.Context, input platform.CreateCo
 	if err != nil {
 		return platform.ConsoleWorkspace{}, err
 	}
+	orgUUID, err := parseDBUUID("organization_uuid", input.OrgUUID)
+	if err != nil {
+		return platform.ConsoleWorkspace{}, platform.ErrNotFound
+	}
 	workspace, err := getConsoleWorkspaceSQLX(ctx, d.sql, `
 		with org as (
-			select uuid, CAST(uuid AS text) as org_uuid
+			select uuid
 			from organizations
-			where CAST(uuid AS text) = :org_uuid
+			where uuid = :org_uuid
 			limit 1
 		)
 		insert into workspaces (
@@ -297,9 +333,9 @@ func (d *DB) CreateConsoleWorkspace(ctx context.Context, input platform.CreateCo
 			archived_at = null,
 			updated_at = now()
 		returning
-			CAST(uuid AS text) AS uuid,
+			uuid,
 			external_id,
-			(select org_uuid from org) AS org_uuid,
+			organization_uuid AS org_uuid,
 			name,
 			display_color AS display_color,
 			display_color AS color,
@@ -310,8 +346,8 @@ func (d *DB) CreateConsoleWorkspace(ctx context.Context, input platform.CreateCo
 			created_at,
 			updated_at
 	`, map[string]any{
-		"org_uuid":       strings.TrimSpace(input.OrgUUID),
-		"uuid":           uuid.NewString(),
+		"org_uuid":       orgUUID,
+		"uuid":           uuid.New(),
 		"external_id":    externalID,
 		"name":           strings.TrimSpace(input.Name),
 		"display_color":  firstNonEmpty(strings.TrimSpace(input.DisplayColor), strings.TrimSpace(input.Color), "#9B87F5"),
@@ -327,7 +363,11 @@ func (d *DB) ListConsoleWorkspaces(ctx context.Context, orgUUID string, includeA
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" {
 		return []platform.ConsoleWorkspace{}, nil
 	}
-	query, arguments := listConsoleWorkspacesQuery(orgUUID, includeArchived)
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return []platform.ConsoleWorkspace{}, nil
+	}
+	query, arguments := listConsoleWorkspacesQuery(typedOrgUUID, includeArchived)
 	workspaces, err := selectConsoleWorkspacesSQLX(ctx, d.sql, query, arguments)
 	if err != nil {
 		if isUndefinedTableError(err) {
@@ -338,16 +378,16 @@ func (d *DB) ListConsoleWorkspaces(ctx context.Context, orgUUID string, includeA
 	return workspaces, nil
 }
 
-func listConsoleWorkspacesQuery(orgUUID string, includeArchived bool) (string, map[string]any) {
+func listConsoleWorkspacesQuery(orgUUID uuid.UUID, includeArchived bool) (string, map[string]any) {
 	archivedFilter := "and w.archived_at is null"
 	if includeArchived {
 		archivedFilter = ""
 	}
 	query := `
 		select
-			CAST(w.uuid AS text) AS uuid,
+			w.uuid,
 			w.external_id,
-			CAST(w.organization_uuid AS text) AS org_uuid,
+			w.organization_uuid AS org_uuid,
 			w.name,
 			w.display_color AS display_color,
 			w.display_color AS color,
@@ -358,11 +398,11 @@ func listConsoleWorkspacesQuery(orgUUID string, includeArchived bool) (string, m
 			w.created_at,
 			w.updated_at
 		from workspaces w
-		where w.organization_uuid = CAST(:org_uuid AS uuid)
+		where w.organization_uuid = :org_uuid
 		` + archivedFilter + `
 		order by w.name asc, w.uuid asc
 	`
-	return query, map[string]any{"org_uuid": strings.TrimSpace(orgUUID)}
+	return query, map[string]any{"org_uuid": orgUUID}
 }
 
 func (r consoleWorkspaceRow) workspace() (platform.ConsoleWorkspace, error) {
@@ -375,9 +415,9 @@ func (r consoleWorkspaceRow) workspace() (platform.ConsoleWorkspace, error) {
 		return platform.ConsoleWorkspace{}, err
 	}
 	return platform.ConsoleWorkspace{
-		UUID:                  r.UUID,
+		UUID:                  r.UUID.String(),
 		ExternalID:            r.ExternalID,
-		OrgUUID:               r.OrgUUID,
+		OrgUUID:               r.OrgUUID.String(),
 		Name:                  r.Name,
 		DisplayColor:          r.DisplayColor,
 		Color:                 r.Color,
@@ -392,34 +432,34 @@ func (r consoleWorkspaceRow) workspace() (platform.ConsoleWorkspace, error) {
 }
 
 const consoleAPIKeySQLXColumns = `external_id AS id,
-	CAST(organization_uuid AS text) AS org_uuid,
-	CAST(workspace_uuid AS text) AS workspace_uuid, workspace_display_id, name,
+	organization_uuid AS org_uuid,
+	workspace_uuid, workspace_display_id, name,
 	key_prefix, key_suffix, status,
-	CAST(created_by_user_ref_uuid AS text) AS created_by_user_uuid,
+	created_by_user_ref_uuid AS created_by_user_uuid,
 	last_used_at, expires_at,
 	archived_at, created_at, updated_at`
 
 type consoleAPIKeyRow struct {
-	ID                 string     `db:"id"`
-	OrgUUID            string     `db:"org_uuid"`
-	WorkspaceUUID      string     `db:"workspace_uuid"`
-	WorkspaceDisplayID string     `db:"workspace_display_id"`
-	Name               string     `db:"name"`
-	KeyPrefix          string     `db:"key_prefix"`
-	KeySuffix          string     `db:"key_suffix"`
-	Status             string     `db:"status"`
-	CreatedByUserUUID  *string    `db:"created_by_user_uuid"`
-	LastUsedAt         *time.Time `db:"last_used_at"`
-	ExpiresAt          *time.Time `db:"expires_at"`
-	ArchivedAt         *time.Time `db:"archived_at"`
-	CreatedAt          time.Time  `db:"created_at"`
-	UpdatedAt          time.Time  `db:"updated_at"`
+	ID                 string        `db:"id"`
+	OrgUUID            uuid.UUID     `db:"org_uuid"`
+	WorkspaceUUID      uuid.UUID     `db:"workspace_uuid"`
+	WorkspaceDisplayID string        `db:"workspace_display_id"`
+	Name               string        `db:"name"`
+	KeyPrefix          string        `db:"key_prefix"`
+	KeySuffix          string        `db:"key_suffix"`
+	Status             string        `db:"status"`
+	CreatedByUserUUID  uuid.NullUUID `db:"created_by_user_uuid"`
+	LastUsedAt         *time.Time    `db:"last_used_at"`
+	ExpiresAt          *time.Time    `db:"expires_at"`
+	ArchivedAt         *time.Time    `db:"archived_at"`
+	CreatedAt          time.Time     `db:"created_at"`
+	UpdatedAt          time.Time     `db:"updated_at"`
 }
 
 type consoleWorkspaceRow struct {
-	UUID          string     `db:"uuid"`
+	UUID          uuid.UUID  `db:"uuid"`
 	ExternalID    string     `db:"external_id"`
-	OrgUUID       string     `db:"org_uuid"`
+	OrgUUID       uuid.UUID  `db:"org_uuid"`
 	Name          string     `db:"name"`
 	DisplayColor  string     `db:"display_color"`
 	Color         string     `db:"color"`
@@ -498,14 +538,14 @@ func selectConsoleWorkspacesSQLX(
 func (r consoleAPIKeyRow) key() platform.ConsoleAPIKey {
 	return platform.ConsoleAPIKey{
 		ID:                 r.ID,
-		OrgUUID:            r.OrgUUID,
-		WorkspaceUUID:      r.WorkspaceUUID,
+		OrgUUID:            r.OrgUUID.String(),
+		WorkspaceUUID:      r.WorkspaceUUID.String(),
 		WorkspaceDisplayID: r.WorkspaceDisplayID,
 		Name:               r.Name,
 		KeyPrefix:          r.KeyPrefix,
 		KeySuffix:          r.KeySuffix,
 		Status:             r.Status,
-		CreatedByUserUUID:  r.CreatedByUserUUID,
+		CreatedByUserUUID:  nullableUUIDString(r.CreatedByUserUUID),
 		LastUsedAt:         r.LastUsedAt,
 		ExpiresAt:          r.ExpiresAt,
 		ArchivedAt:         r.ArchivedAt,

--- a/internal/db/console_api_keys_sqlx_test.go
+++ b/internal/db/console_api_keys_sqlx_test.go
@@ -3,16 +3,19 @@ package db
 import (
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestConsoleAPIKeyQueriesUseSQLXNamedParameters(t *testing.T) {
-	workspaceID := "workspace_test"
-	apiKeyQuery, apiKeyArguments := listConsoleAPIKeysQuery("org_test", &workspaceID)
-	workspaceQuery, workspaceArguments := listConsoleWorkspacesQuery("org_test", false)
+	orgUUID := uuid.MustParse("11111111-1111-4111-8111-111111111111")
+	workspaceUUID := uuid.MustParse("22222222-2222-4222-8222-222222222222")
+	apiKeyQuery, apiKeyArguments := listConsoleAPIKeysQuery(orgUUID, uuid.NullUUID{UUID: workspaceUUID, Valid: true})
+	workspaceQuery, workspaceArguments := listConsoleWorkspacesQuery(orgUUID, false)
 
 	t.Run("rejects a missing named argument", func(t *testing.T) {
 		if _, _, err := bindNamed(postgresRebinder{}, apiKeyQuery, map[string]any{
-			"org_uuid": "org_test",
+			"org_uuid": orgUUID,
 		}); err == nil {
 			t.Fatal("bindNamed() error = nil, want missing workspace_uuid error")
 		}
@@ -50,6 +53,9 @@ func TestConsoleAPIKeyQueriesUseSQLXNamedParameters(t *testing.T) {
 			if strings.Contains(test.query, "::") {
 				t.Fatalf("query uses PostgreSQL cast shorthand: %q", test.query)
 			}
+			if strings.Contains(test.query, " AS uuid)") || strings.Contains(test.query, " AS text)") {
+				t.Fatalf("query contains UUID cast ceremony: %q", test.query)
+			}
 			if len(arguments) != test.wantArgCount {
 				t.Fatalf("argument count = %d, want %d", len(arguments), test.wantArgCount)
 			}
@@ -59,9 +65,9 @@ func TestConsoleAPIKeyQueriesUseSQLXNamedParameters(t *testing.T) {
 
 func TestConsoleWorkspaceRowMapsJSONFields(t *testing.T) {
 	row := consoleWorkspaceRow{
-		UUID:          "workspace_test",
+		UUID:          uuid.MustParse("22222222-2222-4222-8222-222222222222"),
 		ExternalID:    "workspace_external",
-		OrgUUID:       "org_test",
+		OrgUUID:       uuid.MustParse("11111111-1111-4111-8111-111111111111"),
 		DataResidency: []byte(`{"workspace_geo":"us","allowed_inference_geos":"unrestricted","default_inference_geo":"global"}`),
 		Tags:          []byte(`{"team":"platform"}`),
 	}
@@ -73,7 +79,7 @@ func TestConsoleWorkspaceRowMapsJSONFields(t *testing.T) {
 	if workspace.DataResidency == nil || *workspace.DataResidency != "us" {
 		t.Fatalf("data residency = %#v, want us", workspace.DataResidency)
 	}
-	if workspace.UUID != "workspace_test" || workspace.ExternalID != "workspace_external" {
+	if workspace.UUID != "22222222-2222-4222-8222-222222222222" || workspace.ExternalID != "workspace_external" {
 		t.Fatalf("workspace identifiers = (%q, %q), want database UUID and external ID", workspace.UUID, workspace.ExternalID)
 	}
 	if workspace.Tags["team"] != "platform" {

--- a/internal/db/console_invites.go
+++ b/internal/db/console_invites.go
@@ -23,7 +23,7 @@ const (
 			external_id, organization_uuid, email, role, status, invited_at, expires_at
 		)
 		values (
-			:external_id, CAST(:org_uuid AS uuid), :email, :role,
+			:external_id, :org_uuid, :email, :role,
 			'pending', :invited_at, :expires_at
 		)
 		returning
@@ -39,7 +39,7 @@ const (
 		set status = 'pending',
 			invited_at = :invited_at,
 			expires_at = :expires_at
-		where i.organization_uuid = CAST(:org_uuid AS uuid)
+		where i.organization_uuid = :org_uuid
 			and i.external_id = :invite_id
 			and i.deleted_at is null
 		returning ` + consoleInviteColumns + `
@@ -48,7 +48,7 @@ const (
 		update organization_invites i
 		set status = 'deleted',
 			deleted_at = coalesce(i.deleted_at, now())
-		where i.organization_uuid = CAST(:org_uuid AS uuid)
+		where i.organization_uuid = :org_uuid
 			and i.external_id = :invite_id
 		returning ` + consoleInviteColumns + `
 	`
@@ -70,10 +70,14 @@ func (d *DB) ListConsoleInvites(ctx context.Context, orgUUID string, status stri
 	if limit <= 0 || limit > 1000 {
 		limit = 1000
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return []platform.ConsoleInvite{}, nil
+	}
 	query := `
 		select ` + consoleInviteColumns + `
 		from organization_invites i
-		where i.organization_uuid = CAST(:org_uuid AS uuid)
+		where i.organization_uuid = :org_uuid
 	`
 	switch strings.TrimSpace(strings.ToLower(status)) {
 	case "":
@@ -92,8 +96,8 @@ func (d *DB) ListConsoleInvites(ctx context.Context, orgUUID string, status stri
 	query += ` order by i.invited_at desc, i.uuid desc limit :limit`
 
 	var rows []consoleInviteRow
-	err := namedSelectContext(ctx, d.sql, &rows, query, map[string]any{
-		"org_uuid": strings.TrimSpace(orgUUID),
+	err = namedSelectContext(ctx, d.sql, &rows, query, map[string]any{
+		"org_uuid": typedOrgUUID,
 		"limit":    limit,
 	})
 	if err != nil {
@@ -119,9 +123,13 @@ func (d *DB) CreateConsoleInvite(ctx context.Context, input platform.CreateConso
 	if err != nil {
 		return platform.ConsoleInvite{}, err
 	}
+	orgUUID, err := parseDBUUID("organization_uuid", input.OrgUUID)
+	if err != nil {
+		return platform.ConsoleInvite{}, platform.ErrNotFound
+	}
 	now := time.Now().UTC()
 	invite, err := getConsoleInviteSQLX(ctx, d.sql, createConsoleInviteQuery, map[string]any{
-		"org_uuid":    strings.TrimSpace(input.OrgUUID),
+		"org_uuid":    orgUUID,
 		"external_id": externalID,
 		"email":       strings.TrimSpace(input.Email),
 		"role":        strings.TrimSpace(input.Role),
@@ -138,9 +146,13 @@ func (d *DB) ResendConsoleInvite(ctx context.Context, orgUUID string, inviteID s
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(inviteID) == "" {
 		return platform.ConsoleInvite{}, platform.ErrNotFound
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return platform.ConsoleInvite{}, platform.ErrNotFound
+	}
 	now := time.Now().UTC()
 	return getConsoleInviteSQLX(ctx, d.sql, resendConsoleInviteQuery, map[string]any{
-		"org_uuid":   strings.TrimSpace(orgUUID),
+		"org_uuid":   typedOrgUUID,
 		"invite_id":  strings.TrimSpace(inviteID),
 		"invited_at": now,
 		"expires_at": now.Add(21 * 24 * time.Hour),
@@ -151,8 +163,12 @@ func (d *DB) DeleteConsoleInvite(ctx context.Context, orgUUID string, inviteID s
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(inviteID) == "" {
 		return platform.ConsoleInvite{}, platform.ErrNotFound
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return platform.ConsoleInvite{}, platform.ErrNotFound
+	}
 	return getConsoleInviteSQLX(ctx, d.sql, deleteConsoleInviteQuery, map[string]any{
-		"org_uuid":  strings.TrimSpace(orgUUID),
+		"org_uuid":  typedOrgUUID,
 		"invite_id": strings.TrimSpace(inviteID),
 	})
 }

--- a/internal/db/console_invites_sqlx_test.go
+++ b/internal/db/console_invites_sqlx_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
@@ -11,7 +13,7 @@ func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
 	listQuery := `
 		select ` + consoleInviteColumns + `
 		from organization_invites i
-		where i.organization_uuid = CAST(:org_uuid AS uuid)
+		where i.organization_uuid = :org_uuid
 			and i.deleted_at is null
 		order by i.invited_at desc, i.uuid desc
 		limit :limit
@@ -26,7 +28,7 @@ func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
 			name:  "list",
 			query: listQuery,
 			arguments: map[string]any{
-				"org_uuid": "org_test",
+				"org_uuid": uuid.MustParse("11111111-1111-4111-8111-111111111111"),
 				"limit":    100,
 			},
 			wantArgCount: 2,
@@ -35,7 +37,7 @@ func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
 			name:  "create",
 			query: createConsoleInviteQuery,
 			arguments: map[string]any{
-				"org_uuid":    "org_test",
+				"org_uuid":    uuid.MustParse("11111111-1111-4111-8111-111111111111"),
 				"external_id": "invite_test",
 				"email":       "invite@example.test",
 				"role":        "developer",
@@ -48,7 +50,7 @@ func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
 			name:  "resend",
 			query: resendConsoleInviteQuery,
 			arguments: map[string]any{
-				"org_uuid":   "org_test",
+				"org_uuid":   uuid.MustParse("11111111-1111-4111-8111-111111111111"),
 				"invite_id":  "invite_test",
 				"invited_at": now,
 				"expires_at": now.Add(21 * 24 * time.Hour),
@@ -59,7 +61,7 @@ func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
 			name:  "delete",
 			query: deleteConsoleInviteQuery,
 			arguments: map[string]any{
-				"org_uuid":  "org_test",
+				"org_uuid":  uuid.MustParse("11111111-1111-4111-8111-111111111111"),
 				"invite_id": "invite_test",
 			},
 			wantArgCount: 2,
@@ -77,6 +79,9 @@ func TestConsoleInviteQueriesUseSQLXNamedParameters(t *testing.T) {
 			}
 			if strings.Contains(query, ":") {
 				t.Fatalf("bound query still contains a named parameter: %s", query)
+			}
+			if strings.Contains(query, "CAST($1 AS uuid)") {
+				t.Fatalf("bound query contains UUID parameter cast: %s", query)
 			}
 		})
 	}

--- a/internal/db/console_members.go
+++ b/internal/db/console_members.go
@@ -7,18 +7,20 @@ import (
 	"time"
 
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
+
+	"github.com/google/uuid"
 )
 
 const (
 	listOrgUsersQuery = `
 		select
-			CAST(u.uuid AS text) AS user_uuid,
+			u.uuid AS user_uuid,
 			u.email,
 			nullif(u.name, '') AS full_name,
 			u.role,
 			u.added_at
 		from users u
-		where u.organization_uuid = CAST(:org_uuid AS uuid)
+		where u.organization_uuid = :org_uuid
 			and u.deleted_at is null
 		order by u.added_at asc, u.uuid asc
 		limit :limit
@@ -27,15 +29,15 @@ const (
 		update users u
 		set role = :role,
 			updated_at = now()
-		where u.organization_uuid = CAST(:org_uuid AS uuid)
+		where u.organization_uuid = :org_uuid
 			and u.deleted_at is null
 			and (
-				CAST(u.uuid AS text) = :user_id
+				u.uuid = :user_uuid
 				or u.external_id = :user_id
 				or 'user_' || left(replace(CAST(u.uuid AS text), '-', ''), 24) = :user_id
 			)
 		returning
-			CAST(u.uuid AS text) AS user_uuid,
+			u.uuid AS user_uuid,
 			u.email,
 			nullif(u.name, '') AS full_name,
 			u.role,
@@ -45,10 +47,10 @@ const (
 		update users u
 		set deleted_at = coalesce(u.deleted_at, now()),
 			updated_at = now()
-		where u.organization_uuid = CAST(:org_uuid AS uuid)
+		where u.organization_uuid = :org_uuid
 			and u.deleted_at is null
 			and (
-				CAST(u.uuid AS text) = :user_id
+				u.uuid = :user_uuid
 				or u.external_id = :user_id
 				or 'user_' || left(replace(CAST(u.uuid AS text), '-', ''), 24) = :user_id
 			)
@@ -57,9 +59,9 @@ const (
 		with target_user as (
 			select uuid
 			from users
-			where organization_uuid = CAST(:org_uuid AS uuid)
+			where organization_uuid = :org_uuid
 				and (
-					CAST(uuid AS text) = :user_id
+					uuid = :user_uuid
 					or external_id = :user_id
 					or 'user_' || left(replace(CAST(uuid AS text), '-', ''), 24) = :user_id
 				)
@@ -69,14 +71,14 @@ const (
 		set deleted_at = coalesce(wm.deleted_at, now()),
 			updated_at = now()
 		from target_user u
-		where wm.organization_uuid = CAST(:org_uuid AS uuid)
+		where wm.organization_uuid = :org_uuid
 			and wm.user_uuid = u.uuid
 			and wm.deleted_at is null
 	`
 )
 
 type consoleMemberRow struct {
-	UserUUID string    `db:"user_uuid"`
+	UserUUID uuid.UUID `db:"user_uuid"`
 	Email    string    `db:"email"`
 	FullName *string   `db:"full_name"`
 	Role     string    `db:"role"`
@@ -90,9 +92,13 @@ func (d *DB) ListOrgUsers(ctx context.Context, orgUUID string, limit int) ([]pla
 	if limit <= 0 || limit > 1000 {
 		limit = 1000
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return []platform.OrgUser{}, nil
+	}
 	var rows []consoleMemberRow
-	err := namedSelectContext(ctx, d.sql, &rows, listOrgUsersQuery, map[string]any{
-		"org_uuid": strings.TrimSpace(orgUUID),
+	err = namedSelectContext(ctx, d.sql, &rows, listOrgUsersQuery, map[string]any{
+		"org_uuid": typedOrgUUID,
 		"limit":    limit,
 	})
 	if err != nil {
@@ -113,10 +119,15 @@ func (d *DB) UpdateOrgUserRole(ctx context.Context, orgUUID string, userID strin
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(userID) == "" {
 		return nil, nil
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil, nil
+	}
 	user, err := getConsoleMemberSQLX(ctx, d.sql, updateOrgUserRoleQuery, map[string]any{
-		"org_uuid": strings.TrimSpace(orgUUID),
-		"user_id":  strings.TrimSpace(userID),
-		"role":     role,
+		"org_uuid":  typedOrgUUID,
+		"user_id":   strings.TrimSpace(userID),
+		"user_uuid": tryParseDBUUIDIdentifier(userID),
+		"role":      role,
 	})
 	if err != nil {
 		if errors.Is(err, platform.ErrNotFound) {
@@ -131,6 +142,10 @@ func (d *DB) RemoveOrgUser(ctx context.Context, orgUUID string, userID string) (
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(userID) == "" {
 		return false, nil
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return false, nil
+	}
 	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return false, err
@@ -138,8 +153,9 @@ func (d *DB) RemoveOrgUser(ctx context.Context, orgUUID string, userID string) (
 	defer func() { _ = tx.Rollback() }()
 
 	arguments := map[string]any{
-		"org_uuid": strings.TrimSpace(orgUUID),
-		"user_id":  strings.TrimSpace(userID),
+		"org_uuid":  typedOrgUUID,
+		"user_id":   strings.TrimSpace(userID),
+		"user_uuid": tryParseDBUUIDIdentifier(userID),
 	}
 	rowsAffected, err := namedExecRowsAffected(ctx, tx, removeOrgUserQuery, arguments)
 	if err != nil {
@@ -175,7 +191,7 @@ func getConsoleMemberSQLX(
 
 func (r consoleMemberRow) user() platform.OrgUser {
 	return platform.OrgUser{
-		UserUUID: r.UserUUID,
+		UserUUID: r.UserUUID.String(),
 		Email:    r.Email,
 		FullName: r.FullName,
 		Role:     r.Role,

--- a/internal/db/console_members_sqlx_test.go
+++ b/internal/db/console_members_sqlx_test.go
@@ -3,6 +3,8 @@ package db
 import (
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestConsoleMemberQueriesUseSQLXNamedParameters(t *testing.T) {
@@ -16,7 +18,7 @@ func TestConsoleMemberQueriesUseSQLXNamedParameters(t *testing.T) {
 			name:  "list",
 			query: listOrgUsersQuery,
 			arguments: map[string]any{
-				"org_uuid": "org_test",
+				"org_uuid": uuid.MustParse("11111111-1111-4111-8111-111111111111"),
 				"limit":    100,
 			},
 			wantArgCount: 2,
@@ -25,9 +27,10 @@ func TestConsoleMemberQueriesUseSQLXNamedParameters(t *testing.T) {
 			name:  "update role",
 			query: updateOrgUserRoleQuery,
 			arguments: map[string]any{
-				"org_uuid": "org_test",
-				"user_id":  "user_test",
-				"role":     "developer",
+				"org_uuid":  uuid.MustParse("11111111-1111-4111-8111-111111111111"),
+				"user_id":   "user_test",
+				"user_uuid": tryParseDBUUIDIdentifier("user_test"),
+				"role":      "developer",
 			},
 			wantArgCount: 5,
 		},
@@ -35,8 +38,9 @@ func TestConsoleMemberQueriesUseSQLXNamedParameters(t *testing.T) {
 			name:  "remove user",
 			query: removeOrgUserQuery,
 			arguments: map[string]any{
-				"org_uuid": "org_test",
-				"user_id":  "user_test",
+				"org_uuid":  uuid.MustParse("11111111-1111-4111-8111-111111111111"),
+				"user_id":   "user_test",
+				"user_uuid": tryParseDBUUIDIdentifier("user_test"),
 			},
 			wantArgCount: 4,
 		},
@@ -44,8 +48,9 @@ func TestConsoleMemberQueriesUseSQLXNamedParameters(t *testing.T) {
 			name:  "remove workspace memberships",
 			query: removeOrgUserWorkspaceMembershipsQuery,
 			arguments: map[string]any{
-				"org_uuid": "org_test",
-				"user_id":  "user_test",
+				"org_uuid":  uuid.MustParse("11111111-1111-4111-8111-111111111111"),
+				"user_id":   "user_test",
+				"user_uuid": tryParseDBUUIDIdentifier("user_test"),
 			},
 			wantArgCount: 5,
 		},

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/jmoiron/sqlx"
@@ -41,10 +42,10 @@ type DB struct {
 }
 
 type APIKey struct {
-	UUID                string
+	UUID                uuid.UUID
 	ExternalID          string
-	OrganizationUUID    string
-	WorkspaceUUID       string
+	OrganizationUUID    uuid.UUID
+	WorkspaceUUID       uuid.UUID
 	WorkspaceExternalID string
 }
 
@@ -54,11 +55,11 @@ type foreignKeyRow struct {
 }
 
 type apiKeyRow struct {
-	UUID                string `db:"uuid"`
-	ExternalID          string `db:"external_id"`
-	OrganizationUUID    string `db:"organization_uuid"`
-	WorkspaceUUID       string `db:"workspace_uuid"`
-	WorkspaceExternalID string `db:"workspace_external_id"`
+	UUID                uuid.UUID `db:"uuid"`
+	ExternalID          string    `db:"external_id"`
+	OrganizationUUID    uuid.UUID `db:"organization_uuid"`
+	WorkspaceUUID       uuid.UUID `db:"workspace_uuid"`
+	WorkspaceExternalID string    `db:"workspace_external_id"`
 }
 
 const (
@@ -98,23 +99,23 @@ const (
 			where not exists (select 1 from existing)
 			returning uuid
 		)
-		select CAST(uuid AS text) from updated
+		select uuid from updated
 		union all
-		select CAST(uuid AS text) from inserted
+		select uuid from inserted
 		limit 1
 	`
 	seedOrganizationLockQuery = `select pg_advisory_xact_lock(704611533427849228)`
 	seedWorkspaceQuery        = `
 		insert into workspaces (external_id, organization_uuid, name)
-		values (:external_id, CAST(:organization_uuid AS uuid), :name)
+		values (:external_id, :organization_uuid, :name)
 		on conflict (external_id) do update set
 			organization_uuid = excluded.organization_uuid,
 			name = excluded.name
-		returning CAST(uuid AS text)
+		returning uuid
 	`
 	seedUserQuery = `
 		insert into users (external_id, organization_uuid, email, name, role)
-		values (:external_id, CAST(:organization_uuid AS uuid), :email, :name, 'admin')
+		values (:external_id, :organization_uuid, :email, :name, 'admin')
 		on conflict (external_id) do update set
 			organization_uuid = excluded.organization_uuid,
 			email = excluded.email,
@@ -122,7 +123,7 @@ const (
 			role = excluded.role,
 			deleted_at = null,
 			updated_at = now()
-		returning CAST(uuid AS text)
+		returning uuid
 	`
 	seedWorkspaceMemberQuery = `
 		insert into workspace_members (
@@ -130,8 +131,8 @@ const (
 			user_uuid, user_external_id, workspace_role
 		)
 		values (
-			:external_id, CAST(:organization_uuid AS uuid), CAST(:workspace_uuid AS uuid),
-			:workspace_external_id, CAST(:user_uuid AS uuid), :user_external_id, 'workspace_admin'
+			:external_id, :organization_uuid, :workspace_uuid,
+			:workspace_external_id, :user_uuid, :user_external_id, 'workspace_admin'
 		)
 		on conflict (external_id) do update set
 			organization_uuid = excluded.organization_uuid,
@@ -148,8 +149,8 @@ const (
 			external_id, workspace_uuid, key_hash, status, created_by_user_uuid, name, partial_key_hint
 		)
 		values (
-			:external_id, CAST(:workspace_uuid AS uuid), :key_hash, 'active',
-			CAST(:created_by_user_uuid AS uuid), :name, :partial_key_hint
+			:external_id, :workspace_uuid, :key_hash, 'active',
+			:created_by_user_uuid, :name, :partial_key_hint
 		)
 		on conflict (external_id) do update set
 			workspace_uuid = excluded.workspace_uuid,
@@ -161,9 +162,9 @@ const (
 			updated_at = now()
 	`
 	getAPIKeyQuery = `
-		select CAST(ak.uuid AS text) AS uuid, ak.external_id,
-			CAST(w.organization_uuid AS text) as organization_uuid,
-			CAST(w.uuid AS text) as workspace_uuid,
+		select ak.uuid, ak.external_id,
+			w.organization_uuid,
+			w.uuid as workspace_uuid,
 			w.external_id as workspace_external_id
 		from api_keys ak
 		join workspaces w on w.uuid = ak.workspace_uuid
@@ -497,14 +498,14 @@ func (d *DB) Seed(ctx context.Context, seedAPIKeys []config.SeedAPIKey) error {
 	if _, err := tx.ExecContext(ctx, seedOrganizationLockQuery); err != nil {
 		return err
 	}
-	var organizationUUID string
+	var organizationUUID uuid.UUID
 	if err := namedGetContext(ctx, tx, &organizationUUID, seedOrganizationQuery, map[string]any{
 		"workspace_external_id": "workspace_default",
 		"name":                  "default",
 	}); err != nil {
 		return err
 	}
-	var workspaceUUID string
+	var workspaceUUID uuid.UUID
 	if err := namedGetContext(ctx, tx, &workspaceUUID, seedWorkspaceQuery, map[string]any{
 		"external_id":       "workspace_default",
 		"organization_uuid": organizationUUID,
@@ -512,7 +513,7 @@ func (d *DB) Seed(ctx context.Context, seedAPIKeys []config.SeedAPIKey) error {
 	}); err != nil {
 		return err
 	}
-	var userUUID string
+	var userUUID uuid.UUID
 	if err := namedGetContext(ctx, tx, &userUUID, seedUserQuery, map[string]any{
 		"external_id":       "user_default",
 		"organization_uuid": organizationUUID,

--- a/internal/db/db_sqlx_test.go
+++ b/internal/db/db_sqlx_test.go
@@ -3,6 +3,8 @@ package db
 import (
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestDatabaseQueriesUseSQLXNamedParameters(t *testing.T) {
@@ -122,8 +124,8 @@ func TestDatabaseQueriesUseSQLXNamedParameters(t *testing.T) {
 func TestAPIKeyRowMapsDatabaseColumns(t *testing.T) {
 	row := apiKeyRow{
 		ExternalID:          "sk_default",
-		OrganizationUUID:    "22222222-2222-4222-8222-222222222222",
-		WorkspaceUUID:       "11111111-1111-4111-8111-111111111111",
+		OrganizationUUID:    uuid.MustParse("22222222-2222-4222-8222-222222222222"),
+		WorkspaceUUID:       uuid.MustParse("11111111-1111-4111-8111-111111111111"),
 		WorkspaceExternalID: "workspace_default",
 	}
 

--- a/internal/db/deployments.go
+++ b/internal/db/deployments.go
@@ -205,7 +205,7 @@ func (d *DB) UpdateDeployment(ctx context.Context, workspaceUUID string, externa
 	defer tx.Rollback()
 
 	arguments := deploymentArguments(next)
-	arguments["workspace_uuid"] = workspaceUUID
+	arguments["workspace_uuid"] = dbUUID(workspaceUUID)
 	arguments["external_id"] = externalID
 	current, err := getDeploymentSQLX(ctx, tx, lockDeploymentForUpdateQuery, arguments)
 	if err != nil {
@@ -262,7 +262,7 @@ func (d *DB) CreateManualDeploymentRun(ctx context.Context, input CreateManualDe
 	defer tx.Rollback()
 
 	deployment, err := getDeploymentSQLX(ctx, tx, lockDeploymentForManualRunQuery, map[string]any{
-		"workspace_uuid":         input.Run.WorkspaceUUID,
+		"workspace_uuid":         dbUUID(input.Run.WorkspaceUUID),
 		"deployment_external_id": input.DeploymentExternalID,
 	})
 	if err != nil {
@@ -356,7 +356,7 @@ func listDeploymentsQuery(params ListDeploymentsPageParams) (string, map[string]
 		where workspace_uuid = :workspace_uuid and deleted_at is null
 	`
 	arguments := map[string]any{
-		"workspace_uuid": params.WorkspaceUUID,
+		"workspace_uuid": dbUUID(params.WorkspaceUUID),
 		"limit":          params.Limit + 1,
 	}
 	if !params.IncludeArchived {
@@ -379,9 +379,9 @@ func listDeploymentsQuery(params ListDeploymentsPageParams) (string, map[string]
 		arguments["created_at_lte"] = *params.CreatedAtLTE
 	}
 	if params.Cursor != nil {
-		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < CAST(:cursor_uuid AS uuid)))"
+		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < :cursor_uuid))"
 		arguments["cursor_created_at"] = params.Cursor.CreatedAt
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	query += " order by created_at desc, uuid desc limit :limit"
 	return query, arguments
@@ -394,7 +394,7 @@ func listDeploymentRunsQuery(params ListDeploymentRunsPageParams) (string, map[s
 		where workspace_uuid = :workspace_uuid and deleted_at is null
 	`
 	arguments := map[string]any{
-		"workspace_uuid": params.WorkspaceUUID,
+		"workspace_uuid": dbUUID(params.WorkspaceUUID),
 		"limit":          params.Limit + 1,
 	}
 	if params.DeploymentExternalID != "" {
@@ -414,9 +414,9 @@ func listDeploymentRunsQuery(params ListDeploymentRunsPageParams) (string, map[s
 	}
 	query, arguments = deploymentRunTimeFilters(query, arguments, params)
 	if params.Cursor != nil {
-		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < CAST(:cursor_uuid AS uuid)))"
+		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < :cursor_uuid))"
 		arguments["cursor_created_at"] = params.Cursor.CreatedAt
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	query += " order by created_at desc, uuid desc limit :limit"
 	return query, arguments
@@ -448,21 +448,21 @@ func deploymentRunTimeFilters(
 
 func deploymentLookupArguments(workspaceUUID string, externalID string) map[string]any {
 	return map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 	}
 }
 
 func deploymentArguments(deployment Deployment) map[string]any {
 	return map[string]any{
-		"uuid":                    deployment.UUID,
+		"uuid":                    dbUUID(deployment.UUID),
 		"external_id":             deployment.ExternalID,
-		"organization_uuid":       deployment.OrganizationUUID,
-		"workspace_uuid":          deployment.WorkspaceUUID,
-		"created_by_api_key_uuid": deployment.CreatedByAPIKeyUUID,
-		"environment_uuid":        deployment.EnvironmentUUID,
+		"organization_uuid":       dbUUID(deployment.OrganizationUUID),
+		"workspace_uuid":          dbUUID(deployment.WorkspaceUUID),
+		"created_by_api_key_uuid": dbUUID(deployment.CreatedByAPIKeyUUID),
+		"environment_uuid":        dbUUID(deployment.EnvironmentUUID),
 		"environment_external_id": deployment.EnvironmentExternalID,
-		"agent_uuid":              deployment.AgentUUID,
+		"agent_uuid":              dbUUID(deployment.AgentUUID),
 		"agent_external_id":       deployment.AgentExternalID,
 		"agent_version":           deployment.AgentVersion,
 		"agent_snapshot":          jsonArg(deployment.AgentSnapshot),

--- a/internal/db/deployments_sqlx.go
+++ b/internal/db/deployments_sqlx.go
@@ -5,24 +5,26 @@ import (
 	"database/sql"
 	"errors"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
-	deploymentSQLXColumns = `cast(uuid as text) as uuid, external_id,
-		cast(organization_uuid as text) as organization_uuid,
-		cast(workspace_uuid as text) as workspace_uuid,
-		cast(created_by_api_key_uuid as text) as created_by_api_key_uuid,
-		cast(environment_uuid as text) as environment_uuid, environment_external_id,
-		cast(agent_uuid as text) as agent_uuid, agent_external_id,
+	deploymentSQLXColumns = `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		created_by_api_key_uuid,
+		environment_uuid, environment_external_id,
+		agent_uuid, agent_external_id,
 		agent_version, agent_snapshot, name, description,
 		metadata, initial_events, resources, resource_secrets, vault_ids, schedule,
 		last_run_at, status, paused_reason, created_at, updated_at, archived_at, deleted_at`
-	deploymentRunSQLXColumns = `cast(uuid as text) as uuid, external_id,
-		cast(organization_uuid as text) as organization_uuid,
-		cast(workspace_uuid as text) as workspace_uuid,
-		cast(created_by_api_key_uuid as text) as created_by_api_key_uuid,
-		cast(deployment_uuid as text) as deployment_uuid, deployment_external_id,
-		cast(agent_uuid as text) as agent_uuid, agent_external_id,
+	deploymentRunSQLXColumns = `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		created_by_api_key_uuid,
+		deployment_uuid, deployment_external_id,
+		agent_uuid, agent_external_id,
 		agent_version, agent_snapshot, session_external_id,
 		error, trigger_type, trigger_context, created_at, deleted_at`
 	lockDeploymentForManualRunQuery = `
@@ -62,14 +64,14 @@ const (
 // deploymentRow / deploymentRunRow 只承载 sqlx 扫描结果；与领域模型分离后，
 // 可以把 JSONB、nullable 字段和列别名约束收敛在 DB 边界内。
 type deploymentRow struct {
-	UUID                  string     `db:"uuid"`
+	UUID                  uuid.UUID  `db:"uuid"`
 	ExternalID            string     `db:"external_id"`
-	OrganizationUUID      string     `db:"organization_uuid"`
-	WorkspaceUUID         string     `db:"workspace_uuid"`
-	CreatedByAPIKeyUUID   string     `db:"created_by_api_key_uuid"`
-	EnvironmentUUID       string     `db:"environment_uuid"`
+	OrganizationUUID      uuid.UUID  `db:"organization_uuid"`
+	WorkspaceUUID         uuid.UUID  `db:"workspace_uuid"`
+	CreatedByAPIKeyUUID   uuid.UUID  `db:"created_by_api_key_uuid"`
+	EnvironmentUUID       uuid.UUID  `db:"environment_uuid"`
 	EnvironmentExternalID string     `db:"environment_external_id"`
-	AgentUUID             string     `db:"agent_uuid"`
+	AgentUUID             uuid.UUID  `db:"agent_uuid"`
 	AgentExternalID       string     `db:"agent_external_id"`
 	AgentVersion          int        `db:"agent_version"`
 	AgentSnapshot         []byte     `db:"agent_snapshot"`
@@ -91,14 +93,14 @@ type deploymentRow struct {
 }
 
 type deploymentRunRow struct {
-	UUID                 string     `db:"uuid"`
+	UUID                 uuid.UUID  `db:"uuid"`
 	ExternalID           string     `db:"external_id"`
-	OrganizationUUID     string     `db:"organization_uuid"`
-	WorkspaceUUID        string     `db:"workspace_uuid"`
-	CreatedByAPIKeyUUID  string     `db:"created_by_api_key_uuid"`
-	DeploymentUUID       string     `db:"deployment_uuid"`
+	OrganizationUUID     uuid.UUID  `db:"organization_uuid"`
+	WorkspaceUUID        uuid.UUID  `db:"workspace_uuid"`
+	CreatedByAPIKeyUUID  uuid.UUID  `db:"created_by_api_key_uuid"`
+	DeploymentUUID       uuid.UUID  `db:"deployment_uuid"`
 	DeploymentExternalID string     `db:"deployment_external_id"`
-	AgentUUID            string     `db:"agent_uuid"`
+	AgentUUID            uuid.UUID  `db:"agent_uuid"`
 	AgentExternalID      string     `db:"agent_external_id"`
 	AgentVersion         int        `db:"agent_version"`
 	AgentSnapshot        []byte     `db:"agent_snapshot"`
@@ -146,7 +148,7 @@ func updateDeploymentLastRunSQLX(
 	lastRunAt time.Time,
 ) error {
 	result, err := namedExecContext(ctx, database, updateDeploymentLastRunQuery, map[string]any{
-		"workspace_uuid":         workspaceUUID,
+		"workspace_uuid":         dbUUID(workspaceUUID),
 		"deployment_external_id": deploymentExternalID,
 		"last_run_at":            lastRunAt,
 	})
@@ -165,14 +167,14 @@ func updateDeploymentLastRunSQLX(
 
 func deploymentRunArguments(run DeploymentRun) map[string]any {
 	return map[string]any{
-		"run_uuid":                run.UUID,
+		"run_uuid":                dbUUID(run.UUID),
 		"run_external_id":         run.ExternalID,
-		"organization_uuid":       run.OrganizationUUID,
-		"workspace_uuid":          run.WorkspaceUUID,
-		"created_by_api_key_uuid": run.CreatedByAPIKeyUUID,
-		"deployment_uuid":         run.DeploymentUUID,
+		"organization_uuid":       dbUUID(run.OrganizationUUID),
+		"workspace_uuid":          dbUUID(run.WorkspaceUUID),
+		"created_by_api_key_uuid": dbUUID(run.CreatedByAPIKeyUUID),
+		"deployment_uuid":         dbUUID(run.DeploymentUUID),
 		"deployment_external_id":  run.DeploymentExternalID,
-		"agent_uuid":              run.AgentUUID,
+		"agent_uuid":              dbUUID(run.AgentUUID),
 		"agent_external_id":       run.AgentExternalID,
 		"agent_version":           run.AgentVersion,
 		"agent_snapshot":          jsonArg(run.AgentSnapshot),
@@ -186,14 +188,14 @@ func deploymentRunArguments(run DeploymentRun) map[string]any {
 
 func (r deploymentRow) deployment() Deployment {
 	return Deployment{
-		UUID:                  r.UUID,
+		UUID:                  r.UUID.String(),
 		ExternalID:            r.ExternalID,
-		OrganizationUUID:      r.OrganizationUUID,
-		WorkspaceUUID:         r.WorkspaceUUID,
-		CreatedByAPIKeyUUID:   r.CreatedByAPIKeyUUID,
-		EnvironmentUUID:       r.EnvironmentUUID,
+		OrganizationUUID:      r.OrganizationUUID.String(),
+		WorkspaceUUID:         r.WorkspaceUUID.String(),
+		CreatedByAPIKeyUUID:   r.CreatedByAPIKeyUUID.String(),
+		EnvironmentUUID:       r.EnvironmentUUID.String(),
 		EnvironmentExternalID: r.EnvironmentExternalID,
-		AgentUUID:             r.AgentUUID,
+		AgentUUID:             r.AgentUUID.String(),
 		AgentExternalID:       r.AgentExternalID,
 		AgentVersion:          r.AgentVersion,
 		AgentSnapshot:         copyRaw(r.AgentSnapshot),
@@ -217,14 +219,14 @@ func (r deploymentRow) deployment() Deployment {
 
 func (r deploymentRunRow) run() DeploymentRun {
 	return DeploymentRun{
-		UUID:                 r.UUID,
+		UUID:                 r.UUID.String(),
 		ExternalID:           r.ExternalID,
-		OrganizationUUID:     r.OrganizationUUID,
-		WorkspaceUUID:        r.WorkspaceUUID,
-		CreatedByAPIKeyUUID:  r.CreatedByAPIKeyUUID,
-		DeploymentUUID:       r.DeploymentUUID,
+		OrganizationUUID:     r.OrganizationUUID.String(),
+		WorkspaceUUID:        r.WorkspaceUUID.String(),
+		CreatedByAPIKeyUUID:  r.CreatedByAPIKeyUUID.String(),
+		DeploymentUUID:       r.DeploymentUUID.String(),
 		DeploymentExternalID: r.DeploymentExternalID,
-		AgentUUID:            r.AgentUUID,
+		AgentUUID:            r.AgentUUID.String(),
 		AgentExternalID:      r.AgentExternalID,
 		AgentVersion:         r.AgentVersion,
 		AgentSnapshot:        copyRaw(r.AgentSnapshot),

--- a/internal/db/environments.go
+++ b/internal/db/environments.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Environment struct {
@@ -147,7 +149,7 @@ func (d *DB) GetEnvironment(ctx context.Context, workspaceUUID string, externalI
 
 func (d *DB) UpdateEnvironment(ctx context.Context, workspaceUUID string, externalID string, next Environment) (Environment, error) {
 	arguments := environmentArguments(next)
-	arguments["workspace_uuid"] = workspaceUUID
+	arguments["workspace_uuid"] = dbUUID(workspaceUUID)
 	arguments["external_id"] = externalID
 	updated, err := getEnvironmentSQLX(ctx, d.sql, `
 		update environments
@@ -184,9 +186,9 @@ func (d *DB) DeleteEnvironment(ctx context.Context, workspaceUUID string, extern
 	}
 	defer tx.Rollback()
 
-	var environmentUUID string
+	var environmentUUID uuid.UUID
 	err = namedGetContext(ctx, tx, &environmentUUID, `
-		select CAST(uuid AS text)
+		select uuid
 		from environments
 		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 		for update
@@ -206,7 +208,10 @@ func (d *DB) DeleteEnvironment(ctx context.Context, workspaceUUID string, extern
 			and environment_uuid = :environment_uuid
 			and deleted_at is null
 			and state <> 'stopped'
-	`, map[string]any{"workspace_uuid": workspaceUUID, "environment_uuid": environmentUUID}); err != nil {
+	`, map[string]any{
+		"workspace_uuid":   dbUUID(workspaceUUID),
+		"environment_uuid": environmentUUID,
+	}); err != nil {
 		return err
 	}
 	if activeWork > 0 {
@@ -217,9 +222,12 @@ func (d *DB) DeleteEnvironment(ctx context.Context, workspaceUUID string, extern
 		set deleted_at = coalesce(deleted_at, now()),
 			updated_at = now()
 		where workspace_uuid = :workspace_uuid
-			and uuid = CAST(:environment_uuid AS uuid)
+			and uuid = :environment_uuid
 			and deleted_at is null
-	`, map[string]any{"workspace_uuid": workspaceUUID, "environment_uuid": environmentUUID}); err != nil {
+	`, map[string]any{
+		"workspace_uuid":   dbUUID(workspaceUUID),
+		"environment_uuid": environmentUUID,
+	}); err != nil {
 		return err
 	}
 	return tx.Commit()
@@ -245,14 +253,17 @@ func listEnvironmentsQuery(params ListEnvironmentsPageParams) (string, map[strin
 	query := environmentSelectSQL() + `
 		where workspace_uuid = :workspace_uuid and deleted_at is null
 	`
-	arguments := map[string]any{"workspace_uuid": params.WorkspaceUUID, "limit": params.Limit + 1}
+	arguments := map[string]any{
+		"workspace_uuid": dbUUID(params.WorkspaceUUID),
+		"limit":          params.Limit + 1,
+	}
 	if !params.IncludeArchived {
 		query += " and archived_at is null"
 	}
 	if params.Cursor != nil {
-		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < CAST(:cursor_uuid AS uuid)))"
+		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < :cursor_uuid))"
 		arguments["cursor_created_at"] = params.Cursor.CreatedAt
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	query += " order by created_at desc, uuid desc limit :limit"
 	return query, arguments
@@ -277,9 +288,9 @@ func (d *DB) CreateEnvironmentKey(ctx context.Context, key EnvironmentKey, keyHa
 			status = 'active'
 	`, map[string]any{
 		"external_id":             key.ExternalID,
-		"organization_uuid":       key.OrganizationUUID,
-		"workspace_uuid":          key.WorkspaceUUID,
-		"environment_uuid":        key.EnvironmentUUID,
+		"organization_uuid":       dbUUID(key.OrganizationUUID),
+		"workspace_uuid":          dbUUID(key.WorkspaceUUID),
+		"environment_uuid":        dbUUID(key.EnvironmentUUID),
 		"environment_external_id": key.EnvironmentExternalID,
 		"key_hash":                keyHash,
 	})
@@ -295,11 +306,11 @@ func (d *DB) GetEnvironmentKey(ctx context.Context, keyHash string) (Environment
 			where key_hash = :key_hash and status = 'active'
 			returning uuid, external_id, organization_uuid, workspace_uuid, environment_uuid, environment_external_id
 		)
-		select CAST(updated.uuid AS text) AS uuid, updated.external_id,
-			CAST(updated.organization_uuid AS text) AS organization_uuid,
-			CAST(updated.workspace_uuid AS text) AS workspace_uuid,
+		select updated.uuid, updated.external_id,
+			updated.organization_uuid,
+			updated.workspace_uuid,
 			workspaces.external_id AS workspace_external_id,
-			CAST(updated.environment_uuid AS text) AS environment_uuid,
+			updated.environment_uuid,
 			updated.environment_external_id
 		from updated
 		join workspaces on workspaces.uuid = updated.workspace_uuid
@@ -337,7 +348,7 @@ func (d *DB) GetLatestEnvironmentWorkByData(ctx context.Context, workspaceUUID s
 		order by created_at desc, uuid desc
 		limit 1
 	`, map[string]any{
-		"workspace_uuid":          workspaceUUID,
+		"workspace_uuid":          dbUUID(workspaceUUID),
 		"environment_external_id": environmentExternalID,
 		"data_type":               dataType,
 		"data_id":                 dataID,
@@ -367,14 +378,14 @@ func listEnvironmentWorkQuery(params ListEnvironmentWorkPageParams) (string, map
 			and deleted_at is null
 	`
 	arguments := map[string]any{
-		"workspace_uuid":          params.WorkspaceUUID,
+		"workspace_uuid":          dbUUID(params.WorkspaceUUID),
 		"environment_external_id": params.EnvironmentExternalID,
 		"limit":                   params.Limit + 1,
 	}
 	if params.Cursor != nil {
-		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < CAST(:cursor_uuid AS uuid)))"
+		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < :cursor_uuid))"
 		arguments["cursor_created_at"] = params.Cursor.CreatedAt
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	query += " order by created_at desc, uuid desc limit :limit"
 	return query, arguments
@@ -402,7 +413,7 @@ func (d *DB) PollEnvironmentWork(ctx context.Context, workspaceUUID string, envi
 				and deleted_at is null
 			on conflict (environment_uuid, worker_id) do update set last_poll_at = excluded.last_poll_at
 		`, map[string]any{
-			"workspace_uuid":          workspaceUUID,
+			"workspace_uuid":          dbUUID(workspaceUUID),
 			"environment_external_id": environmentExternalID,
 			"worker_id":               workerID,
 		}); err != nil {
@@ -429,7 +440,7 @@ func (d *DB) PollEnvironmentWork(ctx context.Context, workspaceUUID string, envi
 		)
 		returning `+environmentWorkSQLXColumns+`
 	`, map[string]any{
-		"workspace_uuid":          workspaceUUID,
+		"workspace_uuid":          dbUUID(workspaceUUID),
 		"environment_external_id": environmentExternalID,
 		"worker_id":               nullableWorkerID(workerID),
 		"claim_expires_at":        time.Now().UTC().Add(claimFor),
@@ -494,9 +505,12 @@ func (d *DB) PollNextEnvironmentWorkForRunner(ctx context.Context, workerID stri
 func (d *DB) GetEnvironmentByUUID(ctx context.Context, workspaceUUID, environmentUUID string) (Environment, error) {
 	return getEnvironmentSQLX(ctx, d.sql, environmentSelectSQL()+`
 		where workspace_uuid = :workspace_uuid
-			and uuid = CAST(:environment_uuid AS uuid)
+			and uuid = :environment_uuid
 			and deleted_at is null
-	`, map[string]any{"workspace_uuid": workspaceUUID, "environment_uuid": environmentUUID})
+	`, map[string]any{
+		"workspace_uuid":   dbUUID(workspaceUUID),
+		"environment_uuid": dbUUID(environmentUUID),
+	})
 }
 
 func (d *DB) AckEnvironmentWork(ctx context.Context, workspaceUUID string, environmentExternalID, workExternalID string) (EnvironmentWork, error) {
@@ -573,7 +587,7 @@ func (d *DB) HeartbeatEnvironmentWork(ctx context.Context, workspaceUUID string,
 	if nextState == "queued" || nextState == "starting" {
 		nextState = "active"
 	}
-	arguments["work_uuid"] = current.UUID
+	arguments["work_uuid"] = dbUUID(current.UUID)
 	arguments["state"] = nextState
 	arguments["ttl_seconds"] = ttlSeconds
 	updated, err := getEnvironmentWorkSQLX(ctx, tx, `
@@ -582,7 +596,7 @@ func (d *DB) HeartbeatEnvironmentWork(ctx context.Context, workspaceUUID string,
 			latest_heartbeat_at = now(),
 			heartbeat_ttl_seconds = :ttl_seconds,
 			updated_at = now()
-		where uuid = CAST(:work_uuid AS uuid)
+		where uuid = :work_uuid
 			and workspace_uuid = :workspace_uuid
 			and environment_external_id = :environment_external_id
 		returning `+environmentWorkSQLXColumns+`
@@ -643,7 +657,7 @@ func (d *DB) EnvironmentWorkStats(ctx context.Context, workspaceUUID string, env
 			and environment_external_id = :environment_external_id
 			and deleted_at is null
 	`, map[string]any{
-		"workspace_uuid":          workspaceUUID,
+		"workspace_uuid":          dbUUID(workspaceUUID),
 		"environment_external_id": environmentExternalID,
 	})
 	if err != nil {
@@ -687,7 +701,7 @@ func (d *DB) UpdateEnvironmentSandboxState(ctx context.Context, workspaceUUID st
 			updated_at = now()
 		where workspace_uuid = :workspace_uuid and external_id = :external_id
 	`, map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"external_id":         externalID,
 		"state":               state,
 		"provider_sandbox_id": providerSandboxID,
@@ -719,56 +733,56 @@ func (d *DB) GetRenewableEnvironmentSandboxForCodeSession(ctx context.Context, c
 	return getEnvironmentSandboxSQLX(ctx, d.sql, `
 		select `+environmentSandboxSQLXColumns+`
 		from environment_sandboxes
-		where id = (
-			select sandbox.id
+		where uuid = (
+			select sandbox.uuid
 			from code_sessions code_session
 			join environment_work work
-				on work.organization_id = code_session.organization_id
-				and work.workspace_id = code_session.workspace_id
-				and work.environment_id = code_session.environment_id
+				on work.organization_uuid = code_session.organization_uuid
+				and work.workspace_uuid = code_session.workspace_uuid
+				and work.environment_uuid = code_session.environment_uuid
 				and work.environment_external_id = code_session.environment_external_id
 				and work.data->>'type' = 'session'
 				and work.data->>'id' = code_session.session_external_id
 				and work.deleted_at is null
 			join environment_sandboxes sandbox
-				on sandbox.organization_id = code_session.organization_id
-				and sandbox.workspace_id = code_session.workspace_id
-				and sandbox.environment_id = code_session.environment_id
-				and sandbox.work_id = work.id
+				on sandbox.organization_uuid = code_session.organization_uuid
+				and sandbox.workspace_uuid = code_session.workspace_uuid
+				and sandbox.environment_uuid = code_session.environment_uuid
+				and sandbox.work_uuid = work.uuid
 				and sandbox.provider_sandbox_id is not null
 				and sandbox.state = 'running'
 			where code_session.external_id = :code_session_external_id
 				and code_session.status = 'active'
 				and code_session.worker_status = 'running'
 				and code_session.deleted_at is null
-			order by sandbox.created_at desc, sandbox.id desc
+			order by sandbox.created_at desc, sandbox.uuid desc
 			limit 1
 		)
 	`, map[string]any{"code_session_external_id": codeSessionExternalID})
 }
 
 const (
-	environmentSQLXColumns = `CAST(uuid AS text) AS uuid, external_id,
-		CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(created_by_api_key_uuid AS text) AS created_by_api_key_uuid,
+	environmentSQLXColumns = `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		created_by_api_key_uuid,
 		name, description, config, metadata, scope,
 		provider, resolved_template, created_at, updated_at, archived_at, deleted_at`
-	environmentSandboxSQLXColumns = `CAST(uuid AS text) AS uuid, external_id,
-		CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(environment_uuid AS text) AS environment_uuid,
-		environment_external_id, CAST(work_uuid AS text) AS work_uuid,
+	environmentSandboxSQLXColumns = `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		environment_uuid,
+		environment_external_id, work_uuid,
 		work_external_id, provider, template, provider_sandbox_id, state, metadata,
 		last_error, created_at, updated_at, stopped_at`
 )
 
 type environmentRow struct {
-	UUID                string     `db:"uuid"`
+	UUID                uuid.UUID  `db:"uuid"`
 	ExternalID          string     `db:"external_id"`
-	OrganizationUUID    string     `db:"organization_uuid"`
-	WorkspaceUUID       string     `db:"workspace_uuid"`
-	CreatedByAPIKeyUUID string     `db:"created_by_api_key_uuid"`
+	OrganizationUUID    uuid.UUID  `db:"organization_uuid"`
+	WorkspaceUUID       uuid.UUID  `db:"workspace_uuid"`
+	CreatedByAPIKeyUUID uuid.UUID  `db:"created_by_api_key_uuid"`
 	Name                string     `db:"name"`
 	Description         string     `db:"description"`
 	Config              []byte     `db:"config"`
@@ -783,13 +797,13 @@ type environmentRow struct {
 }
 
 type environmentKeyRow struct {
-	UUID                  string `db:"uuid"`
-	ExternalID            string `db:"external_id"`
-	OrganizationUUID      string `db:"organization_uuid"`
-	WorkspaceUUID         string `db:"workspace_uuid"`
-	WorkspaceExternalID   string `db:"workspace_external_id"`
-	EnvironmentUUID       string `db:"environment_uuid"`
-	EnvironmentExternalID string `db:"environment_external_id"`
+	UUID                  uuid.UUID `db:"uuid"`
+	ExternalID            string    `db:"external_id"`
+	OrganizationUUID      uuid.UUID `db:"organization_uuid"`
+	WorkspaceUUID         uuid.UUID `db:"workspace_uuid"`
+	WorkspaceExternalID   string    `db:"workspace_external_id"`
+	EnvironmentUUID       uuid.UUID `db:"environment_uuid"`
+	EnvironmentExternalID string    `db:"environment_external_id"`
 }
 
 type environmentWorkStatsRow struct {
@@ -800,23 +814,23 @@ type environmentWorkStatsRow struct {
 }
 
 type environmentSandboxRow struct {
-	UUID                  string     `db:"uuid"`
-	ExternalID            string     `db:"external_id"`
-	OrganizationUUID      string     `db:"organization_uuid"`
-	WorkspaceUUID         string     `db:"workspace_uuid"`
-	EnvironmentUUID       string     `db:"environment_uuid"`
-	EnvironmentExternalID string     `db:"environment_external_id"`
-	WorkUUID              *string    `db:"work_uuid"`
-	WorkExternalID        *string    `db:"work_external_id"`
-	Provider              string     `db:"provider"`
-	Template              string     `db:"template"`
-	ProviderSandboxID     *string    `db:"provider_sandbox_id"`
-	State                 string     `db:"state"`
-	Metadata              []byte     `db:"metadata"`
-	LastError             *string    `db:"last_error"`
-	CreatedAt             time.Time  `db:"created_at"`
-	UpdatedAt             time.Time  `db:"updated_at"`
-	StoppedAt             *time.Time `db:"stopped_at"`
+	UUID                  uuid.UUID     `db:"uuid"`
+	ExternalID            string        `db:"external_id"`
+	OrganizationUUID      uuid.UUID     `db:"organization_uuid"`
+	WorkspaceUUID         uuid.UUID     `db:"workspace_uuid"`
+	EnvironmentUUID       uuid.UUID     `db:"environment_uuid"`
+	EnvironmentExternalID string        `db:"environment_external_id"`
+	WorkUUID              uuid.NullUUID `db:"work_uuid"`
+	WorkExternalID        *string       `db:"work_external_id"`
+	Provider              string        `db:"provider"`
+	Template              string        `db:"template"`
+	ProviderSandboxID     *string       `db:"provider_sandbox_id"`
+	State                 string        `db:"state"`
+	Metadata              []byte        `db:"metadata"`
+	LastError             *string       `db:"last_error"`
+	CreatedAt             time.Time     `db:"created_at"`
+	UpdatedAt             time.Time     `db:"updated_at"`
+	StoppedAt             *time.Time    `db:"stopped_at"`
 }
 
 func environmentSelectSQL() string {
@@ -910,7 +924,10 @@ func getEnvironmentSandboxSQLX(
 }
 
 func environmentLookupArguments(workspaceUUID string, externalID string) map[string]any {
-	return map[string]any{"workspace_uuid": workspaceUUID, "external_id": externalID}
+	return map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"external_id":    externalID,
+	}
 }
 
 func environmentWorkLookupArguments(
@@ -919,7 +936,7 @@ func environmentWorkLookupArguments(
 	workExternalID string,
 ) map[string]any {
 	return map[string]any{
-		"workspace_uuid":          workspaceUUID,
+		"workspace_uuid":          dbUUID(workspaceUUID),
 		"environment_external_id": environmentExternalID,
 		"work_external_id":        workExternalID,
 	}
@@ -927,11 +944,11 @@ func environmentWorkLookupArguments(
 
 func environmentArguments(env Environment) map[string]any {
 	return map[string]any{
-		"uuid":                    env.UUID,
+		"uuid":                    dbUUID(env.UUID),
 		"external_id":             env.ExternalID,
-		"organization_uuid":       env.OrganizationUUID,
-		"workspace_uuid":          env.WorkspaceUUID,
-		"created_by_api_key_uuid": env.CreatedByAPIKeyUUID,
+		"organization_uuid":       dbUUID(env.OrganizationUUID),
+		"workspace_uuid":          dbUUID(env.WorkspaceUUID),
+		"created_by_api_key_uuid": dbUUID(env.CreatedByAPIKeyUUID),
 		"name":                    env.Name,
 		"description":             env.Description,
 		"config":                  jsonArg(env.Config),
@@ -946,13 +963,13 @@ func environmentArguments(env Environment) map[string]any {
 
 func environmentSandboxArguments(sandbox EnvironmentSandbox) map[string]any {
 	return map[string]any{
-		"uuid":                    sandbox.UUID,
+		"uuid":                    dbUUID(sandbox.UUID),
 		"external_id":             sandbox.ExternalID,
-		"organization_uuid":       sandbox.OrganizationUUID,
-		"workspace_uuid":          sandbox.WorkspaceUUID,
-		"environment_uuid":        sandbox.EnvironmentUUID,
+		"organization_uuid":       dbUUID(sandbox.OrganizationUUID),
+		"workspace_uuid":          dbUUID(sandbox.WorkspaceUUID),
+		"environment_uuid":        dbUUID(sandbox.EnvironmentUUID),
 		"environment_external_id": sandbox.EnvironmentExternalID,
-		"work_uuid":               sandbox.WorkUUID,
+		"work_uuid":               dbNullableUUID(sandbox.WorkUUID),
 		"work_external_id":        sandbox.WorkExternalID,
 		"provider":                sandbox.Provider,
 		"template":                sandbox.Template,
@@ -966,11 +983,11 @@ func environmentSandboxArguments(sandbox EnvironmentSandbox) map[string]any {
 
 func (r environmentRow) environment() Environment {
 	return Environment{
-		UUID:                r.UUID,
+		UUID:                r.UUID.String(),
 		ExternalID:          r.ExternalID,
-		OrganizationUUID:    r.OrganizationUUID,
-		WorkspaceUUID:       r.WorkspaceUUID,
-		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID,
+		OrganizationUUID:    r.OrganizationUUID.String(),
+		WorkspaceUUID:       r.WorkspaceUUID.String(),
+		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID.String(),
 		Name:                r.Name,
 		Description:         r.Description,
 		Config:              copyRaw(r.Config),
@@ -987,25 +1004,25 @@ func (r environmentRow) environment() Environment {
 
 func (r environmentKeyRow) key() EnvironmentKey {
 	return EnvironmentKey{
-		UUID:                  r.UUID,
+		UUID:                  r.UUID.String(),
 		ExternalID:            r.ExternalID,
-		OrganizationUUID:      r.OrganizationUUID,
-		WorkspaceUUID:         r.WorkspaceUUID,
+		OrganizationUUID:      r.OrganizationUUID.String(),
+		WorkspaceUUID:         r.WorkspaceUUID.String(),
 		WorkspaceExternalID:   r.WorkspaceExternalID,
-		EnvironmentUUID:       r.EnvironmentUUID,
+		EnvironmentUUID:       r.EnvironmentUUID.String(),
 		EnvironmentExternalID: r.EnvironmentExternalID,
 	}
 }
 
 func (r environmentSandboxRow) sandbox() EnvironmentSandbox {
 	return EnvironmentSandbox{
-		UUID:                  r.UUID,
+		UUID:                  r.UUID.String(),
 		ExternalID:            r.ExternalID,
-		OrganizationUUID:      r.OrganizationUUID,
-		WorkspaceUUID:         r.WorkspaceUUID,
-		EnvironmentUUID:       r.EnvironmentUUID,
+		OrganizationUUID:      r.OrganizationUUID.String(),
+		WorkspaceUUID:         r.WorkspaceUUID.String(),
+		EnvironmentUUID:       r.EnvironmentUUID.String(),
 		EnvironmentExternalID: r.EnvironmentExternalID,
-		WorkUUID:              r.WorkUUID,
+		WorkUUID:              nullableUUIDString(r.WorkUUID),
 		WorkExternalID:        r.WorkExternalID,
 		Provider:              r.Provider,
 		Template:              r.Template,

--- a/internal/db/files.go
+++ b/internal/db/files.go
@@ -71,8 +71,8 @@ func (d *DB) GetFileByUUIDInOrganization(ctx context.Context, organizationUUID s
 		d.sql,
 		getFileByUUIDInOrganizationQuery,
 		map[string]any{
-			"organization_uuid": organizationUUID,
-			"file_uuid":         fileUUID,
+			"organization_uuid": dbUUID(organizationUUID),
+			"file_uuid":         dbUUID(fileUUID),
 		},
 	)
 }

--- a/internal/db/files_sqlx.go
+++ b/internal/db/files_sqlx.go
@@ -3,40 +3,43 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"slices"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
 
 const (
-	fileSQLXColumns = `cast(uuid as text) as uuid, external_id, cast(workspace_uuid as text) as workspace_uuid, filename, mime_type,
+	fileSQLXColumns = `uuid, external_id, workspace_uuid, filename, mime_type,
 		size_bytes, sha256, s3_bucket, s3_key, downloadable, scope_type, scope_id,
-		cast(created_by_api_key_uuid as text) as created_by_api_key_uuid, created_at`
+		created_by_api_key_uuid, created_at`
 	getFileQuery = `
 		select ` + fileSQLXColumns + `
 		from files
-		where workspace_uuid = cast(:workspace_uuid as uuid)
+		where workspace_uuid = :workspace_uuid
 			and external_id = :file_external_id
 			and deleted_at is null
 	`
 	getFileByUUIDQuery = `
 		select ` + fileSQLXColumns + `
 		from files
-		where workspace_uuid = cast(:workspace_uuid as uuid)
-			and cast(uuid as text) = :file_uuid
+		where workspace_uuid = :workspace_uuid
+			and uuid = :file_uuid
 			and deleted_at is null
 	`
 	getFileByUUIDInOrganizationQuery = `
-		select cast(f.uuid as text) as uuid, f.external_id, cast(f.workspace_uuid as text) as workspace_uuid,
+		select f.uuid, f.external_id, f.workspace_uuid,
 			f.filename, f.mime_type, f.size_bytes, f.sha256, f.s3_bucket, f.s3_key,
 			f.downloadable, f.scope_type, f.scope_id,
-			cast(f.created_by_api_key_uuid as text) as created_by_api_key_uuid, f.created_at
+			f.created_by_api_key_uuid, f.created_at
 		from files f
 		join workspaces w on w.uuid = f.workspace_uuid
-		where w.organization_uuid = cast(:organization_uuid as uuid)
-			and cast(f.uuid as text) = :file_uuid
+		where w.organization_uuid = :organization_uuid
+			and f.uuid = :file_uuid
 			and f.deleted_at is null
 	`
 	insertFileQuery = `
@@ -54,7 +57,7 @@ const (
 	softDeleteFileRecordQuery = `
 		select ` + fileSQLXColumns + `
 		from files
-		where workspace_uuid = cast(:workspace_uuid as uuid)
+		where workspace_uuid = :workspace_uuid
 			and external_id = :file_external_id
 			and deleted_at is null
 		for update
@@ -64,10 +67,10 @@ const (
 			exists (
 				select 1
 				from filestore_entries entry
-				where entry.workspace_uuid = cast(:workspace_uuid as uuid)
+				where entry.workspace_uuid = :workspace_uuid
 					-- 投影不拥有对象也不计入 files_bytes。即使 backing entry 已退休，
 					-- 仍需阻止普通 Files 删除路径把投影当作源文件扣减容量。
-					and entry.uuid = CAST(:file_uuid AS uuid)
+					and entry.uuid = :file_uuid
 			)
 			or exists (
 				select 1
@@ -76,15 +79,15 @@ const (
 					on filesystem.uuid = entry.filesystem_uuid
 					and filesystem.workspace_uuid = entry.workspace_uuid
 					and filesystem.deleted_at is null
-				where entry.workspace_uuid = cast(:workspace_uuid as uuid)
-					and entry.source_file_uuid = CAST(:file_uuid AS uuid)
+				where entry.workspace_uuid = :workspace_uuid
+					and entry.source_file_uuid = :file_uuid
 					and entry.deleted_at is null
 			)
 	`
 	softDeleteFileQuery = `
 		update files
 		set deleted_at = now()
-		where workspace_uuid = cast(:workspace_uuid as uuid)
+		where workspace_uuid = :workspace_uuid
 			and external_id = :file_external_id
 			and deleted_at is null
 	`
@@ -95,17 +98,7 @@ const (
 			:workspace_uuid,
 			'object_cleanup',
 			'pending',
-			jsonb_build_object(
-				'bucket', CAST(:bucket AS text),
-				'key', CAST(:object_key AS text),
-				'file_id', case
-					when CAST(:resource_type AS text) = 'file'
-					then CAST(:resource_id AS text)
-					else ''
-				end,
-				'resource_type', CAST(:resource_type AS text),
-				'resource_id', CAST(:resource_id AS text)
-			)
+			CAST(:payload AS jsonb)
 		)
 	`
 	leaseObjectCleanupJobsQuery = `
@@ -129,8 +122,8 @@ const (
 			updated_at = now()
 		from next_jobs
 		where j.uuid = next_jobs.uuid
-		returning cast(j.uuid as text) as uuid, j.external_id,
-			cast(j.workspace_uuid as text) as workspace_uuid,
+		returning j.uuid, j.external_id,
+			j.workspace_uuid,
 			coalesce(j.payload->>'bucket', '') as bucket,
 			coalesce(j.payload->>'key', '') as object_key,
 			coalesce(j.payload->>'file_id', '') as file_external_id,
@@ -142,7 +135,7 @@ const (
 			locked_by = null,
 			locked_until = null,
 			updated_at = now()
-		where uuid = cast(:job_uuid as uuid) and type = 'object_cleanup'
+		where uuid = :job_uuid and type = 'object_cleanup'
 	`
 	failObjectCleanupJobQuery = `
 		update jobs
@@ -156,16 +149,16 @@ const (
 				'last_error',
 				CAST(:reason AS text)
 			)
-		where uuid = cast(:job_uuid as uuid) and type = 'object_cleanup'
+		where uuid = :job_uuid and type = 'object_cleanup'
 	`
 )
 
 // fileRecordRow / objectCleanupJobRow 用于承接 sqlx 的结构化扫描结果，避免把
 // 数据库存储细节直接泄漏到上层文件服务。
 type fileRecordRow struct {
-	UUID                string    `db:"uuid"`
+	UUID                uuid.UUID `db:"uuid"`
 	ExternalID          string    `db:"external_id"`
-	WorkspaceUUID       string    `db:"workspace_uuid"`
+	WorkspaceUUID       uuid.UUID `db:"workspace_uuid"`
 	Filename            string    `db:"filename"`
 	MimeType            string    `db:"mime_type"`
 	SizeBytes           int64     `db:"size_bytes"`
@@ -175,44 +168,44 @@ type fileRecordRow struct {
 	Downloadable        bool      `db:"downloadable"`
 	ScopeType           *string   `db:"scope_type"`
 	ScopeID             *string   `db:"scope_id"`
-	CreatedByAPIKeyUUID string    `db:"created_by_api_key_uuid"`
+	CreatedByAPIKeyUUID uuid.UUID `db:"created_by_api_key_uuid"`
 	CreatedAt           time.Time `db:"created_at"`
 }
 
 type filePageCursorRow struct {
-	UUID      string    `db:"uuid"`
+	UUID      uuid.UUID `db:"uuid"`
 	CreatedAt time.Time `db:"created_at"`
 }
 
 type objectCleanupJobRow struct {
-	UUID           string `db:"uuid"`
-	ExternalID     string `db:"external_id"`
-	WorkspaceUUID  string `db:"workspace_uuid"`
-	Bucket         string `db:"bucket"`
-	Key            string `db:"object_key"`
-	FileExternalID string `db:"file_external_id"`
-	Attempts       int    `db:"attempts"`
+	UUID           uuid.UUID `db:"uuid"`
+	ExternalID     string    `db:"external_id"`
+	WorkspaceUUID  uuid.UUID `db:"workspace_uuid"`
+	Bucket         string    `db:"bucket"`
+	Key            string    `db:"object_key"`
+	FileExternalID string    `db:"file_external_id"`
+	Attempts       int       `db:"attempts"`
 }
 
 func getFileArguments(workspaceUUID string, fileExternalID string) map[string]any {
 	return map[string]any{
-		"workspace_uuid":   workspaceUUID,
+		"workspace_uuid":   dbUUID(workspaceUUID),
 		"file_external_id": fileExternalID,
 	}
 }
 
 func fileUUIDArguments(workspaceUUID string, fileUUID string) map[string]any {
 	return map[string]any{
-		"workspace_uuid": workspaceUUID,
-		"file_uuid":      fileUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"file_uuid":      dbUUID(fileUUID),
 	}
 }
 
 func fileRecordArguments(file FileRecord) map[string]any {
 	return map[string]any{
-		"file_uuid":               file.UUID,
+		"file_uuid":               dbUUID(file.UUID),
 		"file_external_id":        file.ExternalID,
-		"workspace_uuid":          file.WorkspaceUUID,
+		"workspace_uuid":          dbUUID(file.WorkspaceUUID),
 		"filename":                file.Filename,
 		"mime_type":               file.MimeType,
 		"size_bytes":              file.SizeBytes,
@@ -222,7 +215,7 @@ func fileRecordArguments(file FileRecord) map[string]any {
 		"downloadable":            file.Downloadable,
 		"scope_type":              file.ScopeType,
 		"scope_id":                file.ScopeID,
-		"created_by_api_key_uuid": file.CreatedByAPIKeyUUID,
+		"created_by_api_key_uuid": dbUUID(file.CreatedByAPIKeyUUID),
 		"created_at":              file.CreatedAt,
 	}
 }
@@ -295,7 +288,7 @@ func beginFileCreateSQLXTx(ctx context.Context, database *sqlx.DB, workspaceUUID
 		ctx,
 		tx,
 		fileWorkspaceLockQuery,
-		map[string]any{"workspace_uuid": workspaceUUID},
+		map[string]any{"workspace_uuid": dbUUID(workspaceUUID)},
 	); err != nil {
 		_ = tx.Rollback()
 		return nil, err
@@ -328,10 +321,10 @@ func listFilesSQLXQuery(workspaceUUID string, scopeID string) (string, map[strin
 	query := `
 		select ` + fileSQLXColumns + `
 		from files
-		where workspace_uuid = cast(:workspace_uuid as uuid)
+		where workspace_uuid = :workspace_uuid
 			and deleted_at is null
 	`
-	arguments := map[string]any{"workspace_uuid": workspaceUUID}
+	arguments := map[string]any{"workspace_uuid": dbUUID(workspaceUUID)}
 	if scopeID != "" {
 		query += " and scope_id = :scope_id"
 		arguments["scope_id"] = scopeID
@@ -423,14 +416,14 @@ func filePageCursorSQLXQuery(
 	cursorExternalID string,
 ) (string, map[string]any) {
 	query := `
-		select cast(uuid as text) as uuid, created_at
+		select uuid, created_at
 		from files
-		where workspace_uuid = cast(:workspace_uuid as uuid)
+		where workspace_uuid = :workspace_uuid
 			and external_id = :cursor_external_id
 			and deleted_at is null
 	`
 	arguments := map[string]any{
-		"workspace_uuid":     params.WorkspaceUUID,
+		"workspace_uuid":     dbUUID(params.WorkspaceUUID),
 		"cursor_external_id": cursorExternalID,
 	}
 	if params.ScopeID != "" {
@@ -447,11 +440,11 @@ func listFilesPageSQLXQuery(
 	query := `
 		select ` + fileSQLXColumns + `
 		from files
-		where workspace_uuid = cast(:workspace_uuid as uuid)
+		where workspace_uuid = :workspace_uuid
 			and deleted_at is null
 	`
 	arguments := map[string]any{
-		"workspace_uuid": params.WorkspaceUUID,
+		"workspace_uuid": dbUUID(params.WorkspaceUUID),
 		"limit":          params.Limit + 1,
 	}
 	if params.ScopeID != "" {
@@ -462,7 +455,7 @@ func listFilesPageSQLXQuery(
 		query += `
 			and (
 				created_at < :cursor_created_at
-				or (created_at = :cursor_created_at and uuid < cast(:cursor_uuid as uuid))
+				or (created_at = :cursor_created_at and uuid < :cursor_uuid)
 			)
 		`
 		arguments["cursor_created_at"] = cursor.CreatedAt
@@ -471,7 +464,7 @@ func listFilesPageSQLXQuery(
 		query += `
 			and (
 				created_at > :cursor_created_at
-				or (created_at = :cursor_created_at and uuid > cast(:cursor_uuid as uuid))
+				or (created_at = :cursor_created_at and uuid > :cursor_uuid)
 			)
 		`
 		arguments["cursor_created_at"] = cursor.CreatedAt
@@ -505,7 +498,7 @@ func softDeleteFileSQLX(
 	if err != nil {
 		return err
 	}
-	arguments["file_uuid"] = file.UUID
+	arguments["file_uuid"] = dbUUID(file.UUID)
 	var referenced bool
 	if err := namedGetContext(ctx, tx, &referenced, activeFileReferenceQuery, arguments); err != nil {
 		return err
@@ -528,12 +521,23 @@ func enqueueObjectCleanupResourceJobSQLX(
 	workspaceUUID string,
 	bucket, objectKey, resourceType, resourceID string,
 ) error {
-	_, err := namedExecContext(ctx, database, enqueueObjectCleanupResourceJobQuery, map[string]any{
-		"workspace_uuid": workspaceUUID,
-		"bucket":         bucket,
-		"object_key":     objectKey,
-		"resource_type":  resourceType,
-		"resource_id":    resourceID,
+	fileExternalID := ""
+	if resourceType == "file" {
+		fileExternalID = resourceID
+	}
+	payload, err := json.Marshal(map[string]string{
+		"bucket":        bucket,
+		"key":           objectKey,
+		"file_id":       fileExternalID,
+		"resource_type": resourceType,
+		"resource_id":   resourceID,
+	})
+	if err != nil {
+		return fmt.Errorf("encode object cleanup job payload: %w", err)
+	}
+	_, err = namedExecContext(ctx, database, enqueueObjectCleanupResourceJobQuery, map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"payload":        payload,
 	})
 	return err
 }
@@ -573,7 +577,7 @@ func completeObjectCleanupJobSQLX(
 		ctx,
 		database,
 		completeObjectCleanupJobQuery,
-		map[string]any{"job_uuid": jobUUID},
+		map[string]any{"job_uuid": dbUUID(jobUUID)},
 	)
 	return err
 }
@@ -593,7 +597,7 @@ func failObjectCleanupJobSQLX(
 		status = "failed"
 	}
 	_, err := namedExecContext(ctx, database, failObjectCleanupJobQuery, map[string]any{
-		"job_uuid":  jobUUID,
+		"job_uuid":  dbUUID(jobUUID),
 		"status":    status,
 		"run_after": time.Now().UTC().Add(retryDelay),
 		"attempts":  nextAttempts,
@@ -604,9 +608,9 @@ func failObjectCleanupJobSQLX(
 
 func (r fileRecordRow) record() FileRecord {
 	return FileRecord{
-		UUID:                r.UUID,
+		UUID:                r.UUID.String(),
 		ExternalID:          r.ExternalID,
-		WorkspaceUUID:       r.WorkspaceUUID,
+		WorkspaceUUID:       r.WorkspaceUUID.String(),
 		Filename:            r.Filename,
 		MimeType:            r.MimeType,
 		SizeBytes:           r.SizeBytes,
@@ -616,16 +620,16 @@ func (r fileRecordRow) record() FileRecord {
 		Downloadable:        r.Downloadable,
 		ScopeType:           r.ScopeType,
 		ScopeID:             r.ScopeID,
-		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID,
+		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID.String(),
 		CreatedAt:           r.CreatedAt,
 	}
 }
 
 func (r objectCleanupJobRow) job() ObjectCleanupJob {
 	return ObjectCleanupJob{
-		UUID:           r.UUID,
+		UUID:           r.UUID.String(),
 		ExternalID:     r.ExternalID,
-		WorkspaceUUID:  r.WorkspaceUUID,
+		WorkspaceUUID:  r.WorkspaceUUID.String(),
 		Bucket:         r.Bucket,
 		Key:            r.Key,
 		FileExternalID: r.FileExternalID,

--- a/internal/db/files_sqlx_test.go
+++ b/internal/db/files_sqlx_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestFilesQueriesUseSQLXNamedParameters(t *testing.T) {
@@ -22,7 +24,7 @@ func TestFilesQueriesUseSQLXNamedParameters(t *testing.T) {
 		CreatedByAPIKeyUUID: "00000000-0000-0000-0000-000000000009",
 		CreatedAt:           createdAt,
 	}
-	cursor := filePageCursorRow{UUID: "00000000-0000-0000-0000-000000000010", CreatedAt: createdAt}
+	cursor := filePageCursorRow{UUID: uuid.MustParse("00000000-0000-0000-0000-000000000010"), CreatedAt: createdAt}
 	afterParams := ListFilesPageParams{
 		WorkspaceUUID: "00000000-0000-0000-0000-000000000042",
 		ScopeID:       "scope_test",
@@ -51,14 +53,17 @@ func TestFilesQueriesUseSQLXNamedParameters(t *testing.T) {
 		arguments    map[string]any
 		wantArgCount int
 	}{
-		{"workspace lock", fileWorkspaceLockQuery, map[string]any{"workspace_uuid": file.WorkspaceUUID}, 1},
+		{"workspace lock", fileWorkspaceLockQuery, map[string]any{"workspace_uuid": dbUUID(file.WorkspaceUUID)}, 1},
 		{"insert file", insertFileQuery, fileRecordArguments(file), 14},
 		{"get file", getFileQuery, getFileArguments(file.WorkspaceUUID, file.ExternalID), 2},
 		{"get file by uuid", getFileByUUIDQuery, fileUUIDArguments(file.WorkspaceUUID, file.UUID), 2},
 		{
 			"get file by uuid in organization",
 			getFileByUUIDInOrganizationQuery,
-			map[string]any{"organization_uuid": "00000000-0000-0000-0000-000000000007", "file_uuid": file.UUID},
+			map[string]any{
+				"organization_uuid": dbUUID("00000000-0000-0000-0000-000000000007"),
+				"file_uuid":         dbUUID(file.UUID),
+			},
 			2,
 		},
 		{"list files", listQuery, listArguments, 2},
@@ -69,7 +74,10 @@ func TestFilesQueriesUseSQLXNamedParameters(t *testing.T) {
 		{
 			"active file reference",
 			activeFileReferenceQuery,
-			map[string]any{"workspace_uuid": file.WorkspaceUUID, "file_uuid": file.UUID},
+			map[string]any{
+				"workspace_uuid": dbUUID(file.WorkspaceUUID),
+				"file_uuid":      dbUUID(file.UUID),
+			},
 			4,
 		},
 		{"soft delete", softDeleteFileQuery, getFileArguments(file.WorkspaceUUID, file.ExternalID), 2},
@@ -77,13 +85,10 @@ func TestFilesQueriesUseSQLXNamedParameters(t *testing.T) {
 			"enqueue cleanup",
 			enqueueObjectCleanupResourceJobQuery,
 			map[string]any{
-				"workspace_uuid": file.WorkspaceUUID,
-				"bucket":         "files",
-				"object_key":     "file_test/data.csv",
-				"resource_type":  "file",
-				"resource_id":    file.ExternalID,
+				"workspace_uuid": dbUUID(file.WorkspaceUUID),
+				"payload":        []byte(`{"bucket":"files"}`),
 			},
-			7,
+			2,
 		},
 		{
 			"lease cleanup",
@@ -91,12 +96,17 @@ func TestFilesQueriesUseSQLXNamedParameters(t *testing.T) {
 			map[string]any{"limit": 10, "worker_id": "worker_test"},
 			2,
 		},
-		{"complete cleanup", completeObjectCleanupJobQuery, map[string]any{"job_uuid": "00000000-0000-0000-0000-000000000001"}, 1},
+		{
+			"complete cleanup",
+			completeObjectCleanupJobQuery,
+			map[string]any{"job_uuid": dbUUID("00000000-0000-0000-0000-000000000001")},
+			1,
+		},
 		{
 			"fail cleanup",
 			failObjectCleanupJobQuery,
 			map[string]any{
-				"job_uuid":  "00000000-0000-0000-0000-000000000001",
+				"job_uuid":  dbUUID("00000000-0000-0000-0000-000000000001"),
 				"status":    "retry",
 				"run_after": createdAt,
 				"attempts":  2,

--- a/internal/db/filestore_archive_entries.go
+++ b/internal/db/filestore_archive_entries.go
@@ -23,11 +23,11 @@ type normalizedFilestoreSkillArchiveEntry struct {
 
 var (
 	filestoreSkillArchiveEntryFilesystemQuery = filestoreFilesystemSelectSQL() + `
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
 			and session_uuid = (
 				select uuid
 				from sessions
-				where workspace_uuid = CAST(:workspace_uuid AS uuid)
+				where workspace_uuid = :workspace_uuid
 					and external_id = :session_external_id
 					and deleted_at is null
 			)
@@ -74,9 +74,9 @@ var (
 		values (
 			gen_random_uuid(),
 			concat('fse_', replace(cast(gen_random_uuid() as text), '-', '')),
-			CAST(:organization_uuid AS uuid),
-			CAST(:workspace_uuid AS uuid),
-			CAST(:filesystem_uuid AS uuid),
+			:organization_uuid,
+			:workspace_uuid,
+			:filesystem_uuid,
 			'archive',
 			:entry_path,
 			'/skills',
@@ -90,17 +90,17 @@ var (
 			:s3_bucket,
 			:s3_key,
 			'skill_archive',
-			CAST(:skill_version_uuid AS uuid),
-			CAST(:created_by_api_key_uuid AS uuid),
-			CAST(:created_by_session_uuid AS uuid),
-			CAST(:created_by_code_session_uuid AS uuid),
+			:skill_version_uuid,
+			:created_by_api_key_uuid,
+			:created_by_session_uuid,
+			:created_by_code_session_uuid,
 			:now,
 			:now
 		)
 	`
 	filestoreSkillArchiveEntryListQuery = filestoreEntrySelectSQL() + `
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
-			and filesystem_uuid = CAST(:filesystem_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
+			and filesystem_uuid = :filesystem_uuid
 			and kind = 'archive'
 			and managed_by = 'skill_archive'
 			and deleted_at is null
@@ -131,14 +131,14 @@ func (d *DB) ReplaceFilestoreSkillArchiveEntries(
 	defer tx.Rollback()
 
 	filesystem, err := getFilestoreFilesystemSQLX(ctx, tx, filestoreSkillArchiveEntryFilesystemQuery, map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"session_external_id": sessionExternalID,
 	})
 	if err != nil {
 		return err
 	}
 	if _, err := namedExecContext(ctx, tx, provisionFilestoreNamespaceLockQuery, map[string]any{
-		"filesystem_uuid": filesystem.UUID,
+		"filesystem_uuid": dbUUID(filesystem.UUID),
 	}); err != nil {
 		return err
 	}
@@ -147,8 +147,8 @@ func (d *DB) ReplaceFilestoreSkillArchiveEntries(
 		return err
 	}
 	if _, err := namedExecContext(ctx, tx, filestoreSkillArchiveEntryRetireQuery, map[string]any{
-		"workspace_uuid":  filesystem.WorkspaceUUID,
-		"filesystem_uuid": filesystem.UUID,
+		"workspace_uuid":  dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid": dbUUID(filesystem.UUID),
 		"now":             now,
 	}); err != nil {
 		return err
@@ -156,19 +156,19 @@ func (d *DB) ReplaceFilestoreSkillArchiveEntries(
 
 	for _, entry := range entries {
 		if _, err := namedExecContext(ctx, tx, filestoreSkillArchiveEntryInsertQuery, map[string]any{
-			"organization_uuid":            filesystem.OrganizationUUID,
-			"workspace_uuid":               filesystem.WorkspaceUUID,
-			"filesystem_uuid":              filesystem.UUID,
+			"organization_uuid":            dbUUID(filesystem.OrganizationUUID),
+			"workspace_uuid":               dbUUID(filesystem.WorkspaceUUID),
+			"filesystem_uuid":              dbUUID(filesystem.UUID),
 			"entry_path":                   entry.Path,
 			"source":                       entry.Source,
-			"skill_version_uuid":           entry.SkillVersionUUID,
+			"skill_version_uuid":           dbUUID(entry.SkillVersionUUID),
 			"s3_bucket":                    entry.S3Bucket,
 			"s3_key":                       entry.S3Key,
 			"size_bytes":                   entry.SizeBytes,
 			"sha256":                       entry.SHA256,
-			"created_by_api_key_uuid":      filesystem.CreatedByAPIKeyUUID,
-			"created_by_session_uuid":      filesystem.SessionUUID,
-			"created_by_code_session_uuid": filesystem.CodeSessionUUID,
+			"created_by_api_key_uuid":      dbNullableUUID(filesystem.CreatedByAPIKeyUUID),
+			"created_by_session_uuid":      dbUUID(filesystem.SessionUUID),
+			"created_by_code_session_uuid": dbNullableUUID(filesystem.CodeSessionUUID),
 			"now":                          now,
 		}); err != nil {
 			return err
@@ -186,8 +186,8 @@ func (d *DB) ListFilestoreSkillArchiveEntries(
 ) ([]FilestoreEntry, error) {
 	var rows []filestoreEntryRow
 	if err := namedSelectContext(ctx, d.sql, &rows, filestoreSkillArchiveEntryListQuery, map[string]any{
-		"workspace_uuid":  workspaceUUID,
-		"filesystem_uuid": filesystemUUID,
+		"workspace_uuid":  dbUUID(workspaceUUID),
+		"filesystem_uuid": dbUUID(filesystemUUID),
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/db/filestore_cleanup.go
+++ b/internal/db/filestore_cleanup.go
@@ -3,12 +3,14 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -18,11 +20,8 @@ var (
 			insert into jobs (external_id, workspace_uuid, type, status, payload, run_after)
 			values (
 				concat('job_', replace(CAST(gen_random_uuid() AS text), '-', '')),
-				CAST(:workspace_uuid AS uuid), :job_type, 'pending',
-				jsonb_build_object(
-					'workspace_uuid', CAST(:workspace_uuid AS text),
-					'filesystem_uuid', CAST(:filesystem_uuid AS text)
-				),
+				:workspace_uuid, :job_type, 'pending',
+				CAST(:payload AS jsonb),
 				:run_after
 			)
 			returning *
@@ -30,23 +29,23 @@ var (
 		select ` + filestoreFilesystemCleanupJobColumns("j", "fs") + `
 		from inserted_job j
 		join filestore_filesystems fs
-			on CAST(fs.uuid AS text) = j.payload->>'filesystem_uuid'
+			on fs.uuid = :filesystem_uuid
 			and fs.workspace_uuid = j.workspace_uuid
 	`
 	leasedFilesystemCleanupJobQuery = `
 		select ` + filestoreFilesystemCleanupJobColumns("j", "fs") + `
 		from jobs j
 		join filestore_filesystems fs
-			on cast(fs.uuid as text) = j.payload->>'filesystem_uuid'
+			on j.payload->'filesystem_uuid' = to_jsonb(fs.uuid)
 			and fs.workspace_uuid = j.workspace_uuid
-		where j.uuid = CAST(:job_uuid AS uuid)
+		where j.uuid = :job_uuid
 			and j.type = :job_type and j.status = 'running'
 			and j.locked_by = :lease_token and j.locked_until >= now()
 		for update of j
 	`
 	filesystemCleanupFilesystemQuery = filestoreFilesystemSelectSQL() + `
-		where uuid = CAST(:filesystem_uuid AS uuid)
-			and workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where uuid = :filesystem_uuid
+			and workspace_uuid = :workspace_uuid
 	`
 	filesystemCleanupEntriesQuery = filestoreEntrySelectSQL() + `
 		where workspace_uuid = :workspace_uuid and filesystem_uuid = :filesystem_uuid
@@ -57,7 +56,7 @@ var (
 	`
 	expiredFilestoreEntriesQuery = filestoreEntrySelectSQL() + `
 		where kind = 'file' and deleted_at is null and expires_at <= now()
-			and filesystem_uuid = any(CAST(:filesystem_uuids AS uuid[]))
+			and filesystem_uuid = any(:filesystem_uuids)
 		order by expires_at, uuid
 		limit :limit
 		for update skip locked
@@ -66,8 +65,8 @@ var (
 
 const (
 	expiredFilestoreCleanupScopesQuery = `
-		select distinct CAST(oldest_expired.workspace_uuid AS text) AS workspace_uuid,
-			CAST(oldest_expired.filesystem_uuid AS text) AS filesystem_uuid
+		select distinct oldest_expired.workspace_uuid,
+			oldest_expired.filesystem_uuid
 		from (
 			select workspace_uuid, filesystem_uuid, expires_at, uuid
 			from filestore_entries
@@ -90,7 +89,7 @@ const (
 	retireFilesystemCleanupEntryQuery = `
 		update filestore_entries
 		set deleted_at = :retired_at, updated_at = :retired_at
-		where uuid = CAST(:entry_uuid AS uuid) and deleted_at is null
+		where uuid = :entry_uuid and deleted_at is null
 	`
 	filesystemCleanupFilesRemainQuery = `
 		select exists (
@@ -112,7 +111,7 @@ const (
 		set status = :status, locked_by = null, locked_until = null,
 			run_after = :retired_at, updated_at = :retired_at,
 			payload = payload - 'lease_attempts'
-		where uuid = CAST(:job_uuid AS uuid)
+		where uuid = :job_uuid
 			and type = :job_type and status = 'running'
 			and locked_by = :lease_token
 	`
@@ -143,16 +142,18 @@ func (d *DB) ExpireFilestoreEntries(ctx context.Context, limit int) ([]Filestore
 	var workspaceUUIDs []string
 	var filesystemUUIDs []string
 	for _, row := range scopeRows {
-		if _, found := workspaceUUIDSet[row.WorkspaceUUID]; !found {
-			workspaceUUIDSet[row.WorkspaceUUID] = struct{}{}
-			workspaceUUIDs = append(workspaceUUIDs, row.WorkspaceUUID)
+		workspaceUUID := row.WorkspaceUUID.String()
+		filesystemUUID := row.FilesystemUUID.String()
+		if _, found := workspaceUUIDSet[workspaceUUID]; !found {
+			workspaceUUIDSet[workspaceUUID] = struct{}{}
+			workspaceUUIDs = append(workspaceUUIDs, workspaceUUID)
 		}
-		if _, found := filesystemUUIDSet[row.FilesystemUUID]; !found {
-			filesystemUUIDSet[row.FilesystemUUID] = struct{}{}
-			filesystemUUIDs = append(filesystemUUIDs, row.FilesystemUUID)
+		if _, found := filesystemUUIDSet[filesystemUUID]; !found {
+			filesystemUUIDSet[filesystemUUID] = struct{}{}
+			filesystemUUIDs = append(filesystemUUIDs, filesystemUUID)
 		}
-		cleanupScopeByFilesystemUUID[row.FilesystemUUID] = filestoreEntryCleanupScope{
-			WorkspaceUUID: row.WorkspaceUUID, FilesystemUUID: row.FilesystemUUID,
+		cleanupScopeByFilesystemUUID[filesystemUUID] = filestoreEntryCleanupScope{
+			WorkspaceUUID: workspaceUUID, FilesystemUUID: filesystemUUID,
 		}
 	}
 	if len(workspaceUUIDs) == 0 {
@@ -166,14 +167,14 @@ func (d *DB) ExpireFilestoreEntries(ctx context.Context, limit int) ([]Filestore
 	// 所有容量变更都先锁工作区，再锁文件系统；批处理内部按 UUID 升序取得同类锁。
 	for _, workspaceUUID := range workspaceUUIDs {
 		if _, err := namedExecContext(ctx, tx, filesystemCleanupWorkspaceLockQuery, map[string]any{
-			"workspace_uuid": workspaceUUID,
+			"workspace_uuid": dbUUID(workspaceUUID),
 		}); err != nil {
 			return nil, err
 		}
 	}
 	for _, filesystemUUID := range filesystemUUIDs {
 		if _, err := namedExecContext(ctx, tx, filesystemCleanupFilesystemLockQuery, map[string]any{
-			"filesystem_uuid": filesystemUUID,
+			"filesystem_uuid": dbUUID(filesystemUUID),
 		}); err != nil {
 			return nil, err
 		}
@@ -212,8 +213,11 @@ func (d *DB) ExpireFilestoreEntries(ctx context.Context, limit int) ([]Filestore
 		jobs = append(jobs, job)
 		if _, err := namedExecContext(ctx, tx, `
 			update filestore_entries set deleted_at = :now, updated_at = :now
-			where uuid = CAST(:entry_uuid AS uuid) and deleted_at is null
-		`, map[string]any{"entry_uuid": entry.UUID, "now": now}); err != nil {
+			where uuid = :entry_uuid and deleted_at is null
+		`, map[string]any{
+			"entry_uuid": dbUUID(entry.UUID),
+			"now":        now,
+		}); err != nil {
 			return nil, err
 		}
 		if err := softDeleteSessionFileProjectionByEntryTx(
@@ -230,14 +234,15 @@ func (d *DB) ExpireFilestoreEntries(ctx context.Context, limit int) ([]Filestore
 		releasedBytesByWorkspace[scope.WorkspaceUUID] = releasedBytes
 	}
 	for _, scope := range scopeRows {
-		releasedBytes := releasedBytesByWorkspace[scope.WorkspaceUUID]
+		workspaceUUID := scope.WorkspaceUUID.String()
+		releasedBytes := releasedBytesByWorkspace[workspaceUUID]
 		if releasedBytes == 0 {
 			continue
 		}
-		if err := applyWorkspaceStorageDeltaSQLXTx(ctx, tx, scope.WorkspaceUUID, 0, -releasedBytes, 0); err != nil {
+		if err := applyWorkspaceStorageDeltaSQLXTx(ctx, tx, workspaceUUID, 0, -releasedBytes, 0); err != nil {
 			return nil, err
 		}
-		delete(releasedBytesByWorkspace, scope.WorkspaceUUID)
+		delete(releasedBytesByWorkspace, workspaceUUID)
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, err
@@ -247,10 +252,10 @@ func (d *DB) ExpireFilestoreEntries(ctx context.Context, limit int) ([]Filestore
 
 // LeaseFilestoreFilesystemCleanupJobs 租约一批待拆分的整文件系统清理任务。
 func (d *DB) LeaseFilestoreFilesystemCleanupJobs(ctx context.Context, workerID string, limit, maxLeaseAttempts int) ([]FilestoreFilesystemCleanupJob, error) {
-	var jobs []FilestoreFilesystemCleanupJob
+	var rows []filestoreFilesystemCleanupJobRow
 	err := d.leaseFilestoreCleanupJobs(
 		ctx,
-		&jobs,
+		&rows,
 		filestoreFilesystemCleanupJobType,
 		workerID,
 		limit,
@@ -259,6 +264,10 @@ func (d *DB) LeaseFilestoreFilesystemCleanupJobs(ctx context.Context, workerID s
 	)
 	if err != nil {
 		return nil, err
+	}
+	jobs := make([]FilestoreFilesystemCleanupJob, 0, len(rows))
+	for _, row := range rows {
+		jobs = append(jobs, row.job())
 	}
 	return jobs, nil
 }
@@ -288,21 +297,22 @@ func (d *DB) ProcessLeasedFilestoreFilesystemCleanupJob(
 	defer tx.Rollback()
 
 	arguments := map[string]any{
-		"job_uuid":    jobUUID,
+		"job_uuid":    dbUUID(jobUUID),
 		"job_type":    filestoreFilesystemCleanupJobType,
 		"lease_token": leaseToken,
 		"limit":       limit,
 	}
-	var job FilestoreFilesystemCleanupJob
-	err = namedGetContext(ctx, tx, &job, leasedFilesystemCleanupJobQuery, arguments)
+	var jobRow filestoreFilesystemCleanupJobRow
+	err = namedGetContext(ctx, tx, &jobRow, leasedFilesystemCleanupJobQuery, arguments)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, ErrVersionConflict
 		}
 		return false, err
 	}
-	arguments["workspace_uuid"] = job.WorkspaceUUID
-	arguments["filesystem_uuid"] = job.FilesystemUUID
+	job := jobRow.job()
+	arguments["workspace_uuid"] = jobRow.WorkspaceUUID
+	arguments["filesystem_uuid"] = jobRow.FilesystemUUID
 	if _, err := namedExecContext(ctx, tx, filesystemCleanupWorkspaceLockQuery, arguments); err != nil {
 		return false, err
 	}
@@ -344,7 +354,7 @@ func (d *DB) ProcessLeasedFilestoreFilesystemCleanupJob(
 				return false, err
 			}
 		}
-		arguments["entry_uuid"] = entry.UUID
+		arguments["entry_uuid"] = dbUUID(entry.UUID)
 		if _, err := namedExecContext(ctx, tx, retireFilesystemCleanupEntryQuery, arguments); err != nil {
 			return false, err
 		}
@@ -426,9 +436,9 @@ func (d *DB) AttachFilestoreObjectCleanupJobVersion(ctx context.Context, workspa
 		where external_id = :job_external_id
 			and type = :job_type
 			and status in ('pending', 'retry')
-			and workspace_uuid = CAST(:workspace_uuid AS uuid)
+			and workspace_uuid = :workspace_uuid
 	`, map[string]any{
-		"workspace_uuid":  workspaceUUID,
+		"workspace_uuid":  dbUUID(workspaceUUID),
 		"job_external_id": jobExternalID,
 		"etag":            etag,
 		"version_id":      versionID,
@@ -445,10 +455,10 @@ func (d *DB) AttachFilestoreObjectCleanupJobVersion(ctx context.Context, workspa
 
 // LeaseFilestoreObjectCleanupJobs 以 SKIP LOCKED 租约一批到期任务，允许多个 worker 并行消费。
 func (d *DB) LeaseFilestoreObjectCleanupJobs(ctx context.Context, workerID string, limit, maxLeaseAttempts int) ([]FilestoreObjectCleanupJob, error) {
-	var jobs []FilestoreObjectCleanupJob
+	var rows []filestoreObjectCleanupJobRow
 	err := d.leaseFilestoreCleanupJobs(
 		ctx,
-		&jobs,
+		&rows,
 		filestoreCleanupJobType,
 		workerID,
 		limit,
@@ -457,6 +467,10 @@ func (d *DB) LeaseFilestoreObjectCleanupJobs(ctx context.Context, workerID strin
 	)
 	if err != nil {
 		return nil, err
+	}
+	jobs := make([]FilestoreObjectCleanupJob, 0, len(rows))
+	for _, row := range rows {
+		jobs = append(jobs, row.job())
 	}
 	return jobs, nil
 }
@@ -499,7 +513,7 @@ func (d *DB) leaseFilestoreCleanupJobs(ctx context.Context, destination any, job
 			select j.uuid, j.workspace_uuid
 			from jobs j
 			join filestore_filesystems fs
-				on cast(fs.uuid as text) = j.payload->>'filesystem_uuid'
+				on j.payload->'filesystem_uuid' = to_jsonb(fs.uuid)
 				and fs.workspace_uuid = j.workspace_uuid
 			where j.type = :job_type
 				and j.run_after <= now()
@@ -532,7 +546,7 @@ func (d *DB) leaseFilestoreCleanupJobs(ctx context.Context, destination any, job
 		select `+columns+`
 		from leased_jobs j
 		join filestore_filesystems fs
-			on cast(fs.uuid as text) = j.payload->>'filesystem_uuid'
+			on j.payload->'filesystem_uuid' = to_jsonb(fs.uuid)
 			and fs.workspace_uuid = j.workspace_uuid
 	`, map[string]any{
 		"job_type":           jobType,
@@ -547,10 +561,10 @@ func (d *DB) CompleteFilestoreObjectCleanupJob(ctx context.Context, jobUUID stri
 	rowsAffected, err := namedExecRowsAffected(ctx, d.sql, `
 		update jobs
 		set status = 'completed', locked_by = null, locked_until = null, updated_at = now()
-		where uuid = CAST(:job_uuid AS uuid)
+		where uuid = :job_uuid
 			and type = :job_type and status in ('pending', 'retry')
 	`, map[string]any{
-		"job_uuid": jobUUID,
+		"job_uuid": dbUUID(jobUUID),
 		"job_type": filestoreCleanupJobType,
 	})
 	if err != nil {
@@ -570,11 +584,11 @@ func (d *DB) CompleteLeasedFilestoreObjectCleanupJob(ctx context.Context, jobUUI
 	rowsAffected, err := namedExecRowsAffected(ctx, d.sql, `
 		update jobs
 		set status = 'completed', locked_by = null, locked_until = null, updated_at = now()
-		where uuid = CAST(:job_uuid AS uuid)
+		where uuid = :job_uuid
 			and type = :job_type and status = 'running'
 			and locked_by = :lease_token and locked_until >= now()
 	`, map[string]any{
-		"job_uuid":    jobUUID,
+		"job_uuid":    dbUUID(jobUUID),
 		"job_type":    filestoreCleanupJobType,
 		"lease_token": leaseToken,
 	})
@@ -618,11 +632,11 @@ func (d *DB) failLeasedFilestoreCleanupJob(ctx context.Context, jobUUID string, 
 			updated_at = now(),
 			payload = (payload - 'lease_attempts')
 				|| jsonb_build_object('last_error', cast(:reason as text))
-		where uuid = CAST(:job_uuid AS uuid)
+		where uuid = :job_uuid
 			and type = :job_type and status = 'running'
 			and locked_by = :lease_token and locked_until >= now()
 	`, map[string]any{
-		"job_uuid":     jobUUID,
+		"job_uuid":     dbUUID(jobUUID),
 		"reason":       reason,
 		"run_after":    runAfter,
 		"max_attempts": maxAttempts,
@@ -645,17 +659,28 @@ func enqueueFilestoreFilesystemCleanupJobTx(
 	workspaceUUID string,
 	runAfter time.Time,
 ) (FilestoreFilesystemCleanupJob, error) {
-	var job FilestoreFilesystemCleanupJob
-	err := namedGetContext(ctx, tx, &job, enqueueFilestoreFilesystemCleanupJobQuery, map[string]any{
+	payload, err := json.Marshal(map[string]string{
 		"workspace_uuid":  workspaceUUID,
 		"filesystem_uuid": filesystem.UUID,
+	})
+	if err != nil {
+		return FilestoreFilesystemCleanupJob{}, fmt.Errorf("encode Filestore filesystem cleanup job payload: %w", err)
+	}
+	var row filestoreFilesystemCleanupJobRow
+	err = namedGetContext(ctx, tx, &row, enqueueFilestoreFilesystemCleanupJobQuery, map[string]any{
+		"workspace_uuid":  dbUUID(workspaceUUID),
+		"filesystem_uuid": dbUUID(filesystem.UUID),
+		"payload":         payload,
 		"job_type":        filestoreFilesystemCleanupJobType,
 		"run_after":       runAfter,
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return FilestoreFilesystemCleanupJob{}, ErrNotFound
 	}
-	return job, err
+	if err != nil {
+		return FilestoreFilesystemCleanupJob{}, err
+	}
+	return row.job(), nil
 }
 
 // CancelFilestoreObjectCleanupJob 取消尚未被 worker 执行的清理任务。
@@ -666,9 +691,9 @@ func (d *DB) CancelFilestoreObjectCleanupJob(ctx context.Context, workspaceUUID 
 		where external_id = :job_external_id
 			and type = :job_type
 			and status in ('pending', 'retry')
-			and workspace_uuid = CAST(:workspace_uuid AS uuid)
+			and workspace_uuid = :workspace_uuid
 	`, map[string]any{
-		"workspace_uuid":  workspaceUUID,
+		"workspace_uuid":  dbUUID(workspaceUUID),
 		"job_external_id": jobExternalID,
 		"job_type":        filestoreCleanupJobType,
 	})
@@ -688,9 +713,9 @@ func (d *DB) filestoreCleanupJobMutationMiss(ctx context.Context, workspaceUUID 
 		from jobs
 		where external_id = :job_external_id
 			and type = :job_type
-			and workspace_uuid = CAST(:workspace_uuid AS uuid)
+			and workspace_uuid = :workspace_uuid
 	`, map[string]any{
-		"workspace_uuid":  workspaceUUID,
+		"workspace_uuid":  dbUUID(workspaceUUID),
 		"job_external_id": jobExternalID,
 		"job_type":        filestoreCleanupJobType,
 	})
@@ -709,8 +734,64 @@ type filestoreEntryCleanupScope struct {
 }
 
 type expiredFilestoreCleanupScopeRow struct {
-	WorkspaceUUID  string `db:"workspace_uuid"`
-	FilesystemUUID string `db:"filesystem_uuid"`
+	WorkspaceUUID  uuid.UUID `db:"workspace_uuid"`
+	FilesystemUUID uuid.UUID `db:"filesystem_uuid"`
+}
+
+type filestoreObjectCleanupJobRow struct {
+	UUID                 uuid.UUID `db:"uuid"`
+	ExternalID           string    `db:"external_id"`
+	WorkspaceUUID        uuid.UUID `db:"workspace_uuid"`
+	FilesystemUUID       uuid.UUID `db:"filesystem_uuid"`
+	FilesystemExternalID string    `db:"filesystem_external_id"`
+	EntryExternalID      string    `db:"entry_external_id"`
+	Bucket               string    `db:"bucket"`
+	Key                  string    `db:"key"`
+	ETag                 string    `db:"etag"`
+	VersionID            string    `db:"version_id"`
+	Reason               string    `db:"reason"`
+	Attempts             int       `db:"attempts"`
+	RunAfter             time.Time `db:"run_after"`
+}
+
+type filestoreFilesystemCleanupJobRow struct {
+	UUID                 uuid.UUID `db:"uuid"`
+	ExternalID           string    `db:"external_id"`
+	WorkspaceUUID        uuid.UUID `db:"workspace_uuid"`
+	FilesystemUUID       uuid.UUID `db:"filesystem_uuid"`
+	FilesystemExternalID string    `db:"filesystem_external_id"`
+	Attempts             int       `db:"attempts"`
+	RunAfter             time.Time `db:"run_after"`
+}
+
+func (row filestoreObjectCleanupJobRow) job() FilestoreObjectCleanupJob {
+	return FilestoreObjectCleanupJob{
+		UUID:                 row.UUID.String(),
+		ExternalID:           row.ExternalID,
+		WorkspaceUUID:        row.WorkspaceUUID.String(),
+		FilesystemUUID:       row.FilesystemUUID.String(),
+		FilesystemExternalID: row.FilesystemExternalID,
+		EntryExternalID:      row.EntryExternalID,
+		Bucket:               row.Bucket,
+		Key:                  row.Key,
+		ETag:                 row.ETag,
+		VersionID:            row.VersionID,
+		Reason:               row.Reason,
+		Attempts:             row.Attempts,
+		RunAfter:             row.RunAfter,
+	}
+}
+
+func (row filestoreFilesystemCleanupJobRow) job() FilestoreFilesystemCleanupJob {
+	return FilestoreFilesystemCleanupJob{
+		UUID:                 row.UUID.String(),
+		ExternalID:           row.ExternalID,
+		WorkspaceUUID:        row.WorkspaceUUID.String(),
+		FilesystemUUID:       row.FilesystemUUID.String(),
+		FilesystemExternalID: row.FilesystemExternalID,
+		Attempts:             row.Attempts,
+		RunAfter:             row.RunAfter,
+	}
 }
 
 func enqueueFilestoreEntryCleanupJobTx(ctx context.Context, tx *sqlx.Tx, scope filestoreEntryCleanupScope, entry FilestoreEntry, reason string, runAfter time.Time) (FilestoreObjectCleanupJob, error) {
@@ -831,9 +912,9 @@ func retireExpiredFilestoreSubtreeTx(
 		if _, err := namedExecContext(ctx, tx, `
 			update filestore_entries
 			set deleted_at = :retired_at, updated_at = :retired_at
-			where uuid = CAST(:entry_uuid AS uuid) and deleted_at is null
+			where uuid = :entry_uuid and deleted_at is null
 		`, map[string]any{
-			"entry_uuid": entry.UUID,
+			"entry_uuid": dbUUID(entry.UUID),
 			"retired_at": retiredAt,
 		}); err != nil {
 			return nil, 0, err
@@ -844,8 +925,8 @@ func retireExpiredFilestoreSubtreeTx(
 
 func filestoreSubtreeArguments(filesystem FilestoreFilesystem, rootPath string) map[string]any {
 	return map[string]any{
-		"workspace_uuid":  filesystem.WorkspaceUUID,
-		"filesystem_uuid": filesystem.UUID,
+		"workspace_uuid":  dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid": dbUUID(filesystem.UUID),
 		"root_path":       rootPath,
 	}
 }
@@ -857,12 +938,12 @@ func cancelAttachedFilestoreObjectCleanupJobTx(ctx context.Context, tx *sqlx.Tx,
 		set status = 'canceled', locked_by = null, locked_until = null, updated_at = now()
 		where external_id = :job_external_id and type = :job_type
 			and status in ('pending', 'retry')
-			and workspace_uuid = CAST(:workspace_uuid AS uuid)
+			and workspace_uuid = :workspace_uuid
 			and payload->>'bucket' = :bucket
 			and payload->>'key' = :key
 			and coalesce(payload->>'version_id', '') = :version_id
 	`, map[string]any{
-		"workspace_uuid":  workspaceUUID,
+		"workspace_uuid":  dbUUID(workspaceUUID),
 		"job_external_id": jobExternalID,
 		"job_type":        filestoreCleanupJobType,
 		"bucket":          blob.S3Bucket,
@@ -879,9 +960,9 @@ func cancelAttachedFilestoreObjectCleanupJobTx(ctx context.Context, tx *sqlx.Tx,
 }
 
 func filestoreCleanupJobColumns(jobAlias, filesystemAlias string) string {
-	return fmt.Sprintf(`cast(%[1]s.uuid as text) as uuid, %[1]s.external_id as external_id,
-		cast(%[1]s.workspace_uuid as text) as workspace_uuid,
-		cast(%[2]s.uuid as text) as filesystem_uuid,
+	return fmt.Sprintf(`%[1]s.uuid as uuid, %[1]s.external_id as external_id,
+		%[1]s.workspace_uuid as workspace_uuid,
+		%[2]s.uuid as filesystem_uuid,
 		%[2]s.external_id as filesystem_external_id,
 		coalesce(%[1]s.payload->>'entry_external_id', '') as entry_external_id,
 		coalesce(%[1]s.payload->>'bucket', '') as bucket,
@@ -894,9 +975,9 @@ func filestoreCleanupJobColumns(jobAlias, filesystemAlias string) string {
 }
 
 func filestoreFilesystemCleanupJobColumns(jobAlias, filesystemAlias string) string {
-	return fmt.Sprintf(`cast(%[1]s.uuid as text) as uuid, %[1]s.external_id as external_id,
-		cast(%[1]s.workspace_uuid as text) as workspace_uuid,
-		cast(%[2]s.uuid as text) as filesystem_uuid,
+	return fmt.Sprintf(`%[1]s.uuid as uuid, %[1]s.external_id as external_id,
+		%[1]s.workspace_uuid as workspace_uuid,
+		%[2]s.uuid as filesystem_uuid,
 		%[2]s.external_id as filesystem_external_id,
 		%[1]s.attempts as attempts, %[1]s.run_after as run_after`,
 		jobAlias, filesystemAlias)

--- a/internal/db/filestore_entries.go
+++ b/internal/db/filestore_entries.go
@@ -66,8 +66,8 @@ func buildFilestoreEntriesPageQuery(filesystem FilestoreFilesystem, params ListF
 			and (expires_at is null or expires_at > now())
 	`
 	args := map[string]any{
-		"workspace_uuid":  filesystem.WorkspaceUUID,
-		"filesystem_uuid": filesystem.UUID,
+		"workspace_uuid":  dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid": dbUUID(filesystem.UUID),
 		"fetch_limit":     params.Limit + 1,
 	}
 	if params.Recursive {
@@ -79,9 +79,9 @@ func buildFilestoreEntriesPageQuery(filesystem FilestoreFilesystem, params ListF
 		args["directory_path"] = params.DirectoryPath
 	}
 	if params.Cursor != nil {
-		query += " and (path, uuid) > (:cursor_path, CAST(:cursor_uuid AS uuid))"
+		query += " and (path, uuid) > (:cursor_path, :cursor_uuid)"
 		args["cursor_path"] = params.Cursor.Path
-		args["cursor_uuid"] = params.Cursor.UUID
+		args["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	// 多取一条只用于判定 HasMore；返回页仍严格遵守请求的 Limit。
 	query += " order by path asc, uuid asc limit :fetch_limit"

--- a/internal/db/filestore_entry_helpers.go
+++ b/internal/db/filestore_entry_helpers.go
@@ -27,17 +27,17 @@ func (d *DB) beginFilestoreNamespaceMutation(ctx context.Context, workspaceUUID,
 	// 即使目录操作通常不改变容量，也可能替换到期文件；统一锁序比事后升级锁更安全。
 	if _, err := namedExecContext(ctx, tx, `
 		select pg_advisory_xact_lock(hashtextextended(CAST(:workspace_uuid AS text), 0))
-	`, map[string]any{"workspace_uuid": workspaceUUID}); err != nil {
+	`, map[string]any{"workspace_uuid": dbUUID(workspaceUUID)}); err != nil {
 		return nil, FilestoreFilesystem{}, err
 	}
 	filesystem, err := getFilestoreFilesystemSQLX(ctx, tx, filestoreFilesystemSelectSQL()+`
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
-			and uuid = CAST(:filesystem_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
+			and uuid = :filesystem_uuid
 			and deleted_at is null
 		for update
 	`, map[string]any{
-		"workspace_uuid":  workspaceUUID,
-		"filesystem_uuid": filesystemUUID,
+		"workspace_uuid":  dbUUID(workspaceUUID),
+		"filesystem_uuid": dbUUID(filesystemUUID),
 	})
 	if err != nil {
 		return nil, FilestoreFilesystem{}, err
@@ -49,7 +49,7 @@ func (d *DB) beginFilestoreNamespaceMutation(ctx context.Context, workspaceUUID,
 				0
 			)
 		)
-	`, map[string]any{"filesystem_uuid": filesystem.UUID}); err != nil {
+	`, map[string]any{"filesystem_uuid": dbUUID(filesystem.UUID)}); err != nil {
 		return nil, FilestoreFilesystem{}, err
 	}
 	rollback = false
@@ -117,8 +117,8 @@ func getActiveFilestoreEntryForMutation(ctx context.Context, tx *sqlx.Tx, filesy
 
 func filestoreEntryMutationArguments(filesystem FilestoreFilesystem, entryPath string) map[string]any {
 	return map[string]any{
-		"workspace_uuid":  filesystem.WorkspaceUUID,
-		"filesystem_uuid": filesystem.UUID,
+		"workspace_uuid":  dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid": dbUUID(filesystem.UUID),
 		"entry_path":      entryPath,
 	}
 }
@@ -217,17 +217,17 @@ func ensureFilestoreDirectoryTx(ctx context.Context, tx *sqlx.Tx, filesystem Fil
 				created_at = :now, updated_at = :now
 			where workspace_uuid = :workspace_uuid
 				and filesystem_uuid = :filesystem_uuid
-				and uuid = CAST(:entry_uuid AS uuid)
+				and uuid = :entry_uuid
 				and deleted_at is null
 			returning `+filestoreEntryColumns()+`
 		`, map[string]any{
-			"workspace_uuid":               filesystem.WorkspaceUUID,
-			"filesystem_uuid":              filesystem.UUID,
-			"entry_uuid":                   existing.UUID,
+			"workspace_uuid":               dbUUID(filesystem.WorkspaceUUID),
+			"filesystem_uuid":              dbUUID(filesystem.UUID),
+			"entry_uuid":                   dbUUID(existing.UUID),
 			"parent_path":                  filestoreParentPath(directoryPath),
-			"created_by_api_key_uuid":      filesystem.CreatedByAPIKeyUUID,
-			"created_by_session_uuid":      filesystem.SessionUUID,
-			"created_by_code_session_uuid": filesystem.CodeSessionUUID,
+			"created_by_api_key_uuid":      dbNullableUUID(filesystem.CreatedByAPIKeyUUID),
+			"created_by_session_uuid":      dbUUID(filesystem.SessionUUID),
+			"created_by_code_session_uuid": dbNullableUUID(filesystem.CodeSessionUUID),
 			"now":                          now,
 		})
 		if err != nil {
@@ -258,14 +258,14 @@ func ensureFilestoreDirectoryTx(ctx context.Context, tx *sqlx.Tx, filesystem Fil
 		)
 		returning `+filestoreEntryColumns()+`
 	`, map[string]any{
-		"organization_uuid":            filesystem.OrganizationUUID,
-		"workspace_uuid":               filesystem.WorkspaceUUID,
-		"filesystem_uuid":              filesystem.UUID,
+		"organization_uuid":            dbUUID(filesystem.OrganizationUUID),
+		"workspace_uuid":               dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid":              dbUUID(filesystem.UUID),
 		"entry_path":                   directoryPath,
 		"parent_path":                  filestoreParentPath(directoryPath),
-		"created_by_api_key_uuid":      filesystem.CreatedByAPIKeyUUID,
-		"created_by_session_uuid":      filesystem.SessionUUID,
-		"created_by_code_session_uuid": filesystem.CodeSessionUUID,
+		"created_by_api_key_uuid":      dbNullableUUID(filesystem.CreatedByAPIKeyUUID),
+		"created_by_session_uuid":      dbUUID(filesystem.SessionUUID),
+		"created_by_code_session_uuid": dbNullableUUID(filesystem.CodeSessionUUID),
 		"now":                          now,
 	})
 }
@@ -340,7 +340,7 @@ func putFilestoreFileTx(ctx context.Context, tx *sqlx.Tx, filesystem FilestoreFi
 func writeFilestoreFileTx(ctx context.Context, tx *sqlx.Tx, filesystem FilestoreFilesystem, existing FilestoreEntry, found bool, input putFilestoreFileTxInput) (FilestoreEntry, error) {
 	arguments := filestoreFileWriteArguments(filesystem, input)
 	if found {
-		arguments["entry_uuid"] = existing.UUID
+		arguments["entry_uuid"] = dbUUID(existing.UUID)
 		return getFilestoreEntrySQLX(ctx, tx, `
 			update filestore_entries
 			set kind = 'file', path = :entry_path, parent_path = :parent_path,
@@ -359,7 +359,7 @@ func writeFilestoreFileTx(ctx context.Context, tx *sqlx.Tx, filesystem Filestore
 				created_at = :now, updated_at = :now
 			where workspace_uuid = :workspace_uuid
 				and filesystem_uuid = :filesystem_uuid
-				and uuid = CAST(:entry_uuid AS uuid)
+				and uuid = :entry_uuid
 				and deleted_at is null
 			returning `+filestoreEntryColumns()+`
 		`, arguments)
@@ -389,9 +389,9 @@ func writeFilestoreFileTx(ctx context.Context, tx *sqlx.Tx, filesystem Filestore
 
 func filestoreFileWriteArguments(filesystem FilestoreFilesystem, input putFilestoreFileTxInput) map[string]any {
 	return map[string]any{
-		"organization_uuid":            filesystem.OrganizationUUID,
-		"workspace_uuid":               filesystem.WorkspaceUUID,
-		"filesystem_uuid":              filesystem.UUID,
+		"organization_uuid":            dbUUID(filesystem.OrganizationUUID),
+		"workspace_uuid":               dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid":              dbUUID(filesystem.UUID),
 		"entry_path":                   input.Path,
 		"parent_path":                  filestoreParentPath(input.Path),
 		"size_bytes":                   input.Blob.SizeBytes,
@@ -408,9 +408,9 @@ func filestoreFileWriteArguments(filesystem FilestoreFilesystem, input putFilest
 		"s3_etag":                      filestoreNullableString(input.Blob.S3ETag),
 		"s3_version_id":                filestoreNullableString(input.Blob.S3VersionID),
 		"expires_at":                   input.Blob.ExpiresAt,
-		"created_by_api_key_uuid":      filesystem.CreatedByAPIKeyUUID,
-		"created_by_session_uuid":      filesystem.SessionUUID,
-		"created_by_code_session_uuid": filesystem.CodeSessionUUID,
+		"created_by_api_key_uuid":      dbNullableUUID(filesystem.CreatedByAPIKeyUUID),
+		"created_by_session_uuid":      dbUUID(filesystem.SessionUUID),
+		"created_by_code_session_uuid": dbNullableUUID(filesystem.CodeSessionUUID),
 		"now":                          input.Now,
 	}
 }

--- a/internal/db/filestore_entry_mutations.go
+++ b/internal/db/filestore_entry_mutations.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // MakeFilestoreDirectory 创建目录；MakeParents 为真时整条父链在同一事务内完成。
@@ -226,12 +228,12 @@ func (d *DB) MoveFilestoreFile(ctx context.Context, input MoveFilestoreFileInput
 			set deleted_at = :now, updated_at = :now
 				where workspace_uuid = :workspace_uuid
 					and filesystem_uuid = :filesystem_uuid
-					and uuid = CAST(:entry_uuid AS uuid)
+					and uuid = :entry_uuid
 					and deleted_at is null
 		`, map[string]any{
-			"workspace_uuid":  filesystem.WorkspaceUUID,
-			"filesystem_uuid": filesystem.UUID,
-			"entry_uuid":      destination.UUID,
+			"workspace_uuid":  dbUUID(filesystem.WorkspaceUUID),
+			"filesystem_uuid": dbUUID(filesystem.UUID),
+			"entry_uuid":      dbUUID(destination.UUID),
 			"now":             input.Now,
 		}); err != nil {
 			return FilestoreMutationResult{}, err
@@ -260,13 +262,13 @@ func (d *DB) MoveFilestoreFile(ctx context.Context, input MoveFilestoreFileInput
 			updated_at = :now
 			where workspace_uuid = :workspace_uuid
 				and filesystem_uuid = :filesystem_uuid
-				and uuid = CAST(:entry_uuid AS uuid)
+				and uuid = :entry_uuid
 				and deleted_at is null
 		returning `+filestoreEntryColumns()+`
 	`, map[string]any{
-		"workspace_uuid":          filesystem.WorkspaceUUID,
-		"filesystem_uuid":         filesystem.UUID,
-		"entry_uuid":              source.UUID,
+		"workspace_uuid":          dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid":         dbUUID(filesystem.UUID),
+		"entry_uuid":              dbUUID(source.UUID),
 		"destination_path":        input.DestinationPath,
 		"destination_parent_path": filestoreParentPath(input.DestinationPath),
 		"now":                     input.Now,
@@ -323,8 +325,8 @@ func (d *DB) MoveFilestoreDirectory(ctx context.Context, input MoveFilestoreDire
 	var maxMovedPathBytes int
 	// 在批量更新前按字节预演最长目标路径，避免中途触发约束而留下难以解释的错误。
 	moveArguments := map[string]any{
-		"workspace_uuid":          filesystem.WorkspaceUUID,
-		"filesystem_uuid":         filesystem.UUID,
+		"workspace_uuid":          dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid":         dbUUID(filesystem.UUID),
 		"source_path":             input.SourcePath,
 		"destination_path":        input.DestinationPath,
 		"destination_parent_path": filestoreParentPath(input.DestinationPath),
@@ -350,9 +352,9 @@ func (d *DB) MoveFilestoreDirectory(ctx context.Context, input MoveFilestoreDire
 	if maxMovedPathBytes > filestoreMaxPathBytes {
 		return FilestoreMutationResult{}, ErrPreconditionFailed
 	}
-	var conflictingUUID string
+	var conflictingUUID uuid.UUID
 	err = namedGetContext(ctx, tx, &conflictingUUID, `
-		select CAST(uuid AS text)
+		select uuid
 		from filestore_entries
 		where workspace_uuid = :workspace_uuid
 			and filesystem_uuid = :filesystem_uuid
@@ -458,12 +460,12 @@ func (d *DB) RemoveFilestoreFile(ctx context.Context, input RemoveFilestoreEntry
 		set deleted_at = :now, updated_at = :now
 		where workspace_uuid = :workspace_uuid
 			and filesystem_uuid = :filesystem_uuid
-			and uuid = CAST(:entry_uuid AS uuid)
+			and uuid = :entry_uuid
 			and deleted_at is null
 	`, map[string]any{
-		"workspace_uuid":  filesystem.WorkspaceUUID,
-		"filesystem_uuid": filesystem.UUID,
-		"entry_uuid":      entry.UUID,
+		"workspace_uuid":  dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid": dbUUID(filesystem.UUID),
+		"entry_uuid":      dbUUID(entry.UUID),
 		"now":             input.Now,
 	}); err != nil {
 		return FilestoreMutationResult{}, err
@@ -513,8 +515,8 @@ func (d *DB) RemoveFilestoreDirectory(ctx context.Context, input RemoveFilestore
 	}
 	var childCount int
 	entryArguments := map[string]any{
-		"workspace_uuid":  filesystem.WorkspaceUUID,
-		"filesystem_uuid": filesystem.UUID,
+		"workspace_uuid":  dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid": dbUUID(filesystem.UUID),
 		"entry_path":      input.Path,
 		"now":             input.Now,
 	}

--- a/internal/db/filestore_filesystems.go
+++ b/internal/db/filestore_filesystems.go
@@ -25,9 +25,9 @@ var (
 			update filestore_filesystems fs
 			set deleted_at = coalesce(fs.deleted_at, :retired_at),
 				updated_at = :retired_at
-			where fs.workspace_uuid = CAST(:workspace_uuid AS uuid)
-				and fs.organization_uuid = CAST(:organization_uuid AS uuid)
-				and fs.session_uuid = CAST(:session_uuid AS uuid)
+			where fs.workspace_uuid = :workspace_uuid
+				and fs.organization_uuid = :organization_uuid
+				and fs.session_uuid = :session_uuid
 				and fs.deleted_at is null
 			returning fs.uuid
 		)
@@ -50,24 +50,24 @@ var (
 		)
 	`
 	validateFilestoreSessionBindingQuery = `
-		select CAST(s.workspace_uuid AS text) as workspace_uuid
+		select s.workspace_uuid
 		from sessions s
 		join workspaces w
 			on w.uuid = s.workspace_uuid
 			and w.organization_uuid = s.organization_uuid
-		where s.uuid = CAST(:session_uuid AS uuid)
-			and s.organization_uuid = CAST(:organization_uuid AS uuid)
-			and s.workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where s.uuid = :session_uuid
+			and s.organization_uuid = :organization_uuid
+			and s.workspace_uuid = :workspace_uuid
 			and s.status <> 'terminated'
 			and s.archived_at is null
 			and s.deleted_at is null
 			and w.archived_at is null
 			and (
-				CAST(:code_session_uuid AS uuid) is null
+				not :has_code_session
 				or exists (
 					select 1
 					from code_sessions cs
-					where cs.uuid = CAST(:code_session_uuid AS uuid)
+					where cs.uuid = :code_session_uuid
 						and cs.session_uuid = s.uuid
 						and cs.organization_uuid = s.organization_uuid
 						and cs.workspace_uuid = s.workspace_uuid
@@ -76,11 +76,11 @@ var (
 				)
 			)
 			and (
-				CAST(:created_by_api_key_uuid AS uuid) is null
+				not :has_created_by_api_key
 				or exists (
 					select 1
 					from api_keys ak
-					where ak.uuid = CAST(:created_by_api_key_uuid AS uuid)
+					where ak.uuid = :created_by_api_key_uuid
 						and ak.workspace_uuid = w.uuid
 				)
 			)
@@ -93,10 +93,10 @@ var (
 		)
 	`
 	provisionFilestoreByExternalIDQuery = `
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
 			and (
 				external_id = :filesystem_external_id
-				or CAST(uuid AS text) = lower(:filesystem_external_id)
+				or uuid = :filesystem_uuid
 			)
 			and deleted_at is null
 		order by (external_id = :filesystem_external_id) desc
@@ -104,8 +104,8 @@ var (
 		for update
 	`
 	provisionFilestoreBySessionQuery = `
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
-			and session_uuid = CAST(:session_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
+			and session_uuid = :session_uuid
 			and deleted_at is null
 		limit 1
 		for update
@@ -116,13 +116,13 @@ var (
 			code_session_uuid, created_by_api_key_uuid, created_at, updated_at
 		)
 		values (
-			coalesce(CAST(nullif(:filesystem_uuid, '') AS uuid), gen_random_uuid()),
+			coalesce(:filesystem_uuid, gen_random_uuid()),
 			:filesystem_external_id,
-			CAST(:organization_uuid AS uuid),
-			CAST(:workspace_uuid AS uuid),
-			CAST(:session_uuid AS uuid),
-			CAST(:code_session_uuid AS uuid),
-			CAST(:created_by_api_key_uuid AS uuid),
+			:organization_uuid,
+			:workspace_uuid,
+			:session_uuid,
+			:code_session_uuid,
+			:created_by_api_key_uuid,
 			:now,
 			:now
 		)
@@ -139,16 +139,16 @@ var (
 )
 
 type filestoreSessionBindingRow struct {
-	WorkspaceUUID string `db:"workspace_uuid"`
+	WorkspaceUUID uuid.UUID `db:"workspace_uuid"`
 }
 
 const filestoreSessionTokenScopeQuery = `
-	select cast(o.uuid as text) as organization_uuid,
-		cast(w.uuid as text) as workspace_uuid,
+	select o.uuid as organization_uuid,
+		w.uuid as workspace_uuid,
 		w.external_id as workspace_external_id,
-		cast(u.uuid as text) as account_uuid,
+		u.uuid as account_uuid,
 		u.external_id as account_external_id,
-		cast(fs.uuid as text) as filesystem_uuid,
+		fs.uuid as filesystem_uuid,
 		fs.external_id as filesystem_external_id,
 		coalesce(o.settings->'org_taints', cast('[]' as jsonb)) as org_taints_json,
 		(nullif(trim(w.external_key_id), '') is not null) as workspace_cmek_enabled
@@ -170,7 +170,7 @@ const filestoreSessionTokenScopeQuery = `
 		and fs.workspace_uuid = w.uuid
 		and fs.session_uuid = s.uuid
 		and fs.deleted_at is null
-	where s.workspace_uuid = CAST(:workspace_uuid AS uuid)
+	where s.workspace_uuid = :workspace_uuid
 		and s.external_id = :session_external_id
 		and s.status <> 'terminated'
 		and s.archived_at is null
@@ -194,12 +194,12 @@ func (d *DB) ResolveFilestoreTokenScope(
 	// 查询末尾两列同时取回当前安全策略：组织 taints 来自 settings JSON，
 	// CMEK 状态则由工作区是否配置 external_key_id 推导，供鉴权层校验 JWT 快照。
 	return getFilestoreTokenScopeSQLX(ctx, d.sql, `
-		select cast(o.uuid as text) as organization_uuid,
-			cast(w.uuid as text) as workspace_uuid,
+		select o.uuid as organization_uuid,
+			w.uuid as workspace_uuid,
 			w.external_id as workspace_external_id,
-			cast(u.uuid as text) as account_uuid,
+			u.uuid as account_uuid,
 			u.external_id as account_external_id,
-			cast(fs.uuid as text) as filesystem_uuid,
+			fs.uuid as filesystem_uuid,
 			fs.external_id as filesystem_external_id,
 			coalesce(o.settings->'org_taints', cast('[]' as jsonb)) as org_taints_json,
 			(nullif(trim(w.external_key_id), '') is not null) as workspace_cmek_enabled
@@ -220,25 +220,26 @@ func (d *DB) ResolveFilestoreTokenScope(
 			and s.archived_at is null
 			and s.deleted_at is null
 			and s.status <> 'terminated'
-		where cast(o.uuid as text) = :organization_uuid
-			and cast(u.uuid as text) = :account_uuid
-			and cast(w.uuid as text) = :workspace_uuid
+		where o.uuid = :organization_uuid
+			and u.uuid = :account_uuid
+			and w.uuid = :workspace_uuid
 			and w.external_id = :workspace_tagged_id
 			and w.external_id = :resolved_workspace_tagged_id
 			and (
 				fs.external_id = :filesystem_id
-				or cast(fs.uuid as text) = lower(:filesystem_id)
+				or fs.uuid = :filesystem_uuid
 			)
 			and w.archived_at is null
 		order by (fs.external_id = :filesystem_id) desc
 		limit 1
 	`, map[string]any{
-		"organization_uuid":            strings.TrimSpace(organizationUUID),
-		"account_uuid":                 strings.TrimSpace(accountUUID),
-		"workspace_uuid":               strings.TrimSpace(workspaceUUID),
+		"organization_uuid":            dbUUID(organizationUUID),
+		"account_uuid":                 dbUUID(accountUUID),
+		"workspace_uuid":               dbUUID(workspaceUUID),
 		"workspace_tagged_id":          strings.TrimSpace(workspaceTaggedID),
 		"resolved_workspace_tagged_id": strings.TrimSpace(resolvedWorkspaceTaggedID),
 		"filesystem_id":                strings.TrimSpace(filesystemID),
+		"filesystem_uuid":              tryParseDBUUIDIdentifier(filesystemID),
 	})
 }
 
@@ -392,13 +393,15 @@ func (d *DB) ProvisionFilestoreFilesystem(ctx context.Context, input ProvisionFi
 
 func provisionFilestoreFilesystemArguments(input ProvisionFilestoreFilesystemInput) map[string]any {
 	return map[string]any{
-		"filesystem_uuid":         input.UUID,
+		"filesystem_uuid":         dbNullableUUID(&input.UUID),
 		"filesystem_external_id":  input.ExternalID,
-		"organization_uuid":       input.OrganizationUUID,
-		"workspace_uuid":          input.WorkspaceUUID,
-		"session_uuid":            input.SessionUUID,
-		"code_session_uuid":       input.CodeSessionUUID,
-		"created_by_api_key_uuid": input.CreatedByAPIKeyUUID,
+		"organization_uuid":       dbUUID(input.OrganizationUUID),
+		"workspace_uuid":          dbUUID(input.WorkspaceUUID),
+		"session_uuid":            dbUUID(input.SessionUUID),
+		"code_session_uuid":       dbNullableUUID(input.CodeSessionUUID),
+		"has_code_session":        input.CodeSessionUUID != nil,
+		"created_by_api_key_uuid": dbNullableUUID(input.CreatedByAPIKeyUUID),
+		"has_created_by_api_key":  input.CreatedByAPIKeyUUID != nil,
 		"now":                     input.Now,
 	}
 }
@@ -410,7 +413,7 @@ func ensureProvisionedFilestoreRootsTx(
 	now time.Time,
 ) error {
 	if _, err := namedExecContext(ctx, tx, provisionFilestoreNamespaceLockQuery, map[string]any{
-		"filesystem_uuid": filesystem.UUID,
+		"filesystem_uuid": dbUUID(filesystem.UUID),
 	}); err != nil {
 		return err
 	}
@@ -459,17 +462,18 @@ func ensureFilestoreFixedRootsTx(
 // GetFilestoreFilesystem 在工作区边界内按外部 ID 或 UUID 查找文件系统。
 func (d *DB) GetFilestoreFilesystem(ctx context.Context, workspaceUUID string, externalID string) (FilestoreFilesystem, error) {
 	return getFilestoreFilesystemSQLX(ctx, d.sql, filestoreFilesystemSelectSQL()+`
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
 			and (
 				external_id = :filesystem_id
-				or cast(uuid as text) = lower(:filesystem_id)
+				or uuid = :filesystem_uuid
 			)
 			and deleted_at is null
 		order by (external_id = :filesystem_id) desc
 		limit 1
 	`, map[string]any{
-		"workspace_uuid": workspaceUUID,
-		"filesystem_id":  externalID,
+		"workspace_uuid":  dbUUID(workspaceUUID),
+		"filesystem_id":   externalID,
+		"filesystem_uuid": tryParseDBUUIDIdentifier(externalID),
 	})
 }
 
@@ -477,17 +481,17 @@ func (d *DB) GetFilestoreFilesystem(ctx context.Context, workspaceUUID string, e
 // Code session 是可重建的执行实例，不参与文件系统归属判断。
 func (d *DB) GetFilestoreFilesystemBySession(ctx context.Context, workspaceUUID string, sessionExternalID string) (FilestoreFilesystem, error) {
 	return getFilestoreFilesystemSQLX(ctx, d.sql, filestoreFilesystemSelectSQL()+`
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
 			and session_uuid = (
 				select uuid from sessions
-				where workspace_uuid = CAST(:workspace_uuid AS uuid)
+				where workspace_uuid = :workspace_uuid
 					and external_id = :session_external_id
 					and deleted_at is null
 			)
 			and deleted_at is null
 		limit 1
 	`, map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"session_external_id": sessionExternalID,
 	})
 }
@@ -519,7 +523,7 @@ func (d *DB) GetFilestoreTokenScopeForSessionIssue(ctx context.Context, workspac
 
 func filestoreSessionTokenScopeArguments(workspaceUUID string, sessionExternalID string) map[string]any {
 	return map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"session_external_id": strings.TrimSpace(sessionExternalID),
 	}
 }
@@ -529,9 +533,9 @@ func filestoreSessionTokenScopeArguments(workspaceUUID string, sessionExternalID
 func retireSessionFilesystemTx(ctx context.Context, tx *sqlx.Tx, session Session) error {
 	retiredAt := filestoreNow(session.UpdatedAt)
 	filesystem, err := getFilestoreFilesystemSQLX(ctx, tx, retireSessionFilesystemQuery, map[string]any{
-		"workspace_uuid":    session.WorkspaceUUID,
-		"organization_uuid": session.OrganizationUUID,
-		"session_uuid":      session.UUID,
+		"workspace_uuid":    dbUUID(session.WorkspaceUUID),
+		"organization_uuid": dbUUID(session.OrganizationUUID),
+		"session_uuid":      dbUUID(session.UUID),
 		"retired_at":        retiredAt,
 	})
 	if errors.Is(err, ErrNotFound) {

--- a/internal/db/filestore_filesystems_test.go
+++ b/internal/db/filestore_filesystems_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestFilestoreSessionTokenScopeNamedQuery(t *testing.T) {
@@ -18,7 +20,10 @@ func TestFilestoreSessionTokenScopeNamedQuery(t *testing.T) {
 	if strings.Contains(query, ":workspace_uuid") || strings.Contains(query, ":session_external_id") {
 		t.Fatalf("named parameters remain after binding: %q", query)
 	}
-	if want := []any{"00000000-0000-0000-0000-000000000042", "session_test"}; !reflect.DeepEqual(arguments, want) {
+	if want := []any{
+		uuid.MustParse("00000000-0000-0000-0000-000000000042"),
+		"session_test",
+	}; !reflect.DeepEqual(arguments, want) {
 		t.Fatalf("arguments = %#v, want %#v", arguments, want)
 	}
 }

--- a/internal/db/filestore_scan.go
+++ b/internal/db/filestore_scan.go
@@ -10,12 +10,12 @@ func filestoreFilesystemSelectSQL() string {
 }
 
 func filestoreFilesystemColumns() string {
-	return `cast(uuid as text) as uuid, external_id,
-		cast(organization_uuid as text) as organization_uuid,
-		cast(workspace_uuid as text) as workspace_uuid,
-		cast(session_uuid as text) as session_uuid,
-		cast(code_session_uuid as text) as code_session_uuid,
-		cast(created_by_api_key_uuid as text) as created_by_api_key_uuid,
+	return `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		session_uuid,
+		code_session_uuid,
+		created_by_api_key_uuid,
 		created_at, updated_at, deleted_at`
 }
 
@@ -24,18 +24,18 @@ func filestoreEntrySelectSQL() string {
 }
 
 func filestoreEntryColumns() string {
-	return `cast(uuid as text) as uuid, external_id,
-		cast(organization_uuid as text) as organization_uuid,
-		cast(workspace_uuid as text) as workspace_uuid,
-		cast(filesystem_uuid as text) as filesystem_uuid, kind, path, parent_path,
+	return `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		filesystem_uuid, kind, path, parent_path,
 		size_bytes, media_type, detected_mime_type, metadata, authorization_metadata,
 		cast(coalesce(to_jsonb(tags), cast('[]' as jsonb)) as text) as tags_json,
 		downloadable, md5, sha256, s3_bucket, s3_key, s3_etag, s3_version_id,
-		expires_at, managed_by, cast(managed_resource_uuid as text) as managed_resource_uuid,
-		cast(source_file_uuid as text) as source_file_uuid,
-		cast(created_by_api_key_uuid as text) as created_by_api_key_uuid,
-		cast(created_by_session_uuid as text) as created_by_session_uuid,
-		cast(created_by_code_session_uuid as text) as created_by_code_session_uuid,
+		expires_at, managed_by, managed_resource_uuid,
+		source_file_uuid,
+		created_by_api_key_uuid,
+		created_by_session_uuid,
+		created_by_code_session_uuid,
 		created_at, updated_at, deleted_at`
 }
 

--- a/internal/db/filestore_session_sqlx.go
+++ b/internal/db/filestore_session_sqlx.go
@@ -17,13 +17,13 @@ var insertSessionFilesystemSQLXQuery = `
 		)
 		select
 			:filesystem_external_id, w.organization_uuid, w.uuid,
-			CAST(:session_uuid AS uuid), null, ak.uuid, :created_at, :created_at
+			:session_uuid, null, ak.uuid, :created_at, :created_at
 		from workspaces w
 		join api_keys ak
-			on ak.uuid = CAST(:created_by_api_key_uuid AS uuid)
+			on ak.uuid = :created_by_api_key_uuid
 			and ak.workspace_uuid = w.uuid
-		where w.uuid = CAST(:workspace_uuid AS uuid)
-			and w.organization_uuid = CAST(:organization_uuid AS uuid)
+		where w.uuid = :workspace_uuid
+			and w.organization_uuid = :organization_uuid
 			and w.archived_at is null
 		on conflict on constraint filestore_filesystems_workspace_uuid_external_id_key do nothing
 		returning ` + filestoreFilesystemColumns() + `
@@ -34,7 +34,7 @@ const (
 		select exists (
 			select 1
 			from filestore_filesystems fs
-			where fs.workspace_uuid = CAST(:workspace_uuid AS uuid)
+			where fs.workspace_uuid = :workspace_uuid
 				and fs.external_id = :filesystem_external_id
 		)
 	`
@@ -88,10 +88,10 @@ func insertSessionFilesystemSQLXTx(
 func sessionFilesystemArguments(session Session, externalID string, createdAt time.Time) map[string]any {
 	return map[string]any{
 		"filesystem_external_id":  externalID,
-		"session_uuid":            session.UUID,
-		"organization_uuid":       session.OrganizationUUID,
-		"workspace_uuid":          session.WorkspaceUUID,
-		"created_by_api_key_uuid": session.CreatedByAPIKeyUUID,
+		"session_uuid":            dbUUID(session.UUID),
+		"organization_uuid":       dbUUID(session.OrganizationUUID),
+		"workspace_uuid":          dbUUID(session.WorkspaceUUID),
+		"created_by_api_key_uuid": dbUUID(session.CreatedByAPIKeyUUID),
 		"created_at":              createdAt,
 	}
 }

--- a/internal/db/filestore_sqlx.go
+++ b/internal/db/filestore_sqlx.go
@@ -7,75 +7,77 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type filestoreFilesystemRow struct {
-	UUID                string     `db:"uuid"`
-	ExternalID          string     `db:"external_id"`
-	OrganizationUUID    string     `db:"organization_uuid"`
-	WorkspaceUUID       string     `db:"workspace_uuid"`
-	SessionUUID         string     `db:"session_uuid"`
-	CodeSessionUUID     *string    `db:"code_session_uuid"`
-	CreatedByAPIKeyUUID *string    `db:"created_by_api_key_uuid"`
-	CreatedAt           time.Time  `db:"created_at"`
-	UpdatedAt           time.Time  `db:"updated_at"`
-	DeletedAt           *time.Time `db:"deleted_at"`
+	UUID                uuid.UUID     `db:"uuid"`
+	ExternalID          string        `db:"external_id"`
+	OrganizationUUID    uuid.UUID     `db:"organization_uuid"`
+	WorkspaceUUID       uuid.UUID     `db:"workspace_uuid"`
+	SessionUUID         uuid.UUID     `db:"session_uuid"`
+	CodeSessionUUID     uuid.NullUUID `db:"code_session_uuid"`
+	CreatedByAPIKeyUUID uuid.NullUUID `db:"created_by_api_key_uuid"`
+	CreatedAt           time.Time     `db:"created_at"`
+	UpdatedAt           time.Time     `db:"updated_at"`
+	DeletedAt           *time.Time    `db:"deleted_at"`
 }
 
 type filestoreTokenScopeRow struct {
-	OrganizationUUID     string `db:"organization_uuid"`
-	WorkspaceUUID        string `db:"workspace_uuid"`
-	WorkspaceExternalID  string `db:"workspace_external_id"`
-	AccountUUID          string `db:"account_uuid"`
-	AccountExternalID    string `db:"account_external_id"`
-	FilesystemUUID       string `db:"filesystem_uuid"`
-	FilesystemExternalID string `db:"filesystem_external_id"`
-	OrgTaintsJSON        []byte `db:"org_taints_json"`
-	WorkspaceCMEKEnabled bool   `db:"workspace_cmek_enabled"`
+	OrganizationUUID     uuid.UUID `db:"organization_uuid"`
+	WorkspaceUUID        uuid.UUID `db:"workspace_uuid"`
+	WorkspaceExternalID  string    `db:"workspace_external_id"`
+	AccountUUID          uuid.UUID `db:"account_uuid"`
+	AccountExternalID    string    `db:"account_external_id"`
+	FilesystemUUID       uuid.UUID `db:"filesystem_uuid"`
+	FilesystemExternalID string    `db:"filesystem_external_id"`
+	OrgTaintsJSON        []byte    `db:"org_taints_json"`
+	WorkspaceCMEKEnabled bool      `db:"workspace_cmek_enabled"`
 }
 
 type filestoreEntryRow struct {
-	UUID                     string     `db:"uuid"`
-	ExternalID               string     `db:"external_id"`
-	OrganizationUUID         string     `db:"organization_uuid"`
-	WorkspaceUUID            string     `db:"workspace_uuid"`
-	FilesystemUUID           string     `db:"filesystem_uuid"`
-	Kind                     string     `db:"kind"`
-	Path                     string     `db:"path"`
-	ParentPath               *string    `db:"parent_path"`
-	SizeBytes                *int64     `db:"size_bytes"`
-	MediaType                *string    `db:"media_type"`
-	DetectedMimeType         *string    `db:"detected_mime_type"`
-	Metadata                 []byte     `db:"metadata"`
-	AuthorizationMetadata    []byte     `db:"authorization_metadata"`
-	TagsJSON                 string     `db:"tags_json"`
-	Downloadable             bool       `db:"downloadable"`
-	MD5                      *string    `db:"md5"`
-	SHA256                   *string    `db:"sha256"`
-	S3Bucket                 *string    `db:"s3_bucket"`
-	S3Key                    *string    `db:"s3_key"`
-	S3ETag                   *string    `db:"s3_etag"`
-	S3VersionID              *string    `db:"s3_version_id"`
-	ExpiresAt                *time.Time `db:"expires_at"`
-	ManagedBy                *string    `db:"managed_by"`
-	ManagedResourceUUID      *string    `db:"managed_resource_uuid"`
-	SourceFileUUID           *string    `db:"source_file_uuid"`
-	CreatedByAPIKeyUUID      *string    `db:"created_by_api_key_uuid"`
-	CreatedBySessionUUID     *string    `db:"created_by_session_uuid"`
-	CreatedByCodeSessionUUID *string    `db:"created_by_code_session_uuid"`
-	CreatedAt                time.Time  `db:"created_at"`
-	UpdatedAt                time.Time  `db:"updated_at"`
-	DeletedAt                *time.Time `db:"deleted_at"`
+	UUID                     uuid.UUID     `db:"uuid"`
+	ExternalID               string        `db:"external_id"`
+	OrganizationUUID         uuid.UUID     `db:"organization_uuid"`
+	WorkspaceUUID            uuid.UUID     `db:"workspace_uuid"`
+	FilesystemUUID           uuid.UUID     `db:"filesystem_uuid"`
+	Kind                     string        `db:"kind"`
+	Path                     string        `db:"path"`
+	ParentPath               *string       `db:"parent_path"`
+	SizeBytes                *int64        `db:"size_bytes"`
+	MediaType                *string       `db:"media_type"`
+	DetectedMimeType         *string       `db:"detected_mime_type"`
+	Metadata                 []byte        `db:"metadata"`
+	AuthorizationMetadata    []byte        `db:"authorization_metadata"`
+	TagsJSON                 string        `db:"tags_json"`
+	Downloadable             bool          `db:"downloadable"`
+	MD5                      *string       `db:"md5"`
+	SHA256                   *string       `db:"sha256"`
+	S3Bucket                 *string       `db:"s3_bucket"`
+	S3Key                    *string       `db:"s3_key"`
+	S3ETag                   *string       `db:"s3_etag"`
+	S3VersionID              *string       `db:"s3_version_id"`
+	ExpiresAt                *time.Time    `db:"expires_at"`
+	ManagedBy                *string       `db:"managed_by"`
+	ManagedResourceUUID      uuid.NullUUID `db:"managed_resource_uuid"`
+	SourceFileUUID           uuid.NullUUID `db:"source_file_uuid"`
+	CreatedByAPIKeyUUID      uuid.NullUUID `db:"created_by_api_key_uuid"`
+	CreatedBySessionUUID     uuid.NullUUID `db:"created_by_session_uuid"`
+	CreatedByCodeSessionUUID uuid.NullUUID `db:"created_by_code_session_uuid"`
+	CreatedAt                time.Time     `db:"created_at"`
+	UpdatedAt                time.Time     `db:"updated_at"`
+	DeletedAt                *time.Time    `db:"deleted_at"`
 }
 
 func getFilestoreFilesystemByUUIDSQLX(ctx context.Context, database sqlxNamedQueryer, workspaceUUID, filesystemUUID string) (FilestoreFilesystem, error) {
 	return getFilestoreFilesystemSQLX(ctx, database, filestoreFilesystemSelectSQL()+`
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
-			and uuid = CAST(:filesystem_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
+			and uuid = :filesystem_uuid
 			and deleted_at is null
 	`, map[string]any{
-		"workspace_uuid":  workspaceUUID,
-		"filesystem_uuid": filesystemUUID,
+		"workspace_uuid":  dbUUID(workspaceUUID),
+		"filesystem_uuid": dbUUID(filesystemUUID),
 	})
 }
 
@@ -111,8 +113,8 @@ func getActiveFilestoreEntrySQLX(ctx context.Context, database sqlxNamedQueryer,
 			and deleted_at is null
 			and (expires_at is null or expires_at > now())
 	`, map[string]any{
-		"workspace_uuid":  filesystem.WorkspaceUUID,
-		"filesystem_uuid": filesystem.UUID,
+		"workspace_uuid":  dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid": dbUUID(filesystem.UUID),
 		"entry_path":      entryPath,
 	})
 }
@@ -134,35 +136,8 @@ func insertFilestoreObjectCleanupJobSQLX(
 	database sqlxNamedQueryer,
 	input EnqueueFilestoreObjectCleanupJobInput,
 ) (FilestoreObjectCleanupJob, error) {
-	var job FilestoreObjectCleanupJob
-	err := namedGetContext(ctx, database, &job, `
-		with inserted_job as (
-			insert into jobs (external_id, workspace_uuid, type, status, payload, run_after)
-			values (
-				concat('job_', replace(cast(gen_random_uuid() as text), '-', '')),
-				CAST(:workspace_uuid AS uuid), :job_type, 'pending',
-				jsonb_build_object(
-					'workspace_uuid', cast(:workspace_uuid as text),
-					'filesystem_uuid', cast(:filesystem_uuid as text),
-					'entry_external_id', cast(:entry_external_id as text),
-					'bucket', cast(:bucket as text),
-					'key', cast(:key as text),
-					'etag', cast(:etag as text),
-					'version_id', cast(:version_id as text),
-					'reason', cast(:reason as text)
-				),
-				:run_after
-			)
-			returning *
-		)
-		select `+filestoreCleanupJobColumns("j", "fs")+`
-		from inserted_job j
-		join filestore_filesystems fs
-			on cast(fs.uuid as text) = j.payload->>'filesystem_uuid'
-			and fs.workspace_uuid = j.workspace_uuid
-	`, map[string]any{
+	payload, err := json.Marshal(map[string]string{
 		"workspace_uuid":    input.WorkspaceUUID,
-		"job_type":          filestoreCleanupJobType,
 		"filesystem_uuid":   input.FilesystemUUID,
 		"entry_external_id": input.EntryExternalID,
 		"bucket":            input.Bucket,
@@ -170,7 +145,33 @@ func insertFilestoreObjectCleanupJobSQLX(
 		"etag":              input.ETag,
 		"version_id":        input.VersionID,
 		"reason":            input.Reason,
-		"run_after":         input.RunAfter,
+	})
+	if err != nil {
+		return FilestoreObjectCleanupJob{}, fmt.Errorf("encode Filestore cleanup job payload: %w", err)
+	}
+	var row filestoreObjectCleanupJobRow
+	err = namedGetContext(ctx, database, &row, `
+		with inserted_job as (
+			insert into jobs (external_id, workspace_uuid, type, status, payload, run_after)
+			values (
+				concat('job_', replace(cast(gen_random_uuid() as text), '-', '')),
+				:workspace_uuid, :job_type, 'pending',
+				CAST(:payload AS jsonb),
+				:run_after
+			)
+			returning *
+		)
+		select `+filestoreCleanupJobColumns("j", "fs")+`
+		from inserted_job j
+		join filestore_filesystems fs
+			on fs.uuid = :filesystem_uuid
+			and fs.workspace_uuid = j.workspace_uuid
+	`, map[string]any{
+		"workspace_uuid":  dbUUID(input.WorkspaceUUID),
+		"job_type":        filestoreCleanupJobType,
+		"filesystem_uuid": dbUUID(input.FilesystemUUID),
+		"payload":         payload,
+		"run_after":       input.RunAfter,
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return FilestoreObjectCleanupJob{}, ErrPreconditionFailed
@@ -178,18 +179,18 @@ func insertFilestoreObjectCleanupJobSQLX(
 	if err != nil {
 		return FilestoreObjectCleanupJob{}, err
 	}
-	return job, nil
+	return row.job(), nil
 }
 
 func (row filestoreFilesystemRow) filesystem() FilestoreFilesystem {
 	return FilestoreFilesystem{
-		UUID:                row.UUID,
+		UUID:                row.UUID.String(),
 		ExternalID:          row.ExternalID,
-		OrganizationUUID:    row.OrganizationUUID,
-		WorkspaceUUID:       row.WorkspaceUUID,
-		SessionUUID:         row.SessionUUID,
-		CodeSessionUUID:     row.CodeSessionUUID,
-		CreatedByAPIKeyUUID: row.CreatedByAPIKeyUUID,
+		OrganizationUUID:    row.OrganizationUUID.String(),
+		WorkspaceUUID:       row.WorkspaceUUID.String(),
+		SessionUUID:         row.SessionUUID.String(),
+		CodeSessionUUID:     nullableUUIDString(row.CodeSessionUUID),
+		CreatedByAPIKeyUUID: nullableUUIDString(row.CreatedByAPIKeyUUID),
 		CreatedAt:           row.CreatedAt,
 		UpdatedAt:           row.UpdatedAt,
 		DeletedAt:           row.DeletedAt,
@@ -205,12 +206,12 @@ func (row filestoreTokenScopeRow) scope() (FilestoreTokenScope, error) {
 		orgTaints = []string{}
 	}
 	return FilestoreTokenScope{
-		OrganizationUUID:     row.OrganizationUUID,
-		WorkspaceUUID:        row.WorkspaceUUID,
+		OrganizationUUID:     row.OrganizationUUID.String(),
+		WorkspaceUUID:        row.WorkspaceUUID.String(),
 		WorkspaceExternalID:  row.WorkspaceExternalID,
-		AccountUUID:          row.AccountUUID,
+		AccountUUID:          row.AccountUUID.String(),
 		AccountExternalID:    row.AccountExternalID,
-		FilesystemUUID:       row.FilesystemUUID,
+		FilesystemUUID:       row.FilesystemUUID.String(),
 		FilesystemExternalID: row.FilesystemExternalID,
 		OrgTaints:            orgTaints,
 		WorkspaceCMEKEnabled: row.WorkspaceCMEKEnabled,
@@ -226,11 +227,11 @@ func (row filestoreEntryRow) entry() (FilestoreEntry, error) {
 		tags = []string{}
 	}
 	return FilestoreEntry{
-		UUID:                  row.UUID,
+		UUID:                  row.UUID.String(),
 		ExternalID:            row.ExternalID,
-		OrganizationUUID:      row.OrganizationUUID,
-		WorkspaceUUID:         row.WorkspaceUUID,
-		FilesystemUUID:        row.FilesystemUUID,
+		OrganizationUUID:      row.OrganizationUUID.String(),
+		WorkspaceUUID:         row.WorkspaceUUID.String(),
+		FilesystemUUID:        row.FilesystemUUID.String(),
 		Kind:                  row.Kind,
 		Path:                  row.Path,
 		ParentPath:            row.ParentPath,
@@ -251,11 +252,11 @@ func (row filestoreEntryRow) entry() (FilestoreEntry, error) {
 		// ManagedBy 记录管理来源，ManagedResourceUUID 指向受管的 Session resource，
 		// SourceFileUUID 指向被借用的 Files API 对象，避免重复计费或误删源对象。
 		ManagedBy:                row.ManagedBy,
-		ManagedResourceUUID:      row.ManagedResourceUUID,
-		SourceFileUUID:           row.SourceFileUUID,
-		CreatedByAPIKeyUUID:      row.CreatedByAPIKeyUUID,
-		CreatedBySessionUUID:     row.CreatedBySessionUUID,
-		CreatedByCodeSessionUUID: row.CreatedByCodeSessionUUID,
+		ManagedResourceUUID:      nullableUUIDString(row.ManagedResourceUUID),
+		SourceFileUUID:           nullableUUIDString(row.SourceFileUUID),
+		CreatedByAPIKeyUUID:      nullableUUIDString(row.CreatedByAPIKeyUUID),
+		CreatedBySessionUUID:     nullableUUIDString(row.CreatedBySessionUUID),
+		CreatedByCodeSessionUUID: nullableUUIDString(row.CreatedByCodeSessionUUID),
 		CreatedAt:                row.CreatedAt,
 		UpdatedAt:                row.UpdatedAt,
 		DeletedAt:                row.DeletedAt,

--- a/internal/db/filestore_test.go
+++ b/internal/db/filestore_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestValidateFilestorePath(t *testing.T) {
@@ -159,8 +161,8 @@ func TestBuildFilestoreEntriesPageQuery(t *testing.T) {
 			t.Fatalf("direct-child query = %q", query)
 		}
 		wantArgs := map[string]any{
-			"workspace_uuid":  "workspace-uuid",
-			"filesystem_uuid": "filesystem-uuid",
+			"workspace_uuid":  dbUUID("workspace-uuid"),
+			"filesystem_uuid": dbUUID("filesystem-uuid"),
 			"directory_path":  "/reports",
 			"fetch_limit":     26,
 		}
@@ -177,16 +179,16 @@ func TestBuildFilestoreEntriesPageQuery(t *testing.T) {
 			Cursor:        &FilestoreEntryPageCursor{Path: "/reports/a", UUID: "00000000-0000-4000-8000-000000000010"},
 		})
 		if !strings.Contains(query, "left(path, char_length(:directory_prefix)) = :directory_prefix") ||
-			!strings.Contains(query, "and (path, uuid) > (:cursor_path, CAST(:cursor_uuid AS uuid))") ||
+			!strings.Contains(query, "and (path, uuid) > (:cursor_path, :cursor_uuid)") ||
 			!strings.Contains(query, "limit :fetch_limit") {
 			t.Fatalf("recursive query = %q", query)
 		}
 		wantArgs := map[string]any{
-			"workspace_uuid":   "workspace-uuid",
-			"filesystem_uuid":  "filesystem-uuid",
+			"workspace_uuid":   dbUUID("workspace-uuid"),
+			"filesystem_uuid":  dbUUID("filesystem-uuid"),
 			"directory_prefix": "/reports/",
 			"cursor_path":      "/reports/a",
-			"cursor_uuid":      "00000000-0000-4000-8000-000000000010",
+			"cursor_uuid":      dbUUID("00000000-0000-4000-8000-000000000010"),
 			"fetch_limit":      26,
 		}
 		if !reflect.DeepEqual(args, wantArgs) {
@@ -211,11 +213,11 @@ func TestFilestoreEntrySQLXRowEntry(t *testing.T) {
 
 	t.Run("maps database row to domain entry", func(t *testing.T) {
 		row := filestoreEntryRow{
-			UUID:                  "entry-uuid",
+			UUID:                  uuid.MustParse("00000000-0000-4000-8000-000000000001"),
 			ExternalID:            "file_7",
-			OrganizationUUID:      "organization-uuid",
-			WorkspaceUUID:         "workspace-uuid",
-			FilesystemUUID:        "filesystem-uuid",
+			OrganizationUUID:      uuid.MustParse("00000000-0000-4000-8000-000000000002"),
+			WorkspaceUUID:         uuid.MustParse("00000000-0000-4000-8000-000000000003"),
+			FilesystemUUID:        uuid.MustParse("00000000-0000-4000-8000-000000000004"),
 			Kind:                  FilestoreEntryKindFile,
 			Path:                  "/reports/july.txt",
 			Metadata:              []byte(`{"source":"test"}`),
@@ -226,7 +228,7 @@ func TestFilestoreEntrySQLXRowEntry(t *testing.T) {
 		if err != nil {
 			t.Fatalf("entry() error = %v", err)
 		}
-		if entry.UUID != row.UUID || entry.Path != row.Path || !reflect.DeepEqual(entry.Tags, []string{"report", "july"}) {
+		if entry.UUID != row.UUID.String() || entry.Path != row.Path || !reflect.DeepEqual(entry.Tags, []string{"report", "july"}) {
 			t.Fatalf("entry() = %+v, want row identity and decoded tags", entry)
 		}
 		if string(entry.Metadata) != `{"source":"test"}` {

--- a/internal/db/mcp_oauth_flows.go
+++ b/internal/db/mcp_oauth_flows.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -17,7 +19,7 @@ const (
 		)
 		values (
 			:uuid, :external_id, :organization_uuid, :workspace_uuid, :vault_uuid, :vault_external_id,
-			CAST(nullif(:user_uuid, '') AS uuid), nullif(:user_external_id, ''),
+			:user_uuid, nullif(:user_external_id, ''),
 			nullif(:platform_session_external_id, ''), :mcp_server_url,
 			:redirect_url, :display_name, :source, :authorization_endpoint, :token_endpoint,
 			nullif(:registration_endpoint, ''), nullif(:issuer, ''), :resource,
@@ -53,13 +55,13 @@ const (
 		where external_id = :external_id and status = 'pending'
 	`
 	mcpOAuthFlowReturnColumns = `
-		CAST(uuid AS text) AS uuid,
+		uuid,
 		external_id,
-		CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(vault_uuid AS text) AS vault_uuid,
+		organization_uuid,
+		workspace_uuid,
+		vault_uuid,
 		vault_external_id,
-		coalesce(CAST(user_uuid AS text), '') AS user_uuid,
+		user_uuid,
 		coalesce(user_external_id, '') AS user_external_id,
 		coalesce(platform_session_external_id, '') AS platform_session_external_id,
 		mcp_server_url,
@@ -122,37 +124,37 @@ type MCPOAuthFlow struct {
 }
 
 type mcpOAuthFlowRow struct {
-	UUID                      string     `db:"uuid"`
-	ExternalID                string     `db:"external_id"`
-	OrganizationUUID          string     `db:"organization_uuid"`
-	WorkspaceUUID             string     `db:"workspace_uuid"`
-	VaultUUID                 string     `db:"vault_uuid"`
-	VaultExternalID           string     `db:"vault_external_id"`
-	UserUUID                  string     `db:"user_uuid"`
-	UserExternalID            string     `db:"user_external_id"`
-	PlatformSessionExternalID string     `db:"platform_session_external_id"`
-	MCPServerURL              string     `db:"mcp_server_url"`
-	RedirectURL               string     `db:"redirect_url"`
-	DisplayName               string     `db:"display_name"`
-	Source                    string     `db:"source"`
-	AuthorizationEndpoint     string     `db:"authorization_endpoint"`
-	TokenEndpoint             string     `db:"token_endpoint"`
-	RegistrationEndpoint      string     `db:"registration_endpoint"`
-	Issuer                    string     `db:"issuer"`
-	Resource                  string     `db:"resource"`
-	Scope                     string     `db:"scope"`
-	ClientID                  string     `db:"client_id"`
-	ClientSecret              string     `db:"client_secret"`
-	TokenEndpointAuthMethod   string     `db:"token_endpoint_auth_method"`
-	CodeVerifier              string     `db:"code_verifier"`
-	CodeChallengeMethod       string     `db:"code_challenge_method"`
-	Status                    string     `db:"status"`
-	CredentialExternalID      string     `db:"credential_external_id"`
-	ErrorCode                 string     `db:"error_code"`
-	CreatedAt                 time.Time  `db:"created_at"`
-	UpdatedAt                 time.Time  `db:"updated_at"`
-	ExpiresAt                 time.Time  `db:"expires_at"`
-	CompletedAt               *time.Time `db:"completed_at"`
+	UUID                      uuid.UUID     `db:"uuid"`
+	ExternalID                string        `db:"external_id"`
+	OrganizationUUID          uuid.UUID     `db:"organization_uuid"`
+	WorkspaceUUID             uuid.UUID     `db:"workspace_uuid"`
+	VaultUUID                 uuid.UUID     `db:"vault_uuid"`
+	VaultExternalID           string        `db:"vault_external_id"`
+	UserUUID                  uuid.NullUUID `db:"user_uuid"`
+	UserExternalID            string        `db:"user_external_id"`
+	PlatformSessionExternalID string        `db:"platform_session_external_id"`
+	MCPServerURL              string        `db:"mcp_server_url"`
+	RedirectURL               string        `db:"redirect_url"`
+	DisplayName               string        `db:"display_name"`
+	Source                    string        `db:"source"`
+	AuthorizationEndpoint     string        `db:"authorization_endpoint"`
+	TokenEndpoint             string        `db:"token_endpoint"`
+	RegistrationEndpoint      string        `db:"registration_endpoint"`
+	Issuer                    string        `db:"issuer"`
+	Resource                  string        `db:"resource"`
+	Scope                     string        `db:"scope"`
+	ClientID                  string        `db:"client_id"`
+	ClientSecret              string        `db:"client_secret"`
+	TokenEndpointAuthMethod   string        `db:"token_endpoint_auth_method"`
+	CodeVerifier              string        `db:"code_verifier"`
+	CodeChallengeMethod       string        `db:"code_challenge_method"`
+	Status                    string        `db:"status"`
+	CredentialExternalID      string        `db:"credential_external_id"`
+	ErrorCode                 string        `db:"error_code"`
+	CreatedAt                 time.Time     `db:"created_at"`
+	UpdatedAt                 time.Time     `db:"updated_at"`
+	ExpiresAt                 time.Time     `db:"expires_at"`
+	CompletedAt               *time.Time    `db:"completed_at"`
 }
 
 func (d *DB) CreateMCPOAuthFlow(ctx context.Context, flow MCPOAuthFlow) (MCPOAuthFlow, error) {
@@ -210,13 +212,13 @@ func getMCPOAuthFlowSQLX(
 
 func mcpOAuthFlowArguments(flow MCPOAuthFlow) map[string]any {
 	return map[string]any{
-		"uuid":                         flow.UUID,
+		"uuid":                         dbUUID(flow.UUID),
 		"external_id":                  flow.ExternalID,
-		"organization_uuid":            flow.OrganizationUUID,
-		"workspace_uuid":               flow.WorkspaceUUID,
-		"vault_uuid":                   flow.VaultUUID,
+		"organization_uuid":            dbUUID(flow.OrganizationUUID),
+		"workspace_uuid":               dbUUID(flow.WorkspaceUUID),
+		"vault_uuid":                   dbUUID(flow.VaultUUID),
 		"vault_external_id":            flow.VaultExternalID,
-		"user_uuid":                    flow.UserUUID,
+		"user_uuid":                    dbNullableUUID(&flow.UserUUID),
 		"user_external_id":             flow.UserExternalID,
 		"platform_session_external_id": flow.PlatformSessionExternalID,
 		"mcp_server_url":               flow.MCPServerURL,
@@ -242,13 +244,13 @@ func mcpOAuthFlowArguments(flow MCPOAuthFlow) map[string]any {
 
 func (r mcpOAuthFlowRow) flow() MCPOAuthFlow {
 	return MCPOAuthFlow{
-		UUID:                      r.UUID,
+		UUID:                      r.UUID.String(),
 		ExternalID:                r.ExternalID,
-		OrganizationUUID:          r.OrganizationUUID,
-		WorkspaceUUID:             r.WorkspaceUUID,
-		VaultUUID:                 r.VaultUUID,
+		OrganizationUUID:          r.OrganizationUUID.String(),
+		WorkspaceUUID:             r.WorkspaceUUID.String(),
+		VaultUUID:                 r.VaultUUID.String(),
 		VaultExternalID:           r.VaultExternalID,
-		UserUUID:                  r.UserUUID,
+		UserUUID:                  nullableUUIDValue(r.UserUUID),
 		UserExternalID:            r.UserExternalID,
 		PlatformSessionExternalID: r.PlatformSessionExternalID,
 		MCPServerURL:              r.MCPServerURL,

--- a/internal/db/mcp_tool_catalogs.go
+++ b/internal/db/mcp_tool_catalogs.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
 )
 
@@ -56,7 +57,7 @@ const (
 	`
 	mcpToolCatalogColumns = `
 		id,
-		CAST(uuid AS text) AS uuid,
+		uuid,
 		external_id,
 		transport_type,
 		endpoint_url,
@@ -68,7 +69,7 @@ const (
 
 type mcpToolCatalogRow struct {
 	ID            int64     `db:"id"`
-	UUID          string    `db:"uuid"`
+	UUID          uuid.UUID `db:"uuid"`
 	ExternalID    string    `db:"external_id"`
 	TransportType string    `db:"transport_type"`
 	EndpointURL   string    `db:"endpoint_url"`
@@ -144,7 +145,7 @@ func (r mcpToolCatalogRow) catalog() (MCPToolCatalog, error) {
 	}
 	return MCPToolCatalog{
 		ID:            r.ID,
-		UUID:          r.UUID,
+		UUID:          r.UUID.String(),
 		ExternalID:    r.ExternalID,
 		TransportType: r.TransportType,
 		EndpointURL:   r.EndpointURL,

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type MemoryStore struct {
@@ -184,11 +186,11 @@ func (d *DB) CreateMemoryStore(ctx context.Context, store MemoryStore) (MemorySt
 		)
 		returning `+memoryStoreColumns()+`
 	`, map[string]any{
-		"uuid":                    store.UUID,
+		"uuid":                    dbUUID(store.UUID),
 		"external_id":             store.ExternalID,
-		"organization_uuid":       store.OrganizationUUID,
-		"workspace_uuid":          store.WorkspaceUUID,
-		"created_by_api_key_uuid": store.CreatedByAPIKeyUUID,
+		"organization_uuid":       dbUUID(store.OrganizationUUID),
+		"workspace_uuid":          dbUUID(store.WorkspaceUUID),
+		"created_by_api_key_uuid": dbUUID(store.CreatedByAPIKeyUUID),
 		"name":                    store.Name,
 		"description":             store.Description,
 		"metadata":                jsonArg(store.Metadata),
@@ -199,7 +201,7 @@ func (d *DB) CreateMemoryStore(ctx context.Context, store MemoryStore) (MemorySt
 func (d *DB) GetMemoryStore(ctx context.Context, workspaceUUID, externalID string) (MemoryStore, error) {
 	return getMemoryStoreSQLX(ctx, d.sql, memoryStoreSelectSQL()+`
 		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
-	`, map[string]any{"workspace_uuid": workspaceUUID, "external_id": externalID})
+	`, memoryStoreLookupArguments(workspaceUUID, externalID))
 }
 
 func (d *DB) GetMemoryStoreByExternalID(ctx context.Context, externalID string) (MemoryStore, error) {
@@ -218,7 +220,7 @@ func (d *DB) UpdateMemoryStore(ctx context.Context, workspaceUUID, externalID st
 	current, err := getMemoryStoreSQLX(ctx, tx, memoryStoreSelectSQL()+`
 		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 		for update
-	`, map[string]any{"workspace_uuid": workspaceUUID, "external_id": externalID})
+	`, memoryStoreLookupArguments(workspaceUUID, externalID))
 	if err != nil {
 		return MemoryStore{}, err
 	}
@@ -234,7 +236,7 @@ func (d *DB) UpdateMemoryStore(ctx context.Context, workspaceUUID, externalID st
 		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 		returning `+memoryStoreColumns()+`
 	`, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 		"name":           next.Name,
 		"description":    next.Description,
@@ -257,7 +259,7 @@ func (d *DB) ArchiveMemoryStore(ctx context.Context, workspaceUUID, externalID s
 			updated_at = now()
 		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 		returning `+memoryStoreColumns()+`
-	`, map[string]any{"workspace_uuid": workspaceUUID, "external_id": externalID})
+	`, memoryStoreLookupArguments(workspaceUUID, externalID))
 }
 
 func (d *DB) DeleteMemoryStore(ctx context.Context, workspaceUUID, externalID string) ([]ObjectRef, error) {
@@ -267,10 +269,10 @@ func (d *DB) DeleteMemoryStore(ctx context.Context, workspaceUUID, externalID st
 	}
 	defer tx.Rollback()
 
-	var storeUUID string
-	arguments := map[string]any{"workspace_uuid": workspaceUUID, "external_id": externalID}
+	var storeUUID uuid.UUID
+	arguments := memoryStoreLookupArguments(workspaceUUID, externalID)
 	if err := namedGetContext(ctx, tx, &storeUUID, `
-		select CAST(uuid AS text)
+		select uuid
 		from memory_stores
 		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 		for update
@@ -295,7 +297,7 @@ func (d *DB) DeleteMemoryStore(ctx context.Context, workspaceUUID, externalID st
 	refs := make([]ObjectRef, len(refRows))
 	for index := range refRows {
 		refs[index] = ObjectRef{
-			WorkspaceUUID: refRows[index].WorkspaceUUID,
+			WorkspaceUUID: refRows[index].WorkspaceUUID.String(),
 			Bucket:        refRows[index].Bucket,
 			Key:           refRows[index].Key,
 			ResourceType:  "memory_version",
@@ -317,8 +319,8 @@ func (d *DB) DeleteMemoryStore(ctx context.Context, workspaceUUID, externalID st
 	}
 	if _, err := namedExecContext(ctx, tx, `
 		delete from memory_stores
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
-			and uuid = CAST(:store_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
+			and uuid = :store_uuid
 	`, arguments); err != nil {
 		return nil, err
 	}
@@ -335,7 +337,10 @@ func (d *DB) ListMemoryStoresPage(ctx context.Context, params ListMemoryStoresPa
 	query := memoryStoreSelectSQL() + `
 		where workspace_uuid = :workspace_uuid and deleted_at is null
 	`
-	arguments := map[string]any{"workspace_uuid": params.WorkspaceUUID, "limit": params.Limit + 1}
+	arguments := map[string]any{
+		"workspace_uuid": dbUUID(params.WorkspaceUUID),
+		"limit":          params.Limit + 1,
+	}
 	if !params.IncludeArchived {
 		query += " and archived_at is null"
 	}
@@ -348,9 +353,9 @@ func (d *DB) ListMemoryStoresPage(ctx context.Context, params ListMemoryStoresPa
 		arguments["created_at_lte"] = *params.CreatedAtLTE
 	}
 	if params.Cursor != nil {
-		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < CAST(:cursor_uuid AS uuid)))"
+		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < :cursor_uuid))"
 		arguments["cursor_created_at"] = params.Cursor.CreatedAt
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	query += " order by created_at desc, uuid desc limit :limit"
 
@@ -375,7 +380,7 @@ func (d *DB) CreateMemory(ctx context.Context, memory Memory, version MemoryVers
 	store, err := getMemoryStoreSQLX(ctx, tx, memoryStoreSelectSQL()+`
 		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 		for update
-	`, map[string]any{"workspace_uuid": memory.WorkspaceUUID, "external_id": memory.MemoryStoreExternalID})
+	`, memoryStoreLookupArguments(memory.WorkspaceUUID, memory.MemoryStoreExternalID))
 	if err != nil {
 		return Memory{}, err
 	}
@@ -399,11 +404,11 @@ func (d *DB) CreateMemory(ctx context.Context, memory Memory, version MemoryVers
 		)
 		returning `+memoryColumns()+`
 	`, map[string]any{
-		"uuid":                        memory.UUID,
+		"uuid":                        dbUUID(memory.UUID),
 		"external_id":                 memory.ExternalID,
-		"organization_uuid":           store.OrganizationUUID,
-		"workspace_uuid":              store.WorkspaceUUID,
-		"memory_store_uuid":           store.UUID,
+		"organization_uuid":           dbUUID(store.OrganizationUUID),
+		"workspace_uuid":              dbUUID(store.WorkspaceUUID),
+		"memory_store_uuid":           dbUUID(store.UUID),
 		"memory_store_external_id":    store.ExternalID,
 		"current_version_external_id": version.ExternalID,
 		"path":                        memory.Path,
@@ -432,15 +437,15 @@ func (d *DB) CreateMemory(ctx context.Context, memory Memory, version MemoryVers
 	}
 	updated, err := getMemorySQLX(ctx, tx, `
 		update memories
-		set current_version_uuid = CAST(:version_uuid AS uuid),
+		set current_version_uuid = :version_uuid,
 			current_version_external_id = :version_external_id
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
-			and uuid = CAST(:memory_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
+			and uuid = :memory_uuid
 		returning `+memoryColumns()+`
 	`, map[string]any{
-		"workspace_uuid":      store.WorkspaceUUID,
-		"memory_uuid":         created.UUID,
-		"version_uuid":        insertedVersion.UUID,
+		"workspace_uuid":      dbUUID(store.WorkspaceUUID),
+		"memory_uuid":         dbUUID(created.UUID),
+		"version_uuid":        dbUUID(insertedVersion.UUID),
 		"version_external_id": insertedVersion.ExternalID,
 	})
 	if err != nil {
@@ -459,7 +464,7 @@ func (d *DB) GetMemory(ctx context.Context, workspaceUUID, memoryStoreExternalID
 			and external_id = :memory_external_id
 			and deleted_at is null
 	`, map[string]any{
-		"workspace_uuid":           workspaceUUID,
+		"workspace_uuid":           dbUUID(workspaceUUID),
 		"memory_store_external_id": memoryStoreExternalID,
 		"memory_external_id":       memoryExternalID,
 	})
@@ -546,7 +551,7 @@ func (d *DB) UpdateMemory(ctx context.Context, input UpdateMemoryInput) (MemoryM
 	}
 	updated, err := getMemorySQLX(ctx, tx, `
 		update memories
-		set current_version_uuid = CAST(:version_uuid AS uuid),
+		set current_version_uuid = :version_uuid,
 			current_version_external_id = :version_external_id,
 			path = :path,
 			content_size_bytes = :content_size_bytes,
@@ -560,10 +565,10 @@ func (d *DB) UpdateMemory(ctx context.Context, input UpdateMemoryInput) (MemoryM
 			and deleted_at is null
 		returning `+memoryColumns()+`
 	`, map[string]any{
-		"workspace_uuid":           input.WorkspaceUUID,
+		"workspace_uuid":           dbUUID(input.WorkspaceUUID),
 		"memory_store_external_id": input.MemoryStoreExternalID,
 		"memory_external_id":       input.MemoryExternalID,
-		"version_uuid":             version.UUID,
+		"version_uuid":             dbUUID(version.UUID),
 		"version_external_id":      version.ExternalID,
 		"path":                     targetPath,
 		"content_size_bytes":       targetSize,
@@ -622,7 +627,7 @@ func (d *DB) DeleteMemory(ctx context.Context, input DeleteMemoryInput) error {
 	}
 	rowsAffected, err := namedExecRowsAffected(ctx, tx, `
 		update memories
-		set current_version_uuid = CAST(:version_uuid AS uuid),
+		set current_version_uuid = :version_uuid,
 			current_version_external_id = :version_external_id,
 			updated_at = :updated_at,
 			deleted_at = :updated_at
@@ -631,10 +636,10 @@ func (d *DB) DeleteMemory(ctx context.Context, input DeleteMemoryInput) error {
 			and external_id = :memory_external_id
 			and deleted_at is null
 	`, map[string]any{
-		"workspace_uuid":           input.WorkspaceUUID,
+		"workspace_uuid":           dbUUID(input.WorkspaceUUID),
 		"memory_store_external_id": input.MemoryStoreExternalID,
 		"memory_external_id":       input.MemoryExternalID,
-		"version_uuid":             version.UUID,
+		"version_uuid":             dbUUID(version.UUID),
 		"version_external_id":      version.ExternalID,
 		"updated_at":               input.Now,
 	})
@@ -669,7 +674,7 @@ func (d *DB) ListMemoriesPage(ctx context.Context, params ListMemoriesPageParams
 			and deleted_at is null
 	`
 	arguments := map[string]any{
-		"workspace_uuid":           params.WorkspaceUUID,
+		"workspace_uuid":           dbUUID(params.WorkspaceUUID),
 		"memory_store_external_id": params.MemoryStoreExternalID,
 		"limit":                    params.Limit + 1,
 	}
@@ -678,28 +683,28 @@ func (d *DB) ListMemoriesPage(ctx context.Context, params ListMemoriesPageParams
 		arguments["path_prefix"] = params.PathPrefix
 	}
 	if params.Cursor != nil {
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 		switch orderBy {
 		case "path":
 			op := ">"
 			if order == "desc" {
 				op = "<"
 			}
-			query += fmt.Sprintf(" and (path %s :cursor_path or (path = :cursor_path and uuid %s CAST(:cursor_uuid AS uuid)))", op, op)
+			query += fmt.Sprintf(" and (path %s :cursor_path or (path = :cursor_path and uuid %s :cursor_uuid))", op, op)
 			arguments["cursor_path"] = params.Cursor.Path
 		case "created_at":
 			op := ">"
 			if order == "desc" {
 				op = "<"
 			}
-			query += fmt.Sprintf(" and (created_at %s :cursor_created_at or (created_at = :cursor_created_at and uuid %s CAST(:cursor_uuid AS uuid)))", op, op)
+			query += fmt.Sprintf(" and (created_at %s :cursor_created_at or (created_at = :cursor_created_at and uuid %s :cursor_uuid))", op, op)
 			arguments["cursor_created_at"] = params.Cursor.CreatedAt
 		case "updated_at":
 			op := ">"
 			if order == "desc" {
 				op = "<"
 			}
-			query += fmt.Sprintf(" and (updated_at %s :cursor_updated_at or (updated_at = :cursor_updated_at and uuid %s CAST(:cursor_uuid AS uuid)))", op, op)
+			query += fmt.Sprintf(" and (updated_at %s :cursor_updated_at or (updated_at = :cursor_updated_at and uuid %s :cursor_uuid))", op, op)
 			arguments["cursor_updated_at"] = params.Cursor.UpdatedAt
 		}
 	}
@@ -726,7 +731,7 @@ func (d *DB) ListMemoriesForDepth(ctx context.Context, params ListMemoriesPagePa
 			and deleted_at is null
 	`
 	arguments := map[string]any{
-		"workspace_uuid":           params.WorkspaceUUID,
+		"workspace_uuid":           dbUUID(params.WorkspaceUUID),
 		"memory_store_external_id": params.MemoryStoreExternalID,
 	}
 	if params.PathPrefix != "" {
@@ -743,7 +748,7 @@ func (d *DB) GetMemoryVersion(ctx context.Context, workspaceUUID, memoryStoreExt
 			and memory_store_external_id = :memory_store_external_id
 			and external_id = :version_external_id
 	`, map[string]any{
-		"workspace_uuid":           workspaceUUID,
+		"workspace_uuid":           dbUUID(workspaceUUID),
 		"memory_store_external_id": memoryStoreExternalID,
 		"version_external_id":      versionExternalID,
 	})
@@ -761,7 +766,7 @@ func (d *DB) ListMemoryVersionsPage(ctx context.Context, params ListMemoryVersio
 			and memory_store_external_id = :memory_store_external_id
 	`
 	arguments := map[string]any{
-		"workspace_uuid":           params.WorkspaceUUID,
+		"workspace_uuid":           dbUUID(params.WorkspaceUUID),
 		"memory_store_external_id": params.MemoryStoreExternalID,
 		"limit":                    params.Limit + 1,
 	}
@@ -790,9 +795,9 @@ func (d *DB) ListMemoryVersionsPage(ctx context.Context, params ListMemoryVersio
 		arguments["created_at_lte"] = *params.CreatedAtLTE
 	}
 	if params.Cursor != nil {
-		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < CAST(:cursor_uuid AS uuid)))"
+		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < :cursor_uuid))"
 		arguments["cursor_created_at"] = params.Cursor.CreatedAt
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	query += " order by created_at desc, uuid desc limit :limit"
 
@@ -815,7 +820,7 @@ func (d *DB) RedactMemoryVersion(ctx context.Context, workspaceUUID, memoryStore
 	defer tx.Rollback()
 
 	arguments := map[string]any{
-		"workspace_uuid":           workspaceUUID,
+		"workspace_uuid":           dbUUID(workspaceUUID),
 		"memory_store_external_id": memoryStoreExternalID,
 		"version_external_id":      versionExternalID,
 	}
@@ -830,13 +835,13 @@ func (d *DB) RedactMemoryVersion(ctx context.Context, workspaceUUID, memoryStore
 	}
 
 	var activeHead int
-	arguments["version_uuid"] = version.UUID
+	arguments["version_uuid"] = dbUUID(version.UUID)
 	if err := namedGetContext(ctx, tx, &activeHead, `
 		select CAST(count(*) AS integer)
 		from memories
 		where workspace_uuid = :workspace_uuid
 			and memory_store_external_id = :memory_store_external_id
-			and current_version_uuid = CAST(:version_uuid AS uuid)
+			and current_version_uuid = :version_uuid
 			and deleted_at is null
 	`, arguments); err != nil {
 		return MemoryVersion{}, nil, err
@@ -865,7 +870,7 @@ func (d *DB) RedactMemoryVersion(ctx context.Context, workspaceUUID, memoryStore
 	}
 	arguments["now"] = now
 	arguments["actor_type"] = actor.Type
-	arguments["api_key_uuid"] = nullableString(actor.APIKeyUUID)
+	arguments["api_key_uuid"] = dbNullableUUID(&actor.APIKeyUUID)
 	arguments["api_key_external_id"] = nullableString(actor.APIKeyExternalID)
 	arguments["session_id"] = nullableString(actor.SessionID)
 	arguments["user_id"] = nullableString(actor.UserID)
@@ -878,7 +883,7 @@ func (d *DB) RedactMemoryVersion(ctx context.Context, workspaceUUID, memoryStore
 			s3_key = null,
 			redacted_at = :now,
 			redacted_by_actor_type = :actor_type,
-			redacted_by_api_key_uuid = CAST(:api_key_uuid AS uuid),
+			redacted_by_api_key_uuid = :api_key_uuid,
 			redacted_by_api_key_external_id = :api_key_external_id,
 			redacted_by_session_id = :session_id,
 			redacted_by_user_id = :user_id
@@ -899,11 +904,11 @@ func (d *DB) RedactMemoryVersion(ctx context.Context, workspaceUUID, memoryStore
 func (d *DB) getActiveMemoryForMutation(ctx context.Context, tx sqlxNamedQueryer, workspaceUUID, memoryStoreExternalID, memoryExternalID string) (Memory, bool, error) {
 	var row activeMemoryRow
 	err := namedGetContext(ctx, tx, &row, `
-		select CAST(m.uuid AS text) AS uuid, m.external_id,
-			CAST(m.organization_uuid AS text) AS organization_uuid,
-			CAST(m.workspace_uuid AS text) AS workspace_uuid,
-			CAST(m.memory_store_uuid AS text) AS memory_store_uuid, m.memory_store_external_id,
-			coalesce(CAST(m.current_version_uuid AS text), '') as current_version_uuid,
+		select m.uuid, m.external_id,
+			m.organization_uuid,
+			m.workspace_uuid,
+			m.memory_store_uuid, m.memory_store_external_id,
+			m.current_version_uuid,
 			coalesce(m.current_version_external_id, '') as current_version_external_id,
 			m.path, m.content_size_bytes,
 			m.content_sha256, m.s3_bucket, m.s3_key, m.created_at, m.updated_at,
@@ -917,7 +922,7 @@ func (d *DB) getActiveMemoryForMutation(ctx context.Context, tx sqlxNamedQueryer
 			and ms.deleted_at is null
 		for update of m, ms
 	`, map[string]any{
-		"workspace_uuid":           workspaceUUID,
+		"workspace_uuid":           dbUUID(workspaceUUID),
 		"memory_store_external_id": memoryStoreExternalID,
 		"memory_external_id":       memoryExternalID,
 	})
@@ -931,12 +936,12 @@ func (d *DB) getActiveMemoryForMutation(ctx context.Context, tx sqlxNamedQueryer
 }
 
 func (d *DB) ensureMemoryStoreExists(ctx context.Context, workspaceUUID, memoryStoreExternalID string) error {
-	var storeUUID string
+	var storeUUID uuid.UUID
 	if err := namedGetContext(ctx, d.sql, &storeUUID, `
-		select CAST(uuid AS text)
+		select uuid
 		from memory_stores
 		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
-	`, map[string]any{"workspace_uuid": workspaceUUID, "external_id": memoryStoreExternalID}); errors.Is(err, sql.ErrNoRows) {
+	`, memoryStoreLookupArguments(workspaceUUID, memoryStoreExternalID)); errors.Is(err, sql.ErrNoRows) {
 		return ErrNotFound
 	} else if err != nil {
 		return err
@@ -946,17 +951,22 @@ func (d *DB) ensureMemoryStoreExists(ctx context.Context, workspaceUUID, memoryS
 
 func (d *DB) ensureMemoryPathAvailable(ctx context.Context, tx sqlxNamedQueryer, storeUUID, path, excludeMemoryUUID string) error {
 	var existingID string
-	if err := namedGetContext(ctx, tx, &existingID, `
+	query := `
 		select external_id
 		from memories
 		where memory_store_uuid = :store_uuid
 			and path = :path
-			and (
-				nullif(:exclude_memory_uuid, '') is null
-				or uuid <> CAST(nullif(:exclude_memory_uuid, '') AS uuid)
-			)
-			and deleted_at is null
-	`, map[string]any{"store_uuid": storeUUID, "path": path, "exclude_memory_uuid": excludeMemoryUUID}); errors.Is(err, sql.ErrNoRows) {
+	`
+	arguments := map[string]any{
+		"store_uuid": dbUUID(storeUUID),
+		"path":       path,
+	}
+	if excludeMemoryUUID != "" {
+		query += " and uuid <> :exclude_memory_uuid"
+		arguments["exclude_memory_uuid"] = dbUUID(excludeMemoryUUID)
+	}
+	query += " and deleted_at is null"
+	if err := namedGetContext(ctx, tx, &existingID, query, arguments); errors.Is(err, sql.ErrNoRows) {
 		return nil
 	} else if err != nil {
 		return err
@@ -973,7 +983,10 @@ func (d *DB) memoryPathConflict(ctx context.Context, database sqlxNamedQueryer, 
 			and path = :path
 			and deleted_at is null
 		limit 1
-	`, map[string]any{"store_uuid": storeUUID, "path": path}); err == nil {
+	`, map[string]any{
+		"store_uuid": dbUUID(storeUUID),
+		"path":       path,
+	}); err == nil {
 		return &MemoryPathConflictError{ConflictingMemoryID: existingID, ConflictingPath: path}
 	}
 	return ErrDuplicate
@@ -994,29 +1007,29 @@ const insertMemoryVersionQuery = `
 			:created_by_api_key_uuid, :created_by_api_key_external_id, :created_by_session_id,
 			:created_by_user_id, :created_at
 		)
-		returning ` + `CAST(uuid AS text) AS uuid, external_id,
-			CAST(organization_uuid AS text) AS organization_uuid,
-			CAST(workspace_uuid AS text) AS workspace_uuid,
-			CAST(memory_store_uuid AS text) AS memory_store_uuid,
-			memory_store_external_id, CAST(memory_uuid AS text) AS memory_uuid, memory_external_id,
+		returning ` + `uuid, external_id,
+			organization_uuid,
+			workspace_uuid,
+			memory_store_uuid,
+			memory_store_external_id, memory_uuid, memory_external_id,
 			operation, path, content_size_bytes, content_sha256, s3_bucket, s3_key,
 			created_by_actor_type,
-			coalesce(CAST(created_by_api_key_uuid AS text), '') AS created_by_api_key_uuid,
+			created_by_api_key_uuid,
 			created_by_api_key_external_id,
 			created_by_session_id, created_by_user_id, redacted_at, redacted_by_actor_type,
-			coalesce(CAST(redacted_by_api_key_uuid AS text), '') AS redacted_by_api_key_uuid,
+			redacted_by_api_key_uuid,
 			redacted_by_api_key_external_id, redacted_by_session_id,
 			redacted_by_user_id, created_at`
 
 func insertMemoryVersion(ctx context.Context, tx sqlxNamedQueryer, version MemoryVersion) (MemoryVersion, error) {
 	return getMemoryVersionSQLX(ctx, tx, insertMemoryVersionQuery, map[string]any{
-		"uuid":                           version.UUID,
+		"uuid":                           dbUUID(version.UUID),
 		"external_id":                    version.ExternalID,
-		"organization_uuid":              version.OrganizationUUID,
-		"workspace_uuid":                 version.WorkspaceUUID,
-		"memory_store_uuid":              version.MemoryStoreUUID,
+		"organization_uuid":              dbUUID(version.OrganizationUUID),
+		"workspace_uuid":                 dbUUID(version.WorkspaceUUID),
+		"memory_store_uuid":              dbUUID(version.MemoryStoreUUID),
 		"memory_store_external_id":       version.MemoryStoreExternalID,
-		"memory_uuid":                    version.MemoryUUID,
+		"memory_uuid":                    dbUUID(version.MemoryUUID),
 		"memory_external_id":             version.MemoryExternalID,
 		"operation":                      version.Operation,
 		"path":                           nullableStringPtr(version.Path),
@@ -1025,7 +1038,7 @@ func insertMemoryVersion(ctx context.Context, tx sqlxNamedQueryer, version Memor
 		"s3_bucket":                      nullableStringPtr(version.S3Bucket),
 		"s3_key":                         nullableStringPtr(version.S3Key),
 		"created_by_actor_type":          version.CreatedBy.Type,
-		"created_by_api_key_uuid":        nullableString(version.CreatedBy.APIKeyUUID),
+		"created_by_api_key_uuid":        dbNullableUUID(&version.CreatedBy.APIKeyUUID),
 		"created_by_api_key_external_id": nullableString(version.CreatedBy.APIKeyExternalID),
 		"created_by_session_id":          nullableString(version.CreatedBy.SessionID),
 		"created_by_user_id":             nullableString(version.CreatedBy.UserID),
@@ -1034,10 +1047,10 @@ func insertMemoryVersion(ctx context.Context, tx sqlxNamedQueryer, version Memor
 }
 
 func memoryStoreColumns() string {
-	return `CAST(uuid AS text) as uuid, external_id,
-		CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(created_by_api_key_uuid AS text) AS created_by_api_key_uuid,
+	return `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		created_by_api_key_uuid,
 		name, description, metadata, created_at, updated_at,
 		archived_at, deleted_at`
 }
@@ -1047,11 +1060,11 @@ func memoryStoreSelectSQL() string {
 }
 
 func memoryColumns() string {
-	return `CAST(uuid AS text) as uuid, external_id,
-		CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(memory_store_uuid AS text) AS memory_store_uuid, memory_store_external_id,
-		coalesce(CAST(current_version_uuid AS text), '') as current_version_uuid,
+	return `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		memory_store_uuid, memory_store_external_id,
+		current_version_uuid,
 		coalesce(current_version_external_id, '') as current_version_external_id,
 		path, content_size_bytes, content_sha256, s3_bucket, s3_key,
 		created_at, updated_at, deleted_at`
@@ -1062,22 +1075,29 @@ func memorySelectSQL() string {
 }
 
 func memoryVersionColumns() string {
-	return `CAST(uuid AS text) as uuid, external_id,
-		CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(memory_store_uuid AS text) AS memory_store_uuid,
-		memory_store_external_id, CAST(memory_uuid AS text) AS memory_uuid, memory_external_id,
+	return `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		memory_store_uuid,
+		memory_store_external_id, memory_uuid, memory_external_id,
 		operation, path, content_size_bytes, content_sha256, s3_bucket, s3_key,
-		created_by_actor_type, coalesce(CAST(created_by_api_key_uuid AS text), '') AS created_by_api_key_uuid,
+		created_by_actor_type, created_by_api_key_uuid,
 		created_by_api_key_external_id,
 		created_by_session_id, created_by_user_id, redacted_at, redacted_by_actor_type,
-		coalesce(CAST(redacted_by_api_key_uuid AS text), '') AS redacted_by_api_key_uuid,
+		redacted_by_api_key_uuid,
 		redacted_by_api_key_external_id, redacted_by_session_id,
 		redacted_by_user_id, created_at`
 }
 
 func memoryVersionSelectSQL() string {
 	return `select ` + memoryVersionColumns() + ` from memory_versions`
+}
+
+func memoryStoreLookupArguments(workspaceUUID, externalID string) map[string]any {
+	return map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"external_id":    externalID,
+	}
 }
 
 func nullableString(value string) any {

--- a/internal/db/memory_sqlx.go
+++ b/internal/db/memory_sqlx.go
@@ -5,14 +5,16 @@ import (
 	"database/sql"
 	"errors"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type memoryStoreRow struct {
-	UUID                string     `db:"uuid"`
+	UUID                uuid.UUID  `db:"uuid"`
 	ExternalID          string     `db:"external_id"`
-	OrganizationUUID    string     `db:"organization_uuid"`
-	WorkspaceUUID       string     `db:"workspace_uuid"`
-	CreatedByAPIKeyUUID string     `db:"created_by_api_key_uuid"`
+	OrganizationUUID    uuid.UUID  `db:"organization_uuid"`
+	WorkspaceUUID       uuid.UUID  `db:"workspace_uuid"`
+	CreatedByAPIKeyUUID uuid.UUID  `db:"created_by_api_key_uuid"`
 	Name                string     `db:"name"`
 	Description         string     `db:"description"`
 	Metadata            []byte     `db:"metadata"`
@@ -23,22 +25,22 @@ type memoryStoreRow struct {
 }
 
 type memoryRow struct {
-	UUID                     string     `db:"uuid"`
-	ExternalID               string     `db:"external_id"`
-	OrganizationUUID         string     `db:"organization_uuid"`
-	WorkspaceUUID            string     `db:"workspace_uuid"`
-	MemoryStoreUUID          string     `db:"memory_store_uuid"`
-	MemoryStoreExternalID    string     `db:"memory_store_external_id"`
-	CurrentVersionUUID       string     `db:"current_version_uuid"`
-	CurrentVersionExternalID string     `db:"current_version_external_id"`
-	Path                     string     `db:"path"`
-	ContentSizeBytes         int64      `db:"content_size_bytes"`
-	ContentSHA256            string     `db:"content_sha256"`
-	S3Bucket                 string     `db:"s3_bucket"`
-	S3Key                    string     `db:"s3_key"`
-	CreatedAt                time.Time  `db:"created_at"`
-	UpdatedAt                time.Time  `db:"updated_at"`
-	DeletedAt                *time.Time `db:"deleted_at"`
+	UUID                     uuid.UUID     `db:"uuid"`
+	ExternalID               string        `db:"external_id"`
+	OrganizationUUID         uuid.UUID     `db:"organization_uuid"`
+	WorkspaceUUID            uuid.UUID     `db:"workspace_uuid"`
+	MemoryStoreUUID          uuid.UUID     `db:"memory_store_uuid"`
+	MemoryStoreExternalID    string        `db:"memory_store_external_id"`
+	CurrentVersionUUID       uuid.NullUUID `db:"current_version_uuid"`
+	CurrentVersionExternalID string        `db:"current_version_external_id"`
+	Path                     string        `db:"path"`
+	ContentSizeBytes         int64         `db:"content_size_bytes"`
+	ContentSHA256            string        `db:"content_sha256"`
+	S3Bucket                 string        `db:"s3_bucket"`
+	S3Key                    string        `db:"s3_key"`
+	CreatedAt                time.Time     `db:"created_at"`
+	UpdatedAt                time.Time     `db:"updated_at"`
+	DeletedAt                *time.Time    `db:"deleted_at"`
 }
 
 type activeMemoryRow struct {
@@ -47,13 +49,13 @@ type activeMemoryRow struct {
 }
 
 type memoryVersionRow struct {
-	UUID                       string         `db:"uuid"`
+	UUID                       uuid.UUID      `db:"uuid"`
 	ExternalID                 string         `db:"external_id"`
-	OrganizationUUID           string         `db:"organization_uuid"`
-	WorkspaceUUID              string         `db:"workspace_uuid"`
-	MemoryStoreUUID            string         `db:"memory_store_uuid"`
+	OrganizationUUID           uuid.UUID      `db:"organization_uuid"`
+	WorkspaceUUID              uuid.UUID      `db:"workspace_uuid"`
+	MemoryStoreUUID            uuid.UUID      `db:"memory_store_uuid"`
 	MemoryStoreExternalID      string         `db:"memory_store_external_id"`
-	MemoryUUID                 string         `db:"memory_uuid"`
+	MemoryUUID                 uuid.UUID      `db:"memory_uuid"`
 	MemoryExternalID           string         `db:"memory_external_id"`
 	Operation                  string         `db:"operation"`
 	Path                       sql.NullString `db:"path"`
@@ -62,13 +64,13 @@ type memoryVersionRow struct {
 	S3Bucket                   sql.NullString `db:"s3_bucket"`
 	S3Key                      sql.NullString `db:"s3_key"`
 	CreatedByActorType         string         `db:"created_by_actor_type"`
-	CreatedByAPIKeyUUID        sql.NullString `db:"created_by_api_key_uuid"`
+	CreatedByAPIKeyUUID        uuid.NullUUID  `db:"created_by_api_key_uuid"`
 	CreatedByAPIKeyExternalID  sql.NullString `db:"created_by_api_key_external_id"`
 	CreatedBySessionID         sql.NullString `db:"created_by_session_id"`
 	CreatedByUserID            sql.NullString `db:"created_by_user_id"`
 	RedactedAt                 *time.Time     `db:"redacted_at"`
 	RedactedByActorType        sql.NullString `db:"redacted_by_actor_type"`
-	RedactedByAPIKeyUUID       sql.NullString `db:"redacted_by_api_key_uuid"`
+	RedactedByAPIKeyUUID       uuid.NullUUID  `db:"redacted_by_api_key_uuid"`
 	RedactedByAPIKeyExternalID sql.NullString `db:"redacted_by_api_key_external_id"`
 	RedactedBySessionID        sql.NullString `db:"redacted_by_session_id"`
 	RedactedByUserID           sql.NullString `db:"redacted_by_user_id"`
@@ -76,10 +78,10 @@ type memoryVersionRow struct {
 }
 
 type objectRefRow struct {
-	WorkspaceUUID string `db:"workspace_uuid"`
-	Bucket        string `db:"bucket"`
-	Key           string `db:"key"`
-	ResourceID    string `db:"resource_id"`
+	WorkspaceUUID uuid.UUID `db:"workspace_uuid"`
+	Bucket        string    `db:"bucket"`
+	Key           string    `db:"key"`
+	ResourceID    string    `db:"resource_id"`
 }
 
 func getMemoryStoreSQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) (MemoryStore, error) {
@@ -150,11 +152,11 @@ func selectMemoryVersionsSQLX(ctx context.Context, database sqlxNamedQueryer, qu
 
 func (r memoryStoreRow) store() MemoryStore {
 	return MemoryStore{
-		UUID:                r.UUID,
+		UUID:                r.UUID.String(),
 		ExternalID:          r.ExternalID,
-		OrganizationUUID:    r.OrganizationUUID,
-		WorkspaceUUID:       r.WorkspaceUUID,
-		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID,
+		OrganizationUUID:    r.OrganizationUUID.String(),
+		WorkspaceUUID:       r.WorkspaceUUID.String(),
+		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID.String(),
 		Name:                r.Name,
 		Description:         r.Description,
 		Metadata:            copyRaw(r.Metadata),
@@ -167,13 +169,13 @@ func (r memoryStoreRow) store() MemoryStore {
 
 func (r memoryRow) memory() Memory {
 	return Memory{
-		UUID:                     r.UUID,
+		UUID:                     r.UUID.String(),
 		ExternalID:               r.ExternalID,
-		OrganizationUUID:         r.OrganizationUUID,
-		WorkspaceUUID:            r.WorkspaceUUID,
-		MemoryStoreUUID:          r.MemoryStoreUUID,
+		OrganizationUUID:         r.OrganizationUUID.String(),
+		WorkspaceUUID:            r.WorkspaceUUID.String(),
+		MemoryStoreUUID:          r.MemoryStoreUUID.String(),
 		MemoryStoreExternalID:    r.MemoryStoreExternalID,
-		CurrentVersionUUID:       r.CurrentVersionUUID,
+		CurrentVersionUUID:       nullableUUIDValue(r.CurrentVersionUUID),
 		CurrentVersionExternalID: r.CurrentVersionExternalID,
 		Path:                     r.Path,
 		ContentSizeBytes:         r.ContentSizeBytes,
@@ -188,13 +190,13 @@ func (r memoryRow) memory() Memory {
 
 func (r memoryVersionRow) version() MemoryVersion {
 	version := MemoryVersion{
-		UUID:                  r.UUID,
+		UUID:                  r.UUID.String(),
 		ExternalID:            r.ExternalID,
-		OrganizationUUID:      r.OrganizationUUID,
-		WorkspaceUUID:         r.WorkspaceUUID,
-		MemoryStoreUUID:       r.MemoryStoreUUID,
+		OrganizationUUID:      r.OrganizationUUID.String(),
+		WorkspaceUUID:         r.WorkspaceUUID.String(),
+		MemoryStoreUUID:       r.MemoryStoreUUID.String(),
 		MemoryStoreExternalID: r.MemoryStoreExternalID,
-		MemoryUUID:            r.MemoryUUID,
+		MemoryUUID:            r.MemoryUUID.String(),
 		MemoryExternalID:      r.MemoryExternalID,
 		Operation:             r.Operation,
 		Path:                  nullStringPtr(r.Path),
@@ -204,7 +206,7 @@ func (r memoryVersionRow) version() MemoryVersion {
 		S3Key:                 nullStringPtr(r.S3Key),
 		CreatedBy: MemoryActor{
 			Type:             r.CreatedByActorType,
-			APIKeyUUID:       nullStringValue(r.CreatedByAPIKeyUUID),
+			APIKeyUUID:       nullableUUIDValue(r.CreatedByAPIKeyUUID),
 			APIKeyExternalID: nullStringValue(r.CreatedByAPIKeyExternalID),
 			SessionID:        nullStringValue(r.CreatedBySessionID),
 			UserID:           nullStringValue(r.CreatedByUserID),
@@ -215,7 +217,7 @@ func (r memoryVersionRow) version() MemoryVersion {
 	if r.RedactedByActorType.Valid {
 		version.RedactedBy = &MemoryActor{
 			Type:             r.RedactedByActorType.String,
-			APIKeyUUID:       nullStringValue(r.RedactedByAPIKeyUUID),
+			APIKeyUUID:       nullableUUIDValue(r.RedactedByAPIKeyUUID),
 			APIKeyExternalID: nullStringValue(r.RedactedByAPIKeyExternalID),
 			SessionID:        nullStringValue(r.RedactedBySessionID),
 			UserID:           nullStringValue(r.RedactedByUserID),

--- a/internal/db/memory_sqlx_test.go
+++ b/internal/db/memory_sqlx_test.go
@@ -56,26 +56,29 @@ func TestMemoryColumnListsSupportStructScan(t *testing.T) {
 		{
 			name:    "memory store",
 			columns: memoryStoreColumns(),
-			want:    []string{"CAST(uuid AS text) as uuid", "metadata", "archived_at"},
+			want:    []string{"uuid", "metadata", "archived_at"},
 		},
 		{
 			name:    "memory",
 			columns: memoryColumns(),
 			want: []string{
-				"coalesce(CAST(current_version_uuid AS text), '') as current_version_uuid",
+				"current_version_uuid",
 				"coalesce(current_version_external_id, '') as current_version_external_id",
 			},
 		},
 		{
 			name:    "memory version",
 			columns: memoryVersionColumns(),
-			want:    []string{"CAST(uuid AS text) as uuid", "redacted_by_actor_type", "created_at"},
+			want:    []string{"uuid", "redacted_by_actor_type", "created_at"},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if strings.Contains(test.columns, "::") {
 				t.Fatalf("columns contain PostgreSQL shorthand cast: %q", test.columns)
+			}
+			if strings.Contains(strings.ToLower(test.columns), "cast(") {
+				t.Fatalf("typed UUID columns contain SQL casts: %q", test.columns)
 			}
 			for _, fragment := range test.want {
 				if !strings.Contains(test.columns, fragment) {

--- a/internal/db/platform_auth.go
+++ b/internal/db/platform_auth.go
@@ -71,7 +71,7 @@ type PlatformAuthAPIKeyInput struct {
 const (
 	findPlatformAuthUserContextQuery = `
 		select u.external_id AS user_external_id,
-			CAST(u.organization_uuid AS text) AS org_uuid
+			u.organization_uuid AS org_uuid
 		from users u
 		where lower(u.email) = lower(:email)
 		  and u.deleted_at is null
@@ -86,11 +86,11 @@ const (
 		limit 1
 	`
 	resolvePlatformSessionIdentityQuery = `
-		select CAST(u.organization_uuid AS text) AS organization_uuid,
-			CAST(w.uuid AS text) AS workspace_uuid,
+		select u.organization_uuid AS organization_uuid,
+			w.uuid AS workspace_uuid,
 			w.external_id AS workspace_external_id,
-			CAST(u.uuid AS text) AS user_uuid, u.external_id AS user_external_id,
-			CAST(ak.uuid AS text) AS api_key_uuid,
+			u.uuid AS user_uuid, u.external_id AS user_external_id,
+			ak.uuid AS api_key_uuid,
 			ak.external_id AS api_key_external_id
 		from users u
 		join lateral (
@@ -112,12 +112,12 @@ const (
 				created_at asc, uuid asc
 			limit 1
 		) ak on true
-		where CAST(u.organization_uuid AS text) = :org_uuid
+		where u.organization_uuid = :org_uuid
 		  and u.deleted_at is null
 		  and (
-			u.external_id = :user_uuid
-			or CAST(u.uuid AS text) = :user_uuid
-			or 'user_' || left(replace(CAST(u.uuid AS text), '-', ''), 24) = :user_uuid
+			u.external_id = :user_id
+			or u.uuid = :user_uuid
+			or 'user_' || left(replace(CAST(u.uuid AS text), '-', ''), 24) = :user_id
 		  )
 		limit 1
 	`
@@ -164,7 +164,7 @@ func (tx PlatformAuthTx) FindUserContextByEmail(ctx context.Context, email strin
 	if err != nil {
 		return PlatformAuthUserContext{}, mapNoRows(err)
 	}
-	return PlatformAuthUserContext{UserExternalID: row.UserExternalID, OrgUUID: row.OrgUUID}, nil
+	return PlatformAuthUserContext{UserExternalID: row.UserExternalID, OrgUUID: row.OrgUUID.String()}, nil
 }
 
 func (tx PlatformAuthTx) UpdateEmptyUserName(ctx context.Context, userExternalID string, defaultName string) error {
@@ -186,58 +186,58 @@ func (tx PlatformAuthTx) InsertOrganization(ctx context.Context, input PlatformA
 	if err := namedGetContext(ctx, tx.tx, &row, `
 		insert into organizations (name)
 		values (:name)
-		returning CAST(uuid AS text) AS uuid
+		returning uuid
 	`, map[string]any{"name": input.Name}); err != nil {
 		return PlatformAuthOrganizationRef{}, err
 	}
-	return PlatformAuthOrganizationRef{UUID: row.UUID}, nil
+	return PlatformAuthOrganizationRef{UUID: row.UUID.String()}, nil
 }
 
 func (tx PlatformAuthTx) InsertUser(ctx context.Context, input PlatformAuthUserInput) (PlatformAuthUserRef, error) {
-	var out PlatformAuthUserRef
+	var out uuid.UUID
 	role := strings.TrimSpace(input.Role)
 	if role == "" {
 		role = "admin"
 	}
-	if err := namedGetContext(ctx, tx.tx, &out.UUID, `
+	if err := namedGetContext(ctx, tx.tx, &out, `
 		insert into users (uuid, external_id, organization_uuid, email, name, role)
 		values (
-			CAST(:uuid AS uuid), :external_id, CAST(:organization_uuid AS uuid),
+			:uuid, :external_id, :organization_uuid,
 			:email, :name, :role
 		)
-		returning CAST(uuid AS text)
+		returning uuid
 	`, map[string]any{
-		"uuid":              input.UUID,
+		"uuid":              dbUUID(input.UUID),
 		"external_id":       input.ExternalID,
-		"organization_uuid": input.OrganizationUUID,
+		"organization_uuid": dbUUID(input.OrganizationUUID),
 		"email":             input.Email,
 		"name":              input.Name,
 		"role":              role,
 	}); err != nil {
 		return PlatformAuthUserRef{}, err
 	}
-	return out, nil
+	return PlatformAuthUserRef{UUID: out.String()}, nil
 }
 
 func (tx PlatformAuthTx) InsertWorkspace(ctx context.Context, input PlatformAuthWorkspaceInput) (PlatformAuthWorkspaceRef, error) {
-	var out PlatformAuthWorkspaceRef
-	if err := namedGetContext(ctx, tx.tx, &out.UUID, `
+	var out uuid.UUID
+	if err := namedGetContext(ctx, tx.tx, &out, `
 		insert into workspaces (uuid, external_id, organization_uuid, name, compartment_id)
 		values (
-			CAST(:uuid AS uuid), :external_id, CAST(:organization_uuid AS uuid),
+			:uuid, :external_id, :organization_uuid,
 			:name, :compartment_id
 		)
-		returning CAST(uuid AS text)
+		returning uuid
 	`, map[string]any{
-		"uuid":              input.UUID,
+		"uuid":              dbUUID(input.UUID),
 		"external_id":       input.ExternalID,
-		"organization_uuid": input.OrganizationUUID,
+		"organization_uuid": dbUUID(input.OrganizationUUID),
 		"name":              input.Name,
 		"compartment_id":    input.CompartmentID,
 	}); err != nil {
 		return PlatformAuthWorkspaceRef{}, err
 	}
-	return out, nil
+	return PlatformAuthWorkspaceRef{UUID: out.String()}, nil
 }
 
 func (tx PlatformAuthTx) InsertWorkspaceMember(ctx context.Context, input PlatformAuthWorkspaceMemberInput) error {
@@ -251,15 +251,15 @@ func (tx PlatformAuthTx) InsertWorkspaceMember(ctx context.Context, input Platfo
 			user_uuid, user_external_id, workspace_role
 		)
 		values (
-			:external_id, CAST(:organization_uuid AS uuid), CAST(:workspace_uuid AS uuid),
-			:workspace_external_id, CAST(:user_uuid AS uuid), :user_external_id, :workspace_role
+			:external_id, :organization_uuid, :workspace_uuid,
+			:workspace_external_id, :user_uuid, :user_external_id, :workspace_role
 		)
 	`, map[string]any{
 		"external_id":           input.ExternalID,
-		"organization_uuid":     input.OrganizationUUID,
-		"workspace_uuid":        input.WorkspaceUUID,
+		"organization_uuid":     dbUUID(input.OrganizationUUID),
+		"workspace_uuid":        dbUUID(input.WorkspaceUUID),
 		"workspace_external_id": input.WorkspaceExternalID,
-		"user_uuid":             input.UserUUID,
+		"user_uuid":             dbUUID(input.UserUUID),
 		"user_external_id":      input.UserExternalID,
 		"workspace_role":        workspaceRole,
 	})
@@ -280,16 +280,16 @@ func (tx PlatformAuthTx) InsertAPIKey(ctx context.Context, input PlatformAuthAPI
 			external_id, workspace_uuid, key_hash, status, created_by_user_uuid, name, partial_key_hint
 		)
 		values (
-			:external_id, CAST(:workspace_uuid AS uuid), :key_hash, :status,
-			CAST(:created_by_user_uuid AS uuid),
+			:external_id, :workspace_uuid, :key_hash, :status,
+			:created_by_user_uuid,
 			:name, :partial_key_hint
 		)
 	`, map[string]any{
 		"external_id":          input.ExternalID,
-		"workspace_uuid":       input.WorkspaceUUID,
+		"workspace_uuid":       dbUUID(input.WorkspaceUUID),
 		"key_hash":             input.KeyHash,
 		"status":               status,
-		"created_by_user_uuid": input.CreatedByUserUUID,
+		"created_by_user_uuid": dbUUID(input.CreatedByUserUUID),
 		"name":                 name,
 		"partial_key_hint":     input.PartialKeyHint,
 	})
@@ -305,9 +305,15 @@ func (d *DB) ResolvePlatformSessionIdentity(ctx context.Context, input platforms
 	}
 
 	var row platformSessionIdentityRow
+	userID := strings.TrimSpace(input.UserUUID)
+	var userUUID any
+	if parsed, err := uuid.Parse(userID); err == nil && parsed != uuid.Nil {
+		userUUID = parsed
+	}
 	if err := namedGetContext(ctx, d.sql, &row, resolvePlatformSessionIdentityQuery, map[string]any{
-		"org_uuid":  strings.TrimSpace(input.OrgUUID),
-		"user_uuid": strings.TrimSpace(input.UserUUID),
+		"org_uuid":  dbUUID(strings.TrimSpace(input.OrgUUID)),
+		"user_id":   userID,
+		"user_uuid": userUUID,
 	}); err != nil {
 		return platformsession.Session{}, mapNoRows(err)
 	}
@@ -319,32 +325,32 @@ func (d *DB) ResolvePlatformSessionIdentity(ctx context.Context, input platforms
 }
 
 type platformAuthUserContextRow struct {
-	UserExternalID string `db:"user_external_id"`
-	OrgUUID        string `db:"org_uuid"`
+	UserExternalID string    `db:"user_external_id"`
+	OrgUUID        uuid.UUID `db:"org_uuid"`
 }
 
 type platformAuthOrganizationRefRow struct {
-	UUID string `db:"uuid"`
+	UUID uuid.UUID `db:"uuid"`
 }
 
 type platformSessionIdentityRow struct {
-	OrganizationUUID    string `db:"organization_uuid"`
-	WorkspaceUUID       string `db:"workspace_uuid"`
-	WorkspaceExternalID string `db:"workspace_external_id"`
-	UserUUID            string `db:"user_uuid"`
-	UserExternalID      string `db:"user_external_id"`
-	APIKeyUUID          string `db:"api_key_uuid"`
-	APIKeyExternalID    string `db:"api_key_external_id"`
+	OrganizationUUID    uuid.UUID `db:"organization_uuid"`
+	WorkspaceUUID       uuid.UUID `db:"workspace_uuid"`
+	WorkspaceExternalID string    `db:"workspace_external_id"`
+	UserUUID            uuid.UUID `db:"user_uuid"`
+	UserExternalID      string    `db:"user_external_id"`
+	APIKeyUUID          uuid.UUID `db:"api_key_uuid"`
+	APIKeyExternalID    string    `db:"api_key_external_id"`
 }
 
 func (r platformSessionIdentityRow) session() platformsession.Session {
 	return platformsession.Session{
-		OrganizationUUID:    r.OrganizationUUID,
-		WorkspaceUUID:       r.WorkspaceUUID,
+		OrganizationUUID:    r.OrganizationUUID.String(),
+		WorkspaceUUID:       r.WorkspaceUUID.String(),
 		WorkspaceExternalID: r.WorkspaceExternalID,
-		UserUUID:            r.UserUUID,
+		UserUUID:            r.UserUUID.String(),
 		UserExternalID:      r.UserExternalID,
-		APIKeyUUID:          r.APIKeyUUID,
+		APIKeyUUID:          r.APIKeyUUID.String(),
 		APIKeyExternalID:    r.APIKeyExternalID,
 	}
 }

--- a/internal/db/platform_auth_sqlx_test.go
+++ b/internal/db/platform_auth_sqlx_test.go
@@ -3,6 +3,8 @@ package db
 import (
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 )
 
 func TestPlatformAuthQueriesUseSQLXNamedParameters(t *testing.T) {
@@ -10,7 +12,7 @@ func TestPlatformAuthQueriesUseSQLXNamedParameters(t *testing.T) {
 		if _, _, err := bindNamed(postgresRebinder{}, resolvePlatformSessionIdentityQuery, map[string]any{
 			"org_uuid": "org_test",
 		}); err == nil {
-			t.Fatal("bindNamed() error = nil, want missing user_uuid error")
+			t.Fatal("bindNamed() error = nil, want missing user identity error")
 		}
 	})
 
@@ -31,6 +33,7 @@ func TestPlatformAuthQueriesUseSQLXNamedParameters(t *testing.T) {
 			query: resolvePlatformSessionIdentityQuery,
 			arguments: map[string]any{
 				"org_uuid":  "org_test",
+				"user_id":   "user_test",
 				"user_uuid": "user_test",
 			},
 			wantArgCount: 4,
@@ -58,20 +61,20 @@ func TestPlatformAuthQueriesUseSQLXNamedParameters(t *testing.T) {
 
 func TestPlatformSessionIdentityRowMapping(t *testing.T) {
 	row := platformSessionIdentityRow{
-		OrganizationUUID:    "org-uuid",
-		WorkspaceUUID:       "workspace-uuid",
+		OrganizationUUID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		WorkspaceUUID:       uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 		WorkspaceExternalID: "workspace_test",
-		UserUUID:            "user-uuid",
+		UserUUID:            uuid.MustParse("00000000-0000-0000-0000-000000000003"),
 		UserExternalID:      "user_test",
-		APIKeyUUID:          "api-key-uuid",
+		APIKeyUUID:          uuid.MustParse("00000000-0000-0000-0000-000000000004"),
 		APIKeyExternalID:    "api_key_test",
 	}
 
 	session := row.session()
-	if session.OrganizationUUID != row.OrganizationUUID ||
+	if session.OrganizationUUID != row.OrganizationUUID.String() ||
 		session.WorkspaceExternalID != row.WorkspaceExternalID ||
-		session.UserUUID != row.UserUUID ||
-		session.APIKeyUUID != row.APIKeyUUID ||
+		session.UserUUID != row.UserUUID.String() ||
+		session.APIKeyUUID != row.APIKeyUUID.String() ||
 		session.APIKeyExternalID != row.APIKeyExternalID {
 		t.Fatalf("session = %#v, want values from row %#v", session, row)
 	}

--- a/internal/db/runtime_resources_sqlx_test.go
+++ b/internal/db/runtime_resources_sqlx_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestRuntimeResourceQueriesUseSQLXNamedParameters(t *testing.T) {
@@ -43,19 +45,19 @@ func TestRuntimeResourceQueriesUseSQLXNamedParameters(t *testing.T) {
 			name:      "get file",
 			query:     getFileQuery,
 			arguments: getFileArguments(resource.WorkspaceUUID, "file_test"),
-			want:      []any{resource.WorkspaceUUID, "file_test"},
+			want:      []any{uuid.MustParse(resource.WorkspaceUUID), "file_test"},
 		},
 		{
 			name:      "get session",
 			query:     getSessionQuery,
 			arguments: sessionLookupArguments(resource.WorkspaceUUID, "session_test"),
-			want:      []any{resource.WorkspaceUUID, "session_test"},
+			want:      []any{uuid.MustParse(resource.WorkspaceUUID), "session_test"},
 		},
 		{
 			name:      "list session resources",
 			query:     listSessionResourcesQuery,
 			arguments: sessionLookupArguments(resource.WorkspaceUUID, "session_test"),
-			want:      []any{resource.WorkspaceUUID, "session_test"},
+			want:      []any{uuid.MustParse(resource.WorkspaceUUID), "session_test"},
 		},
 		{
 			name:      "create session resource",

--- a/internal/db/session_events_sqlx.go
+++ b/internal/db/session_events_sqlx.go
@@ -6,15 +6,16 @@ import (
 	"errors"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
 
 const (
-	sessionEventSQLXColumns = `cast(uuid as text) as uuid, external_id,
-		cast(organization_uuid as text) as organization_uuid,
-		cast(workspace_uuid as text) as workspace_uuid,
-		cast(session_uuid as text) as session_uuid, session_external_id,
-		cast(thread_uuid as text) as thread_uuid, thread_external_id,
+	sessionEventSQLXColumns = `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		session_uuid, session_external_id,
+		thread_uuid, thread_external_id,
 		event_type, payload, processed_at, created_at, deleted_at`
 	lockSessionForEventsQuery = `
 		select ` + sessionSQLXColumns + `
@@ -61,19 +62,19 @@ const (
 )
 
 type sessionEventRow struct {
-	UUID              string     `db:"uuid"`
-	ExternalID        string     `db:"external_id"`
-	OrganizationUUID  string     `db:"organization_uuid"`
-	WorkspaceUUID     string     `db:"workspace_uuid"`
-	SessionUUID       string     `db:"session_uuid"`
-	SessionExternalID string     `db:"session_external_id"`
-	ThreadUUID        *string    `db:"thread_uuid"`
-	ThreadExternalID  *string    `db:"thread_external_id"`
-	EventType         string     `db:"event_type"`
-	Payload           []byte     `db:"payload"`
-	ProcessedAt       time.Time  `db:"processed_at"`
-	CreatedAt         time.Time  `db:"created_at"`
-	DeletedAt         *time.Time `db:"deleted_at"`
+	UUID              uuid.UUID     `db:"uuid"`
+	ExternalID        string        `db:"external_id"`
+	OrganizationUUID  uuid.UUID     `db:"organization_uuid"`
+	WorkspaceUUID     uuid.UUID     `db:"workspace_uuid"`
+	SessionUUID       uuid.UUID     `db:"session_uuid"`
+	SessionExternalID string        `db:"session_external_id"`
+	ThreadUUID        uuid.NullUUID `db:"thread_uuid"`
+	ThreadExternalID  *string       `db:"thread_external_id"`
+	EventType         string        `db:"event_type"`
+	Payload           []byte        `db:"payload"`
+	ProcessedAt       time.Time     `db:"processed_at"`
+	CreatedAt         time.Time     `db:"created_at"`
+	DeletedAt         *time.Time    `db:"deleted_at"`
 }
 
 func insertSessionEventsSQLXTx(
@@ -84,7 +85,7 @@ func insertSessionEventsSQLXTx(
 	ignoreExisting bool,
 ) ([]SessionEvent, error) {
 	primary, err := getSessionThreadSQLX(ctx, tx, primarySessionThreadQuery, map[string]any{
-		"workspace_uuid":      session.WorkspaceUUID,
+		"workspace_uuid":      dbUUID(session.WorkspaceUUID),
 		"session_external_id": session.ExternalID,
 	})
 	if err != nil {
@@ -103,7 +104,7 @@ func insertSessionEventsSQLXTx(
 			event.ThreadExternalID = &threadExternalID
 		} else {
 			thread, err := getSessionThreadSQLX(ctx, tx, sessionThreadByExternalIDQuery, map[string]any{
-				"workspace_uuid":      session.WorkspaceUUID,
+				"workspace_uuid":      dbUUID(session.WorkspaceUUID),
 				"session_external_id": session.ExternalID,
 				"thread_external_id":  *event.ThreadExternalID,
 			})
@@ -193,13 +194,13 @@ func insertSessionEventSQLX(
 
 func sessionEventArguments(event SessionEvent) map[string]any {
 	return map[string]any{
-		"event_uuid":          event.UUID,
+		"event_uuid":          dbUUID(event.UUID),
 		"event_external_id":   event.ExternalID,
-		"organization_uuid":   event.OrganizationUUID,
-		"workspace_uuid":      event.WorkspaceUUID,
-		"session_uuid":        event.SessionUUID,
+		"organization_uuid":   dbUUID(event.OrganizationUUID),
+		"workspace_uuid":      dbUUID(event.WorkspaceUUID),
+		"session_uuid":        dbUUID(event.SessionUUID),
 		"session_external_id": event.SessionExternalID,
-		"thread_uuid":         event.ThreadUUID,
+		"thread_uuid":         dbNullableUUID(event.ThreadUUID),
 		"thread_external_id":  event.ThreadExternalID,
 		"event_type":          event.EventType,
 		"payload":             jsonArg(event.Payload),
@@ -210,13 +211,13 @@ func sessionEventArguments(event SessionEvent) map[string]any {
 
 func (r sessionEventRow) event() SessionEvent {
 	return SessionEvent{
-		UUID:              r.UUID,
+		UUID:              r.UUID.String(),
 		ExternalID:        r.ExternalID,
-		OrganizationUUID:  r.OrganizationUUID,
-		WorkspaceUUID:     r.WorkspaceUUID,
-		SessionUUID:       r.SessionUUID,
+		OrganizationUUID:  r.OrganizationUUID.String(),
+		WorkspaceUUID:     r.WorkspaceUUID.String(),
+		SessionUUID:       r.SessionUUID.String(),
 		SessionExternalID: r.SessionExternalID,
-		ThreadUUID:        r.ThreadUUID,
+		ThreadUUID:        nullableUUIDString(r.ThreadUUID),
 		ThreadExternalID:  r.ThreadExternalID,
 		EventType:         r.EventType,
 		Payload:           copyRaw(r.Payload),

--- a/internal/db/session_file_mounts_sqlx.go
+++ b/internal/db/session_file_mounts_sqlx.go
@@ -47,7 +47,7 @@ const (
 			created_by_api_key_uuid, created_at
 		)
 		values (
-			CAST(:file_uuid AS uuid),
+			:file_uuid,
 			concat('file_', replace(CAST(gen_random_uuid() AS text), '-', '')),
 			:workspace_uuid, :filename, :mime_type, :size_bytes, :sha256,
 			:s3_bucket, :s3_key, :downloadable, :scope_type, :scope_id,
@@ -71,7 +71,7 @@ const (
 		update files
 		set deleted_at = now()
 		where workspace_uuid = :workspace_uuid
-			and uuid = CAST(:file_uuid AS uuid)
+			and uuid = :file_uuid
 			and scope_type = :scope_type
 			and scope_id = :scope_id
 			and deleted_at is null
@@ -89,7 +89,7 @@ const (
 		set deleted_at = now()
 		where projection.workspace_uuid = :workspace_uuid
 			and projection.scope_type = :scope_type
-			and projection.uuid = CAST(:file_uuid AS uuid)
+			and projection.uuid = :file_uuid
 			and projection.deleted_at is null
 	`
 	softDeleteSessionFileProjectionSubtreeSQL = `
@@ -126,7 +126,7 @@ func enforceSessionFileResourceCapacityTx(
 	}
 	var activeFiles int
 	if err := namedGetContext(ctx, tx, &activeFiles, countSessionFileResourcesSQL, map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"session_external_id": sessionExternalID,
 		"resource_type":       SessionResourceTypeFile,
 	}); err != nil {
@@ -163,18 +163,18 @@ func lockSessionFilestoreMutationTx(
 	session Session,
 ) (FilestoreFilesystem, error) {
 	if _, err := namedExecContext(ctx, tx, fileWorkspaceLockQuery, map[string]any{
-		"workspace_uuid": session.WorkspaceUUID,
+		"workspace_uuid": dbUUID(session.WorkspaceUUID),
 	}); err != nil {
 		return FilestoreFilesystem{}, err
 	}
 	filesystem, err := getFilestoreFilesystemSQLX(ctx, tx, filestoreFilesystemSelectSQL()+`
-		where workspace_uuid = CAST(:workspace_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid
 			and session_uuid = :session_uuid
 			and deleted_at is null
 		for update
 	`, map[string]any{
-		"workspace_uuid": session.WorkspaceUUID,
-		"session_uuid":   session.UUID,
+		"workspace_uuid": dbUUID(session.WorkspaceUUID),
+		"session_uuid":   dbUUID(session.UUID),
 	})
 	if err != nil {
 		return FilestoreFilesystem{}, err
@@ -186,7 +186,7 @@ func lockSessionFilestoreMutationTx(
 				0
 			)
 		)
-	`, map[string]any{"filesystem_uuid": filesystem.UUID}); err != nil {
+	`, map[string]any{"filesystem_uuid": dbUUID(filesystem.UUID)}); err != nil {
 		return FilestoreFilesystem{}, err
 	}
 	return filesystem, nil
@@ -267,9 +267,9 @@ func bindSessionFileResourceWithLockedFilesystemTx(
 		)
 		returning `+filestoreEntryColumns()+`
 	`, map[string]any{
-		"organization_uuid":            filesystem.OrganizationUUID,
-		"workspace_uuid":               filesystem.WorkspaceUUID,
-		"filesystem_uuid":              filesystem.UUID,
+		"organization_uuid":            dbUUID(filesystem.OrganizationUUID),
+		"workspace_uuid":               dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid":              dbUUID(filesystem.UUID),
 		"entry_path":                   mount.Path,
 		"parent_path":                  filestoreParentPath(mount.Path),
 		"size_bytes":                   file.SizeBytes,
@@ -279,11 +279,11 @@ func bindSessionFileResourceWithLockedFilesystemTx(
 		"s3_bucket":                    file.S3Bucket,
 		"s3_key":                       file.S3Key,
 		"managed_by":                   sessionFileResourceManagedBy,
-		"managed_resource_uuid":        resource.UUID,
-		"source_file_uuid":             file.UUID,
-		"created_by_api_key_uuid":      filesystem.CreatedByAPIKeyUUID,
-		"created_by_session_uuid":      filesystem.SessionUUID,
-		"created_by_code_session_uuid": filesystem.CodeSessionUUID,
+		"managed_resource_uuid":        dbUUID(resource.UUID),
+		"source_file_uuid":             dbUUID(file.UUID),
+		"created_by_api_key_uuid":      dbNullableUUID(filesystem.CreatedByAPIKeyUUID),
+		"created_by_session_uuid":      dbUUID(filesystem.SessionUUID),
+		"created_by_code_session_uuid": dbNullableUUID(filesystem.CodeSessionUUID),
 		"created_at":                   filestoreNow(resource.CreatedAt),
 	})
 	if isUniqueViolation(err) {
@@ -304,8 +304,8 @@ func upsertSessionFileProjectionTx(
 	createdAt time.Time,
 ) error {
 	_, err := namedExecContext(ctx, tx, upsertSessionFileProjectionSQL, map[string]any{
-		"file_uuid":               entryUUID,
-		"workspace_uuid":          session.WorkspaceUUID,
+		"file_uuid":               dbUUID(entryUUID),
+		"workspace_uuid":          dbUUID(session.WorkspaceUUID),
 		"filename":                file.Filename,
 		"mime_type":               file.MimeType,
 		"size_bytes":              file.SizeBytes,
@@ -315,7 +315,7 @@ func upsertSessionFileProjectionTx(
 		"downloadable":            file.Downloadable,
 		"scope_type":              sessionFileProjectionScope,
 		"scope_id":                session.ExternalID,
-		"created_by_api_key_uuid": session.CreatedByAPIKeyUUID,
+		"created_by_api_key_uuid": dbUUID(session.CreatedByAPIKeyUUID),
 		"created_at":              filestoreNow(createdAt),
 	})
 	return err
@@ -393,11 +393,11 @@ func getSessionForFileProjectionTx(
 		select `+sessionSQLXColumns+`
 		from sessions
 		where workspace_uuid = :workspace_uuid
-			and uuid = CAST(:session_uuid AS uuid)
+			and uuid = :session_uuid
 			and deleted_at is null
 	`, map[string]any{
-		"workspace_uuid": workspaceUUID,
-		"session_uuid":   sessionUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"session_uuid":   dbUUID(sessionUUID),
 	})
 }
 
@@ -408,9 +408,9 @@ func softDeleteSessionFileProjectionByEntryTx(
 	entryUUID string,
 ) error {
 	_, err := namedExecContext(ctx, tx, softDeleteSessionFileProjectionByEntrySQL, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"scope_type":     sessionFileProjectionScope,
-		"file_uuid":      entryUUID,
+		"file_uuid":      dbUUID(entryUUID),
 	})
 	return err
 }
@@ -423,9 +423,9 @@ func softDeleteSessionFileProjectionSubtreeTx(
 	rootPath string,
 ) error {
 	_, err := namedExecContext(ctx, tx, softDeleteSessionFileProjectionSubtreeSQL, map[string]any{
-		"workspace_uuid":  workspaceUUID,
+		"workspace_uuid":  dbUUID(workspaceUUID),
 		"scope_type":      sessionFileProjectionScope,
-		"filesystem_uuid": filesystem.UUID,
+		"filesystem_uuid": dbUUID(filesystem.UUID),
 		"root_path":       rootPath,
 	})
 	return err
@@ -442,8 +442,8 @@ func rejectSessionFileMountConflictTx(
 	// return 400; ordinary occupied entries remain ErrFilestorePathExists/409.
 	var conflictingPath string
 	err := namedGetContext(ctx, tx, &conflictingPath, findSessionFileMountConflictSQL, map[string]any{
-		"workspace_uuid":  filesystem.WorkspaceUUID,
-		"filesystem_uuid": filesystem.UUID,
+		"workspace_uuid":  dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid": dbUUID(filesystem.UUID),
 		"managed_by":      sessionFileResourceManagedBy,
 		"entry_path":      path,
 	})
@@ -476,7 +476,7 @@ func getSessionResourceForMutationSQLX(
 			and deleted_at is null
 		for update
 	`, map[string]any{
-		"workspace_uuid":       workspaceUUID,
+		"workspace_uuid":       dbUUID(workspaceUUID),
 		"session_external_id":  sessionExternalID,
 		"resource_external_id": resourceExternalID,
 	})
@@ -513,10 +513,10 @@ func unbindSessionFileResourceTx(
 			and deleted_at is null
 		for update
 	`, map[string]any{
-		"workspace_uuid":  filesystem.WorkspaceUUID,
-		"filesystem_uuid": filesystem.UUID,
+		"workspace_uuid":  dbUUID(filesystem.WorkspaceUUID),
+		"filesystem_uuid": dbUUID(filesystem.UUID),
 		"managed_by":      sessionFileResourceManagedBy,
-		"resource_uuid":   resource.UUID,
+		"resource_uuid":   dbUUID(resource.UUID),
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil
@@ -527,12 +527,12 @@ func unbindSessionFileResourceTx(
 	if _, err := namedExecContext(ctx, tx, `
 		update filestore_entries
 		set deleted_at = now(), updated_at = now()
-		where uuid = CAST(:entry_uuid AS uuid) and deleted_at is null
+		where uuid = :entry_uuid and deleted_at is null
 	`, map[string]any{"entry_uuid": entry.UUID}); err != nil {
 		return err
 	}
 	if _, err := namedExecContext(ctx, tx, softDeleteSessionFileProjectionSQL, map[string]any{
-		"workspace_uuid": session.WorkspaceUUID,
+		"workspace_uuid": dbUUID(session.WorkspaceUUID),
 		"file_uuid":      entry.UUID,
 		"scope_type":     sessionFileProjectionScope,
 		"scope_id":       session.ExternalID,
@@ -557,7 +557,7 @@ func softDeleteSessionResourceSQLX(
 			and external_id = :resource_external_id
 			and deleted_at is null
 	`, map[string]any{
-		"workspace_uuid":       workspaceUUID,
+		"workspace_uuid":       dbUUID(workspaceUUID),
 		"session_external_id":  sessionExternalID,
 		"resource_external_id": resourceExternalID,
 	})

--- a/internal/db/session_file_mounts_sqlx_test.go
+++ b/internal/db/session_file_mounts_sqlx_test.go
@@ -98,7 +98,7 @@ func TestSessionFileProjectionQueriesBindNamedArguments(t *testing.T) {
 				"created_at":              time.Unix(1, 0).UTC(),
 			},
 			wantClauses: []string{
-				"CAST($1 AS uuid)",
+				"values (\n\t\t\t$1,",
 				"on conflict (uuid) do update",
 				"deleted_at = null",
 			},
@@ -114,7 +114,7 @@ func TestSessionFileProjectionQueriesBindNamedArguments(t *testing.T) {
 			},
 			wantClauses: []string{
 				"workspace_uuid = $1",
-				"uuid = CAST($2 AS uuid)",
+				"uuid = $2",
 				"scope_type = $3",
 				"scope_id = $4",
 			},
@@ -144,7 +144,7 @@ func TestSessionFileProjectionQueriesBindNamedArguments(t *testing.T) {
 			wantClauses: []string{
 				"projection.workspace_uuid = $1",
 				"projection.scope_type = $2",
-				"projection.uuid = CAST($3 AS uuid)",
+				"projection.uuid = $3",
 			},
 		},
 		{

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -225,7 +225,7 @@ func (d *DB) GetSession(ctx context.Context, workspaceUUID string, externalID st
 
 func (d *DB) UpdateSession(ctx context.Context, workspaceUUID string, externalID string, next Session) (Session, error) {
 	return getSessionSQLX(ctx, d.sql, updateSessionQuery, map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"session_external_id": externalID,
 		"agent_snapshot":      jsonArg(next.AgentSnapshot),
 		"title":               next.Title,
@@ -236,7 +236,7 @@ func (d *DB) UpdateSession(ctx context.Context, workspaceUUID string, externalID
 
 func (d *DB) PatchSessionMetadata(ctx context.Context, workspaceUUID string, externalID string, patch json.RawMessage) (Session, error) {
 	return getSessionSQLX(ctx, d.sql, patchSessionMetadataQuery, map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"session_external_id": externalID,
 		"metadata_patch":      jsonArg(patch),
 	})
@@ -244,7 +244,7 @@ func (d *DB) PatchSessionMetadata(ctx context.Context, workspaceUUID string, ext
 
 func (d *DB) SetSessionOutcomeEvaluations(ctx context.Context, workspaceUUID string, externalID string, evaluations json.RawMessage) (Session, error) {
 	return getSessionSQLX(ctx, d.sql, setSessionOutcomeEvaluationsQuery, map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"session_external_id": externalID,
 		"outcome_evaluations": jsonArg(evaluations),
 	})
@@ -252,7 +252,7 @@ func (d *DB) SetSessionOutcomeEvaluations(ctx context.Context, workspaceUUID str
 
 func (d *DB) SetSessionStatus(ctx context.Context, workspaceUUID string, externalID, status string) error {
 	rowsAffected, err := namedExecRowsAffected(ctx, d.sql, setSessionStatusQuery, map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"session_external_id": externalID,
 		"status":              status,
 	})
@@ -267,7 +267,7 @@ func (d *DB) SetSessionStatus(ctx context.Context, workspaceUUID string, externa
 
 func (d *DB) SetSessionThreadStatus(ctx context.Context, workspaceUUID string, sessionExternalID, threadExternalID, status string) error {
 	rowsAffected, err := namedExecRowsAffected(ctx, d.sql, setSessionThreadStatusQuery, map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"session_external_id": sessionExternalID,
 		"thread_external_id":  threadExternalID,
 		"status":              status,
@@ -317,7 +317,7 @@ func (d *DB) DeleteSession(ctx context.Context, workspaceUUID string, externalID
 		return Session{}, err
 	}
 	if _, err := namedExecContext(ctx, tx, softDeleteSessionFileProjectionsByScopeSQL, map[string]any{
-		"workspace_uuid": session.WorkspaceUUID,
+		"workspace_uuid": dbUUID(session.WorkspaceUUID),
 		"scope_type":     sessionFileProjectionScope,
 		"scope_id":       session.ExternalID,
 	}); err != nil {
@@ -360,7 +360,7 @@ func (d *DB) ListSessionsPage(ctx context.Context, params ListSessionsPageParams
 		where s.workspace_uuid = :workspace_uuid and s.deleted_at is null
 	`
 	arguments := map[string]any{
-		"workspace_uuid": params.WorkspaceUUID,
+		"workspace_uuid": dbUUID(params.WorkspaceUUID),
 		"limit":          params.Limit + 1,
 	}
 	if !params.IncludeArchived {
@@ -414,9 +414,9 @@ func (d *DB) ListSessionsPage(ctx context.Context, params ListSessionsPageParams
 	}
 	if params.Cursor != nil {
 		query += " and (s.created_at " + comparison + ` :cursor_created_at
-			or (s.created_at = :cursor_created_at and s.uuid ` + comparison + ` CAST(:cursor_uuid AS uuid)))`
+			or (s.created_at = :cursor_created_at and s.uuid ` + comparison + ` :cursor_uuid))`
 		arguments["cursor_created_at"] = params.Cursor.CreatedAt
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	query += " order by s.created_at " + order + ", s.uuid " + order + " limit :limit"
 
@@ -456,9 +456,9 @@ func (d *DB) ListSessionThreadsPage(ctx context.Context, params ListSessionThrea
 	arguments["limit"] = params.Limit + 1
 	if params.Cursor != nil {
 		query += ` and (created_at < :cursor_created_at
-			or (created_at = :cursor_created_at and uuid < CAST(:cursor_uuid AS uuid)))`
+			or (created_at = :cursor_created_at and uuid < :cursor_uuid))`
 		arguments["cursor_created_at"] = params.Cursor.CreatedAt
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	query += " order by created_at desc, uuid desc limit :limit"
 	threads, err := listSessionThreadsSQLX(ctx, d.sql, query, arguments)
@@ -757,9 +757,9 @@ func (d *DB) ListSessionEventsPage(ctx context.Context, params ListSessionEvents
 	}
 	if params.Cursor != nil {
 		query += " and (created_at " + comparison + ` :cursor_created_at
-			or (created_at = :cursor_created_at and uuid ` + comparison + ` CAST(:cursor_uuid AS uuid)))`
+			or (created_at = :cursor_created_at and uuid ` + comparison + ` :cursor_uuid))`
 		arguments["cursor_created_at"] = params.Cursor.CreatedAt
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	query += " order by created_at " + order + ", uuid " + order + " limit :limit"
 	events, err := listSessionEventsSQLX(ctx, d.sql, query, arguments)
@@ -803,7 +803,7 @@ func (d *DB) ChildSessionToolUseIDs(ctx context.Context, workspaceUUID string, s
 				e.payload->>'id'
 			) = any(CAST(:tool_use_ids AS text[]))
 	`, map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"session_external_id": sessionExternalID,
 		"event_types":         []string{"agent.tool_use", "agent.mcp_tool_use", "agent.custom_tool_use"},
 		"tool_use_ids":        toolUseIDs,

--- a/internal/db/sessions_migration_sqlx_test.go
+++ b/internal/db/sessions_migration_sqlx_test.go
@@ -167,6 +167,7 @@ func TestMigratedSessionQueriesBindNamedArguments(t *testing.T) {
 			arguments: map[string]any{
 				"workspace_uuid":  "00000000-0000-0000-0000-000000000002",
 				"filesystem_uuid": "00000000-0000-0000-0000-000000000004",
+				"payload":         []byte(`{"filesystem_uuid":"00000000-0000-0000-0000-000000000004"}`),
 				"job_type":        filestoreFilesystemCleanupJobType,
 				"run_after":       now,
 			},

--- a/internal/db/sessions_sqlx.go
+++ b/internal/db/sessions_sqlx.go
@@ -6,23 +6,24 @@ import (
 	"errors"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
 
 const (
-	sessionSQLXColumns = `cast(uuid as text) as uuid, external_id,
-		cast(organization_uuid as text) as organization_uuid,
-		cast(workspace_uuid as text) as workspace_uuid,
-		cast(created_by_api_key_uuid as text) as created_by_api_key_uuid,
-		cast(environment_uuid as text) as environment_uuid, environment_external_id,
-		cast(agent_uuid as text) as agent_uuid, agent_external_id,
-		agent_version, agent_snapshot, cast(deployment_uuid as text) as deployment_uuid,
+	sessionSQLXColumns = `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		created_by_api_key_uuid,
+		environment_uuid, environment_external_id,
+		agent_uuid, agent_external_id,
+		agent_version, agent_snapshot, deployment_uuid,
 		deployment_external_id, title, metadata, vault_ids, status, usage, stats,
 		outcome_evaluations, created_at, updated_at, archived_at, deleted_at`
-	sessionResourceSQLXColumns = `cast(uuid as text) as uuid, external_id,
-		cast(organization_uuid as text) as organization_uuid,
-		cast(workspace_uuid as text) as workspace_uuid,
-		cast(session_uuid as text) as session_uuid,
+	sessionResourceSQLXColumns = `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		session_uuid,
 		session_external_id, resource_type, payload, secret_payload,
 		created_at, updated_at, deleted_at`
 	getSessionQuery = `
@@ -187,7 +188,7 @@ const (
 			:session_uuid, :session_external_id, :organization_uuid, :workspace_uuid, :created_by_api_key_uuid,
 			:environment_uuid, :environment_external_id, :agent_uuid, :agent_external_id,
 			:agent_version, CAST(:agent_snapshot AS jsonb),
-			CAST(:deployment_uuid AS uuid), :deployment_external_id, :title,
+			:deployment_uuid, :deployment_external_id, :title,
 			CAST(:metadata AS jsonb), CAST(:vault_ids AS jsonb), :status,
 			CAST(:usage AS jsonb), CAST(:stats AS jsonb), CAST(:outcome_evaluations AS jsonb),
 			:created_at, :created_at
@@ -239,16 +240,16 @@ const (
 		)
 		returning ` + environmentWorkSQLXColumns + `
 	`
-	sessionThreadSQLXColumns = `cast(uuid as text) as uuid, external_id,
-		cast(organization_uuid as text) as organization_uuid,
-		cast(workspace_uuid as text) as workspace_uuid,
-		cast(session_uuid as text) as session_uuid, session_external_id,
-		cast(parent_thread_uuid as text) as parent_thread_uuid, parent_thread_external_id,
+	sessionThreadSQLXColumns = `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		session_uuid, session_external_id,
+		parent_thread_uuid, parent_thread_external_id,
 		agent_snapshot, status, usage, stats, created_at, updated_at, archived_at, deleted_at`
-	environmentWorkSQLXColumns = `cast(uuid as text) as uuid, external_id,
-		cast(organization_uuid as text) as organization_uuid,
-		cast(workspace_uuid as text) as workspace_uuid,
-		cast(environment_uuid as text) as environment_uuid,
+	environmentWorkSQLXColumns = `uuid, external_id,
+		organization_uuid,
+		workspace_uuid,
+		environment_uuid,
 		environment_external_id, data, metadata, secret, state,
 		claimed_by_worker_id, claim_expires_at, acknowledged_at, started_at, latest_heartbeat_at,
 		heartbeat_ttl_seconds, stop_requested_at, stopped_at, created_at, updated_at, deleted_at`
@@ -257,38 +258,38 @@ const (
 // 这些 *Row 结构体是 sessions 相关表的 sqlx 扫描边界；领域层拿到的仍是
 // Session / SessionResource 等业务模型，而不是直接暴露 JSONB 原始字段。
 type sessionRow struct {
-	UUID                  string     `db:"uuid"`
-	ExternalID            string     `db:"external_id"`
-	OrganizationUUID      string     `db:"organization_uuid"`
-	WorkspaceUUID         string     `db:"workspace_uuid"`
-	CreatedByAPIKeyUUID   string     `db:"created_by_api_key_uuid"`
-	EnvironmentUUID       string     `db:"environment_uuid"`
-	EnvironmentExternalID string     `db:"environment_external_id"`
-	AgentUUID             string     `db:"agent_uuid"`
-	AgentExternalID       string     `db:"agent_external_id"`
-	AgentVersion          int        `db:"agent_version"`
-	AgentSnapshot         []byte     `db:"agent_snapshot"`
-	DeploymentUUID        *string    `db:"deployment_uuid"`
-	DeploymentID          *string    `db:"deployment_external_id"`
-	Title                 *string    `db:"title"`
-	Metadata              []byte     `db:"metadata"`
-	VaultIDs              []byte     `db:"vault_ids"`
-	Status                string     `db:"status"`
-	Usage                 []byte     `db:"usage"`
-	Stats                 []byte     `db:"stats"`
-	OutcomeEvaluations    []byte     `db:"outcome_evaluations"`
-	CreatedAt             time.Time  `db:"created_at"`
-	UpdatedAt             time.Time  `db:"updated_at"`
-	ArchivedAt            *time.Time `db:"archived_at"`
-	DeletedAt             *time.Time `db:"deleted_at"`
+	UUID                  uuid.UUID     `db:"uuid"`
+	ExternalID            string        `db:"external_id"`
+	OrganizationUUID      uuid.UUID     `db:"organization_uuid"`
+	WorkspaceUUID         uuid.UUID     `db:"workspace_uuid"`
+	CreatedByAPIKeyUUID   uuid.UUID     `db:"created_by_api_key_uuid"`
+	EnvironmentUUID       uuid.UUID     `db:"environment_uuid"`
+	EnvironmentExternalID string        `db:"environment_external_id"`
+	AgentUUID             uuid.UUID     `db:"agent_uuid"`
+	AgentExternalID       string        `db:"agent_external_id"`
+	AgentVersion          int           `db:"agent_version"`
+	AgentSnapshot         []byte        `db:"agent_snapshot"`
+	DeploymentUUID        uuid.NullUUID `db:"deployment_uuid"`
+	DeploymentID          *string       `db:"deployment_external_id"`
+	Title                 *string       `db:"title"`
+	Metadata              []byte        `db:"metadata"`
+	VaultIDs              []byte        `db:"vault_ids"`
+	Status                string        `db:"status"`
+	Usage                 []byte        `db:"usage"`
+	Stats                 []byte        `db:"stats"`
+	OutcomeEvaluations    []byte        `db:"outcome_evaluations"`
+	CreatedAt             time.Time     `db:"created_at"`
+	UpdatedAt             time.Time     `db:"updated_at"`
+	ArchivedAt            *time.Time    `db:"archived_at"`
+	DeletedAt             *time.Time    `db:"deleted_at"`
 }
 
 type sessionResourceRow struct {
-	UUID              string     `db:"uuid"`
+	UUID              uuid.UUID  `db:"uuid"`
 	ExternalID        string     `db:"external_id"`
-	OrganizationUUID  string     `db:"organization_uuid"`
-	WorkspaceUUID     string     `db:"workspace_uuid"`
-	SessionUUID       string     `db:"session_uuid"`
+	OrganizationUUID  uuid.UUID  `db:"organization_uuid"`
+	WorkspaceUUID     uuid.UUID  `db:"workspace_uuid"`
+	SessionUUID       uuid.UUID  `db:"session_uuid"`
 	SessionExternalID string     `db:"session_external_id"`
 	ResourceType      string     `db:"resource_type"`
 	Payload           []byte     `db:"payload"`
@@ -299,30 +300,30 @@ type sessionResourceRow struct {
 }
 
 type sessionThreadRow struct {
-	UUID                   string     `db:"uuid"`
-	ExternalID             string     `db:"external_id"`
-	OrganizationUUID       string     `db:"organization_uuid"`
-	WorkspaceUUID          string     `db:"workspace_uuid"`
-	SessionUUID            string     `db:"session_uuid"`
-	SessionExternalID      string     `db:"session_external_id"`
-	ParentThreadUUID       *string    `db:"parent_thread_uuid"`
-	ParentThreadExternalID *string    `db:"parent_thread_external_id"`
-	AgentSnapshot          []byte     `db:"agent_snapshot"`
-	Status                 string     `db:"status"`
-	Usage                  []byte     `db:"usage"`
-	Stats                  []byte     `db:"stats"`
-	CreatedAt              time.Time  `db:"created_at"`
-	UpdatedAt              time.Time  `db:"updated_at"`
-	ArchivedAt             *time.Time `db:"archived_at"`
-	DeletedAt              *time.Time `db:"deleted_at"`
+	UUID                   uuid.UUID     `db:"uuid"`
+	ExternalID             string        `db:"external_id"`
+	OrganizationUUID       uuid.UUID     `db:"organization_uuid"`
+	WorkspaceUUID          uuid.UUID     `db:"workspace_uuid"`
+	SessionUUID            uuid.UUID     `db:"session_uuid"`
+	SessionExternalID      string        `db:"session_external_id"`
+	ParentThreadUUID       uuid.NullUUID `db:"parent_thread_uuid"`
+	ParentThreadExternalID *string       `db:"parent_thread_external_id"`
+	AgentSnapshot          []byte        `db:"agent_snapshot"`
+	Status                 string        `db:"status"`
+	Usage                  []byte        `db:"usage"`
+	Stats                  []byte        `db:"stats"`
+	CreatedAt              time.Time     `db:"created_at"`
+	UpdatedAt              time.Time     `db:"updated_at"`
+	ArchivedAt             *time.Time    `db:"archived_at"`
+	DeletedAt              *time.Time    `db:"deleted_at"`
 }
 
 type environmentWorkRow struct {
-	UUID                  string     `db:"uuid"`
+	UUID                  uuid.UUID  `db:"uuid"`
 	ExternalID            string     `db:"external_id"`
-	OrganizationUUID      string     `db:"organization_uuid"`
-	WorkspaceUUID         string     `db:"workspace_uuid"`
-	EnvironmentUUID       string     `db:"environment_uuid"`
+	OrganizationUUID      uuid.UUID  `db:"organization_uuid"`
+	WorkspaceUUID         uuid.UUID  `db:"workspace_uuid"`
+	EnvironmentUUID       uuid.UUID  `db:"environment_uuid"`
 	EnvironmentExternalID string     `db:"environment_external_id"`
 	Data                  []byte     `db:"data"`
 	Metadata              []byte     `db:"metadata"`
@@ -343,7 +344,7 @@ type environmentWorkRow struct {
 
 func sessionLookupArguments(workspaceUUID string, sessionExternalID string) map[string]any {
 	return map[string]any{
-		"workspace_uuid":      workspaceUUID,
+		"workspace_uuid":      dbUUID(workspaceUUID),
 		"session_external_id": sessionExternalID,
 	}
 }
@@ -438,10 +439,10 @@ func createSessionResourceSQLX(
 ) (SessionResource, error) {
 	var row sessionResourceRow
 	err := namedGetContext(ctx, database, &row, createSessionResourceQuery, map[string]any{
-		"resource_uuid":        resource.UUID,
+		"resource_uuid":        dbUUID(resource.UUID),
 		"resource_external_id": resource.ExternalID,
-		"organization_uuid":    resource.OrganizationUUID,
-		"workspace_uuid":       resource.WorkspaceUUID,
+		"organization_uuid":    dbUUID(resource.OrganizationUUID),
+		"workspace_uuid":       dbUUID(resource.WorkspaceUUID),
 		"session_external_id":  resource.SessionExternalID,
 		"resource_type":        resource.ResourceType,
 		"payload":              jsonArg(resource.Payload),
@@ -584,18 +585,18 @@ func insertEnvironmentWorkSQLX(
 
 func createSessionArguments(session Session) map[string]any {
 	return map[string]any{
-		"session_uuid":            session.UUID,
+		"session_uuid":            dbUUID(session.UUID),
 		"session_external_id":     session.ExternalID,
-		"organization_uuid":       session.OrganizationUUID,
-		"workspace_uuid":          session.WorkspaceUUID,
-		"created_by_api_key_uuid": session.CreatedByAPIKeyUUID,
-		"environment_uuid":        session.EnvironmentUUID,
+		"organization_uuid":       dbUUID(session.OrganizationUUID),
+		"workspace_uuid":          dbUUID(session.WorkspaceUUID),
+		"created_by_api_key_uuid": dbUUID(session.CreatedByAPIKeyUUID),
+		"environment_uuid":        dbUUID(session.EnvironmentUUID),
 		"environment_external_id": session.EnvironmentExternalID,
-		"agent_uuid":              session.AgentUUID,
+		"agent_uuid":              dbUUID(session.AgentUUID),
 		"agent_external_id":       session.AgentExternalID,
 		"agent_version":           session.AgentVersion,
 		"agent_snapshot":          jsonArg(session.AgentSnapshot),
-		"deployment_uuid":         session.DeploymentUUID,
+		"deployment_uuid":         dbNullableUUID(session.DeploymentUUID),
 		"deployment_external_id":  session.DeploymentID,
 		"title":                   session.Title,
 		"metadata":                jsonArg(session.Metadata),
@@ -610,13 +611,13 @@ func createSessionArguments(session Session) map[string]any {
 
 func createSessionThreadArguments(thread SessionThread) map[string]any {
 	return map[string]any{
-		"thread_uuid":               thread.UUID,
+		"thread_uuid":               dbUUID(thread.UUID),
 		"thread_external_id":        thread.ExternalID,
-		"organization_uuid":         thread.OrganizationUUID,
-		"workspace_uuid":            thread.WorkspaceUUID,
-		"session_uuid":              thread.SessionUUID,
+		"organization_uuid":         dbUUID(thread.OrganizationUUID),
+		"workspace_uuid":            dbUUID(thread.WorkspaceUUID),
+		"session_uuid":              dbUUID(thread.SessionUUID),
 		"session_external_id":       thread.SessionExternalID,
-		"parent_thread_uuid":        thread.ParentThreadUUID,
+		"parent_thread_uuid":        dbNullableUUID(thread.ParentThreadUUID),
 		"parent_thread_external_id": thread.ParentThreadExternalID,
 		"agent_snapshot":            jsonArg(thread.AgentSnapshot),
 		"status":                    thread.Status,
@@ -628,11 +629,11 @@ func createSessionThreadArguments(thread SessionThread) map[string]any {
 
 func createEnvironmentWorkArguments(work EnvironmentWork) map[string]any {
 	return map[string]any{
-		"work_uuid":               work.UUID,
+		"work_uuid":               dbUUID(work.UUID),
 		"work_external_id":        work.ExternalID,
-		"organization_uuid":       work.OrganizationUUID,
-		"workspace_uuid":          work.WorkspaceUUID,
-		"environment_uuid":        work.EnvironmentUUID,
+		"organization_uuid":       dbUUID(work.OrganizationUUID),
+		"workspace_uuid":          dbUUID(work.WorkspaceUUID),
+		"environment_uuid":        dbUUID(work.EnvironmentUUID),
 		"environment_external_id": work.EnvironmentExternalID,
 		"data":                    jsonArg(work.Data),
 		"metadata":                jsonArg(work.Metadata),
@@ -644,18 +645,18 @@ func createEnvironmentWorkArguments(work EnvironmentWork) map[string]any {
 
 func (r sessionRow) session() Session {
 	return Session{
-		UUID:                  r.UUID,
+		UUID:                  r.UUID.String(),
 		ExternalID:            r.ExternalID,
-		OrganizationUUID:      r.OrganizationUUID,
-		WorkspaceUUID:         r.WorkspaceUUID,
-		CreatedByAPIKeyUUID:   r.CreatedByAPIKeyUUID,
-		EnvironmentUUID:       r.EnvironmentUUID,
+		OrganizationUUID:      r.OrganizationUUID.String(),
+		WorkspaceUUID:         r.WorkspaceUUID.String(),
+		CreatedByAPIKeyUUID:   r.CreatedByAPIKeyUUID.String(),
+		EnvironmentUUID:       r.EnvironmentUUID.String(),
 		EnvironmentExternalID: r.EnvironmentExternalID,
-		AgentUUID:             r.AgentUUID,
+		AgentUUID:             r.AgentUUID.String(),
 		AgentExternalID:       r.AgentExternalID,
 		AgentVersion:          r.AgentVersion,
 		AgentSnapshot:         copyRaw(r.AgentSnapshot),
-		DeploymentUUID:        r.DeploymentUUID,
+		DeploymentUUID:        nullableUUIDString(r.DeploymentUUID),
 		DeploymentID:          r.DeploymentID,
 		Title:                 r.Title,
 		Metadata:              copyRaw(r.Metadata),
@@ -673,13 +674,13 @@ func (r sessionRow) session() Session {
 
 func (r sessionThreadRow) thread() SessionThread {
 	return SessionThread{
-		UUID:                   r.UUID,
+		UUID:                   r.UUID.String(),
 		ExternalID:             r.ExternalID,
-		OrganizationUUID:       r.OrganizationUUID,
-		WorkspaceUUID:          r.WorkspaceUUID,
-		SessionUUID:            r.SessionUUID,
+		OrganizationUUID:       r.OrganizationUUID.String(),
+		WorkspaceUUID:          r.WorkspaceUUID.String(),
+		SessionUUID:            r.SessionUUID.String(),
 		SessionExternalID:      r.SessionExternalID,
-		ParentThreadUUID:       r.ParentThreadUUID,
+		ParentThreadUUID:       nullableUUIDString(r.ParentThreadUUID),
 		ParentThreadExternalID: r.ParentThreadExternalID,
 		AgentSnapshot:          copyRaw(r.AgentSnapshot),
 		Status:                 r.Status,
@@ -694,11 +695,11 @@ func (r sessionThreadRow) thread() SessionThread {
 
 func (r sessionResourceRow) resource() SessionResource {
 	return SessionResource{
-		UUID:              r.UUID,
+		UUID:              r.UUID.String(),
 		ExternalID:        r.ExternalID,
-		OrganizationUUID:  r.OrganizationUUID,
-		WorkspaceUUID:     r.WorkspaceUUID,
-		SessionUUID:       r.SessionUUID,
+		OrganizationUUID:  r.OrganizationUUID.String(),
+		WorkspaceUUID:     r.WorkspaceUUID.String(),
+		SessionUUID:       r.SessionUUID.String(),
 		SessionExternalID: r.SessionExternalID,
 		ResourceType:      r.ResourceType,
 		Payload:           copyRaw(r.Payload),
@@ -711,11 +712,11 @@ func (r sessionResourceRow) resource() SessionResource {
 
 func (r environmentWorkRow) work() EnvironmentWork {
 	return EnvironmentWork{
-		UUID:                  r.UUID,
+		UUID:                  r.UUID.String(),
 		ExternalID:            r.ExternalID,
-		OrganizationUUID:      r.OrganizationUUID,
-		WorkspaceUUID:         r.WorkspaceUUID,
-		EnvironmentUUID:       r.EnvironmentUUID,
+		OrganizationUUID:      r.OrganizationUUID.String(),
+		WorkspaceUUID:         r.WorkspaceUUID.String(),
+		EnvironmentUUID:       r.EnvironmentUUID.String(),
 		EnvironmentExternalID: r.EnvironmentExternalID,
 		Data:                  copyRaw(r.Data),
 		Metadata:              copyRaw(r.Metadata),

--- a/internal/db/skills.go
+++ b/internal/db/skills.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const skillDisplayTitleUniqueIndex = "skills_workspace_display_title_active_key"
@@ -42,10 +44,10 @@ type SkillVersion struct {
 }
 
 type skillRow struct {
-	UUID                string     `db:"uuid"`
+	UUID                uuid.UUID  `db:"uuid"`
 	ExternalID          string     `db:"external_id"`
-	WorkspaceUUID       string     `db:"workspace_uuid"`
-	CreatedByAPIKeyUUID string     `db:"created_by_api_key_uuid"`
+	WorkspaceUUID       uuid.UUID  `db:"workspace_uuid"`
+	CreatedByAPIKeyUUID uuid.UUID  `db:"created_by_api_key_uuid"`
 	DisplayTitle        *string    `db:"display_title"`
 	LatestVersion       *string    `db:"latest_version"`
 	Source              string     `db:"source"`
@@ -55,10 +57,10 @@ type skillRow struct {
 }
 
 type skillVersionRow struct {
-	UUID                string     `db:"uuid"`
+	UUID                uuid.UUID  `db:"uuid"`
 	ExternalID          string     `db:"external_id"`
-	WorkspaceUUID       string     `db:"workspace_uuid"`
-	SkillUUID           string     `db:"skill_uuid"`
+	WorkspaceUUID       uuid.UUID  `db:"workspace_uuid"`
+	SkillUUID           uuid.UUID  `db:"skill_uuid"`
 	SkillExternalID     string     `db:"skill_external_id"`
 	Version             string     `db:"version"`
 	Name                string     `db:"name"`
@@ -68,7 +70,7 @@ type skillVersionRow struct {
 	S3Key               string     `db:"s3_key"`
 	SizeBytes           int64      `db:"size_bytes"`
 	SHA256              string     `db:"sha256"`
-	CreatedByAPIKeyUUID string     `db:"created_by_api_key_uuid"`
+	CreatedByAPIKeyUUID uuid.UUID  `db:"created_by_api_key_uuid"`
 	CreatedAt           time.Time  `db:"created_at"`
 	DeletedAt           *time.Time `db:"deleted_at"`
 }
@@ -109,11 +111,14 @@ func (d *DB) CreateSkillWithVersion(ctx context.Context, skill Skill, version Sk
 	err = namedGetContext(ctx, tx, &existingID, `
 		select external_id
 		from skills
-		where workspace_uuid = cast(:workspace_uuid as uuid)
+		where workspace_uuid = :workspace_uuid
 			and display_title = :display_title
 			and deleted_at is null
-		limit 1
-	`, map[string]any{"workspace_uuid": skill.WorkspaceUUID, "display_title": *skill.DisplayTitle})
+			limit 1
+	`, map[string]any{
+		"workspace_uuid": dbUUID(skill.WorkspaceUUID),
+		"display_title":  *skill.DisplayTitle,
+	})
 	if err == nil {
 		return Skill{}, SkillVersion{}, &SkillDisplayTitleConflictError{DisplayTitle: *skill.DisplayTitle}
 	}
@@ -132,10 +137,10 @@ func (d *DB) CreateSkillWithVersion(ctx context.Context, skill Skill, version Sk
 		)
 		returning `+skillColumns()+`
 	`, map[string]any{
-		"uuid":                    skill.UUID,
+		"uuid":                    dbUUID(skill.UUID),
 		"external_id":             skill.ExternalID,
-		"workspace_uuid":          skill.WorkspaceUUID,
-		"created_by_api_key_uuid": skill.CreatedByAPIKeyUUID,
+		"workspace_uuid":          dbUUID(skill.WorkspaceUUID),
+		"created_by_api_key_uuid": dbUUID(skill.CreatedByAPIKeyUUID),
 		"display_title":           skill.DisplayTitle,
 		"latest_version":          version.Version,
 		"created_at":              skill.CreatedAt,
@@ -167,9 +172,12 @@ func (d *DB) CreateSkillVersion(ctx context.Context, workspaceUUID string, skill
 	defer tx.Rollback()
 
 	skill, err := getSkillSQLX(ctx, tx, skillSelectSQL()+`
-		where workspace_uuid = cast(:workspace_uuid as uuid) and external_id = :external_id and deleted_at is null
+		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 		for update
-	`, map[string]any{"workspace_uuid": workspaceUUID, "external_id": skillExternalID})
+	`, map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"external_id":    skillExternalID,
+	})
 	if err != nil {
 		return Skill{}, SkillVersion{}, err
 	}
@@ -188,10 +196,10 @@ func (d *DB) CreateSkillVersion(ctx context.Context, workspaceUUID string, skill
 		update skills
 		set latest_version = :latest_version,
 			updated_at = :updated_at
-		where workspace_uuid = cast(:workspace_uuid as uuid) and external_id = :external_id and deleted_at is null
+		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 		returning `+skillColumns()+`
 	`, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    skillExternalID,
 		"latest_version": createdVersion.Version,
 		"updated_at":     createdVersion.CreatedAt,
@@ -207,8 +215,11 @@ func (d *DB) CreateSkillVersion(ctx context.Context, workspaceUUID string, skill
 
 func (d *DB) GetSkill(ctx context.Context, workspaceUUID string, externalID string) (Skill, error) {
 	return getSkillSQLX(ctx, d.sql, skillSelectSQL()+`
-		where workspace_uuid = cast(:workspace_uuid as uuid) and external_id = :external_id and deleted_at is null
-	`, map[string]any{"workspace_uuid": workspaceUUID, "external_id": externalID})
+		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
+	`, map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"external_id":    externalID,
+	})
 }
 
 func (d *DB) ListSkillsPage(ctx context.Context, params ListSkillsPageParams) ([]Skill, bool, error) {
@@ -219,11 +230,11 @@ func (d *DB) ListSkillsPage(ctx context.Context, params ListSkillsPageParams) ([
 		params.Offset = 0
 	}
 	skills, err := selectSkillsSQLX(ctx, d.sql, skillSelectSQL()+`
-		where workspace_uuid = cast(:workspace_uuid as uuid) and deleted_at is null
+		where workspace_uuid = :workspace_uuid and deleted_at is null
 		order by created_at desc, uuid desc
 		limit :limit offset :offset
 	`, map[string]any{
-		"workspace_uuid": params.WorkspaceUUID,
+		"workspace_uuid": dbUUID(params.WorkspaceUUID),
 		"limit":          params.Limit + 1,
 		"offset":         params.Offset,
 	})
@@ -239,12 +250,12 @@ func (d *DB) ListSkillsPage(ctx context.Context, params ListSkillsPageParams) ([
 
 func (d *DB) GetSkillVersion(ctx context.Context, workspaceUUID string, skillExternalID, version string) (SkillVersion, error) {
 	return getSkillVersionSQLX(ctx, d.sql, skillVersionSelectSQL()+`
-			where workspace_uuid = cast(:workspace_uuid as uuid)
+			where workspace_uuid = :workspace_uuid
 				and skill_external_id = :skill_external_id
 				and version = :version
 				and deleted_at is null
 		`, map[string]any{
-		"workspace_uuid":    workspaceUUID,
+		"workspace_uuid":    dbUUID(workspaceUUID),
 		"skill_external_id": skillExternalID,
 		"version":           version,
 	})
@@ -252,22 +263,25 @@ func (d *DB) GetSkillVersion(ctx context.Context, workspaceUUID string, skillExt
 
 func (d *DB) GetLatestSkillVersion(ctx context.Context, workspaceUUID string, skillExternalID string) (SkillVersion, error) {
 	return getSkillVersionSQLX(ctx, d.sql, `
-			select CAST(sv.uuid AS text) AS uuid, sv.external_id,
-				CAST(sv.workspace_uuid AS text) AS workspace_uuid, CAST(sv.skill_uuid AS text) AS skill_uuid,
+			select sv.uuid, sv.external_id,
+				sv.workspace_uuid, sv.skill_uuid,
 				sv.skill_external_id,
 				sv.version, sv.name, sv.description, sv.directory, sv.s3_bucket, sv.s3_key, sv.size_bytes, sv.sha256,
-				CAST(sv.created_by_api_key_uuid AS text) AS created_by_api_key_uuid, sv.created_at, sv.deleted_at
+				sv.created_by_api_key_uuid, sv.created_at, sv.deleted_at
 			from skills s
 			join skill_versions sv
 				on sv.skill_uuid = s.uuid
 				and sv.version = s.latest_version
 				and sv.deleted_at is null
-			where s.workspace_uuid = cast(:workspace_uuid as uuid)
+			where s.workspace_uuid = :workspace_uuid
 				and s.external_id = :skill_external_id
 				and s.deleted_at is null
 				and s.latest_version is not null
 				and s.latest_version <> ''
-		`, map[string]any{"workspace_uuid": workspaceUUID, "skill_external_id": skillExternalID})
+		`, map[string]any{
+		"workspace_uuid":    dbUUID(workspaceUUID),
+		"skill_external_id": skillExternalID,
+	})
 }
 
 func (d *DB) ListSkillVersionsPage(ctx context.Context, params ListSkillVersionsPageParams) ([]SkillVersion, bool, error) {
@@ -277,13 +291,13 @@ func (d *DB) ListSkillVersionsPage(ctx context.Context, params ListSkillVersions
 	if params.Offset < 0 {
 		params.Offset = 0
 	}
-	var skillUUID string
+	var skillUUID uuid.UUID
 	if err := namedGetContext(ctx, d.sql, &skillUUID, `
-		select cast(uuid as text)
+		select uuid
 		from skills
-		where workspace_uuid = cast(:workspace_uuid as uuid) and external_id = :external_id and deleted_at is null
+		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 	`, map[string]any{
-		"workspace_uuid": params.WorkspaceUUID,
+		"workspace_uuid": dbUUID(params.WorkspaceUUID),
 		"external_id":    params.SkillExternalID,
 	}); errors.Is(err, sql.ErrNoRows) {
 		return nil, false, ErrNotFound
@@ -292,7 +306,7 @@ func (d *DB) ListSkillVersionsPage(ctx context.Context, params ListSkillVersions
 	}
 
 	versions, err := selectSkillVersionsSQLX(ctx, d.sql, skillVersionSelectSQL()+`
-		where skill_uuid = cast(:skill_uuid as uuid) and deleted_at is null
+		where skill_uuid = :skill_uuid and deleted_at is null
 		order by created_at desc, uuid desc
 		limit :limit offset :offset
 	`, map[string]any{"skill_uuid": skillUUID, "limit": params.Limit + 1, "offset": params.Offset})
@@ -314,17 +328,20 @@ func (d *DB) SoftDeleteSkill(ctx context.Context, workspaceUUID string, external
 	defer tx.Rollback()
 
 	skill, err := getSkillSQLX(ctx, tx, skillSelectSQL()+`
-		where workspace_uuid = cast(:workspace_uuid as uuid) and external_id = :external_id and deleted_at is null
+		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 		for update
-	`, map[string]any{"workspace_uuid": workspaceUUID, "external_id": externalID})
+	`, map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"external_id":    externalID,
+	})
 	if err != nil {
 		return Skill{}, nil, err
 	}
 
 	versions, err := selectSkillVersionsSQLX(ctx, tx, skillVersionSelectSQL()+`
-		where skill_uuid = cast(:skill_uuid as uuid) and deleted_at is null
+		where skill_uuid = :skill_uuid and deleted_at is null
 		order by created_at desc, uuid desc
-	`, map[string]any{"skill_uuid": skill.UUID})
+	`, map[string]any{"skill_uuid": dbUUID(skill.UUID)})
 	if err != nil {
 		return Skill{}, nil, err
 	}
@@ -332,17 +349,17 @@ func (d *DB) SoftDeleteSkill(ctx context.Context, workspaceUUID string, external
 	if _, err := namedExecContext(ctx, tx, `
 		update skill_versions
 		set deleted_at = now()
-		where skill_uuid = cast(:skill_uuid as uuid) and deleted_at is null
-	`, map[string]any{"skill_uuid": skill.UUID}); err != nil {
+		where skill_uuid = :skill_uuid and deleted_at is null
+	`, map[string]any{"skill_uuid": dbUUID(skill.UUID)}); err != nil {
 		return Skill{}, nil, err
 	}
 	deletedSkill, err := getSkillSQLX(ctx, tx, `
 		update skills
 		set deleted_at = now(),
 			updated_at = now()
-		where uuid = cast(:skill_uuid as uuid) and deleted_at is null
+		where uuid = :skill_uuid and deleted_at is null
 		returning `+skillColumns()+`
-	`, map[string]any{"skill_uuid": skill.UUID})
+	`, map[string]any{"skill_uuid": dbUUID(skill.UUID)})
 	if err != nil {
 		return Skill{}, nil, err
 	}
@@ -360,9 +377,12 @@ func (d *DB) SoftDeleteSkillVersion(ctx context.Context, workspaceUUID string, s
 	defer tx.Rollback()
 
 	skill, err := getSkillSQLX(ctx, tx, skillSelectSQL()+`
-		where workspace_uuid = cast(:workspace_uuid as uuid) and external_id = :external_id and deleted_at is null
+		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 		for update
-	`, map[string]any{"workspace_uuid": workspaceUUID, "external_id": skillExternalID})
+	`, map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"external_id":    skillExternalID,
+	})
 	if err != nil {
 		return SkillVersion{}, nil, err
 	}
@@ -370,9 +390,9 @@ func (d *DB) SoftDeleteSkillVersion(ctx context.Context, workspaceUUID string, s
 	deletedVersion, err := getSkillVersionSQLX(ctx, tx, `
 		update skill_versions
 		set deleted_at = now()
-		where skill_uuid = cast(:skill_uuid as uuid) and version = :version and deleted_at is null
+		where skill_uuid = :skill_uuid and version = :version and deleted_at is null
 		returning `+skillVersionColumns()+`
-	`, map[string]any{"skill_uuid": skill.UUID, "version": version})
+	`, map[string]any{"skill_uuid": dbUUID(skill.UUID), "version": version})
 	if err != nil {
 		return SkillVersion{}, nil, err
 	}
@@ -382,10 +402,10 @@ func (d *DB) SoftDeleteSkillVersion(ctx context.Context, workspaceUUID string, s
 	err = namedGetContext(ctx, tx, &latest, `
 		select version
 		from skill_versions
-		where skill_uuid = cast(:skill_uuid as uuid) and deleted_at is null
+		where skill_uuid = :skill_uuid and deleted_at is null
 		order by created_at desc, uuid desc
 		limit 1
-	`, map[string]any{"skill_uuid": skill.UUID})
+	`, map[string]any{"skill_uuid": dbUUID(skill.UUID)})
 	if errors.Is(err, sql.ErrNoRows) {
 		latestVersion = nil
 	} else if err != nil {
@@ -398,8 +418,11 @@ func (d *DB) SoftDeleteSkillVersion(ctx context.Context, workspaceUUID string, s
 		update skills
 		set latest_version = :latest_version,
 			updated_at = now()
-		where uuid = cast(:skill_uuid as uuid)
-	`, map[string]any{"skill_uuid": skill.UUID, "latest_version": latestVersion}); err != nil {
+		where uuid = :skill_uuid
+	`, map[string]any{
+		"skill_uuid":     dbUUID(skill.UUID),
+		"latest_version": latestVersion,
+	}); err != nil {
 		return SkillVersion{}, nil, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -419,17 +442,17 @@ const insertSkillVersionQuery = `
 			:name, :description, :directory, :s3_bucket, :s3_key, :size_bytes, :sha256,
 			:created_by_api_key_uuid, :created_at
 		)
-		returning ` + `CAST(uuid AS text) AS uuid, external_id,
-			CAST(workspace_uuid AS text) AS workspace_uuid, CAST(skill_uuid AS text) AS skill_uuid, skill_external_id,
+		returning ` + `uuid, external_id,
+			workspace_uuid, skill_uuid, skill_external_id,
 			version, name, description, directory, s3_bucket, s3_key, size_bytes, sha256,
-			CAST(created_by_api_key_uuid AS text) AS created_by_api_key_uuid, created_at, deleted_at`
+			created_by_api_key_uuid, created_at, deleted_at`
 
 func insertSkillVersion(ctx context.Context, database sqlxNamedQueryer, version SkillVersion) (SkillVersion, error) {
 	return getSkillVersionSQLX(ctx, database, insertSkillVersionQuery, map[string]any{
-		"uuid":                    version.UUID,
+		"uuid":                    dbUUID(version.UUID),
 		"external_id":             version.ExternalID,
-		"workspace_uuid":          version.WorkspaceUUID,
-		"skill_uuid":              version.SkillUUID,
+		"workspace_uuid":          dbUUID(version.WorkspaceUUID),
+		"skill_uuid":              dbUUID(version.SkillUUID),
 		"skill_external_id":       version.SkillExternalID,
 		"version":                 version.Version,
 		"name":                    version.Name,
@@ -439,7 +462,7 @@ func insertSkillVersion(ctx context.Context, database sqlxNamedQueryer, version 
 		"s3_key":                  version.S3Key,
 		"size_bytes":              version.SizeBytes,
 		"sha256":                  version.SHA256,
-		"created_by_api_key_uuid": version.CreatedByAPIKeyUUID,
+		"created_by_api_key_uuid": dbUUID(version.CreatedByAPIKeyUUID),
 		"created_at":              version.CreatedAt,
 	})
 }
@@ -453,16 +476,16 @@ func skillVersionSelectSQL() string {
 }
 
 func skillColumns() string {
-	return `CAST(uuid AS text) AS uuid, external_id, CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(created_by_api_key_uuid AS text) AS created_by_api_key_uuid,
+	return `uuid, external_id, workspace_uuid,
+		created_by_api_key_uuid,
 		display_title, latest_version, source, created_at, updated_at, deleted_at`
 }
 
 func skillVersionColumns() string {
-	return `CAST(uuid AS text) AS uuid, external_id, CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(skill_uuid AS text) AS skill_uuid, skill_external_id,
+	return `uuid, external_id, workspace_uuid,
+		skill_uuid, skill_external_id,
 		version, name, description, directory, s3_bucket, s3_key, size_bytes, sha256,
-		CAST(created_by_api_key_uuid AS text) AS created_by_api_key_uuid, created_at, deleted_at`
+		created_by_api_key_uuid, created_at, deleted_at`
 }
 
 func getSkillSQLX(ctx context.Context, database sqlxNamedQueryer, query string, arguments map[string]any) (Skill, error) {
@@ -511,10 +534,10 @@ func selectSkillVersionsSQLX(ctx context.Context, database sqlxNamedQueryer, que
 
 func (r skillRow) skill() Skill {
 	return Skill{
-		UUID:                r.UUID,
+		UUID:                r.UUID.String(),
 		ExternalID:          r.ExternalID,
-		WorkspaceUUID:       r.WorkspaceUUID,
-		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID,
+		WorkspaceUUID:       r.WorkspaceUUID.String(),
+		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID.String(),
 		DisplayTitle:        r.DisplayTitle,
 		LatestVersion:       r.LatestVersion,
 		Source:              r.Source,
@@ -526,10 +549,10 @@ func (r skillRow) skill() Skill {
 
 func (r skillVersionRow) version() SkillVersion {
 	return SkillVersion{
-		UUID:                r.UUID,
+		UUID:                r.UUID.String(),
 		ExternalID:          r.ExternalID,
-		WorkspaceUUID:       r.WorkspaceUUID,
-		SkillUUID:           r.SkillUUID,
+		WorkspaceUUID:       r.WorkspaceUUID.String(),
+		SkillUUID:           r.SkillUUID.String(),
 		SkillExternalID:     r.SkillExternalID,
 		Version:             r.Version,
 		Name:                r.Name,
@@ -539,7 +562,7 @@ func (r skillVersionRow) version() SkillVersion {
 		S3Key:               r.S3Key,
 		SizeBytes:           r.SizeBytes,
 		SHA256:              r.SHA256,
-		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID,
+		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID.String(),
 		CreatedAt:           r.CreatedAt,
 		DeletedAt:           r.DeletedAt,
 	}

--- a/internal/db/sqlx.go
+++ b/internal/db/sqlx.go
@@ -18,7 +18,11 @@ type sqlxNamedExecer interface {
 }
 
 func bindNamed(database interface{ Rebind(string) string }, query string, arguments map[string]any) (string, []any, error) {
-	boundQuery, values, err := sqlx.Named(query, arguments)
+	typedArguments, err := typedDBUUIDArguments(arguments)
+	if err != nil {
+		return "", nil, err
+	}
+	boundQuery, values, err := sqlx.Named(query, typedArguments)
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/db/uuid.go
+++ b/internal/db/uuid.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+type rawDBUUIDArgument struct {
+	value    *string
+	required bool
+}
+
+func dbUUID(value string) rawDBUUIDArgument {
+	return rawDBUUIDArgument{value: &value, required: true}
+}
+
+func dbNullableUUID(value *string) rawDBUUIDArgument {
+	return rawDBUUIDArgument{value: value}
+}
+
+func (argument rawDBUUIDArgument) typedValue(name string) (any, error) {
+	if argument.value == nil || strings.TrimSpace(*argument.value) == "" {
+		if argument.required {
+			return nil, fmt.Errorf("%s must be a non-nil UUID", name)
+		}
+		return uuid.NullUUID{}, nil
+	}
+	parsed, err := parseDBUUID(name, *argument.value)
+	if err != nil {
+		return nil, err
+	}
+	if argument.required {
+		return parsed, nil
+	}
+	return uuid.NullUUID{UUID: parsed, Valid: true}, nil
+}
+
+func tryParseDBUUIDIdentifier(value string) uuid.NullUUID {
+	parsed, err := uuid.Parse(strings.TrimSpace(value))
+	if err != nil || parsed == uuid.Nil {
+		return uuid.NullUUID{}
+	}
+	return uuid.NullUUID{UUID: parsed, Valid: true}
+}
+
+func parseDBUUID(name, value string) (uuid.UUID, error) {
+	parsed, err := uuid.Parse(strings.TrimSpace(value))
+	if err != nil || parsed == uuid.Nil {
+		return uuid.Nil, fmt.Errorf("%s must be a non-nil UUID", name)
+	}
+	return parsed, nil
+}
+
+func parseDBNullableUUID(name string, value *string) (uuid.NullUUID, error) {
+	if value == nil || strings.TrimSpace(*value) == "" {
+		return uuid.NullUUID{}, nil
+	}
+	parsed, err := parseDBUUID(name, *value)
+	if err != nil {
+		return uuid.NullUUID{}, err
+	}
+	return uuid.NullUUID{UUID: parsed, Valid: true}, nil
+}
+
+func typedDBUUIDArguments(arguments map[string]any) (map[string]any, error) {
+	var typed map[string]any
+	for name, value := range arguments {
+		argument, ok := value.(rawDBUUIDArgument)
+		if !ok {
+			continue
+		}
+		typedValue, err := argument.typedValue(name)
+		if err != nil {
+			return nil, err
+		}
+		if typed == nil {
+			typed = make(map[string]any, len(arguments))
+			for existingName, existingValue := range arguments {
+				typed[existingName] = existingValue
+			}
+		}
+		typed[name] = typedValue
+	}
+	if typed == nil {
+		return arguments, nil
+	}
+	return typed, nil
+}
+
+func nullableUUIDString(value uuid.NullUUID) *string {
+	if !value.Valid {
+		return nil
+	}
+	text := value.UUID.String()
+	return &text
+}
+
+func nullableUUIDValue(value uuid.NullUUID) string {
+	if !value.Valid {
+		return ""
+	}
+	return value.UUID.String()
+}

--- a/internal/db/uuid_cast_guard_test.go
+++ b/internal/db/uuid_cast_guard_test.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+var forbiddenUUIDBoundaryPatterns = []struct {
+	name    string
+	pattern *regexp.Regexp
+}{
+	{
+		name:    "UUID input parameter cast",
+		pattern: regexp.MustCompile(`(?i)cast\(\s*:[a-z0-9_]*(?:uuid|_uuid)\s+as\s+uuid\s*\)`),
+	},
+	{
+		name:    "UUID output column cast",
+		pattern: regexp.MustCompile(`(?i)cast\(\s*[a-z0-9_.]*(?:uuid|_uuid)\s+as\s+text\s*\)\s+as\s+[a-z0-9_]*(?:uuid|_uuid)`),
+	},
+	{
+		name:    "UUID identifier column cast",
+		pattern: regexp.MustCompile(`(?i)cast\(\s*[a-z0-9_.]*(?:uuid|_uuid)\s+as\s+text\s*\)\s*=\s*:[a-z0-9_]+`),
+	},
+}
+
+func TestForbiddenUUIDBoundaryPatternsMatchMultilineSQL(t *testing.T) {
+	samples := []string{
+		"CAST(\n :workspace_uuid\n AS uuid\n)",
+		"CAST(\n workspaces.uuid\n AS text\n) AS workspace_uuid",
+		"CAST(\n workspaces.uuid\n AS text\n) = :identifier",
+	}
+	if len(samples) != len(forbiddenUUIDBoundaryPatterns) {
+		t.Fatalf("sample count = %d, pattern count = %d", len(samples), len(forbiddenUUIDBoundaryPatterns))
+	}
+	for index, forbidden := range forbiddenUUIDBoundaryPatterns {
+		if !forbidden.pattern.MatchString(samples[index]) {
+			t.Errorf("%s did not match multiline SQL %q", forbidden.name, samples[index])
+		}
+	}
+}
+
+func TestProductionSQLKeepsTypedUUIDBoundary(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate UUID cast guard source")
+	}
+	directory := filepath.Dir(currentFile)
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatalf("read db package: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") ||
+			strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(directory, entry.Name())
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", entry.Name(), err)
+		}
+		for _, forbidden := range forbiddenUUIDBoundaryPatterns {
+			for _, location := range forbidden.pattern.FindAllIndex(contents, -1) {
+				lineNumber := bytes.Count(contents[:location[0]], []byte{'\n'}) + 1
+				matchedSQL := strings.Join(strings.Fields(string(contents[location[0]:location[1]])), " ")
+				t.Errorf(
+					"%s:%d contains forbidden %s: %s",
+					entry.Name(),
+					lineNumber,
+					forbidden.name,
+					matchedSQL,
+				)
+			}
+		}
+	}
+}

--- a/internal/db/uuid_test.go
+++ b/internal/db/uuid_test.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestParseDBUUIDRejectsInvalidValues(t *testing.T) {
+	for _, value := range []string{"", "not-a-uuid", uuid.Nil.String()} {
+		if _, err := parseDBUUID("workspace_uuid", value); err == nil {
+			t.Fatalf("parseDBUUID(%q) error = nil, want validation error", value)
+		}
+	}
+}
+
+func TestTypedDBUUIDArgumentsRejectsInvalidValues(t *testing.T) {
+	_, err := typedDBUUIDArguments(map[string]any{
+		"workspace_uuid": dbUUID("not-a-uuid"),
+	})
+	if err == nil {
+		t.Fatal("typedDBUUIDArguments(invalid UUID) error = nil")
+	}
+}
+
+func TestTypedDBUUIDArgumentsUsesStandardUUIDTypes(t *testing.T) {
+	required := "11111111-1111-4111-8111-111111111111"
+	nullable := "22222222-2222-4222-8222-222222222222"
+	value, err := typedDBUUIDArguments(map[string]any{
+		"workspace_uuid": dbUUID(required),
+		"user_uuid":      dbNullableUUID(&nullable),
+		"api_key_uuid":   dbNullableUUID(nil),
+		"name":           "unchanged",
+	})
+	if err != nil {
+		t.Fatalf("typedDBUUIDArguments() error = %v", err)
+	}
+	if got, ok := value["workspace_uuid"].(uuid.UUID); !ok || got.String() != required {
+		t.Fatalf("workspace_uuid = %#v, want uuid.UUID(%s)", value["workspace_uuid"], required)
+	}
+	if got, ok := value["user_uuid"].(uuid.NullUUID); !ok || !got.Valid || got.UUID.String() != nullable {
+		t.Fatalf("user_uuid = %#v, want valid uuid.NullUUID(%s)", value["user_uuid"], nullable)
+	}
+	if got, ok := value["api_key_uuid"].(uuid.NullUUID); !ok || got.Valid {
+		t.Fatalf("api_key_uuid = %#v, want invalid uuid.NullUUID", value["api_key_uuid"])
+	}
+	if got := value["name"]; got != "unchanged" {
+		t.Fatalf("name = %#v, want unchanged", got)
+	}
+}
+
+func TestTryParseDBUUIDIdentifierPreservesCompatibilityLookup(t *testing.T) {
+	valid := tryParseDBUUIDIdentifier("11111111-1111-4111-8111-111111111111")
+	if !valid.Valid {
+		t.Fatal("tryParseDBUUIDIdentifier(valid UUID) returned null")
+	}
+	for _, value := range []string{"", "external_id", uuid.Nil.String()} {
+		if got := tryParseDBUUIDIdentifier(value); got.Valid {
+			t.Fatalf("tryParseDBUUIDIdentifier(%q) = %+v, want null", value, got)
+		}
+	}
+}

--- a/internal/db/vaults.go
+++ b/internal/db/vaults.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type Vault struct {
@@ -90,14 +92,18 @@ func (d *DB) GetVault(ctx context.Context, workspaceUUID, externalID string) (Va
 func (d *DB) GetVaultByExternalIDOrUUID(ctx context.Context, workspaceUUID, identifier string) (Vault, error) {
 	return getVaultSQLX(ctx, d.sql, vaultSelectSQL()+`
 		where workspace_uuid = :workspace_uuid
-			and (external_id = :identifier or CAST(uuid AS text) = :identifier)
+			and (external_id = :identifier or uuid = :vault_uuid)
 			and deleted_at is null
-	`, map[string]any{"workspace_uuid": workspaceUUID, "identifier": identifier})
+	`, map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"identifier":     identifier,
+		"vault_uuid":     tryParseDBUUIDIdentifier(identifier),
+	})
 }
 
 func (d *DB) UpdateVault(ctx context.Context, workspaceUUID, externalID string, next Vault) (Vault, error) {
 	arguments := vaultArguments(next)
-	arguments["workspace_uuid"] = workspaceUUID
+	arguments["workspace_uuid"] = dbUUID(workspaceUUID)
 	arguments["external_id"] = externalID
 	return getVaultSQLX(ctx, d.sql, `
 		update vaults
@@ -132,7 +138,10 @@ func (d *DB) ArchiveVault(ctx context.Context, workspaceUUID, externalID string)
 			secret_payload = null,
 			updated_at = now()
 		where workspace_uuid = :workspace_uuid and vault_uuid = :vault_uuid and deleted_at is null
-	`, map[string]any{"workspace_uuid": workspaceUUID, "vault_uuid": vault.UUID}); err != nil {
+	`, map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"vault_uuid":     dbUUID(vault.UUID),
+	}); err != nil {
 		return Vault{}, err
 	}
 	if err := tx.Commit(); err != nil {
@@ -148,9 +157,9 @@ func (d *DB) DeleteVault(ctx context.Context, workspaceUUID, externalID string) 
 	}
 	defer tx.Rollback()
 
-	var vaultUUID string
+	var vaultUUID uuid.UUID
 	err = namedGetContext(ctx, tx, &vaultUUID, `
-		select CAST(uuid AS text)
+		select uuid
 		from vaults
 		where workspace_uuid = :workspace_uuid and external_id = :external_id and deleted_at is null
 		for update
@@ -161,7 +170,10 @@ func (d *DB) DeleteVault(ctx context.Context, workspaceUUID, externalID string) 
 	if err != nil {
 		return err
 	}
-	arguments := map[string]any{"workspace_uuid": workspaceUUID, "vault_uuid": vaultUUID}
+	arguments := map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"vault_uuid":     vaultUUID,
+	}
 	if _, err := namedExecContext(ctx, tx, `
 		delete from vault_credentials
 		where workspace_uuid = :workspace_uuid and vault_uuid = :vault_uuid
@@ -170,7 +182,7 @@ func (d *DB) DeleteVault(ctx context.Context, workspaceUUID, externalID string) 
 	}
 	if _, err := namedExecContext(ctx, tx, `
 		delete from vaults
-		where workspace_uuid = :workspace_uuid and uuid = CAST(:vault_uuid AS uuid)
+		where workspace_uuid = :workspace_uuid and uuid = :vault_uuid
 	`, arguments); err != nil {
 		return err
 	}
@@ -200,9 +212,9 @@ func (d *DB) CreateVaultCredential(ctx context.Context, credential VaultCredenti
 	}
 	defer tx.Rollback()
 
-	var vaultUUID string
+	var vaultUUID uuid.UUID
 	err = namedGetContext(ctx, tx, &vaultUUID, `
-		select CAST(uuid AS text)
+		select uuid
 		from vaults
 		where workspace_uuid = :workspace_uuid
 			and external_id = :vault_external_id
@@ -210,7 +222,7 @@ func (d *DB) CreateVaultCredential(ctx context.Context, credential VaultCredenti
 			and archived_at is null
 		for update
 	`, map[string]any{
-		"workspace_uuid":    credential.WorkspaceUUID,
+		"workspace_uuid":    dbUUID(credential.WorkspaceUUID),
 		"vault_external_id": credential.VaultExternalID,
 	})
 	if errors.Is(err, sql.ErrNoRows) {
@@ -228,14 +240,17 @@ func (d *DB) CreateVaultCredential(ctx context.Context, credential VaultCredenti
 			and vault_uuid = :vault_uuid
 			and deleted_at is null
 			and archived_at is null
-	`, map[string]any{"workspace_uuid": credential.WorkspaceUUID, "vault_uuid": vaultUUID}); err != nil {
+	`, map[string]any{
+		"workspace_uuid": dbUUID(credential.WorkspaceUUID),
+		"vault_uuid":     vaultUUID,
+	}); err != nil {
 		return VaultCredential{}, err
 	}
 	if activeCount >= 20 {
 		return VaultCredential{}, ErrLimitExceeded
 	}
 
-	credential.VaultUUID = vaultUUID
+	credential.VaultUUID = vaultUUID.String()
 	created, err := getVaultCredentialSQLX(ctx, tx, `
 		insert into vault_credentials (
 			uuid, external_id, organization_uuid, workspace_uuid, vault_uuid, vault_external_id,
@@ -244,7 +259,7 @@ func (d *DB) CreateVaultCredential(ctx context.Context, credential VaultCredenti
 		)
 		values (
 			:uuid, :external_id, :organization_uuid, :workspace_uuid, :vault_uuid,
-			:vault_external_id, CAST(nullif(:created_by_api_key_uuid, '') AS uuid), :display_name,
+			:vault_external_id, :created_by_api_key_uuid, :display_name,
 			CAST(:metadata AS jsonb), :auth_type, :credential_key,
 			CAST(:auth AS jsonb), CAST(:secret_payload AS jsonb),
 			:created_at, :created_at
@@ -274,7 +289,7 @@ func (d *DB) GetVaultCredential(ctx context.Context, workspaceUUID, vaultExterna
 
 func (d *DB) UpdateVaultCredential(ctx context.Context, workspaceUUID, vaultExternalID, credentialExternalID string, next VaultCredential) (VaultCredential, error) {
 	arguments := vaultCredentialArguments(next)
-	arguments["workspace_uuid"] = workspaceUUID
+	arguments["workspace_uuid"] = dbUUID(workspaceUUID)
 	arguments["vault_external_id"] = vaultExternalID
 	arguments["credential_external_id"] = credentialExternalID
 	return getVaultCredentialSQLX(ctx, d.sql, `
@@ -341,23 +356,23 @@ func (d *DB) ListVaultCredentialsPage(ctx context.Context, params ListVaultCrede
 }
 
 const (
-	vaultSQLXColumns = `CAST(uuid AS text) AS uuid, external_id, CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid, CAST(created_by_api_key_uuid AS text) AS created_by_api_key_uuid, display_name, metadata, created_at,
+	vaultSQLXColumns = `uuid, external_id, organization_uuid,
+		workspace_uuid, created_by_api_key_uuid, display_name, metadata, created_at,
 		updated_at, archived_at, deleted_at`
-	vaultCredentialSQLXColumns = `CAST(uuid AS text) AS uuid, external_id,
-		CAST(organization_uuid AS text) AS organization_uuid, CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(vault_uuid AS text) AS vault_uuid, vault_external_id,
-		coalesce(CAST(created_by_api_key_uuid AS text), '') AS created_by_api_key_uuid,
+	vaultCredentialSQLXColumns = `uuid, external_id,
+		organization_uuid, workspace_uuid,
+		vault_uuid, vault_external_id,
+		created_by_api_key_uuid,
 		display_name, metadata, auth_type, credential_key, auth, secret_payload,
 		created_at, updated_at, archived_at, deleted_at`
 )
 
 type vaultRow struct {
-	UUID                string     `db:"uuid"`
+	UUID                uuid.UUID  `db:"uuid"`
 	ExternalID          string     `db:"external_id"`
-	OrganizationUUID    string     `db:"organization_uuid"`
-	WorkspaceUUID       string     `db:"workspace_uuid"`
-	CreatedByAPIKeyUUID string     `db:"created_by_api_key_uuid"`
+	OrganizationUUID    uuid.UUID  `db:"organization_uuid"`
+	WorkspaceUUID       uuid.UUID  `db:"workspace_uuid"`
+	CreatedByAPIKeyUUID uuid.UUID  `db:"created_by_api_key_uuid"`
 	DisplayName         string     `db:"display_name"`
 	Metadata            []byte     `db:"metadata"`
 	CreatedAt           time.Time  `db:"created_at"`
@@ -367,23 +382,23 @@ type vaultRow struct {
 }
 
 type vaultCredentialRow struct {
-	UUID                string     `db:"uuid"`
-	ExternalID          string     `db:"external_id"`
-	OrganizationUUID    string     `db:"organization_uuid"`
-	WorkspaceUUID       string     `db:"workspace_uuid"`
-	VaultUUID           string     `db:"vault_uuid"`
-	VaultExternalID     string     `db:"vault_external_id"`
-	CreatedByAPIKeyUUID string     `db:"created_by_api_key_uuid"`
-	DisplayName         string     `db:"display_name"`
-	Metadata            []byte     `db:"metadata"`
-	AuthType            string     `db:"auth_type"`
-	CredentialKey       string     `db:"credential_key"`
-	Auth                []byte     `db:"auth"`
-	SecretPayload       []byte     `db:"secret_payload"`
-	CreatedAt           time.Time  `db:"created_at"`
-	UpdatedAt           time.Time  `db:"updated_at"`
-	ArchivedAt          *time.Time `db:"archived_at"`
-	DeletedAt           *time.Time `db:"deleted_at"`
+	UUID                uuid.UUID     `db:"uuid"`
+	ExternalID          string        `db:"external_id"`
+	OrganizationUUID    uuid.UUID     `db:"organization_uuid"`
+	WorkspaceUUID       uuid.UUID     `db:"workspace_uuid"`
+	VaultUUID           uuid.UUID     `db:"vault_uuid"`
+	VaultExternalID     string        `db:"vault_external_id"`
+	CreatedByAPIKeyUUID uuid.NullUUID `db:"created_by_api_key_uuid"`
+	DisplayName         string        `db:"display_name"`
+	Metadata            []byte        `db:"metadata"`
+	AuthType            string        `db:"auth_type"`
+	CredentialKey       string        `db:"credential_key"`
+	Auth                []byte        `db:"auth"`
+	SecretPayload       []byte        `db:"secret_payload"`
+	CreatedAt           time.Time     `db:"created_at"`
+	UpdatedAt           time.Time     `db:"updated_at"`
+	ArchivedAt          *time.Time    `db:"archived_at"`
+	DeletedAt           *time.Time    `db:"deleted_at"`
 }
 
 func vaultSelectSQL() string {
@@ -396,14 +411,17 @@ func vaultCredentialSelectSQL() string {
 
 func listVaultsQuery(params ListVaultsPageParams) (string, map[string]any) {
 	query := vaultSelectSQL() + ` where workspace_uuid = :workspace_uuid and deleted_at is null`
-	arguments := map[string]any{"workspace_uuid": params.WorkspaceUUID, "limit": params.Limit + 1}
+	arguments := map[string]any{
+		"workspace_uuid": dbUUID(params.WorkspaceUUID),
+		"limit":          params.Limit + 1,
+	}
 	if !params.IncludeArchived {
 		query += " and archived_at is null"
 	}
 	if params.Cursor != nil {
-		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < CAST(:cursor_uuid AS uuid)))"
+		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < :cursor_uuid))"
 		arguments["cursor_created_at"] = params.Cursor.CreatedAt
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	query += " order by created_at desc, uuid desc limit :limit"
 	return query, arguments
@@ -416,7 +434,7 @@ func listVaultCredentialsQuery(params ListVaultCredentialsPageParams) (string, m
 			and deleted_at is null
 	`
 	arguments := map[string]any{
-		"workspace_uuid":    params.WorkspaceUUID,
+		"workspace_uuid":    dbUUID(params.WorkspaceUUID),
 		"vault_external_id": params.VaultExternalID,
 		"limit":             params.Limit + 1,
 	}
@@ -424,9 +442,9 @@ func listVaultCredentialsQuery(params ListVaultCredentialsPageParams) (string, m
 		query += " and archived_at is null"
 	}
 	if params.Cursor != nil {
-		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < CAST(:cursor_uuid AS uuid)))"
+		query += " and (created_at < :cursor_created_at or (created_at = :cursor_created_at and uuid < :cursor_uuid))"
 		arguments["cursor_created_at"] = params.Cursor.CreatedAt
-		arguments["cursor_uuid"] = params.Cursor.UUID
+		arguments["cursor_uuid"] = dbUUID(params.Cursor.UUID)
 	}
 	query += " order by created_at desc, uuid desc limit :limit"
 	return query, arguments
@@ -499,7 +517,10 @@ func selectVaultCredentialsSQLX(
 }
 
 func vaultLookupArguments(workspaceUUID, externalID string) map[string]any {
-	return map[string]any{"workspace_uuid": workspaceUUID, "external_id": externalID}
+	return map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"external_id":    externalID,
+	}
 }
 
 func vaultCredentialLookupArguments(
@@ -508,7 +529,7 @@ func vaultCredentialLookupArguments(
 	credentialExternalID string,
 ) map[string]any {
 	return map[string]any{
-		"workspace_uuid":         workspaceUUID,
+		"workspace_uuid":         dbUUID(workspaceUUID),
 		"vault_external_id":      vaultExternalID,
 		"credential_external_id": credentialExternalID,
 	}
@@ -516,11 +537,11 @@ func vaultCredentialLookupArguments(
 
 func vaultArguments(vault Vault) map[string]any {
 	return map[string]any{
-		"uuid":                    vault.UUID,
+		"uuid":                    dbUUID(vault.UUID),
 		"external_id":             vault.ExternalID,
-		"organization_uuid":       vault.OrganizationUUID,
-		"workspace_uuid":          vault.WorkspaceUUID,
-		"created_by_api_key_uuid": vault.CreatedByAPIKeyUUID,
+		"organization_uuid":       dbUUID(vault.OrganizationUUID),
+		"workspace_uuid":          dbUUID(vault.WorkspaceUUID),
+		"created_by_api_key_uuid": dbUUID(vault.CreatedByAPIKeyUUID),
 		"display_name":            vault.DisplayName,
 		"metadata":                jsonArg(vault.Metadata),
 		"created_at":              vault.CreatedAt,
@@ -530,13 +551,13 @@ func vaultArguments(vault Vault) map[string]any {
 
 func vaultCredentialArguments(credential VaultCredential) map[string]any {
 	return map[string]any{
-		"uuid":                    credential.UUID,
+		"uuid":                    dbUUID(credential.UUID),
 		"external_id":             credential.ExternalID,
-		"organization_uuid":       credential.OrganizationUUID,
-		"workspace_uuid":          credential.WorkspaceUUID,
-		"vault_uuid":              credential.VaultUUID,
+		"organization_uuid":       dbUUID(credential.OrganizationUUID),
+		"workspace_uuid":          dbUUID(credential.WorkspaceUUID),
+		"vault_uuid":              dbUUID(credential.VaultUUID),
 		"vault_external_id":       credential.VaultExternalID,
-		"created_by_api_key_uuid": credential.CreatedByAPIKeyUUID,
+		"created_by_api_key_uuid": dbNullableUUID(&credential.CreatedByAPIKeyUUID),
 		"display_name":            credential.DisplayName,
 		"metadata":                jsonArg(credential.Metadata),
 		"auth_type":               credential.AuthType,
@@ -550,11 +571,11 @@ func vaultCredentialArguments(credential VaultCredential) map[string]any {
 
 func (r vaultRow) vault() Vault {
 	return Vault{
-		UUID:                r.UUID,
+		UUID:                r.UUID.String(),
 		ExternalID:          r.ExternalID,
-		OrganizationUUID:    r.OrganizationUUID,
-		WorkspaceUUID:       r.WorkspaceUUID,
-		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID,
+		OrganizationUUID:    r.OrganizationUUID.String(),
+		WorkspaceUUID:       r.WorkspaceUUID.String(),
+		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID.String(),
 		DisplayName:         r.DisplayName,
 		Metadata:            copyRaw(r.Metadata),
 		CreatedAt:           r.CreatedAt,
@@ -566,13 +587,13 @@ func (r vaultRow) vault() Vault {
 
 func (r vaultCredentialRow) credential() VaultCredential {
 	return VaultCredential{
-		UUID:                r.UUID,
+		UUID:                r.UUID.String(),
 		ExternalID:          r.ExternalID,
-		OrganizationUUID:    r.OrganizationUUID,
-		WorkspaceUUID:       r.WorkspaceUUID,
-		VaultUUID:           r.VaultUUID,
+		OrganizationUUID:    r.OrganizationUUID.String(),
+		WorkspaceUUID:       r.WorkspaceUUID.String(),
+		VaultUUID:           r.VaultUUID.String(),
 		VaultExternalID:     r.VaultExternalID,
-		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID,
+		CreatedByAPIKeyUUID: nullableUUIDValue(r.CreatedByAPIKeyUUID),
 		DisplayName:         r.DisplayName,
 		Metadata:            copyRaw(r.Metadata),
 		AuthType:            r.AuthType,

--- a/internal/db/webhook_endpoints.go
+++ b/internal/db/webhook_endpoints.go
@@ -5,15 +5,17 @@ import (
 	"database/sql"
 	"encoding/json"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
 	webhookEndpointColumns = `
-		CAST(uuid AS text) AS uuid,
+		uuid,
 		external_id,
-		CAST(organization_uuid AS text) AS organization_uuid,
-		CAST(workspace_uuid AS text) AS workspace_uuid,
-		CAST(created_by_api_key_uuid AS text) AS created_by_api_key_uuid,
+		organization_uuid,
+		workspace_uuid,
+		created_by_api_key_uuid,
 		url,
 		name,
 		description,
@@ -28,10 +30,10 @@ const (
 	`
 	getWorkspaceIdentifiersQuery = `
 		select
-			CAST(w.organization_uuid AS text) AS organization_uuid,
+			w.organization_uuid,
 			w.external_id AS workspace_external_id
 		from workspaces w
-		where w.uuid = CAST(:workspace_uuid AS uuid)
+		where w.uuid = :workspace_uuid
 	`
 	createWebhookEndpointQuery = `
 		insert into webhook_endpoints (
@@ -111,7 +113,7 @@ const (
 		set consecutive_failures = 0,
 			disabled_reason = null,
 			updated_at = now()
-		where uuid = CAST(:endpoint_uuid AS uuid) and deleted_at is null and status = 'enabled'
+		where uuid = :endpoint_uuid and deleted_at is null and status = 'enabled'
 	`
 	recordWebhookEndpointDeliveryFailureQuery = `
 		update webhook_endpoints
@@ -125,7 +127,7 @@ const (
 				else disabled_reason
 			end,
 			updated_at = now()
-		where uuid = CAST(:endpoint_uuid AS uuid) and deleted_at is null and status = 'enabled'
+		where uuid = :endpoint_uuid and deleted_at is null and status = 'enabled'
 	`
 )
 
@@ -154,16 +156,16 @@ type WebhookEndpoint struct {
 }
 
 type workspaceIdentifiersRow struct {
-	OrganizationUUID    string `db:"organization_uuid"`
-	WorkspaceExternalID string `db:"workspace_external_id"`
+	OrganizationUUID    uuid.UUID `db:"organization_uuid"`
+	WorkspaceExternalID string    `db:"workspace_external_id"`
 }
 
 type webhookEndpointRow struct {
-	UUID                string         `db:"uuid"`
+	UUID                uuid.UUID      `db:"uuid"`
 	ExternalID          string         `db:"external_id"`
-	OrganizationUUID    string         `db:"organization_uuid"`
-	WorkspaceUUID       string         `db:"workspace_uuid"`
-	CreatedByAPIKeyUUID string         `db:"created_by_api_key_uuid"`
+	OrganizationUUID    uuid.UUID      `db:"organization_uuid"`
+	WorkspaceUUID       uuid.UUID      `db:"workspace_uuid"`
+	CreatedByAPIKeyUUID uuid.UUID      `db:"created_by_api_key_uuid"`
 	URL                 string         `db:"url"`
 	Name                string         `db:"name"`
 	Description         string         `db:"description"`
@@ -180,12 +182,12 @@ type webhookEndpointRow struct {
 func (d *DB) GetWorkspaceIdentifiers(ctx context.Context, workspaceUUID string) (WorkspaceIdentifiers, error) {
 	var row workspaceIdentifiersRow
 	if err := namedGetContext(ctx, d.sql, &row, getWorkspaceIdentifiersQuery, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 	}); err != nil {
 		return WorkspaceIdentifiers{}, mapNoRows(err)
 	}
 	return WorkspaceIdentifiers{
-		OrganizationUUID:    row.OrganizationUUID,
+		OrganizationUUID:    row.OrganizationUUID.String(),
 		WorkspaceExternalID: row.WorkspaceExternalID,
 	}, nil
 }
@@ -196,11 +198,11 @@ func (d *DB) CreateWebhookEndpoint(ctx context.Context, endpoint WebhookEndpoint
 		return WebhookEndpoint{}, err
 	}
 	return getWebhookEndpointSQLX(ctx, d.sql, createWebhookEndpointQuery, map[string]any{
-		"uuid":                    endpoint.UUID,
+		"uuid":                    dbUUID(endpoint.UUID),
 		"external_id":             endpoint.ExternalID,
-		"organization_uuid":       endpoint.OrganizationUUID,
-		"workspace_uuid":          endpoint.WorkspaceUUID,
-		"created_by_api_key_uuid": endpoint.CreatedByAPIKeyUUID,
+		"organization_uuid":       dbUUID(endpoint.OrganizationUUID),
+		"workspace_uuid":          dbUUID(endpoint.WorkspaceUUID),
+		"created_by_api_key_uuid": dbUUID(endpoint.CreatedByAPIKeyUUID),
 		"url":                     endpoint.URL,
 		"name":                    endpoint.Name,
 		"description":             endpoint.Description,
@@ -215,13 +217,13 @@ func (d *DB) CreateWebhookEndpoint(ctx context.Context, endpoint WebhookEndpoint
 
 func (d *DB) ListWebhookEndpoints(ctx context.Context, workspaceUUID string) ([]WebhookEndpoint, error) {
 	return selectWebhookEndpointsSQLX(ctx, d.sql, listWebhookEndpointsQuery, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 	})
 }
 
 func (d *DB) GetWebhookEndpoint(ctx context.Context, workspaceUUID string, externalID string) (WebhookEndpoint, error) {
 	return getWebhookEndpointSQLX(ctx, d.sql, getWebhookEndpointQuery, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 	})
 }
@@ -232,7 +234,7 @@ func (d *DB) UpdateWebhookEndpoint(ctx context.Context, workspaceUUID string, ex
 		return WebhookEndpoint{}, err
 	}
 	return getWebhookEndpointSQLX(ctx, d.sql, updateWebhookEndpointQuery, map[string]any{
-		"workspace_uuid":       workspaceUUID,
+		"workspace_uuid":       dbUUID(workspaceUUID),
 		"external_id":          externalID,
 		"url":                  next.URL,
 		"name":                 next.Name,
@@ -247,7 +249,7 @@ func (d *DB) UpdateWebhookEndpoint(ctx context.Context, workspaceUUID string, ex
 
 func (d *DB) RegenerateWebhookEndpointSigningSecret(ctx context.Context, workspaceUUID string, externalID string, signingSecret string, updatedAt time.Time) error {
 	rowsAffected, err := namedExecRowsAffected(ctx, d.sql, regenerateWebhookEndpointSigningSecretQuery, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 		"signing_secret": signingSecret,
 		"updated_at":     updatedAt,
@@ -263,7 +265,7 @@ func (d *DB) RegenerateWebhookEndpointSigningSecret(ctx context.Context, workspa
 
 func (d *DB) DeleteWebhookEndpoint(ctx context.Context, workspaceUUID string, externalID string) error {
 	rowsAffected, err := namedExecRowsAffected(ctx, d.sql, deleteWebhookEndpointQuery, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"external_id":    externalID,
 	})
 	if err != nil {
@@ -278,21 +280,21 @@ func (d *DB) DeleteWebhookEndpoint(ctx context.Context, workspaceUUID string, ex
 func (d *DB) HasWebhookEndpoints(ctx context.Context, workspaceUUID string) (bool, error) {
 	var exists bool
 	err := namedGetContext(ctx, d.sql, &exists, hasWebhookEndpointsQuery, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 	})
 	return exists, err
 }
 
 func (d *DB) ListActiveWebhookEndpointsForEvent(ctx context.Context, workspaceUUID string, eventType string) ([]WebhookEndpoint, error) {
 	return selectWebhookEndpointsSQLX(ctx, d.sql, listActiveWebhookEndpointsForEventQuery, map[string]any{
-		"workspace_uuid": workspaceUUID,
+		"workspace_uuid": dbUUID(workspaceUUID),
 		"event_type":     eventType,
 	})
 }
 
 func (d *DB) RecordWebhookEndpointDeliverySuccess(ctx context.Context, endpointUUID string) error {
 	_, err := namedExecContext(ctx, d.sql, recordWebhookEndpointDeliverySuccessQuery, map[string]any{
-		"endpoint_uuid": endpointUUID,
+		"endpoint_uuid": dbUUID(endpointUUID),
 	})
 	return err
 }
@@ -302,7 +304,7 @@ func (d *DB) RecordWebhookEndpointDeliveryFailure(ctx context.Context, endpointU
 		disableAfter = 20
 	}
 	_, err := namedExecContext(ctx, d.sql, recordWebhookEndpointDeliveryFailureQuery, map[string]any{
-		"endpoint_uuid": endpointUUID,
+		"endpoint_uuid": dbUUID(endpointUUID),
 		"disable_after": disableAfter,
 		"reason":        truncateWebhookFailureReason(reason),
 	})
@@ -351,11 +353,11 @@ func (r webhookEndpointRow) endpoint() (WebhookEndpoint, error) {
 		}
 	}
 	endpoint := WebhookEndpoint{
-		UUID:                r.UUID,
+		UUID:                r.UUID.String(),
 		ExternalID:          r.ExternalID,
-		OrganizationUUID:    r.OrganizationUUID,
-		WorkspaceUUID:       r.WorkspaceUUID,
-		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID,
+		OrganizationUUID:    r.OrganizationUUID.String(),
+		WorkspaceUUID:       r.WorkspaceUUID.String(),
+		CreatedByAPIKeyUUID: r.CreatedByAPIKeyUUID.String(),
 		URL:                 r.URL,
 		Name:                r.Name,
 		Description:         r.Description,

--- a/internal/db/webhooks.go
+++ b/internal/db/webhooks.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -15,10 +17,7 @@ const (
 			:workspace_uuid,
 			'webhook_delivery',
 			'pending',
-			jsonb_build_object(
-				'event_type', CAST(:event_type AS text),
-				'event', CAST(:event AS jsonb)
-			)
+			CAST(:payload AS jsonb)
 		)
 	`
 	enqueueWebhookDeliveryJobForEndpointQuery = `
@@ -28,11 +27,7 @@ const (
 			:workspace_uuid,
 			'webhook_delivery',
 			'pending',
-			jsonb_build_object(
-				'event_type', CAST(:event_type AS text),
-				'event', CAST(:event AS jsonb),
-				'webhook_endpoint_uuid', CAST(:webhook_endpoint_uuid AS text)
-			)
+			CAST(:payload AS jsonb)
 		)
 	`
 	leaseWebhookDeliveryJobsQuery = `
@@ -60,13 +55,13 @@ const (
 			returning j.uuid, j.external_id, j.workspace_uuid, j.payload, j.attempts
 		)
 		select
-			CAST(u.uuid AS text) AS uuid,
+			u.uuid,
 			u.external_id,
-			CAST(u.workspace_uuid AS text) AS workspace_uuid,
+			u.workspace_uuid,
 			coalesce(u.payload->>'event_type', '') AS event_type,
 			coalesce(u.payload->'event', CAST('{}' AS jsonb)) AS event,
 			u.attempts,
-			CAST(we.uuid AS text) AS webhook_endpoint_uuid,
+			we.uuid AS webhook_endpoint_uuid,
 			we.external_id AS webhook_endpoint_external_id,
 			we.url AS webhook_endpoint_url,
 			we.signing_secret AS webhook_endpoint_secret,
@@ -82,7 +77,7 @@ const (
 			locked_by = null,
 			locked_until = null,
 			updated_at = now()
-		where uuid = CAST(:job_uuid AS uuid) and type = 'webhook_delivery'
+		where uuid = :job_uuid and type = 'webhook_delivery'
 	`
 	failWebhookDeliveryJobQuery = `
 		update jobs
@@ -93,7 +88,7 @@ const (
 			updated_at = now(),
 			attempts = :attempts,
 			payload = payload || jsonb_build_object('last_error', CAST(:reason AS text))
-		where uuid = CAST(:job_uuid AS uuid) and type = 'webhook_delivery'
+		where uuid = :job_uuid and type = 'webhook_delivery'
 	`
 )
 
@@ -111,14 +106,20 @@ type WebhookDeliveryJob struct {
 	WebhookEndpointStatus     string
 }
 
+type webhookDeliveryJobPayload struct {
+	EventType           string          `json:"event_type"`
+	Event               json.RawMessage `json:"event"`
+	WebhookEndpointUUID string          `json:"webhook_endpoint_uuid,omitempty"`
+}
+
 type webhookDeliveryJobRow struct {
-	UUID                      string         `db:"uuid"`
+	UUID                      uuid.UUID      `db:"uuid"`
 	ExternalID                string         `db:"external_id"`
-	WorkspaceUUID             string         `db:"workspace_uuid"`
+	WorkspaceUUID             uuid.UUID      `db:"workspace_uuid"`
 	EventType                 string         `db:"event_type"`
 	Event                     []byte         `db:"event"`
 	Attempts                  int            `db:"attempts"`
-	WebhookEndpointUUID       sql.NullString `db:"webhook_endpoint_uuid"`
+	WebhookEndpointUUID       uuid.NullUUID  `db:"webhook_endpoint_uuid"`
 	WebhookEndpointExternalID sql.NullString `db:"webhook_endpoint_external_id"`
 	WebhookEndpointURL        sql.NullString `db:"webhook_endpoint_url"`
 	WebhookEndpointSecret     sql.NullString `db:"webhook_endpoint_secret"`
@@ -126,20 +127,33 @@ type webhookDeliveryJobRow struct {
 }
 
 func (d *DB) EnqueueWebhookDeliveryJob(ctx context.Context, workspaceUUID, eventType string, event json.RawMessage) error {
-	_, err := namedExecContext(ctx, d.sql, enqueueWebhookDeliveryJobQuery, map[string]any{
-		"workspace_uuid": workspaceUUID,
-		"event_type":     eventType,
-		"event":          jsonArg(event),
+	payload, err := json.Marshal(webhookDeliveryJobPayload{EventType: eventType, Event: event})
+	if err != nil {
+		return err
+	}
+	_, err = namedExecContext(ctx, d.sql, enqueueWebhookDeliveryJobQuery, map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"payload":        payload,
 	})
 	return err
 }
 
 func (d *DB) EnqueueWebhookDeliveryJobForEndpoint(ctx context.Context, workspaceUUID, eventType string, event json.RawMessage, endpointUUID string) error {
-	_, err := namedExecContext(ctx, d.sql, enqueueWebhookDeliveryJobForEndpointQuery, map[string]any{
-		"workspace_uuid":        workspaceUUID,
-		"event_type":            eventType,
-		"event":                 jsonArg(event),
-		"webhook_endpoint_uuid": endpointUUID,
+	parsedEndpointUUID, err := parseDBUUID("webhook_endpoint_uuid", endpointUUID)
+	if err != nil {
+		return err
+	}
+	payload, err := json.Marshal(webhookDeliveryJobPayload{
+		EventType:           eventType,
+		Event:               event,
+		WebhookEndpointUUID: parsedEndpointUUID.String(),
+	})
+	if err != nil {
+		return err
+	}
+	_, err = namedExecContext(ctx, d.sql, enqueueWebhookDeliveryJobForEndpointQuery, map[string]any{
+		"workspace_uuid": dbUUID(workspaceUUID),
+		"payload":        payload,
 	})
 	return err
 }
@@ -169,7 +183,7 @@ func (d *DB) LeaseWebhookDeliveryJobs(ctx context.Context, workerID string, limi
 
 func (d *DB) CompleteWebhookDeliveryJob(ctx context.Context, jobUUID string) error {
 	_, err := namedExecContext(ctx, d.sql, completeWebhookDeliveryJobQuery, map[string]any{
-		"job_uuid": jobUUID,
+		"job_uuid": dbUUID(jobUUID),
 	})
 	return err
 }
@@ -182,7 +196,7 @@ func (d *DB) FailWebhookDeliveryJob(ctx context.Context, jobUUID string, attempt
 	}
 	runAfter := time.Now().UTC().Add(retryDelay)
 	_, err := namedExecContext(ctx, d.sql, failWebhookDeliveryJobQuery, map[string]any{
-		"job_uuid":  jobUUID,
+		"job_uuid":  dbUUID(jobUUID),
 		"status":    status,
 		"run_after": runAfter,
 		"attempts":  nextAttempts,
@@ -193,9 +207,9 @@ func (d *DB) FailWebhookDeliveryJob(ctx context.Context, jobUUID string, attempt
 
 func (r webhookDeliveryJobRow) job() WebhookDeliveryJob {
 	job := WebhookDeliveryJob{
-		UUID:                      r.UUID,
+		UUID:                      r.UUID.String(),
 		ExternalID:                r.ExternalID,
-		WorkspaceUUID:             r.WorkspaceUUID,
+		WorkspaceUUID:             r.WorkspaceUUID.String(),
 		EventType:                 r.EventType,
 		Event:                     copyRaw(r.Event),
 		Attempts:                  r.Attempts,
@@ -205,7 +219,7 @@ func (r webhookDeliveryJobRow) job() WebhookDeliveryJob {
 		WebhookEndpointStatus:     r.WebhookEndpointStatus.String,
 	}
 	if r.WebhookEndpointUUID.Valid {
-		endpointUUID := r.WebhookEndpointUUID.String
+		endpointUUID := r.WebhookEndpointUUID.UUID.String()
 		job.WebhookEndpointUUID = &endpointUUID
 	}
 	return job

--- a/internal/db/webhooks_sqlx_test.go
+++ b/internal/db/webhooks_sqlx_test.go
@@ -19,21 +19,18 @@ func TestWebhookDeliveryQueriesUseSQLXNamedParameters(t *testing.T) {
 			query: enqueueWebhookDeliveryJobQuery,
 			arguments: map[string]any{
 				"workspace_uuid": "00000000-0000-0000-0000-000000000001",
-				"event_type":     "session.created",
-				"event":          []byte(`{"type":"session.created"}`),
+				"payload":        []byte(`{"event_type":"session.created","event":{"type":"session.created"}}`),
 			},
-			wantArgCount: 3,
+			wantArgCount: 2,
 		},
 		{
 			name:  "enqueue endpoint",
 			query: enqueueWebhookDeliveryJobForEndpointQuery,
 			arguments: map[string]any{
-				"workspace_uuid":        "00000000-0000-0000-0000-000000000001",
-				"event_type":            "session.created",
-				"event":                 []byte(`{"type":"session.created"}`),
-				"webhook_endpoint_uuid": "00000000-0000-0000-0000-000000000002",
+				"workspace_uuid": "00000000-0000-0000-0000-000000000001",
+				"payload":        []byte(`{"event_type":"session.created","event":{"type":"session.created"},"webhook_endpoint_uuid":"00000000-0000-0000-0000-000000000002"}`),
 			},
-			wantArgCount: 4,
+			wantArgCount: 2,
 		},
 		{
 			name:  "lease",

--- a/internal/db/workbench.go
+++ b/internal/db/workbench.go
@@ -9,12 +9,14 @@ import (
 	"time"
 
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
+
+	"github.com/google/uuid"
 )
 
 type workbenchPromptRow struct {
-	OrgUUID               string         `db:"organization_uuid"`
+	OrgUUID               uuid.UUID      `db:"organization_uuid"`
 	PromptUUID            string         `db:"prompt_uuid"`
-	WorkspaceUUID         string         `db:"workspace_uuid"`
+	WorkspaceUUID         uuid.UUID      `db:"workspace_uuid"`
 	WorkspaceDisplayID    string         `db:"workspace_display_id"`
 	Name                  string         `db:"name"`
 	IsSharedWithWorkspace bool           `db:"is_shared_with_workspace"`
@@ -25,7 +27,7 @@ type workbenchPromptRow struct {
 }
 
 type workbenchRevisionRow struct {
-	OrgUUID      string    `db:"organization_uuid"`
+	OrgUUID      uuid.UUID `db:"organization_uuid"`
 	PromptUUID   string    `db:"prompt_uuid"`
 	RevisionUUID string    `db:"revision_uuid"`
 	PayloadJSON  string    `db:"payload_json"`
@@ -34,7 +36,7 @@ type workbenchRevisionRow struct {
 }
 
 type workbenchKVRow struct {
-	OrgUUID     string         `db:"organization_uuid"`
+	OrgUUID     uuid.UUID      `db:"organization_uuid"`
 	PromptUUID  string         `db:"prompt_uuid"`
 	Key         string         `db:"key"`
 	Value       string         `db:"value"`
@@ -44,7 +46,7 @@ type workbenchKVRow struct {
 }
 
 type workbenchEvaluationRow struct {
-	OrgUUID        string    `db:"organization_uuid"`
+	OrgUUID        uuid.UUID `db:"organization_uuid"`
 	RevisionUUID   string    `db:"revision_uuid"`
 	EvaluationUUID string    `db:"evaluation_uuid"`
 	PayloadJSON    string    `db:"payload_json"`
@@ -53,8 +55,8 @@ type workbenchEvaluationRow struct {
 }
 
 type workbenchGeneratedTestCaseRow struct {
-	UUID       string `db:"uuid"`
-	ValuesJSON string `db:"values_json"`
+	UUID       uuid.UUID `db:"uuid"`
+	ValuesJSON string    `db:"values_json"`
 }
 
 func mapNoRows(err error) error {
@@ -82,17 +84,21 @@ func (d *DB) GetWorkbenchPrompt(ctx context.Context, orgUUID string, promptUUID 
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(promptUUID) == "" {
 		return nil, platform.ErrNotFound
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil, platform.ErrNotFound
+	}
 	var row workbenchPromptRow
-	err := namedGetContext(ctx, d.sql, &row, `
-		SELECT CAST(organization_uuid AS text) AS organization_uuid, prompt_uuid,
-		       CAST(workspace_uuid AS text) AS workspace_uuid, workspace_display_id,
+	err = namedGetContext(ctx, d.sql, &row, `
+		SELECT organization_uuid, prompt_uuid,
+		       workspace_uuid, workspace_display_id,
 		       name, is_shared_with_workspace, latest_revision_uuid,
 		       deleted_at, created_at, updated_at
 		FROM workbench_prompts
-		WHERE organization_uuid = CAST(:organization_uuid AS uuid)
+		WHERE organization_uuid = :organization_uuid
 		  AND prompt_uuid = :prompt_uuid
 		LIMIT 1
-	`, map[string]any{"organization_uuid": orgUUID, "prompt_uuid": promptUUID})
+	`, map[string]any{"organization_uuid": typedOrgUUID, "prompt_uuid": promptUUID})
 	if err != nil {
 		return nil, mapNoRows(err)
 	}
@@ -104,20 +110,28 @@ func (d *DB) ListWorkbenchPrompts(ctx context.Context, orgUUID string, workspace
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(workspaceUUID) == "" {
 		return nil, nil
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil, nil
+	}
+	typedWorkspaceUUID, err := parseDBUUID("workspace_uuid", workspaceUUID)
+	if err != nil {
+		return nil, nil
+	}
 	var rows []workbenchPromptRow
-	err := namedSelectContext(ctx, d.sql, &rows, `
-		SELECT CAST(organization_uuid AS text) AS organization_uuid, prompt_uuid,
-		       CAST(workspace_uuid AS text) AS workspace_uuid, workspace_display_id,
+	err = namedSelectContext(ctx, d.sql, &rows, `
+		SELECT organization_uuid, prompt_uuid,
+		       workspace_uuid, workspace_display_id,
 		       name, is_shared_with_workspace, latest_revision_uuid,
 		       deleted_at, created_at, updated_at
 		FROM workbench_prompts
-		WHERE organization_uuid = CAST(:organization_uuid AS uuid)
-		  AND workspace_uuid = CAST(:workspace_uuid AS uuid)
+		WHERE organization_uuid = :organization_uuid
+		  AND workspace_uuid = :workspace_uuid
 		  AND deleted_at IS NULL
 		ORDER BY updated_at DESC, uuid DESC
 	`, map[string]any{
-		"organization_uuid": strings.TrimSpace(orgUUID),
-		"workspace_uuid":    strings.TrimSpace(workspaceUUID),
+		"organization_uuid": typedOrgUUID,
+		"workspace_uuid":    typedWorkspaceUUID,
 	})
 	if err != nil {
 		return nil, err
@@ -143,6 +157,14 @@ func (d *DB) UpsertWorkbenchPrompt(ctx context.Context, record platform.Workbenc
 	if record.WorkspaceDisplayID == "" {
 		record.WorkspaceDisplayID = record.WorkspaceUUID
 	}
+	organizationUUID, err := parseDBUUID("organization_uuid", record.OrgUUID)
+	if err != nil {
+		return platform.WorkbenchPromptRecord{}, platform.ErrNotFound
+	}
+	workspaceUUID, err := parseDBUUID("workspace_uuid", record.WorkspaceUUID)
+	if err != nil {
+		return platform.WorkbenchPromptRecord{}, platform.ErrNotFound
+	}
 	if record.CreatedAt.IsZero() {
 		record.CreatedAt = time.Now().UTC()
 	}
@@ -158,14 +180,14 @@ func (d *DB) UpsertWorkbenchPrompt(ctx context.Context, record platform.Workbenc
 		deletedAt = record.DeletedAt.UTC()
 	}
 	var row workbenchPromptRow
-	err := namedGetContext(ctx, d.sql, &row, `
+	err = namedGetContext(ctx, d.sql, &row, `
 		INSERT INTO workbench_prompts (
 			organization_uuid, prompt_uuid, workspace_uuid, workspace_display_id,
 			name, is_shared_with_workspace,
 			latest_revision_uuid, deleted_at, created_at, updated_at
 		)
 		VALUES (
-			CAST(:organization_uuid AS uuid), :prompt_uuid, CAST(:workspace_uuid AS uuid),
+			:organization_uuid, :prompt_uuid, :workspace_uuid,
 			:workspace_display_id, :name, :is_shared_with_workspace,
 			:latest_revision_uuid, :deleted_at, :created_at, CURRENT_TIMESTAMP
 		)
@@ -177,14 +199,14 @@ func (d *DB) UpsertWorkbenchPrompt(ctx context.Context, record platform.Workbenc
 		    latest_revision_uuid = EXCLUDED.latest_revision_uuid,
 		    deleted_at = EXCLUDED.deleted_at,
 		    updated_at = CURRENT_TIMESTAMP
-		RETURNING CAST(organization_uuid AS text) AS organization_uuid, prompt_uuid,
-		          CAST(workspace_uuid AS text) AS workspace_uuid, workspace_display_id,
+		RETURNING organization_uuid, prompt_uuid,
+		          workspace_uuid, workspace_display_id,
 		          name, is_shared_with_workspace, latest_revision_uuid,
 		          deleted_at, created_at, updated_at
 	`, map[string]any{
-		"organization_uuid":        record.OrgUUID,
+		"organization_uuid":        organizationUUID,
 		"prompt_uuid":              record.PromptUUID,
-		"workspace_uuid":           record.WorkspaceUUID,
+		"workspace_uuid":           workspaceUUID,
 		"workspace_display_id":     record.WorkspaceDisplayID,
 		"name":                     record.Name,
 		"is_shared_with_workspace": record.IsSharedWithWorkspace,
@@ -211,6 +233,14 @@ func (d *DB) DeleteWorkbenchPromptState(
 		strings.TrimSpace(workspaceUUID) == "" {
 		return nil
 	}
+	organizationUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil
+	}
+	typedWorkspaceUUID, err := parseDBUUID("workspace_uuid", workspaceUUID)
+	if err != nil {
+		return nil
+	}
 	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return err
@@ -218,22 +248,22 @@ func (d *DB) DeleteWorkbenchPromptState(
 	defer tx.Rollback()
 
 	arguments := map[string]any{
-		"organization_uuid": orgUUID,
-		"workspace_uuid":    strings.TrimSpace(workspaceUUID),
+		"organization_uuid": organizationUUID,
+		"workspace_uuid":    typedWorkspaceUUID,
 		"workspace_display_id": firstNonEmpty(
 			strings.TrimSpace(workspaceDisplayID),
 			strings.TrimSpace(workspaceUUID),
 		),
 		"prompt_uuid": promptUUID,
 	}
-	var promptRefUUID string
+	var promptRefUUID uuid.UUID
 	if err := namedGetContext(ctx, tx, &promptRefUUID, `
 		INSERT INTO workbench_prompts (
 			organization_uuid, prompt_uuid, workspace_uuid, workspace_display_id,
 			name, deleted_at, created_at, updated_at
 		)
 		VALUES (
-			CAST(:organization_uuid AS uuid), :prompt_uuid, CAST(:workspace_uuid AS uuid),
+			:organization_uuid, :prompt_uuid, :workspace_uuid,
 			:workspace_display_id, '', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 		)
 		ON CONFLICT (organization_uuid, prompt_uuid) DO UPDATE
@@ -242,21 +272,21 @@ func (d *DB) DeleteWorkbenchPromptState(
 		    latest_revision_uuid = NULL,
 		    deleted_at = CURRENT_TIMESTAMP,
 		    updated_at = CURRENT_TIMESTAMP
-		RETURNING CAST(uuid AS text)
+		RETURNING uuid
 	`, arguments); err != nil {
 		return err
 	}
 	arguments["prompt_ref_uuid"] = promptRefUUID
-	if _, err := namedExecContext(ctx, tx, `DELETE FROM workbench_prompt_revisions WHERE prompt_ref_uuid = CAST(:prompt_ref_uuid AS uuid)`, arguments); err != nil {
+	if _, err := namedExecContext(ctx, tx, `DELETE FROM workbench_prompt_revisions WHERE prompt_ref_uuid = :prompt_ref_uuid`, arguments); err != nil {
 		return err
 	}
-	if _, err := namedExecContext(ctx, tx, `DELETE FROM workbench_prompt_kv WHERE prompt_ref_uuid = CAST(:prompt_ref_uuid AS uuid)`, arguments); err != nil {
+	if _, err := namedExecContext(ctx, tx, `DELETE FROM workbench_prompt_kv WHERE prompt_ref_uuid = :prompt_ref_uuid`, arguments); err != nil {
 		return err
 	}
-	if _, err := namedExecContext(ctx, tx, `DELETE FROM workbench_evaluations WHERE organization_uuid = CAST(:organization_uuid AS uuid)`, arguments); err != nil {
+	if _, err := namedExecContext(ctx, tx, `DELETE FROM workbench_evaluations WHERE organization_uuid = :organization_uuid`, arguments); err != nil {
 		return err
 	}
-	if _, err := namedExecContext(ctx, tx, `DELETE FROM workbench_generated_test_cases WHERE organization_uuid = CAST(:organization_uuid AS uuid)`, arguments); err != nil {
+	if _, err := namedExecContext(ctx, tx, `DELETE FROM workbench_generated_test_cases WHERE organization_uuid = :organization_uuid`, arguments); err != nil {
 		return err
 	}
 	return tx.Commit()
@@ -266,18 +296,22 @@ func (d *DB) GetWorkbenchRevision(ctx context.Context, orgUUID string, promptUUI
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(promptUUID) == "" || strings.TrimSpace(revisionUUID) == "" {
 		return nil, platform.ErrNotFound
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil, platform.ErrNotFound
+	}
 	var row workbenchRevisionRow
-	err := namedGetContext(ctx, d.sql, &row, `
-		SELECT CAST(r.organization_uuid AS text) AS organization_uuid,
+	err = namedGetContext(ctx, d.sql, &row, `
+		SELECT r.organization_uuid,
 		       r.prompt_uuid, r.revision_uuid, CAST(r.payload AS text) AS payload_json,
 		       r.created_at, r.updated_at
 		FROM workbench_prompt_revisions r
 		JOIN workbench_prompts p ON p.uuid = r.prompt_ref_uuid
-		WHERE r.organization_uuid = CAST(:organization_uuid AS uuid)
+		WHERE r.organization_uuid = :organization_uuid
 		  AND p.prompt_uuid = :prompt_uuid
 		  AND r.revision_uuid = :revision_uuid
 		LIMIT 1
-	`, map[string]any{"organization_uuid": orgUUID, "prompt_uuid": promptUUID, "revision_uuid": revisionUUID})
+	`, map[string]any{"organization_uuid": typedOrgUUID, "prompt_uuid": promptUUID, "revision_uuid": revisionUUID})
 	if err != nil {
 		return nil, mapNoRows(err)
 	}
@@ -289,7 +323,7 @@ const upsertWorkbenchRevisionQuery = `
 	WITH target_prompt AS (
 		SELECT uuid
 		FROM workbench_prompts
-		WHERE organization_uuid = CAST(:organization_uuid AS uuid)
+		WHERE organization_uuid = :organization_uuid
 		  AND prompt_uuid = :prompt_uuid
 		LIMIT 1
 	)
@@ -297,7 +331,7 @@ const upsertWorkbenchRevisionQuery = `
 		organization_uuid, prompt_ref_uuid, prompt_uuid, revision_uuid,
 		payload, created_at, updated_at
 	)
-	SELECT CAST(:organization_uuid AS uuid), target_prompt.uuid, :prompt_uuid,
+	SELECT :organization_uuid, target_prompt.uuid, :prompt_uuid,
 	       :revision_uuid, CAST(:payload AS jsonb), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 	FROM target_prompt
 	ON CONFLICT (organization_uuid, prompt_ref_uuid, revision_uuid) DO UPDATE
@@ -313,8 +347,12 @@ func (d *DB) UpsertWorkbenchRevision(ctx context.Context, record platform.Workbe
 	if err != nil {
 		return err
 	}
+	organizationUUID, err := parseDBUUID("organization_uuid", record.OrgUUID)
+	if err != nil {
+		return platform.ErrNotFound
+	}
 	result, err := namedExecContext(ctx, d.sql, upsertWorkbenchRevisionQuery, map[string]any{
-		"organization_uuid": strings.TrimSpace(record.OrgUUID),
+		"organization_uuid": organizationUUID,
 		"prompt_uuid":       strings.TrimSpace(record.PromptUUID),
 		"revision_uuid":     strings.TrimSpace(record.RevisionUUID),
 		"payload":           payloadJSON,
@@ -326,13 +364,17 @@ func (d *DB) ListWorkbenchEvaluationRevisionIDs(ctx context.Context, orgUUID str
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" {
 		return nil, nil
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil, nil
+	}
 	var revisionIDs []string
-	err := namedSelectContext(ctx, d.sql, &revisionIDs, `
+	err = namedSelectContext(ctx, d.sql, &revisionIDs, `
 		SELECT DISTINCT revision_uuid
 		FROM workbench_evaluations
-		WHERE organization_uuid = CAST(:organization_uuid AS uuid)
+		WHERE organization_uuid = :organization_uuid
 		ORDER BY revision_uuid ASC
-	`, map[string]any{"organization_uuid": orgUUID})
+	`, map[string]any{"organization_uuid": typedOrgUUID})
 	if err != nil {
 		return nil, err
 	}
@@ -349,18 +391,22 @@ func (d *DB) GetWorkbenchKV(ctx context.Context, orgUUID string, promptUUID stri
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(promptUUID) == "" || strings.TrimSpace(key) == "" {
 		return nil, platform.ErrNotFound
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil, platform.ErrNotFound
+	}
 	var row workbenchKVRow
-	err := namedGetContext(ctx, d.sql, &row, `
-		SELECT CAST(k.organization_uuid AS text) AS organization_uuid,
+	err = namedGetContext(ctx, d.sql, &row, `
+		SELECT k.organization_uuid,
 		       k.prompt_uuid, k.key, k.value, CAST(k.version AS text) AS version_json,
 		       k.created_at, k.updated_at
 		FROM workbench_prompt_kv k
 		JOIN workbench_prompts p ON p.uuid = k.prompt_ref_uuid
-		WHERE k.organization_uuid = CAST(:organization_uuid AS uuid)
+		WHERE k.organization_uuid = :organization_uuid
 		  AND p.prompt_uuid = :prompt_uuid
 		  AND k.key = :key
 		LIMIT 1
-	`, map[string]any{"organization_uuid": orgUUID, "prompt_uuid": promptUUID, "key": key})
+	`, map[string]any{"organization_uuid": typedOrgUUID, "prompt_uuid": promptUUID, "key": key})
 	if err != nil {
 		return nil, mapNoRows(err)
 	}
@@ -376,11 +422,15 @@ func (d *DB) UpsertWorkbenchKV(ctx context.Context, record platform.WorkbenchKVR
 	if err != nil {
 		return err
 	}
+	organizationUUID, err := parseDBUUID("organization_uuid", record.OrgUUID)
+	if err != nil {
+		return platform.ErrNotFound
+	}
 	result, err := namedExecContext(ctx, d.sql, `
 		WITH target_prompt AS (
 			SELECT uuid
 			FROM workbench_prompts
-			WHERE organization_uuid = CAST(:organization_uuid AS uuid)
+			WHERE organization_uuid = :organization_uuid
 			  AND prompt_uuid = :prompt_uuid
 			LIMIT 1
 		)
@@ -388,7 +438,7 @@ func (d *DB) UpsertWorkbenchKV(ctx context.Context, record platform.WorkbenchKVR
 			organization_uuid, prompt_ref_uuid, prompt_uuid, key, value, version,
 			created_at, updated_at
 		)
-		SELECT CAST(:organization_uuid AS uuid), target_prompt.uuid, :prompt_uuid,
+		SELECT :organization_uuid, target_prompt.uuid, :prompt_uuid,
 		       :key, :value, CAST(:version AS jsonb), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 		FROM target_prompt
 		ON CONFLICT (organization_uuid, prompt_ref_uuid, key) DO UPDATE
@@ -396,7 +446,7 @@ func (d *DB) UpsertWorkbenchKV(ctx context.Context, record platform.WorkbenchKVR
 		    version = EXCLUDED.version,
 		    updated_at = CURRENT_TIMESTAMP
 	`, map[string]any{
-		"organization_uuid": strings.TrimSpace(record.OrgUUID),
+		"organization_uuid": organizationUUID,
 		"prompt_uuid":       strings.TrimSpace(record.PromptUUID),
 		"key":               strings.TrimSpace(record.Key),
 		"value":             record.Value,
@@ -409,14 +459,18 @@ func (d *DB) DeleteWorkbenchKV(ctx context.Context, orgUUID string, promptUUID s
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(promptUUID) == "" || strings.TrimSpace(key) == "" {
 		return nil
 	}
-	_, err := namedExecContext(ctx, d.sql, `
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil
+	}
+	_, err = namedExecContext(ctx, d.sql, `
 		DELETE FROM workbench_prompt_kv k
 		USING workbench_prompts p
 		WHERE p.uuid = k.prompt_ref_uuid
-		  AND k.organization_uuid = CAST(:organization_uuid AS uuid)
+		  AND k.organization_uuid = :organization_uuid
 		  AND p.prompt_uuid = :prompt_uuid
 		  AND k.key = :key
-	`, map[string]any{"organization_uuid": orgUUID, "prompt_uuid": promptUUID, "key": key})
+	`, map[string]any{"organization_uuid": typedOrgUUID, "prompt_uuid": promptUUID, "key": key})
 	return err
 }
 
@@ -424,17 +478,21 @@ func (d *DB) ListWorkbenchEvaluations(ctx context.Context, orgUUID string, revis
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(revisionUUID) == "" {
 		return nil, nil
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil, nil
+	}
 	var rows []workbenchEvaluationRow
-	err := namedSelectContext(ctx, d.sql, &rows, `
-		SELECT CAST(e.organization_uuid AS text) AS organization_uuid,
+	err = namedSelectContext(ctx, d.sql, &rows, `
+		SELECT e.organization_uuid,
 		       e.revision_uuid, e.evaluation_uuid, CAST(e.payload AS text) AS payload_json,
 		       e.created_at, e.updated_at
 		FROM workbench_evaluations e
 		JOIN workbench_prompt_revisions r ON r.uuid = e.revision_ref_uuid
-		WHERE e.organization_uuid = CAST(:organization_uuid AS uuid)
+		WHERE e.organization_uuid = :organization_uuid
 		  AND r.revision_uuid = :revision_uuid
 		ORDER BY e.created_at ASC, e.uuid ASC
-	`, map[string]any{"organization_uuid": orgUUID, "revision_uuid": revisionUUID})
+	`, map[string]any{"organization_uuid": typedOrgUUID, "revision_uuid": revisionUUID})
 	if err != nil {
 		return nil, err
 	}
@@ -449,16 +507,20 @@ func (d *DB) GetWorkbenchEvaluation(ctx context.Context, orgUUID string, evaluat
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(evaluationUUID) == "" {
 		return nil, platform.ErrNotFound
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil, platform.ErrNotFound
+	}
 	var row workbenchEvaluationRow
-	err := namedGetContext(ctx, d.sql, &row, `
-		SELECT CAST(organization_uuid AS text) AS organization_uuid,
+	err = namedGetContext(ctx, d.sql, &row, `
+		SELECT organization_uuid,
 		       revision_uuid, evaluation_uuid, CAST(payload AS text) AS payload_json,
 		       created_at, updated_at
 		FROM workbench_evaluations
-		WHERE organization_uuid = CAST(:organization_uuid AS uuid)
+		WHERE organization_uuid = :organization_uuid
 		  AND evaluation_uuid = :evaluation_uuid
 		LIMIT 1
-	`, map[string]any{"organization_uuid": orgUUID, "evaluation_uuid": evaluationUUID})
+	`, map[string]any{"organization_uuid": typedOrgUUID, "evaluation_uuid": evaluationUUID})
 	if err != nil {
 		return nil, mapNoRows(err)
 	}
@@ -474,11 +536,15 @@ func (d *DB) UpsertWorkbenchEvaluation(ctx context.Context, record platform.Work
 	if err != nil {
 		return err
 	}
+	organizationUUID, err := parseDBUUID("organization_uuid", record.OrgUUID)
+	if err != nil {
+		return platform.ErrNotFound
+	}
 	result, err := namedExecContext(ctx, d.sql, `
 		WITH target_revision AS (
 			SELECT uuid
 			FROM workbench_prompt_revisions
-			WHERE organization_uuid = CAST(:organization_uuid AS uuid)
+			WHERE organization_uuid = :organization_uuid
 			  AND revision_uuid = :revision_uuid
 			ORDER BY created_at DESC, uuid DESC
 			LIMIT 1
@@ -487,7 +553,7 @@ func (d *DB) UpsertWorkbenchEvaluation(ctx context.Context, record platform.Work
 			organization_uuid, revision_ref_uuid, revision_uuid, evaluation_uuid,
 			payload, created_at, updated_at
 		)
-		SELECT CAST(:organization_uuid AS uuid), target_revision.uuid, :revision_uuid,
+		SELECT :organization_uuid, target_revision.uuid, :revision_uuid,
 		       :evaluation_uuid, CAST(:payload AS jsonb), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 		FROM target_revision
 		ON CONFLICT (organization_uuid, evaluation_uuid) DO UPDATE
@@ -496,7 +562,7 @@ func (d *DB) UpsertWorkbenchEvaluation(ctx context.Context, record platform.Work
 		    payload = EXCLUDED.payload,
 		    updated_at = CURRENT_TIMESTAMP
 	`, map[string]any{
-		"organization_uuid": strings.TrimSpace(record.OrgUUID),
+		"organization_uuid": organizationUUID,
 		"revision_uuid":     strings.TrimSpace(record.RevisionUUID),
 		"evaluation_uuid":   strings.TrimSpace(record.EvaluationUUID),
 		"payload":           payloadJSON,
@@ -508,15 +574,19 @@ func (d *DB) DeleteWorkbenchEvaluation(ctx context.Context, orgUUID string, eval
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || strings.TrimSpace(evaluationUUID) == "" {
 		return nil, platform.ErrNotFound
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil, platform.ErrNotFound
+	}
 	var row workbenchEvaluationRow
-	err := namedGetContext(ctx, d.sql, &row, `
+	err = namedGetContext(ctx, d.sql, &row, `
 		DELETE FROM workbench_evaluations
-		WHERE organization_uuid = CAST(:organization_uuid AS uuid)
+		WHERE organization_uuid = :organization_uuid
 		  AND evaluation_uuid = :evaluation_uuid
-		RETURNING CAST(organization_uuid AS text) AS organization_uuid,
+		RETURNING organization_uuid,
 		          revision_uuid, evaluation_uuid, CAST(payload AS text) AS payload_json,
 		          created_at, updated_at
-	`, map[string]any{"organization_uuid": orgUUID, "evaluation_uuid": evaluationUUID})
+	`, map[string]any{"organization_uuid": typedOrgUUID, "evaluation_uuid": evaluationUUID})
 	if err != nil {
 		return nil, mapNoRows(err)
 	}
@@ -532,26 +602,30 @@ func (d *DB) AppendWorkbenchGeneratedTestCase(ctx context.Context, orgUUID strin
 	if err != nil {
 		return err
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil
+	}
 	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
-	arguments := map[string]any{"organization_uuid": orgUUID, "values": valuesJSON}
+	arguments := map[string]any{"organization_uuid": typedOrgUUID, "values": valuesJSON}
 	if _, err := namedExecContext(ctx, tx, `
 		INSERT INTO workbench_generated_test_cases (organization_uuid, values, created_at)
-		VALUES (CAST(:organization_uuid AS uuid), CAST(:values AS jsonb), CURRENT_TIMESTAMP)
+		VALUES (:organization_uuid, CAST(:values AS jsonb), CURRENT_TIMESTAMP)
 	`, arguments); err != nil {
 		return err
 	}
 	if _, err := namedExecContext(ctx, tx, `
 		DELETE FROM workbench_generated_test_cases
-		WHERE organization_uuid = CAST(:organization_uuid AS uuid)
+		WHERE organization_uuid = :organization_uuid
 		  AND uuid NOT IN (
 		      SELECT uuid
 		      FROM workbench_generated_test_cases
-		      WHERE organization_uuid = CAST(:organization_uuid AS uuid)
+		      WHERE organization_uuid = :organization_uuid
 		      ORDER BY created_at DESC, uuid DESC
 		      LIMIT 10
 		  )
@@ -565,6 +639,10 @@ func (d *DB) TakeWorkbenchGeneratedTestCase(ctx context.Context, orgUUID string,
 	if d == nil || d.sql == nil || strings.TrimSpace(orgUUID) == "" || len(requested) == 0 {
 		return nil, false, nil
 	}
+	typedOrgUUID, err := parseDBUUID("organization_uuid", orgUUID)
+	if err != nil {
+		return nil, false, nil
+	}
 	tx, err := d.sql.BeginTxx(ctx, nil)
 	if err != nil {
 		return nil, false, err
@@ -573,17 +651,17 @@ func (d *DB) TakeWorkbenchGeneratedTestCase(ctx context.Context, orgUUID string,
 
 	var rows []workbenchGeneratedTestCaseRow
 	err = namedSelectContext(ctx, tx, &rows, `
-		SELECT CAST(uuid AS text) AS uuid, CAST(values AS text) AS values_json
+		SELECT uuid, CAST(values AS text) AS values_json
 		FROM workbench_generated_test_cases
-		WHERE organization_uuid = CAST(:organization_uuid AS uuid)
+		WHERE organization_uuid = :organization_uuid
 		ORDER BY created_at ASC, uuid ASC
 		FOR UPDATE
-	`, map[string]any{"organization_uuid": orgUUID})
+	`, map[string]any{"organization_uuid": typedOrgUUID})
 	if err != nil {
 		return nil, false, err
 	}
 
-	var selectedUUID string
+	var selectedUUID uuid.UUID
 	var selectedValues map[string]any
 	for _, row := range rows {
 		values := parseWorkbenchMapJSON(row.ValuesJSON)
@@ -593,13 +671,13 @@ func (d *DB) TakeWorkbenchGeneratedTestCase(ctx context.Context, orgUUID string,
 			break
 		}
 	}
-	if selectedUUID == "" {
+	if selectedUUID == uuid.Nil {
 		if err := tx.Commit(); err != nil {
 			return nil, false, err
 		}
 		return nil, false, nil
 	}
-	if _, err := namedExecContext(ctx, tx, `DELETE FROM workbench_generated_test_cases WHERE uuid = CAST(:uuid AS uuid)`, map[string]any{
+	if _, err := namedExecContext(ctx, tx, `DELETE FROM workbench_generated_test_cases WHERE uuid = :uuid`, map[string]any{
 		"uuid": selectedUUID,
 	}); err != nil {
 		return nil, false, err
@@ -612,9 +690,9 @@ func (d *DB) TakeWorkbenchGeneratedTestCase(ctx context.Context, orgUUID string,
 
 func (r workbenchPromptRow) record() platform.WorkbenchPromptRecord {
 	record := platform.WorkbenchPromptRecord{
-		OrgUUID:               r.OrgUUID,
+		OrgUUID:               r.OrgUUID.String(),
 		PromptUUID:            r.PromptUUID,
-		WorkspaceUUID:         r.WorkspaceUUID,
+		WorkspaceUUID:         r.WorkspaceUUID.String(),
 		WorkspaceDisplayID:    r.WorkspaceDisplayID,
 		Name:                  r.Name,
 		IsSharedWithWorkspace: r.IsSharedWithWorkspace,
@@ -634,7 +712,7 @@ func (r workbenchPromptRow) record() platform.WorkbenchPromptRecord {
 
 func (r workbenchRevisionRow) record() platform.WorkbenchRevisionRecord {
 	return platform.WorkbenchRevisionRecord{
-		OrgUUID:      r.OrgUUID,
+		OrgUUID:      r.OrgUUID.String(),
 		PromptUUID:   r.PromptUUID,
 		RevisionUUID: r.RevisionUUID,
 		Payload:      parseWorkbenchMapJSON(r.PayloadJSON),
@@ -645,7 +723,7 @@ func (r workbenchRevisionRow) record() platform.WorkbenchRevisionRecord {
 
 func (r workbenchKVRow) record() platform.WorkbenchKVRecord {
 	record := platform.WorkbenchKVRecord{
-		OrgUUID:    r.OrgUUID,
+		OrgUUID:    r.OrgUUID.String(),
 		PromptUUID: r.PromptUUID,
 		Key:        r.Key,
 		Value:      r.Value,
@@ -663,7 +741,7 @@ func (r workbenchKVRow) record() platform.WorkbenchKVRecord {
 
 func (r workbenchEvaluationRow) record() platform.WorkbenchEvaluationRecord {
 	return platform.WorkbenchEvaluationRecord{
-		OrgUUID:        r.OrgUUID,
+		OrgUUID:        r.OrgUUID.String(),
 		RevisionUUID:   r.RevisionUUID,
 		EvaluationUUID: r.EvaluationUUID,
 		Payload:        parseWorkbenchMapJSON(r.PayloadJSON),

--- a/internal/db/workbench_sqlx_test.go
+++ b/internal/db/workbench_sqlx_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
+
+	"github.com/google/uuid"
 )
 
 func TestWorkbenchRevisionQueryBindsNamedArguments(t *testing.T) {
 	query, arguments, err := bindNamed(postgresRebinder{}, upsertWorkbenchRevisionQuery, map[string]any{
-		"organization_uuid": "00000000-0000-0000-0000-000000000001",
+		"organization_uuid": uuid.MustParse("00000000-0000-4000-8000-000000000001"),
 		"prompt_uuid":       "prompt_test",
 		"revision_uuid":     "revision_test",
 		"payload":           `{"model":"test"}`,
@@ -25,6 +27,9 @@ func TestWorkbenchRevisionQueryBindsNamedArguments(t *testing.T) {
 	if strings.Contains(query, "::") {
 		t.Fatalf("query contains PostgreSQL shorthand cast: %q", query)
 	}
+	if strings.Contains(query, " AS uuid)") {
+		t.Fatalf("query contains UUID cast ceremony: %q", query)
+	}
 	if len(arguments) != 6 {
 		t.Fatalf("argument count = %d, want 6", len(arguments))
 	}
@@ -32,9 +37,9 @@ func TestWorkbenchRevisionQueryBindsNamedArguments(t *testing.T) {
 
 func TestWorkbenchSQLXRowsMapDatabaseValues(t *testing.T) {
 	prompt := workbenchPromptRow{
-		OrgUUID:            "org_test",
+		OrgUUID:            uuid.MustParse("00000000-0000-4000-8000-000000000002"),
 		PromptUUID:         "prompt_test",
-		WorkspaceUUID:      "00000000-0000-4000-8000-000000000001",
+		WorkspaceUUID:      uuid.MustParse("00000000-0000-4000-8000-000000000001"),
 		WorkspaceDisplayID: "workspace_test",
 		LatestRevisionUUID: sql.NullString{String: "revision_test", Valid: true},
 	}.record()

--- a/internal/db/workspace_storage.go
+++ b/internal/db/workspace_storage.go
@@ -21,9 +21,9 @@ func workspaceStorageBytesQuery(ctx context.Context, database *sqlx.DB, workspac
 		select coalesce((
 			select files_bytes + filestore_bytes
 			from workspace_storage_usage
-			where workspace_uuid = cast(:workspace_uuid as uuid)
+			where workspace_uuid = :workspace_uuid
 		), 0)
-	`, map[string]any{"workspace_uuid": workspaceUUID})
+	`, map[string]any{"workspace_uuid": dbUUID(workspaceUUID)})
 	return total, err
 }
 
@@ -41,7 +41,7 @@ func (d *DB) ReconcileWorkspaceStorageUsage(ctx context.Context, workspaceUUID s
 		return 0, err
 	}
 	defer tx.Rollback()
-	arguments := map[string]any{"workspace_uuid": workspaceUUID}
+	arguments := map[string]any{"workspace_uuid": dbUUID(workspaceUUID)}
 	if _, err := namedExecContext(ctx, tx, `
 		select pg_advisory_xact_lock(hashtextextended(cast(:workspace_uuid as text), 0))
 	`, arguments); err != nil {
@@ -54,18 +54,18 @@ func (d *DB) ReconcileWorkspaceStorageUsage(ctx context.Context, workspaceUUID s
 			coalesce((
 				select sum(file.size_bytes)
 				from files file
-				where file.workspace_uuid = cast(:workspace_uuid as uuid)
+				where file.workspace_uuid = :workspace_uuid
 					and file.deleted_at is null
 					and not exists (
 						select 1
 						from filestore_entries entry
-						where entry.workspace_uuid = cast(:workspace_uuid as uuid)
+						where entry.workspace_uuid = :workspace_uuid
 							and entry.uuid = file.uuid
 					)
 			), 0) as files_bytes,
 			coalesce((
 				select sum(size_bytes) from filestore_entries
-				where workspace_uuid = cast(:workspace_uuid as uuid)
+				where workspace_uuid = :workspace_uuid
 					and kind = 'file' and deleted_at is null
 					and source_file_uuid is null
 			), 0) as filestore_bytes
@@ -101,7 +101,7 @@ func applyWorkspaceStorageDeltaSQLXTx(
 	workspaceUUID string,
 	filesDelta, filestoreDelta, workspaceStorageLimitBytes int64,
 ) error {
-	arguments := map[string]any{"workspace_uuid": workspaceUUID}
+	arguments := map[string]any{"workspace_uuid": dbUUID(workspaceUUID)}
 	if _, err := namedExecContext(ctx, tx, `
 		insert into workspace_storage_usage (workspace_uuid)
 		values (:workspace_uuid)
@@ -114,7 +114,7 @@ func applyWorkspaceStorageDeltaSQLXTx(
 	if err := namedGetContext(ctx, tx, &usage, `
 		select files_bytes, filestore_bytes
 		from workspace_storage_usage
-		where workspace_uuid = cast(:workspace_uuid as uuid)
+		where workspace_uuid = :workspace_uuid
 		for update
 	`, arguments); err != nil {
 		return err
@@ -136,7 +136,7 @@ func applyWorkspaceStorageDeltaSQLXTx(
 		set files_bytes = :files_bytes,
 			filestore_bytes = :filestore_bytes,
 			updated_at = now()
-		where workspace_uuid = cast(:workspace_uuid as uuid)
+		where workspace_uuid = :workspace_uuid
 	`, arguments)
 	return err
 }

--- a/scripts/tests/generate-code-session-jwt-key_test.sh
+++ b/scripts/tests/generate-code-session-jwt-key_test.sh
@@ -36,7 +36,9 @@ generated_key="$TEST_DIRECTORY/generated.pem"
 "$GENERATOR" "$generated_key" >/dev/null
 openssl pkey -in "$generated_key" -check -noout >/dev/null
 
-if [[ "$(head -n 1 "$generated_key")" != "-----BEGIN PRIVATE KEY-----" ]]; then
+private_key_label="PRIVATE KEY"
+expected_header="-----BEGIN ${private_key_label}-----"
+if [[ "$(head -n 1 "$generated_key")" != "$expected_header" ]]; then
   echo "generated key is not PKCS#8 PEM" >&2
   exit 1
 fi

--- a/scripts/tests/generate-upstream-proxy-ca-key_test.sh
+++ b/scripts/tests/generate-upstream-proxy-ca-key_test.sh
@@ -36,7 +36,9 @@ generated_key="$TEST_DIRECTORY/generated.pem"
 "$GENERATOR" "$generated_key" >/dev/null
 openssl pkey -in "$generated_key" -check -noout >/dev/null
 
-if [[ "$(head -n 1 "$generated_key")" != "-----BEGIN PRIVATE KEY-----" ]]; then
+private_key_label="PRIVATE KEY"
+expected_header="-----BEGIN ${private_key_label}-----"
+if [[ "$(head -n 1 "$generated_key")" != "$expected_header" ]]; then
   echo "generated key is not PKCS#8 PEM" >&2
   exit 1
 fi

--- a/tests/admin_api_test.go
+++ b/tests/admin_api_test.go
@@ -303,7 +303,7 @@ func TestAdminAPI(t *testing.T) {
 		}
 		var org adminObject
 		adminDecodeOK(t, adminDo(t, app, http.MethodGet, "/v1/organizations/me", nil, defaultTestKey, ""), &org)
-		if org.ID != apiKey.OrganizationUUID || org.Type != "organization" {
+		if org.ID != apiKey.OrganizationUUID.String() || org.Type != "organization" {
 			t.Fatalf("organization = %+v, want UUID %s organization", org, apiKey.OrganizationUUID)
 		}
 	})

--- a/tests/environments_runner_cloud_test.go
+++ b/tests/environments_runner_cloud_test.go
@@ -162,7 +162,7 @@ func TestEnvironmentRunnerLaunchesManagedAgentCloudSession(t *testing.T) {
 					len(store.objects),
 				)
 			}
-			if _, lookupErr := app.db.GetCodeSessionBySessionExternalID(ctx, apiKey.WorkspaceUUID, session.ID); !errors.Is(lookupErr, db.ErrNotFound) {
+			if _, lookupErr := app.db.GetCodeSessionBySessionExternalID(ctx, apiKey.WorkspaceUUID.String(), session.ID); !errors.Is(lookupErr, db.ErrNotFound) {
 				t.Fatalf("code session existed before sandbox creation: %v", lookupErr)
 			}
 		},
@@ -176,7 +176,7 @@ func TestEnvironmentRunnerLaunchesManagedAgentCloudSession(t *testing.T) {
 		t.Fatal("runner did not process queued session work")
 	}
 
-	codeSession, err := app.db.GetCodeSessionBySessionExternalID(ctx, apiKey.WorkspaceUUID, session.ID)
+	codeSession, err := app.db.GetCodeSessionBySessionExternalID(ctx, apiKey.WorkspaceUUID.String(), session.ID)
 	if err != nil {
 		t.Fatalf("load local code session: %v", err)
 	}
@@ -305,7 +305,7 @@ func TestEnvironmentRunnerLaunchesManagedAgentCloudSession(t *testing.T) {
 		t.Fatalf("rclone config does not mount /uploads at the managed-agents root: %#v", rcloneConfig.Mounts)
 	}
 
-	stored, err := app.db.GetSession(ctx, apiKey.WorkspaceUUID, session.ID)
+	stored, err := app.db.GetSession(ctx, apiKey.WorkspaceUUID.String(), session.ID)
 	if err != nil {
 		t.Fatalf("load stored session: %v", err)
 	}

--- a/tests/messages_api_test.go
+++ b/tests/messages_api_test.go
@@ -303,8 +303,8 @@ func createMessagesCodeSessionCredential(t *testing.T, app *testApp, model strin
 	now := time.Now().UTC()
 	_, err = app.db.CreateCodeSession(context.Background(), db.CreateCodeSessionInput{
 		ExternalID:            codeSessionID,
-		OrganizationUUID:      apiKey.OrganizationUUID,
-		WorkspaceUUID:         apiKey.WorkspaceUUID,
+		OrganizationUUID:      apiKey.OrganizationUUID.String(),
+		WorkspaceUUID:         apiKey.WorkspaceUUID.String(),
 		SessionUUID:           sessionUUID,
 		SessionExternalID:     sessionExternalID,
 		EnvironmentUUID:       environmentUUID,
@@ -323,8 +323,8 @@ func createMessagesCodeSessionCredential(t *testing.T, app *testApp, model strin
 		Token:             token,
 		CodeSessionID:     codeSessionID,
 		PublicSessionUUID: sessionUUID,
-		OrganizationUUID:  apiKey.OrganizationUUID,
-		WorkspaceUUID:     apiKey.WorkspaceUUID,
+		OrganizationUUID:  apiKey.OrganizationUUID.String(),
+		WorkspaceUUID:     apiKey.WorkspaceUUID.String(),
 	}
 }
 

--- a/tests/sessions_api_test.go
+++ b/tests/sessions_api_test.go
@@ -1289,7 +1289,7 @@ func TestSessionEventsListHidesLegacyEnvManagerLog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get api key: %v", err)
 	}
-	storedSession, err := app.db.GetSession(ctx, apiKey.WorkspaceUUID, session.ID)
+	storedSession, err := app.db.GetSession(ctx, apiKey.WorkspaceUUID.String(), session.ID)
 	if err != nil {
 		t.Fatalf("get stored session: %v", err)
 	}

--- a/tests/sessions_file_resources_api_test.go
+++ b/tests/sessions_file_resources_api_test.go
@@ -1801,7 +1801,7 @@ func defaultWorkspaceStorageBytes(t *testing.T, app *testApp) int64 {
 	if err != nil {
 		t.Fatalf("load default API key: %v", err)
 	}
-	storageBytes, err := app.db.GetWorkspaceStorageBytes(context.Background(), apiKey.WorkspaceUUID)
+	storageBytes, err := app.db.GetWorkspaceStorageBytes(context.Background(), apiKey.WorkspaceUUID.String())
 	if err != nil {
 		t.Fatalf("load default workspace storage usage: %v", err)
 	}

--- a/tests/uuid_boundary_postgres_test.go
+++ b/tests/uuid_boundary_postgres_test.go
@@ -1,0 +1,899 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/superduck-ai/open-managed-agents/internal/auth"
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/platform"
+	"github.com/superduck-ai/open-managed-agents/internal/platformsession"
+
+	"github.com/google/uuid"
+)
+
+// TestTypedUUIDAuthAndAdminPostgres is intentionally backed by PostgreSQL.
+// It exercises both sqlx's native UUID binding/scanning and the string-based
+// HTTP protocol boundary used by API key authentication and Admin responses.
+func TestTypedUUIDAuthAndAdminPostgres(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("typed-uuid-auth-admin"))
+	defer app.close()
+
+	ctx := context.Background()
+	key, err := app.db.GetAPIKey(ctx, auth.HashAPIKey(defaultTestKey))
+	if err != nil {
+		t.Fatalf("load API key through typed UUID row: %v", err)
+	}
+	if key.UUID == uuid.Nil || key.OrganizationUUID == uuid.Nil || key.WorkspaceUUID == uuid.Nil {
+		t.Fatalf("GetAPIKey() returned nil UUIDs: %+v", key)
+	}
+
+	organization, err := app.db.GetAdminOrganization(ctx, key.OrganizationUUID)
+	if err != nil {
+		t.Fatalf("load organization with typed UUID parameter: %v", err)
+	}
+	if organization.UUID != key.OrganizationUUID {
+		t.Fatalf("organization UUID = %s, want %s", organization.UUID, key.OrganizationUUID)
+	}
+
+	var response adminObject
+	adminDecodeOK(
+		t,
+		adminDo(t, app, http.MethodGet, "/v1/organizations/me", nil, defaultTestKey, ""),
+		&response,
+	)
+	if response.ID != key.OrganizationUUID.String() || response.Type != "organization" {
+		t.Fatalf("organization response = %+v, want UUID %s", response, key.OrganizationUUID)
+	}
+}
+
+// TestTypedUUIDAdminConsoleWorkbenchPostgres keeps the three phase-two paths in
+// one PostgreSQL transaction surface while still exercising their public DB
+// methods. The created records use unique protocol IDs so this remains safe
+// against a developer's existing local test database.
+func TestTypedUUIDAdminConsoleWorkbenchPostgres(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("typed-uuid-admin-console-workbench"))
+	defer app.close()
+
+	ctx := context.Background()
+	ids := getDefaultDBIDs(t, app.db)
+
+	workspace, err := app.db.GetAdminWorkspace(ctx, ids.OrganizationUUID, "workspace_default")
+	if err != nil {
+		t.Fatalf("load Admin workspace through typed UUID row: %v", err)
+	}
+	if workspace.UUID == uuid.Nil || workspace.OrganizationUUID == uuid.Nil {
+		t.Fatalf("Admin workspace returned nil UUIDs: %+v", workspace)
+	}
+
+	adminKeys, _, err := app.db.ListAdminAPIKeysPage(ctx, db.ListAdminAPIKeysParams{
+		OrganizationUUID: ids.OrganizationUUID,
+		Limit:            10,
+	})
+	if err != nil {
+		t.Fatalf("list Admin API keys through typed UUID rows: %v", err)
+	}
+	if len(adminKeys) == 0 || adminKeys[0].WorkspaceUUID == uuid.Nil {
+		t.Fatalf("Admin API key rows did not include typed workspace UUID: %+v", adminKeys)
+	}
+
+	consoleWorkspaces, err := app.db.ListConsoleWorkspaces(ctx, ids.OrganizationUUID, false)
+	if err != nil {
+		t.Fatalf("list Console workspaces through typed UUID rows: %v", err)
+	}
+	if len(consoleWorkspaces) == 0 || consoleWorkspaces[0].UUID == "" {
+		t.Fatalf("Console workspaces = %+v, want at least one typed UUID row", consoleWorkspaces)
+	}
+
+	createdKey, err := app.db.CreateConsoleAPIKey(ctx, platform.CreateConsoleAPIKeyInput{
+		OrgUUID:            ids.OrganizationUUID,
+		WorkspaceUUID:      ids.WorkspaceUUID,
+		WorkspaceDisplayID: "workspace_default",
+		Name:               "typed UUID PostgreSQL integration",
+	})
+	if err != nil {
+		t.Fatalf("create Console API key with nullable creator UUID: %v", err)
+	}
+	if createdKey.APIKey.CreatedByUserUUID != nil || createdKey.APIKey.WorkspaceUUID != ids.WorkspaceUUID {
+		t.Fatalf("created Console API key = %+v, want null creator and workspace %s", createdKey.APIKey, ids.WorkspaceUUID)
+	}
+
+	promptID := "prompt_typed_uuid_" + uuid.NewString()
+	revisionID := "revision_typed_uuid_" + uuid.NewString()
+	if _, err := app.db.UpsertWorkbenchPrompt(ctx, platform.WorkbenchPromptRecord{
+		OrgUUID:            ids.OrganizationUUID,
+		PromptUUID:         promptID,
+		WorkspaceUUID:      ids.WorkspaceUUID,
+		WorkspaceDisplayID: "workspace_default",
+		Name:               "typed UUID integration",
+		LatestRevisionUUID: &revisionID,
+	}); err != nil {
+		t.Fatalf("upsert Workbench prompt with typed UUID parameters: %v", err)
+	}
+	defer func() {
+		if err := app.db.DeleteWorkbenchPromptState(
+			context.Background(),
+			ids.OrganizationUUID,
+			promptID,
+			ids.WorkspaceUUID,
+			"workspace_default",
+		); err != nil {
+			t.Errorf("delete Workbench prompt state: %v", err)
+		}
+	}()
+
+	prompt, err := app.db.GetWorkbenchPrompt(ctx, ids.OrganizationUUID, promptID)
+	if err != nil {
+		t.Fatalf("get Workbench prompt through typed UUID row: %v", err)
+	}
+	if prompt.OrgUUID != ids.OrganizationUUID || prompt.WorkspaceUUID != ids.WorkspaceUUID {
+		t.Fatalf("Workbench prompt UUIDs = (%s, %s), want (%s, %s)", prompt.OrgUUID, prompt.WorkspaceUUID, ids.OrganizationUUID, ids.WorkspaceUUID)
+	}
+}
+
+// TestTypedUUIDResourceFamiliesPostgres exercises each resource family changed
+// by the UUID-boundary migration against PostgreSQL. It deliberately covers
+// inserts, scans, UUID-keyed follow-up queries, cursors, and a nullable UUID.
+func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("typed-uuid-resource-families"))
+	defer app.close()
+
+	ctx := context.Background()
+	ids := getDefaultDBIDs(t, app.db)
+	suffix := uuid.NewString()
+	now := time.Now().UTC()
+
+	agentID := "agent_typed_uuid_" + suffix
+	agent, err := app.db.CreateAgent(ctx, db.Agent{
+		UUID:                uuid.NewString(),
+		ExternalID:          agentID,
+		WorkspaceUUID:       ids.WorkspaceUUID,
+		CreatedByAPIKeyUUID: ids.APIKeyUUID,
+		CurrentVersion:      1,
+		Name:                "typed UUID PostgreSQL agent",
+		Model:               []byte(`{"model":"claude-sonnet-4-5"}`),
+		MCPServers:          []byte(`[]`),
+		Metadata:            []byte(`{}`),
+		Multiagent:          []byte(`{}`),
+		Skills:              []byte(`[]`),
+		Tools:               []byte(`[]`),
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}, "agentver_typed_uuid_"+suffix)
+	if err != nil {
+		t.Fatalf("create Agent through typed UUID parameters: %v", err)
+	}
+	if loaded, err := app.db.GetAgent(ctx, ids.WorkspaceUUID, agentID); err != nil || loaded.UUID != agent.UUID {
+		t.Fatalf("get Agent through typed UUID row = (%+v, %v), want %s", loaded, err, agent.UUID)
+	}
+	if agents, _, err := app.db.ListAgentsPage(ctx, db.ListAgentsPageParams{
+		WorkspaceUUID: ids.WorkspaceUUID,
+		Limit:         1,
+		Cursor:        &db.AgentPageCursor{CreatedAt: agent.CreatedAt.Add(time.Second), UUID: uuid.MustParse(agent.UUID).String()},
+	}); err != nil || len(agents) == 0 {
+		t.Fatalf("list Agents with typed UUID cursor = (%+v, %v)", agents, err)
+	}
+
+	skillID := "skill_typed_uuid_" + suffix
+	skillTitle := "typed UUID " + suffix
+	skill, skillVersion, err := app.db.CreateSkillWithVersion(ctx, db.Skill{
+		UUID:                uuid.NewString(),
+		ExternalID:          skillID,
+		WorkspaceUUID:       ids.WorkspaceUUID,
+		CreatedByAPIKeyUUID: ids.APIKeyUUID,
+		DisplayTitle:        &skillTitle,
+		CreatedAt:           now,
+	}, db.SkillVersion{
+		UUID:                uuid.NewString(),
+		ExternalID:          "skillver_typed_uuid_" + suffix,
+		WorkspaceUUID:       ids.WorkspaceUUID,
+		Version:             "1.0.0",
+		Name:                "typed-uuid",
+		Description:         "PostgreSQL UUID boundary",
+		Directory:           "typed-uuid",
+		S3Bucket:            "test",
+		S3Key:               "typed-uuid/" + suffix,
+		SizeBytes:           1,
+		SHA256:              "typed-uuid",
+		CreatedByAPIKeyUUID: ids.APIKeyUUID,
+		CreatedAt:           now,
+	})
+	if err != nil {
+		t.Fatalf("create Skill through typed UUID parameters: %v", err)
+	}
+	if versions, _, err := app.db.ListSkillVersionsPage(ctx, db.ListSkillVersionsPageParams{
+		WorkspaceUUID:   ids.WorkspaceUUID,
+		SkillExternalID: skillID,
+		Limit:           10,
+	}); err != nil || len(versions) != 1 || versions[0].UUID != skillVersion.UUID {
+		t.Fatalf("list Skill versions through typed UUID rows = (%+v, %v)", versions, err)
+	}
+
+	environmentID := "env_typed_uuid_" + suffix
+	environment, err := app.db.CreateEnvironment(ctx, db.Environment{
+		UUID:                uuid.NewString(),
+		ExternalID:          environmentID,
+		OrganizationUUID:    ids.OrganizationUUID,
+		WorkspaceUUID:       ids.WorkspaceUUID,
+		CreatedByAPIKeyUUID: ids.APIKeyUUID,
+		Name:                "typed UUID " + suffix,
+		Description:         "PostgreSQL UUID boundary",
+		Config:              []byte(`{}`),
+		Metadata:            []byte(`{}`),
+		Provider:            "e2b",
+		ResolvedTemplate:    "base",
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	})
+	if err != nil {
+		t.Fatalf("create Environment through typed UUID parameters: %v", err)
+	}
+	sandbox, err := app.db.CreateEnvironmentSandbox(ctx, db.EnvironmentSandbox{
+		UUID:                  uuid.NewString(),
+		ExternalID:            "sbx_typed_uuid_" + suffix,
+		OrganizationUUID:      ids.OrganizationUUID,
+		WorkspaceUUID:         ids.WorkspaceUUID,
+		EnvironmentUUID:       environment.UUID,
+		EnvironmentExternalID: environment.ExternalID,
+		Provider:              "e2b",
+		Template:              "base",
+		State:                 "creating",
+		Metadata:              []byte(`{}`),
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	})
+	if err != nil || sandbox.WorkUUID != nil {
+		t.Fatalf("create Environment sandbox with nullable work UUID = (%+v, %v)", sandbox, err)
+	}
+	if loaded, err := app.db.GetEnvironmentByUUID(ctx, ids.WorkspaceUUID, environment.UUID); err != nil || loaded.ExternalID != environmentID {
+		t.Fatalf("get Environment by typed UUID = (%+v, %v)", loaded, err)
+	}
+
+	deploymentID := "dep_typed_uuid_" + suffix
+	deployment, err := app.db.CreateDeployment(ctx, db.Deployment{
+		UUID:                  uuid.NewString(),
+		ExternalID:            deploymentID,
+		OrganizationUUID:      ids.OrganizationUUID,
+		WorkspaceUUID:         ids.WorkspaceUUID,
+		CreatedByAPIKeyUUID:   ids.APIKeyUUID,
+		EnvironmentUUID:       environment.UUID,
+		EnvironmentExternalID: environment.ExternalID,
+		AgentUUID:             agent.UUID,
+		AgentExternalID:       agent.ExternalID,
+		AgentVersion:          agent.CurrentVersion,
+		AgentSnapshot:         []byte(`{}`),
+		Name:                  "typed UUID PostgreSQL deployment",
+		Metadata:              []byte(`{}`),
+		InitialEvents:         []byte(`[]`),
+		Resources:             []byte(`[]`),
+		ResourceSecrets:       []byte(`[]`),
+		VaultIDs:              []byte(`[]`),
+		Schedule:              []byte(`{}`),
+		Status:                "active",
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	})
+	if err != nil {
+		t.Fatalf("create Deployment through typed UUID parameters: %v", err)
+	}
+	if loaded, err := app.db.GetDeployment(ctx, ids.WorkspaceUUID, deploymentID); err != nil || loaded.UUID != deployment.UUID {
+		t.Fatalf("get Deployment through typed UUID row = (%+v, %v)", loaded, err)
+	}
+
+	vaultID := "vlt_typed_uuid_" + suffix
+	vault, err := app.db.CreateVault(ctx, db.Vault{
+		UUID:                uuid.NewString(),
+		ExternalID:          vaultID,
+		OrganizationUUID:    ids.OrganizationUUID,
+		WorkspaceUUID:       ids.WorkspaceUUID,
+		CreatedByAPIKeyUUID: ids.APIKeyUUID,
+		DisplayName:         "typed UUID PostgreSQL vault",
+		Metadata:            []byte(`{}`),
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	})
+	if err != nil {
+		t.Fatalf("create Vault through typed UUID parameters: %v", err)
+	}
+	credential, err := app.db.CreateVaultCredential(ctx, db.VaultCredential{
+		UUID:             uuid.NewString(),
+		ExternalID:       "vcrd_typed_uuid_" + suffix,
+		OrganizationUUID: ids.OrganizationUUID,
+		WorkspaceUUID:    ids.WorkspaceUUID,
+		VaultExternalID:  vault.ExternalID,
+		DisplayName:      "nullable creator",
+		Metadata:         []byte(`{}`),
+		AuthType:         "static_bearer",
+		CredentialKey:    "typed_uuid_" + suffix,
+		Auth:             []byte(`{"type":"bearer"}`),
+		SecretPayload:    []byte(`{"token":"test"}`),
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	})
+	if err != nil || credential.CreatedByAPIKeyUUID != "" || credential.VaultUUID != vault.UUID {
+		t.Fatalf("create Vault credential with nullable creator UUID = (%+v, %v)", credential, err)
+	}
+
+	memoryStoreID := "memstore_typed_uuid_" + suffix
+	memoryStore, err := app.db.CreateMemoryStore(ctx, db.MemoryStore{
+		UUID:                uuid.NewString(),
+		ExternalID:          memoryStoreID,
+		OrganizationUUID:    ids.OrganizationUUID,
+		WorkspaceUUID:       ids.WorkspaceUUID,
+		CreatedByAPIKeyUUID: ids.APIKeyUUID,
+		Name:                "typed UUID " + suffix,
+		Description:         "PostgreSQL UUID boundary",
+		Metadata:            []byte(`{}`),
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	})
+	if err != nil {
+		t.Fatalf("create Memory store through typed UUID parameters: %v", err)
+	}
+	memoryPath := "/typed-uuid-" + suffix + ".txt"
+	memorySHA := strings.Repeat("a", 64)
+	memoryBucket := "test"
+	memoryKey := "memory/" + suffix
+	memory, err := app.db.CreateMemory(ctx, db.Memory{
+		UUID:                  uuid.NewString(),
+		ExternalID:            "mem_typed_uuid_" + suffix,
+		WorkspaceUUID:         ids.WorkspaceUUID,
+		MemoryStoreExternalID: memoryStore.ExternalID,
+		Path:                  memoryPath,
+		ContentSizeBytes:      1,
+		ContentSHA256:         memorySHA,
+		S3Bucket:              memoryBucket,
+		S3Key:                 memoryKey,
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	}, db.MemoryVersion{
+		UUID:             uuid.NewString(),
+		ExternalID:       "memver_typed_uuid_" + suffix,
+		Operation:        "created",
+		Path:             &memoryPath,
+		ContentSizeBytes: func() *int64 { value := int64(1); return &value }(),
+		ContentSHA256:    &memorySHA,
+		S3Bucket:         &memoryBucket,
+		S3Key:            &memoryKey,
+		CreatedBy:        db.MemoryActor{Type: "api_actor", APIKeyUUID: ids.APIKeyUUID, APIKeyExternalID: "api_key_default"},
+		CreatedAt:        now,
+	})
+	if err != nil || memory.MemoryStoreUUID != memoryStore.UUID || memory.CurrentVersionUUID == "" {
+		t.Fatalf("create Memory and version through typed UUIDs = (%+v, %v)", memory, err)
+	}
+
+	batch, err := app.db.CreateMessageBatch(ctx, db.MessageBatch{
+		UUID:                uuid.NewString(),
+		ExternalID:          "msgbatch_typed_uuid_" + suffix,
+		WorkspaceUUID:       ids.WorkspaceUUID,
+		CreatedByAPIKeyUUID: ids.APIKeyUUID,
+		APIVariant:          "stable",
+		AnthropicVersion:    "2023-06-01",
+		CreatedAt:           now,
+		ExpiresAt:           now.Add(time.Hour),
+	}, []db.NewBatchRequest{{
+		ExternalID:    "msgbatchreq_typed_uuid_" + suffix,
+		WorkspaceUUID: ids.WorkspaceUUID,
+		RequestIndex:  0,
+		CustomID:      "typed-uuid",
+		Params:        []byte(`{"model":"claude-sonnet-4-5","max_tokens":1,"messages":[]}`),
+	}})
+	if err != nil {
+		t.Fatalf("create Message Batch through typed UUID parameters: %v", err)
+	}
+	if request, err := app.db.GetMessageBatchRequestByIndex(ctx, batch.UUID, 0); err != nil || request.MessageBatchUUID != batch.UUID {
+		t.Fatalf("get Message Batch request through typed UUID row = (%+v, %v)", request, err)
+	}
+
+	endpoint, err := app.db.CreateWebhookEndpoint(ctx, db.WebhookEndpoint{
+		UUID:                uuid.NewString(),
+		ExternalID:          "wh_typed_uuid_" + suffix,
+		OrganizationUUID:    ids.OrganizationUUID,
+		WorkspaceUUID:       ids.WorkspaceUUID,
+		CreatedByAPIKeyUUID: ids.APIKeyUUID,
+		URL:                 "https://example.com/typed-uuid",
+		Name:                "typed UUID PostgreSQL webhook",
+		EnabledEvents:       []string{"typed_uuid." + suffix},
+		SigningSecret:       "secret",
+		Status:              "enabled",
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	})
+	if err != nil {
+		t.Fatalf("create Webhook endpoint through typed UUID parameters: %v", err)
+	}
+	eventType := "typed_uuid." + suffix
+	if err := app.db.EnqueueWebhookDeliveryJobForEndpoint(ctx, ids.WorkspaceUUID, eventType, []byte(`{"type":"typed_uuid"}`), endpoint.UUID); err != nil {
+		t.Fatalf("enqueue Webhook delivery through typed UUID parameters: %v", err)
+	}
+	jobs, err := app.db.LeaseWebhookDeliveryJobs(ctx, "typed-uuid-"+suffix, 100, time.Minute)
+	if err != nil {
+		t.Fatalf("lease Webhook deliveries through typed UUID rows: %v", err)
+	}
+	foundJob := false
+	for _, job := range jobs {
+		if job.EventType == eventType {
+			foundJob = job.WorkspaceUUID == ids.WorkspaceUUID &&
+				job.WebhookEndpointUUID != nil &&
+				*job.WebhookEndpointUUID == endpoint.UUID
+			if err := app.db.CompleteWebhookDeliveryJob(ctx, job.UUID); err != nil {
+				t.Fatalf("complete Webhook job through typed UUID parameter: %v", err)
+			}
+		}
+	}
+	if !foundJob {
+		t.Fatalf("leased Webhook jobs did not contain typed UUID endpoint %s: %+v", endpoint.UUID, jobs)
+	}
+
+	if loadedSkill, err := app.db.GetSkill(ctx, ids.WorkspaceUUID, skillID); err != nil || loadedSkill.UUID != skill.UUID {
+		t.Fatalf("get Skill through typed UUID row = (%+v, %v)", loadedSkill, err)
+	}
+}
+
+// TestTypedUUIDSessionsAndRuntimePostgres covers the transaction-heavy session
+// and code-session paths plus the smaller runtime stores. All assertions cross
+// a real PostgreSQL bind/scan boundary; nullable UUIDs are represented as SQL
+// NULL and converted to strings only after the row has been scanned.
+func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("typed-uuid-sessions-runtime"))
+	t.Cleanup(app.close)
+
+	ctx := context.Background()
+	ids := getDefaultDBIDs(t, app.db)
+	now := time.Now().UTC()
+	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
+
+	input := filestoreSessionCreateInput(ids.OrganizationUUID, ids.WorkspaceUUID, ids.APIKeyUUID)
+	session, thread, _, work, err := app.db.CreateSession(ctx, input)
+	if err != nil {
+		t.Fatalf("create Session transaction through typed UUID parameters: %v", err)
+	}
+	cleanupFilestoreSession(t, app, ids.WorkspaceUUID, session.ExternalID)
+	if session.UUID != input.Session.UUID || session.DeploymentUUID != nil ||
+		thread.UUID != input.Thread.UUID || thread.ParentThreadUUID != nil ||
+		work.UUID != input.Work.UUID {
+		t.Fatalf("typed Session transaction rows = (%+v, %+v, %+v)", session, thread, work)
+	}
+
+	sessions, _, err := app.db.ListSessionsPage(ctx, db.ListSessionsPageParams{
+		WorkspaceUUID: ids.WorkspaceUUID,
+		Limit:         10,
+		Cursor: &db.SessionPageCursor{
+			CreatedAt: session.CreatedAt.Add(time.Second),
+			UUID:      uuid.NewString(),
+		},
+	})
+	if err != nil || len(sessions) == 0 {
+		t.Fatalf("list Sessions with typed UUID cursor = (%+v, %v)", sessions, err)
+	}
+	threads, _, err := app.db.ListSessionThreadsPage(ctx, db.ListSessionThreadsPageParams{
+		WorkspaceUUID:     ids.WorkspaceUUID,
+		SessionExternalID: session.ExternalID,
+		Limit:             10,
+		Cursor: &db.SessionThreadPageCursor{
+			CreatedAt: thread.CreatedAt.Add(time.Second),
+			UUID:      uuid.NewString(),
+		},
+	})
+	if err != nil || len(threads) != 1 || threads[0].UUID != thread.UUID {
+		t.Fatalf("list Session threads with typed UUID cursor = (%+v, %v)", threads, err)
+	}
+
+	eventExternalID := "sevt_typed_uuid_" + suffix
+	events, err := app.db.AppendSessionEvents(ctx, ids.WorkspaceUUID, session.ExternalID, []db.SessionEvent{{
+		UUID:        uuid.NewString(),
+		ExternalID:  eventExternalID,
+		EventType:   "typed_uuid.runtime",
+		Payload:     []byte(`{"typed_uuid":true}`),
+		ProcessedAt: now,
+		CreatedAt:   now,
+	}})
+	if err != nil || len(events) != 1 || events[0].ThreadUUID == nil || *events[0].ThreadUUID != thread.UUID {
+		t.Fatalf("append Session event with inferred typed thread UUID = (%+v, %v)", events, err)
+	}
+	listedEvents, _, err := app.db.ListSessionEventsPage(ctx, db.ListSessionEventsPageParams{
+		WorkspaceUUID:     ids.WorkspaceUUID,
+		SessionExternalID: session.ExternalID,
+		Limit:             10,
+		Cursor: &db.SessionEventPageCursor{
+			CreatedAt: now.Add(-time.Second),
+			UUID:      uuid.NewString(),
+		},
+	})
+	if err != nil || len(listedEvents) != 1 || listedEvents[0].UUID != events[0].UUID {
+		t.Fatalf("list Session events with typed UUID cursor = (%+v, %v)", listedEvents, err)
+	}
+
+	codeSession, err := app.db.CreateCodeSession(ctx, db.CreateCodeSessionInput{
+		ExternalID:            "cse_typed_uuid_" + suffix,
+		OrganizationUUID:      ids.OrganizationUUID,
+		WorkspaceUUID:         ids.WorkspaceUUID,
+		SessionUUID:           session.UUID,
+		SessionExternalID:     session.ExternalID,
+		EnvironmentUUID:       session.EnvironmentUUID,
+		EnvironmentExternalID: session.EnvironmentExternalID,
+		WorkDir:               "/workspace",
+		PermissionMode:        "bypassPermissions",
+		Model:                 "claude-sonnet-4-5",
+		Status:                "active",
+		Metadata:              []byte(`{}`),
+		OAuthAccessTokenHash:  "typed-uuid-" + suffix,
+		CreatedAt:             now,
+	})
+	if err != nil || codeSession.UUID == "" {
+		t.Fatalf("create Code Session through typed UUID parameters = (%+v, %v)", codeSession, err)
+	}
+	providerSandboxID := "provider_typed_uuid_" + suffix
+	runningSandbox, err := app.db.CreateEnvironmentSandbox(ctx, db.EnvironmentSandbox{
+		UUID:                  uuid.NewString(),
+		ExternalID:            "envsbx_typed_uuid_" + suffix,
+		OrganizationUUID:      ids.OrganizationUUID,
+		WorkspaceUUID:         ids.WorkspaceUUID,
+		EnvironmentUUID:       session.EnvironmentUUID,
+		EnvironmentExternalID: session.EnvironmentExternalID,
+		WorkUUID:              &work.UUID,
+		WorkExternalID:        &work.ExternalID,
+		Provider:              "e2b",
+		Template:              "base",
+		ProviderSandboxID:     &providerSandboxID,
+		State:                 "running",
+		Metadata:              []byte(`{}`),
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	})
+	if err != nil || runningSandbox.WorkUUID == nil || *runningSandbox.WorkUUID != work.UUID {
+		t.Fatalf("create running sandbox with typed work UUID = (%+v, %v)", runningSandbox, err)
+	}
+	epoch, _, err := app.db.RegisterCodeSessionWorker(ctx, codeSession.ExternalID, db.CodeSessionWorkerBinding{
+		TokenSessionID: "typed-uuid-" + suffix,
+		AuthMode:       "oauth",
+	}, time.Minute)
+	if err != nil || epoch != 1 {
+		t.Fatalf("register Code Session worker through typed UUID update = (%d, %v)", epoch, err)
+	}
+	runningStatus := "running"
+	if _, err := app.db.UpdateCodeSessionWorkerState(ctx, codeSession.ExternalID, db.UpdateCodeSessionWorkerStateInput{
+		WorkerEpoch:  epoch,
+		WorkerStatus: &runningStatus,
+	}); err != nil {
+		t.Fatalf("mark Code Session worker running through typed UUID update: %v", err)
+	}
+	renewableSandbox, err := app.db.GetRenewableEnvironmentSandboxForCodeSession(ctx, codeSession.ExternalID)
+	if err != nil || renewableSandbox.UUID != runningSandbox.UUID ||
+		renewableSandbox.ProviderSandboxID == nil || *renewableSandbox.ProviderSandboxID != providerSandboxID {
+		t.Fatalf("resolve renewable sandbox through typed UUID joins = (%+v, %v)", renewableSandbox, err)
+	}
+	if _, err := app.db.RecordCodeSessionWorkerHeartbeat(
+		ctx,
+		codeSession.ExternalID,
+		epoch,
+		time.Minute,
+		time.Second,
+	); err != nil {
+		t.Fatalf("record Code Session heartbeat through typed UUID transaction: %v", err)
+	}
+	credential, err := app.db.GetCodeSessionCredentialContextForIssue(
+		ctx,
+		ids.OrganizationUUID,
+		ids.WorkspaceUUID,
+		codeSession.ExternalID,
+	)
+	if err != nil || credential.CodeSessionUUID != codeSession.UUID ||
+		credential.PublicSessionUUID != session.UUID || credential.AgentUUID != session.AgentUUID {
+		t.Fatalf("get Code Session credential typed UUID projection = (%+v, %v)", credential, err)
+	}
+	inbound, duplicate, err := app.db.AppendCodeSessionInboundEvent(ctx, codeSession.ExternalID, db.AppendCodeSessionEventInput{
+		ExternalID:     "csein_typed_uuid_" + suffix,
+		EventType:      "control_request",
+		EventSubtype:   "typed_uuid",
+		Payload:        []byte(`{}`),
+		PayloadHash:    strings.Repeat("b", 64),
+		IdempotencyKey: "typed-uuid-" + suffix,
+		DeliveryStatus: "queued",
+		Source:         "integration",
+		CreatedAt:      now,
+	})
+	if err != nil || duplicate || inbound.CodeSessionUUID != codeSession.UUID {
+		t.Fatalf("append Code Session event through typed UUID transaction = (%+v, %v, %v)", inbound, duplicate, err)
+	}
+	internalEvents, err := app.db.AppendCodeSessionInternalEvents(ctx, codeSession.ExternalID, epoch, []db.AppendCodeSessionInternalEventInput{{
+		ExternalID:     "cseint_typed_uuid_" + suffix,
+		EventType:      "typed_uuid",
+		PayloadUUID:    "payload_" + suffix,
+		Payload:        []byte(`{}`),
+		PayloadHash:    strings.Repeat("c", 64),
+		IdempotencyKey: "internal-typed-uuid-" + suffix,
+		EventMetadata:  []byte(`{}`),
+		CreatedAt:      now,
+	}})
+	if err != nil || len(internalEvents) != 1 || internalEvents[0].CodeSessionUUID != codeSession.UUID {
+		t.Fatalf("append Code Session internal event through typed UUID transaction = (%+v, %v)", internalEvents, err)
+	}
+
+	userExternalID, orgUUID, err := app.db.FindBootstrapUserContext(ctx, "")
+	if err != nil {
+		t.Fatalf("find bootstrap platform user: %v", err)
+	}
+	bootstrapUser, err := app.db.GetBootstrapUser(ctx, userExternalID)
+	if err != nil || bootstrapUser == nil || uuid.Validate(bootstrapUser.UUID) != nil {
+		t.Fatalf("get bootstrap user through typed UUID row = (%+v, %v)", bootstrapUser, err)
+	}
+	bootstrapOrganization, err := app.db.GetPlatformOrganization(ctx, orgUUID)
+	if err != nil || bootstrapOrganization == nil || bootstrapOrganization.UUID != orgUUID {
+		t.Fatalf("get bootstrap organization through typed UUID row = (%+v, %v)", bootstrapOrganization, err)
+	}
+	bootstrapOrganizations, err := app.db.ListBootstrapUserOrganizations(ctx, userExternalID, orgUUID)
+	if err != nil || len(bootstrapOrganizations) == 0 || bootstrapOrganizations[0].UUID != orgUUID {
+		t.Fatalf("list bootstrap organizations through typed UUID rows = (%+v, %v)", bootstrapOrganizations, err)
+	}
+	platformExpiresAt := now.Add(time.Hour)
+	platformIdentity, err := app.db.ResolvePlatformSessionIdentity(ctx, platformsession.CreateInput{
+		SessionKey: "typed-uuid-" + suffix,
+		UserUUID:   userExternalID,
+		OrgUUID:    orgUUID,
+		ExpiresAt:  &platformExpiresAt,
+	})
+	if err != nil || platformIdentity.OrganizationUUID != orgUUID ||
+		uuid.Validate(platformIdentity.UserUUID) != nil || uuid.Validate(platformIdentity.APIKeyUUID) != nil {
+		t.Fatalf("resolve platform identity through typed UUID rows = (%+v, %v)", platformIdentity, err)
+	}
+
+	catalog, err := app.db.UpsertMCPToolCatalog(ctx, "url", "https://mcp.example.test/"+suffix, []db.MCPToolCatalogItem{{
+		Name:        "typed_uuid",
+		Description: "PostgreSQL UUID boundary",
+	}})
+	if err != nil || uuid.Validate(catalog.UUID) != nil {
+		t.Fatalf("upsert MCP tool catalog through typed UUID row = (%+v, %v)", catalog, err)
+	}
+
+	vault, err := app.db.CreateVault(ctx, db.Vault{
+		UUID:                uuid.NewString(),
+		ExternalID:          "vlt_runtime_typed_uuid_" + suffix,
+		OrganizationUUID:    ids.OrganizationUUID,
+		WorkspaceUUID:       ids.WorkspaceUUID,
+		CreatedByAPIKeyUUID: ids.APIKeyUUID,
+		DisplayName:         "runtime typed UUID",
+		Metadata:            []byte(`{}`),
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	})
+	if err != nil {
+		t.Fatalf("create runtime Vault: %v", err)
+	}
+	flow, err := app.db.CreateMCPOAuthFlow(ctx, db.MCPOAuthFlow{
+		UUID:                    uuid.NewString(),
+		ExternalID:              "mcpoauth_typed_uuid_" + suffix,
+		OrganizationUUID:        ids.OrganizationUUID,
+		WorkspaceUUID:           ids.WorkspaceUUID,
+		VaultUUID:               vault.UUID,
+		VaultExternalID:         vault.ExternalID,
+		MCPServerURL:            "https://mcp.example.test/" + suffix,
+		RedirectURL:             "https://app.example.test/callback",
+		DisplayName:             "typed UUID",
+		Source:                  "integration",
+		AuthorizationEndpoint:   "https://auth.example.test/authorize",
+		TokenEndpoint:           "https://auth.example.test/token",
+		Resource:                "https://mcp.example.test",
+		ClientID:                "typed-uuid",
+		TokenEndpointAuthMethod: "none",
+		CodeVerifier:            "typed-uuid-verifier",
+		CodeChallengeMethod:     "S256",
+		Status:                  "pending",
+		CreatedAt:               now,
+		ExpiresAt:               now.Add(10 * time.Minute),
+	})
+	if err != nil || flow.UserUUID != "" || flow.UUID == "" {
+		t.Fatalf("create MCP OAuth flow with nullable typed user UUID = (%+v, %v)", flow, err)
+	}
+
+	builtin, builtinVersion, err := app.db.UpsertBuiltinSkillWithVersion(ctx, db.BuiltinSkill{
+		ExternalID:   "builtin_typed_uuid_" + suffix,
+		DisplayTitle: "typed UUID",
+		CreatedAt:    now,
+	}, db.BuiltinSkillVersion{
+		ExternalID:  "builtinver_typed_uuid_" + suffix,
+		Version:     "1.0.0",
+		Name:        "typed-uuid",
+		Description: "PostgreSQL UUID boundary",
+		Directory:   "typed-uuid",
+		S3Bucket:    "test",
+		S3Key:       "typed-uuid/" + suffix,
+		SizeBytes:   1,
+		SHA256:      strings.Repeat("d", 64),
+		CreatedAt:   now,
+	})
+	if err != nil || uuid.Validate(builtin.UUID) != nil || uuid.Validate(builtinVersion.UUID) != nil {
+		t.Fatalf("upsert builtin Skill through typed UUID rows = (%+v, %+v, %v)", builtin, builtinVersion, err)
+	}
+}
+
+// TestTypedUUIDFilesAndFilestorePostgres exercises the final UUID migration
+// surface against PostgreSQL: Files rows and cursors, storage accounting,
+// filesystem provisioning, nullable Filestore entry references, expiry
+// batching, and cleanup-job leases.
+func TestTypedUUIDFilesAndFilestorePostgres(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("typed-uuid-files-filestore"))
+	t.Cleanup(app.close)
+
+	_, _, organizationUUID, workspaceUUID, _, _, _, sessionUUID, codeSessionUUID, apiKeyUUID :=
+		seedFilestoreLookupScope(t, app)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	suffix := uuid.NewString()
+
+	firstFile := db.FileRecord{
+		UUID:                uuid.NewString(),
+		ExternalID:          "file_typed_uuid_first_" + suffix,
+		WorkspaceUUID:       workspaceUUID,
+		Filename:            "first.txt",
+		MimeType:            "text/plain",
+		SizeBytes:           3,
+		SHA256:              strings.Repeat("1", 64),
+		S3Bucket:            "typed-uuid",
+		S3Key:               "files/" + suffix + "/first.txt",
+		Downloadable:        true,
+		CreatedByAPIKeyUUID: apiKeyUUID,
+		CreatedAt:           now,
+	}
+	secondFile := firstFile
+	secondFile.UUID = uuid.NewString()
+	secondFile.ExternalID = "file_typed_uuid_second_" + suffix
+	secondFile.Filename = "second.txt"
+	secondFile.SizeBytes = 4
+	secondFile.SHA256 = strings.Repeat("2", 64)
+	secondFile.S3Key = "files/" + suffix + "/second.txt"
+	secondFile.CreatedAt = now.Add(time.Millisecond)
+	for _, file := range []db.FileRecord{firstFile, secondFile} {
+		if err := app.db.CreateFile(ctx, file); err != nil {
+			t.Fatalf("create File through typed UUID parameters: %v", err)
+		}
+	}
+	loadedFile, err := app.db.GetFileByUUIDInOrganization(ctx, organizationUUID, firstFile.UUID)
+	if err != nil || loadedFile.WorkspaceUUID != workspaceUUID || loadedFile.CreatedByAPIKeyUUID != apiKeyUUID {
+		t.Fatalf("get File through typed UUID row = (%+v, %v)", loadedFile, err)
+	}
+	firstPage, hasMore, err := app.db.ListFilesPage(ctx, db.ListFilesPageParams{
+		WorkspaceUUID: workspaceUUID,
+		Limit:         1,
+	})
+	if err != nil || !hasMore || len(firstPage) != 1 || firstPage[0].ExternalID != secondFile.ExternalID {
+		t.Fatalf("first Files page through typed UUID rows = (%+v, %v, %v)", firstPage, hasMore, err)
+	}
+	secondPage, _, err := app.db.ListFilesPage(ctx, db.ListFilesPageParams{
+		WorkspaceUUID: workspaceUUID,
+		AfterID:       secondFile.ExternalID,
+		Limit:         1,
+	})
+	if err != nil || len(secondPage) != 1 || secondPage[0].ExternalID != firstFile.ExternalID {
+		t.Fatalf("Files page with typed UUID cursor = (%+v, %v)", secondPage, err)
+	}
+
+	filesystemUUID := uuid.NewString()
+	filesystem, created, err := app.db.ProvisionFilestoreFilesystem(ctx, db.ProvisionFilestoreFilesystemInput{
+		UUID:                filesystemUUID,
+		ExternalID:          "claude_chat_typed_uuid_" + strings.ReplaceAll(suffix, "-", ""),
+		OrganizationUUID:    organizationUUID,
+		WorkspaceUUID:       workspaceUUID,
+		SessionUUID:         sessionUUID,
+		CodeSessionUUID:     &codeSessionUUID,
+		CreatedByAPIKeyUUID: &apiKeyUUID,
+		Now:                 now,
+	})
+	if err != nil || !created || filesystem.UUID != filesystemUUID ||
+		filesystem.CodeSessionUUID == nil || *filesystem.CodeSessionUUID != codeSessionUUID {
+		t.Fatalf("provision Filestore filesystem through typed UUIDs = (%+v, %v, %v)", filesystem, created, err)
+	}
+	loadedFilesystem, err := app.db.GetFilestoreFilesystem(ctx, workspaceUUID, filesystem.UUID)
+	if err != nil || loadedFilesystem.ExternalID != filesystem.ExternalID {
+		t.Fatalf("get Filestore filesystem by typed UUID identifier = (%+v, %v)", loadedFilesystem, err)
+	}
+
+	activeResult, err := app.db.PutFilestoreFile(ctx, db.PutFilestoreFileInput{
+		WorkspaceUUID:  workspaceUUID,
+		FilesystemUUID: filesystem.UUID,
+		Path:           "/outputs/active.txt",
+		Blob: db.FilestoreFileBlob{
+			SizeBytes:             9,
+			MediaType:             "text/plain",
+			DetectedMimeType:      "text/plain",
+			Metadata:              []byte(`{"typed_uuid":true}`),
+			AuthorizationMetadata: []byte(`{}`),
+			Tags:                  []string{"typed-uuid"},
+			Downloadable:          true,
+			MD5:                   strings.Repeat("a", 32),
+			SHA256:                strings.Repeat("a", 64),
+			S3Bucket:              "typed-uuid",
+			S3Key:                 "filestore/" + suffix + "/active.txt",
+			S3ETag:                "etag-active",
+			S3VersionID:           "version-active",
+		},
+		Now: now,
+	})
+	if err != nil {
+		t.Fatalf("put Filestore file through typed UUID parameters: %v", err)
+	}
+	if activeResult.Entry.UUID == "" || activeResult.Entry.ManagedResourceUUID != nil ||
+		activeResult.Entry.SourceFileUUID != nil ||
+		activeResult.Entry.CreatedByCodeSessionUUID == nil ||
+		*activeResult.Entry.CreatedByCodeSessionUUID != codeSessionUUID {
+		t.Fatalf("Filestore nullable UUID row = %+v", activeResult.Entry)
+	}
+
+	expiredAt := now.Add(-time.Minute)
+	if _, err := app.db.PutFilestoreFile(ctx, db.PutFilestoreFileInput{
+		WorkspaceUUID:  workspaceUUID,
+		FilesystemUUID: filesystem.UUID,
+		Path:           "/outputs/expired.txt",
+		Blob: db.FilestoreFileBlob{
+			SizeBytes:             5,
+			MediaType:             "text/plain",
+			Metadata:              []byte(`{}`),
+			AuthorizationMetadata: []byte(`{}`),
+			MD5:                   strings.Repeat("b", 32),
+			SHA256:                strings.Repeat("b", 64),
+			S3Bucket:              "typed-uuid",
+			S3Key:                 "filestore/" + suffix + "/expired.txt",
+			ExpiresAt:             &expiredAt,
+		},
+		Now: now,
+	}); err != nil {
+		t.Fatalf("put expiring Filestore file: %v", err)
+	}
+	expiryJobs, err := app.db.ExpireFilestoreEntries(ctx, 10)
+	if err != nil || len(expiryJobs) == 0 {
+		t.Fatalf("expire Filestore entries through UUID array binding = (%+v, %v)", expiryJobs, err)
+	}
+
+	page, err := app.db.ListFilestoreEntriesPage(ctx, db.ListFilestoreEntriesPageParams{
+		WorkspaceUUID:  workspaceUUID,
+		FilesystemUUID: filesystem.UUID,
+		DirectoryPath:  "/outputs",
+		Recursive:      true,
+		Limit:          1,
+		Cursor: &db.FilestoreEntryPageCursor{
+			Path: "/outputs",
+			UUID: uuid.NewString(),
+		},
+	})
+	if err != nil || len(page.Entries) != 1 || page.Entries[0].UUID != activeResult.Entry.UUID {
+		t.Fatalf("list Filestore entries with typed UUID cursor = (%+v, %v)", page, err)
+	}
+
+	cleanupJob, err := app.db.EnqueueFilestoreObjectCleanupJob(ctx, db.EnqueueFilestoreObjectCleanupJobInput{
+		WorkspaceUUID:   workspaceUUID,
+		FilesystemUUID:  filesystem.UUID,
+		EntryExternalID: activeResult.Entry.ExternalID,
+		Bucket:          "typed-uuid",
+		Key:             "filestore/" + suffix + "/sentinel.txt",
+		Reason:          "typed_uuid_integration",
+		RunAfter:        now,
+	})
+	if err != nil || cleanupJob.WorkspaceUUID != workspaceUUID || cleanupJob.FilesystemUUID != filesystem.UUID {
+		t.Fatalf("enqueue Filestore cleanup job through typed UUID row = (%+v, %v)", cleanupJob, err)
+	}
+	leaseToken := "typed-uuid-" + suffix
+	leasedJobs, err := app.db.LeaseFilestoreObjectCleanupJobs(ctx, leaseToken, 100, 10)
+	if err != nil {
+		t.Fatalf("lease Filestore cleanup jobs through typed UUID rows: %v", err)
+	}
+	foundCleanupJob := false
+	for _, job := range leasedJobs {
+		if job.UUID == cleanupJob.UUID {
+			foundCleanupJob = job.WorkspaceUUID == workspaceUUID && job.FilesystemUUID == filesystem.UUID
+			if err := app.db.CompleteLeasedFilestoreObjectCleanupJob(ctx, job.UUID, leaseToken); err != nil {
+				t.Fatalf("complete Filestore cleanup job with typed UUID parameter: %v", err)
+			}
+		}
+	}
+	if !foundCleanupJob {
+		t.Fatalf("leased Filestore cleanup jobs do not contain %s: %+v", cleanupJob.UUID, leasedJobs)
+	}
+
+	storageBytes, err := app.db.GetWorkspaceStorageBytes(ctx, workspaceUUID)
+	if err != nil || storageBytes != firstFile.SizeBytes+secondFile.SizeBytes+activeResult.Entry.OwnedBytes() {
+		t.Fatalf("workspace storage bytes = (%d, %v), want %d", storageBytes, err, 16)
+	}
+}

--- a/tests/webhooks_api_test.go
+++ b/tests/webhooks_api_test.go
@@ -117,7 +117,7 @@ func TestWebhooksAPI(t *testing.T) {
 		if err != nil {
 			t.Fatalf("load api key: %v", err)
 		}
-		storedWebhook, err := app.db.GetWebhookEndpoint(context.Background(), apiKey.WorkspaceUUID, created.ID)
+		storedWebhook, err := app.db.GetWebhookEndpoint(context.Background(), apiKey.WorkspaceUUID.String(), created.ID)
 		if err != nil {
 			t.Fatalf("load stored webhook: %v", err)
 		}
@@ -181,8 +181,8 @@ func TestWebhookEndpointDelivery(t *testing.T) {
 	enqueuer := webhooks.NewEnqueuer(app.db, app.cfg.Webhook, nil)
 	enqueue := func(eventType, resourceID string) {
 		enqueuer.Enqueue(ctx, webhooks.EnqueueInput{
-			WorkspaceUUID:       apiKey.WorkspaceUUID,
-			OrganizationUUID:    apiKey.OrganizationUUID,
+			WorkspaceUUID:       apiKey.WorkspaceUUID.String(),
+			OrganizationUUID:    apiKey.OrganizationUUID.String(),
 			WorkspaceExternalID: apiKey.WorkspaceExternalID,
 			EventType:           eventType,
 			ResourceID:          resourceID,
@@ -226,7 +226,7 @@ func TestWebhookEndpointDelivery(t *testing.T) {
 		payload.Type != "event" ||
 		payload.Data.Type != "session.status_idled" ||
 		payload.Data.ID != sessionID ||
-		payload.Data.OrganizationID != apiKey.OrganizationUUID {
+		payload.Data.OrganizationID != apiKey.OrganizationUUID.String() {
 		t.Fatalf("unexpected webhook event=%+v payload=%+v body=%s", event, payload, delivered.Body)
 	}
 


### PR DESCRIPTION
## Summary

- Migrate application SQL access from native pgx APIs to sqlx across core database resources.
- Add UUID-based identifier boundary protections, casts, helpers, and regression coverage.
- Update admin, auth, session, file, webhook, workspace, and related service paths to use the shared sqlx layer.
- Document database identifier reference conventions.

## Testing

- Added and updated unit, integration, and PostgreSQL-backed tests covering sqlx queries, UUID boundaries, identifier casts, and affected API resources.
- Existing API and database test suites were updated for the new access patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UUID validation and handling across authentication, administration, workspaces, sessions, files, webhooks, and storage operations.
  * Invalid or missing organization and resource identifiers now produce consistent not-found or empty-result behavior.
  * Improved support for UUID-based lookups, pagination, nullable relationships, and transactions.

* **Tests**
  * Added comprehensive database integration coverage for UUID binding, scanning, nullable values, pagination, and regression protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->