### PR TITLE
Add MCP HTTP proxy and managed-agent upstream policy controls

### DIFF
--- a/docs/design/be/ccrv2/upstream-proxy-and-model-runtime.md
+++ b/docs/design/be/ccrv2/upstream-proxy-and-model-runtime.md
@@ -149,6 +149,20 @@ Proxy-Authorization: Basic base64(code_session_id:session_ingress_jwt)
 - MITM 关闭：拨号成功后返回 framed `HTTP/1.1 200 Connection Established`，后续 chunk 作为原始 TCP bytes 双向转发。
 - MITM 开启：先加载 CA、动态签发目标 leaf certificate，并完成真实上游 TLS 握手；全部成功后才返回 `200`。服务端随后把 framed WebSocket 适配为 `net.Conn`，作为 TLS server 解密客户端 HTTP，并使用独立 TLS client 验证真实目标证书。
 
+### `GET|POST|DELETE /v2/ccr-sessions/{code_session_id}/mcp`
+
+Managed Agent 的远程 MCP 不再由 Sandbox 直接访问。Runner 在 environment-manager payload 边界把 Agent Snapshot 中的真实 URL 编码到 `mcp_url`，并将 MCP config 的连接地址改成此 session 级代理，同时通过 config header 携带 session-ingress JWT。
+
+代理执行以下边界：
+
+1. 从 `Authorization: Bearer` 或 `X-Api-Key` 读取 session-ingress JWT，并将签名 claims 中的 `session_id` 绑定到路径参数。
+2. `mcp_url` 必须是唯一、长度不超过 2048 字节、不含 userinfo/fragment 的绝对 HTTP(S) URL，并精确匹配当前 Session Agent Snapshot 的一个远程 MCP URL。
+3. 每次请求新鲜读取 Code Session → Environment / Session 租户关系，并在加载边界通过 `ParseMCPProxyPolicy` 一次性把 Agent Snapshot 编译为精确 URL 集合、MCP host 集合以及 Environment host/port matcher。handler 只把未改写的 `mcp_url` 交给 `AuthorizeMCPURL`；策略同时完成精确 URL 与真实 scheme/host/有效端口授权，不使用伪造的 `host:443`，也不在 handler 中重新解析 snapshot。随后解析目标地址并应用与 upstream proxy 相同的公网 IP / DNS rebinding 防护。受控本地排障可复用 `upstream_proxy_disable_ssrf_protection`，生产默认不得关闭。
+4. 删除 OMA 的 `Authorization`、`X-Api-Key`、`Proxy-Authorization` 和 `Proxy-Connection`，保留 MCP 协议与 content negotiation header。真实 MCP 凭证只允许在服务端 header injector 边界按已验签 session claims 和目标 URL 注入；默认实现不注入。
+5. 请求 method、body、目标 path/query、上游状态、端到端响应 header 和响应 body 均流式转发；`Mcp-Session-Id`、`Last-Event-ID` 与 SSE 不被缓冲或改写。
+
+该接口只接受 MCP Streamable HTTP 所需的 `GET`、`POST`、`DELETE`，不是任意 method 或任意 URL 的开放反向代理。收到合法代理请求时记录 method、Code Session ID、去除 query 的 `mcp_url`、Content-Type 和 Content-Length；策略日志另外记录租户、目标 host、reason 和错误。除白名单化的 Content-Type 外，日志不记录 `mcp_url` query、其他 header 值或 body。
+
 ## HTTPS MITM 边界
 
 根 CA 生命周期、动态 leaf 签发、缓存并发和有效期续签限制的完整设计见 [《CCRv2 MITM 证书签发设计》](./mitm-certificate-issuance.md)。
@@ -184,9 +198,11 @@ upstream proxy 是 Environment networking（`unrestricted` / `limited`）的**�
 
 ### 策略来源与解析时机
 
-- 策略模块是 `internal/networkpolicy`：纯策略深模块，不访问数据库。Environment 配置与 Session AgentSnapshot 的原始 JSON 只在加载边界出现，随后按命名 wire schema 解析为领域 `Config`，其中 allowlist 字符串只解析一次并保存为已校验、已归一化的 host/port/wildcard 值，再编译为类型化 `Policy`。proxy matcher 与 E2B provider projection 都消费这份领域值，避免 IDNA、IP、大小写和尾点语义漂移。授权函数只接收编译后策略与 CONNECT target，返回带机器可测 reason 的 `Decision`；org/workspace/environment 标识保留在 `codesessions` 上下文中用于数据库作用域与审计日志。
+- 策略模块是 `internal/networkpolicy`：纯策略深模块，不访问数据库。Environment 配置与 Session AgentSnapshot 的原始 JSON 只在加载边界出现，随后按命名 wire schema 解析为领域 `Config`，其中 allowlist 字符串只解析一次并保存为已校验、已归一化的 host/port/wildcard 值。CONNECT 使用编译后的 `Policy`；MCP HTTP proxy 使用 `MCPProxyPolicy`，在一次 snapshot 解析中同时编译精确 URL set、MCP host set 和相同的 Environment host matcher。两类 `codesessions` 策略上下文只保存各自的编译后策略与审计作用域，不保存或复制原始 Agent Snapshot。授权函数接收真实 CONNECT target 或未改写的 MCP URL，返回带机器可测 reason 的 `Decision`；org/workspace/environment 标识保留在 `codesessions` 上下文中用于数据库作用域与审计日志。
 - proxy 在 CONNECT Basic 双重凭证校验**之后**、DNS 解析与拨号**之前**，保留经 JWT 验证的 code session ID、organization UUID 与 workspace UUID，并通过单条租户作用域查询同时校验 `CodeSession` → Environment / Session 的内部 ID、external ID、organization 和 workspace 关系，读取 Environment 当前配置与 Session AgentSnapshot。查询同时要求 Code Session 为 `active` 且 Session 未 `terminated`，使会话停止后的下一次 CONNECT 立即失效。该查询在**每次 CONNECT 新鲜执行**（不缓存）。Environment 编辑因此对存活 Sandbox 的代理出口即时生效；E2B 层仍是 Sandbox 创建时的固定快照，两层语义差异是有意取舍（收紧即时生效优先于两层严格一致）。跨 CONNECT 复用 DB 结果与编译策略需要明确 revision 与失效语义，在 [#137](https://github.com/superduck-ai/open-managed-agents/issues/137) 单独设计；本阶段不引入可能延迟权限撤销的临时缓存。
-- Code Session、Environment、Session 任一读取失败，Environment 配置畸形，或 `allow_mcp_servers=true` 时 Session AgentSnapshot（包括 JSON `null`）/ 非空 MCP URL 无法解析，都必须 **fail-closed**：拒绝 CONNECT 并记录 `policy_unavailable`，绝不降级为 unrestricted 或跳过坏条目后部分放行。`networking` 对象存在但 `type` 未知（含空串）同样 fail-closed；只有顶层 `type` 为 `cloud` 的 Environment 配置才评估 networking（非 cloud Environment 没有受管 Sandbox 出口，视为 unrestricted）。整条链从已认证的 Code Session 行出发，relay 提交的任何 environment ID 或 allowlist 都不被信任，跨 workspace 借用 allowlist 在结构上不可能。
+- Code Session、Environment、Session 任一读取失败或 Environment 配置畸形都必须 **fail-closed**。CONNECT 在 `allow_mcp_servers=true` 时还要求 Session AgentSnapshot（包括 JSON `null`）及其中 MCP URL 可解析；MCP proxy 无论 networking 模式如何都要求 snapshot 合法，因为精确 URL set 是该接口的必需授权条件。失败时记录 `policy_unavailable`，绝不降级为 unrestricted 或跳过坏条目后部分放行。`networking` 对象存在但 `type` 未知（含空串）同样 fail-closed；只有顶层 `type` 为 `cloud` 的 Environment 配置才评估 networking（非 cloud Environment 没有受管 Sandbox 出口，视为 unrestricted）。整条链从已认证的 Code Session 行出发，relay 提交的任何 environment ID 或 allowlist 都不被信任，跨 workspace 借用 allowlist 在结构上不可能。
+
+精确 URL 与 Environment host policy 属于静态授权模型，由 `AuthorizeMCPURL` 统一裁决；公网 IP、DNS rebinding 和拨号地址锁定依赖请求时的 DNS 结果，仍属于 transport dialer 的运行时安全边界。两者顺序固定为先授权、后解析和拨号，不能用拨号层代替策略授权。
 
 ```mermaid
 flowchart TD
@@ -215,9 +231,9 @@ flowchart TD
 
 Go 官方 module proxy 对较大的 module zip（例如 `github.com/aws/aws-sdk-go@v1.55.8`）会重定向到 `storage.googleapis.com/proxy-golang-org-prod/...`。为了使 `allow_package_managers=true` 对这类真实下载保持完整，本阶段把 `storage.googleapis.com` 作为 package-manager host 放行。当前 CONNECT 策略只能按 host 决策，不能把授权限制到 `proxy-golang-org-prod` path，因此这是有意接受的 host 级权限扩大：启用 package-manager 网络访问也会允许该公共 GCS host 上的其他 HTTPS 路径。若未来需要只允许 Go proxy 签名重定向路径，必须在独立的 MITM path-aware 策略中实现，不能在明文 CONNECT 层伪造路径隔离。
 
-匹配规则：`*.example.com` 匹配任意深度子域但**不含 apex**（`example.com` 需单独列出）；带非 443 端口的条目对 proxy 惰性（CONNECT 只放行 443）；allowlist 条目在策略解析时先校验端口范围和完整 hostname label 语义，任一非法条目使整份策略 fail-closed。合法 allowlist 条目与 CONNECT target 匹配前统一归一化（小写、去尾点、IDNA→punycode）；DNS 子域与 wildcard 的字符、label 和 253 长度边界使用与 Kubernetes 同款的 RFC 1123 validator（vendored 自 `k8s.io/apimachinery` 的 `pkg/util/validation` 最小子集，位于 `internal/networkpolicy/dns1123.go`，正则与错误信息与上游逐字一致，不引入 k8s 依赖链），不在本项目维护自制正则。IDNA lookup 保留浏览器兼容映射，Unicode host 先转 punycode 再校验。IPv4/IPv6 字面量在 IDNA 前通过 `netip` 规范化，IPv4-mapped IPv6 统一为 IPv4，带 zone 的 IPv6 不接受；IP allowlist 只做精确匹配且仍须通过 SSRF/公网 IP 检查。编译后 `Policy` 用 exact set 和按 DNS label 倒序的 wildcard 索引匹配 target，不在授权时逐条重复解析 allowlist。策略授权不替代既有 443 端口、SSRF、公网 IP、DNS rebinding 与 MITM Host/SNI 检查。
+匹配规则：`*.example.com` 匹配任意深度子域但**不含 apex**（`example.com` 需单独列出）；无端口条目匹配该 host 的任意有效端口，显式端口条目只匹配相同端口。因 CONNECT 只接受 443，带非 443 端口的条目对 CONNECT 仍然惰性；MCP URL 则按 `http` 默认 80、`https` 默认 443 或 URL 显式端口匹配。allowlist 条目在策略解析时先校验端口范围和完整 hostname label 语义，任一非法条目使整份策略 fail-closed。合法 allowlist 条目与 target 匹配前统一归一化（小写、去尾点、IDNA→punycode）；DNS 子域与 wildcard 的字符、label 和 253 长度边界使用与 Kubernetes 同款的 RFC 1123 validator（vendored 自 `k8s.io/apimachinery` 的 `pkg/util/validation` 最小子集，位于 `internal/networkpolicy/dns1123.go`，正则与错误信息与上游逐字一致，不引入 k8s 依赖链），不在本项目维护自制正则。IDNA lookup 保留浏览器兼容映射，Unicode host 先转 punycode 再校验。IPv4/IPv6 字面量在 IDNA 前通过 `netip` 规范化，IPv4-mapped IPv6 统一为 IPv4，带 zone 的 IPv6 不接受；IP allowlist 只做精确匹配且仍须通过 SSRF/公网 IP 检查。编译后 `Policy` 使用一棵按 DNS label 倒序的 trie，节点按端口保存 exact 与 wildcard 终止规则，不在授权时逐条重复解析 allowlist。策略授权不替代既有 CONNECT 443 限制、SSRF、公网 IP、DNS rebinding 与 MITM Host/SNI 检查。
 
-`unrestricted` 保持既有行为：允许通过 SSRF 安全检查的任意公网 `host:443`。
+`unrestricted` 保持 CONNECT 的既有行为：允许通过 SSRF 安全检查的任意公网 `host:443`；MCP proxy 仍要求 URL 精确存在于当前 Session Agent Snapshot，但允许其中通过 SSRF 检查的 HTTP(S) 实际端口。
 
 ### 拒绝语义与观测
 

--- a/docs/design/be/managed-agent-claude-code-permission-bridge.md
+++ b/docs/design/be/managed-agent-claude-code-permission-bridge.md
@@ -29,14 +29,17 @@ Claude Code 运行在 `environment-manager` 中，它通过 MCP config 加载 MC
 
 ### 2.1 连接层
 
-`managedAgentSessionConfig` 继续从 agent snapshot 中读取 `mcp_servers`，生成 Claude Code 可加载的 MCP config file：
+`managedAgentSessionConfig` 继续从 agent snapshot 中读取 `mcp_servers`。Runner 创建 Code Session 后，在写入 environment-manager v0 payload 前把每个真实 MCP URL 放入 `mcp_url`，并把 Claude Code 实际连接地址改成 session 级 OMA proxy：
 
 ```json
 {
   "mcpServers": {
     "weather_service": {
       "type": "http",
-      "url": "http://host.docker.internal:39090/mcp"
+      "url": "http://host.docker.internal:38080/v2/ccr-sessions/cse_123/mcp?mcp_url=https%3A%2F%2Fmcp.example.com%2Fmcp",
+      "headers": {
+        "Authorization": "Bearer sk-ant-si-<JWT>"
+      }
     }
   }
 }
@@ -57,7 +60,7 @@ session config 继续通过现有字段传给 `environment-manager`：
 }
 ```
 
-`environment-manager` 已经会把 `claude_code_args` 展开成 Claude Code CLI 参数，因此本设计不改变 v0 stdin schema，也不修改 `environment-manager` 代码。
+`environment-manager` 已经会把 `claude_code_args` 展开成 Claude Code CLI 参数，因此本设计不改变 v0 stdin schema，也不修改 `environment-manager` 代码。MCP config file 保持 `0600`；代理验证 session-ingress JWT 与路径中的 Code Session ID，并要求 `mcp_url` 精确匹配该 Session Agent Snapshot 中的 MCP URL。转发前删除 OMA 的 `Authorization` / `X-Api-Key`，保留 `Mcp-Session-Id`、`Last-Event-ID`、content negotiation 等端到端 header。服务端凭证注入集中在独立 header injector 边界，当前默认不注入，后续可按已验签 claims、目标 URL 和 vault 写入真实上游凭证。
 
 ### 2.2 静态提示层
 
@@ -277,11 +280,12 @@ Claude Code 可能通过 `/worker/events` batch endpoint 上报 `can_use_tool`�
 
 ## 6. 实现边界
 
-不新增公开 API，不修改 `environment-manager`。
+新增 Code Session 专用的 `/v2/ccr-sessions/{code_session_id}/mcp` 代理接口，不修改 `environment-manager`。
 
 实现应集中在 `claude-api-server`：
 
-- Managed Agent session config 继续生成 MCP config file 和 `claude_code_args["mcp-config"]`。
+- Managed Agent session config 继续生成 MCP config file 和 `claude_code_args["mcp-config"]`；environment-manager payload 边界将其中的真实 URL 重写为 session 级代理 URL。
+- Code Session handler 负责 MCP proxy 的 JWT/path 绑定；加载边界通过 `ParseMCPProxyPolicy` 一次性把 Agent Snapshot 的精确 URL set 与 Environment host/port policy 编译为单一授权对象，handler 只调用 `AuthorizeMCPURL`，不保存或重解析原始 snapshot。授权后再执行拨号期 SSRF 防护、流式转发和凭证 header 注入边界。
 - Code session service 新增 policy-aware permission handler。
 - Session events 接收 `user.tool_confirmation` 后，将 public blocking event id 解析为 worker `tool_use_id`，补齐到 Claude Code `control_response` 的路由；旧 worker `tool_use_id` 作为兼容输入继续支持。
 - 日志只记录 tool name、server name、resolved permission、code session id、request id 等诊断字段；不要记录 secret、header value 或完整 tool input。
@@ -363,7 +367,7 @@ tools:
 期望：
 
 - 新 session 的 agent snapshot 包含 `weather_service` 和 `mcp_toolset`。
-- `/tmp/managed-agent-mcp-config.json` 包含 `weather_service`。
+- `/tmp/managed-agent-mcp-config.json` 包含 `weather_service`，其连接地址为 `/v2/ccr-sessions/{code_session_id}/mcp`，原始 URL 只出现在 `mcp_url`。
 - Claude Code init event 显示 MCP server connected。
 - 调用 `mcp__weather_service__get_weather` 时不再卡在 permission prompt。
 - DB 中能看到 `can_use_tool` outbound 和对应 auto `control_response` inbound。

--- a/internal/codesessions/handler.go
+++ b/internal/codesessions/handler.go
@@ -3,6 +3,8 @@ package codesessions
 import (
 	"context"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -20,9 +22,12 @@ type Handler struct {
 	logger                 *slog.Logger
 	sandboxTimeoutExtender SandboxTimeoutExtender
 	upstreamProxy          upstreamProxyRuntime
-	// loadPolicyContext 解析 CONNECT 授权所需的策略上下文；测试可替换为 fixture。
-	loadPolicyContext func(ctx context.Context, identity upstreamProxyIdentity) (upstreamProxyPolicyContext, error)
-	otlpLogMu         sync.Mutex
+	mcpProxyTransport      http.RoundTripper
+	injectMCPProxyHeaders  mcpProxyHeaderInjector
+	// 策略加载函数在生产环境读取数据库，测试可替换为 fixture。
+	loadUpstreamPolicyContext func(ctx context.Context, identity upstreamProxyIdentity) (upstreamProxyPolicyContext, error)
+	loadMCPPolicyContext      func(ctx context.Context, identity upstreamProxyIdentity) (mcpProxyPolicyContext, error)
+	otlpLogMu                 sync.Mutex
 }
 
 // SandboxTimeoutExtender renews the provider-side lifetime of a managed-agent
@@ -45,8 +50,11 @@ func NewHandler(cfg config.Config, service *Service, sandboxTimeoutExtender Sand
 		logger:                 logger,
 		sandboxTimeoutExtender: sandboxTimeoutExtender,
 		upstreamProxy:          newUpstreamProxyRuntime(),
+		mcpProxyTransport:      newMCPProxyTransport(cfg.CodeSession.UpstreamProxyDisableSSRFProtection),
+		injectMCPProxyHeaders:  func(context.Context, SessionCredentialClaims, *url.URL, http.Header) error { return nil },
 	}
-	handler.loadPolicyContext = handler.loadUpstreamProxyPolicyContext
+	handler.loadUpstreamPolicyContext = handler.loadUpstreamProxyPolicyContext
+	handler.loadMCPPolicyContext = handler.loadMCPProxyPolicyContext
 	// 只有 MITM 开启时才在构造阶段读取稳定私钥并签发一年期根证书，使配置错误在启动期失败。
 	// MITM 关闭时私钥路径完全休眠，由 CA 下载接口按需生成进程级临时 CA。
 	if cfg.CodeSession.UpstreamProxyMITMEnabled {

--- a/internal/codesessions/mcp_proxy.go
+++ b/internal/codesessions/mcp_proxy.go
@@ -1,0 +1,159 @@
+package codesessions
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
+	"github.com/superduck-ai/open-managed-agents/internal/networkpolicy"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const maxMCPProxyURLBytes = 2048
+
+// mcpProxyHeaderInjector 是服务端 MCP 凭证注入边界。默认实现不注入任何凭证；
+// 后续可在这里按已验签的 session claims 和目标 URL 从 vault 解析上游 header。
+type mcpProxyHeaderInjector func(context.Context, SessionCredentialClaims, *url.URL, http.Header) error
+
+func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request) {
+	codeSessionID := strings.TrimSpace(chi.URLParam(r, "code_session_id"))
+	claims, _, ok := h.authenticateRuntimeSession(w, r)
+	if !ok {
+		return
+	}
+	if codeSessionID == "" || claims.SessionID != codeSessionID {
+		httpapi.WriteError(w, r, httpapi.NewError(http.StatusUnauthorized, "authentication_error", "Invalid code session token"))
+		return
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodPost && r.Method != http.MethodDelete {
+		httpapi.WriteError(w, r, httpapi.NewError(http.StatusMethodNotAllowed, "invalid_request_error", "MCP proxy only supports GET, POST, and DELETE"))
+		return
+	}
+	target, rawTarget, err := parseMCPProxyTarget(r.URL.RawQuery)
+	if err != nil {
+		httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", err.Error()))
+		return
+	}
+	logTarget := *target
+	logTarget.RawQuery = ""
+	logTarget.ForceQuery = false
+	h.logger.InfoContext(r.Context(), "MCP proxy request received",
+		"code_session_id", codeSessionID,
+		"method", r.Method,
+		"mcp_url", logTarget.String(),
+		"content_type", strings.TrimSpace(r.Header.Get("Content-Type")),
+		"content_length", r.ContentLength,
+	)
+	identity := upstreamProxyIdentity{
+		codeSessionExternalID: claims.SessionID,
+		organizationUUID:      claims.OrganizationUUID,
+		workspaceUUID:         claims.WorkspaceUUID,
+	}
+	if !h.authorizeMCPProxyTarget(r.Context(), identity, target, rawTarget) {
+		httpapi.WriteError(w, r, httpapi.NewError(http.StatusForbidden, "permission_error", "MCP upstream is not allowed"))
+		return
+	}
+
+	headers := r.Header.Clone()
+	for _, name := range []string{"Authorization", "X-Api-Key", "Proxy-Authorization", "Proxy-Connection"} {
+		headers.Del(name)
+	}
+	if h.injectMCPProxyHeaders != nil {
+		if err := h.injectMCPProxyHeaders(r.Context(), claims, target, headers); err != nil {
+			h.logger.ErrorContext(r.Context(), "inject MCP proxy credentials", "code_session_id", codeSessionID, "host", target.Hostname(), "error", err)
+			httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadGateway, "api_error", "MCP upstream credentials are unavailable"))
+			return
+		}
+	}
+	request := r.Clone(r.Context())
+	request.Header = headers
+	h.serveMCPProxy(w, request, target, codeSessionID)
+}
+
+func (h *Handler) authorizeMCPProxyTarget(ctx context.Context, identity upstreamProxyIdentity, target *url.URL, rawTarget string) bool {
+	policyContext, err := h.loadMCPPolicyContext(ctx, identity)
+	if err != nil {
+		h.logger.WarnContext(ctx, "MCP proxy policy denied", "organization_uuid", identity.organizationUUID, "workspace_uuid", identity.workspaceUUID, "code_session_id", identity.codeSessionExternalID, "reason", string(networkpolicy.ReasonPolicyUnavailable), "host", target.Hostname(), "error", err)
+		return false
+	}
+	decision := policyContext.policy.AuthorizeMCPURL(rawTarget)
+	if !decision.Allow {
+		h.logger.WarnContext(ctx, "MCP proxy policy denied", "organization_uuid", policyContext.organizationUUID, "workspace_uuid", policyContext.workspaceUUID, "environment_id", policyContext.environmentExternalID, "code_session_id", identity.codeSessionExternalID, "reason", string(decision.Reason), "host", decision.Host)
+		return false
+	}
+	h.logger.DebugContext(ctx, "MCP proxy policy allowed", "organization_uuid", policyContext.organizationUUID, "workspace_uuid", policyContext.workspaceUUID, "environment_id", policyContext.environmentExternalID, "code_session_id", identity.codeSessionExternalID, "reason", string(decision.Reason), "host", decision.Host)
+	return true
+}
+
+func (h *Handler) serveMCPProxy(w http.ResponseWriter, r *http.Request, target *url.URL, codeSessionID string) {
+	transport := h.mcpProxyTransport
+	if transport == nil {
+		transport = newMCPProxyTransport(h.cfg.CodeSession.UpstreamProxyDisableSSRFProtection)
+	}
+	proxy := &httputil.ReverseProxy{
+		Transport:     transport,
+		FlushInterval: -1,
+		Rewrite: func(request *httputil.ProxyRequest) {
+			upstreamURL := *target
+			request.Out.URL = &upstreamURL
+			request.Out.Host = target.Host
+		},
+		ErrorHandler: func(writer http.ResponseWriter, request *http.Request, err error) {
+			if request.Context().Err() == nil {
+				h.logger.WarnContext(request.Context(), "proxy MCP upstream request", "code_session_id", codeSessionID, "host", target.Hostname(), "error", err)
+			}
+			httpapi.WriteError(writer, request, httpapi.NewError(http.StatusBadGateway, "api_error", "MCP upstream is unavailable"))
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+func parseMCPProxyTarget(rawQuery string) (*url.URL, string, error) {
+	query, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return nil, "", errors.New("mcp_url query parameter is invalid")
+	}
+	values := query["mcp_url"]
+	if len(values) != 1 {
+		return nil, "", errors.New("exactly one mcp_url query parameter is required")
+	}
+	rawTarget := strings.TrimSpace(values[0])
+	if rawTarget == "" || len(rawTarget) > maxMCPProxyURLBytes {
+		return nil, "", errors.New("mcp_url query parameter is invalid")
+	}
+	target, err := url.Parse(rawTarget)
+	if err != nil || !target.IsAbs() || target.Host == "" || target.Hostname() == "" {
+		return nil, "", errors.New("mcp_url must be an absolute HTTP(S) URL")
+	}
+	target.Scheme = strings.ToLower(target.Scheme)
+	if (target.Scheme != "http" && target.Scheme != "https") || target.User != nil || target.Fragment != "" {
+		return nil, "", errors.New("mcp_url must be an absolute HTTP(S) URL without credentials or fragments")
+	}
+	return target, rawTarget, nil
+}
+
+func newMCPProxyTransport(disableSSRFProtection bool) http.RoundTripper {
+	transport := &http.Transport{DisableCompression: true, MaxIdleConnsPerHost: 32}
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok && defaultTransport != nil {
+		transport = defaultTransport.Clone()
+		transport.Proxy = nil
+		transport.DisableCompression = true
+		transport.MaxIdleConnsPerHost = 32
+	}
+	dialer := net.Dialer{Timeout: upstreamProxyDialTimeout, KeepAlive: 30 * time.Second}
+	transport.DialContext = func(ctx context.Context, _ string, address string) (net.Conn, error) {
+		resolved, err := resolveProxyTarget(ctx, address, disableSSRFProtection, false)
+		if err != nil {
+			return nil, err
+		}
+		return dialer.DialContext(ctx, "tcp", resolved)
+	}
+	return transport
+}

--- a/internal/codesessions/mcp_proxy_test.go
+++ b/internal/codesessions/mcp_proxy_test.go
@@ -1,0 +1,187 @@
+package codesessions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+	"github.com/superduck-ai/open-managed-agents/internal/networkpolicy"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestParseMCPProxyTargetRejectsInvalidTargets(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		query string
+	}{
+		{name: "missing", query: "other=value"},
+		{name: "duplicate", query: "mcp_url=https%3A%2F%2Fone.example&mcp_url=https%3A%2F%2Ftwo.example"},
+		{name: "relative", query: "mcp_url=%2Fapi%2Fmcp"},
+		{name: "unsupported scheme", query: "mcp_url=ftp%3A%2F%2Fexample.test%2Fmcp"},
+		{name: "embedded credentials", query: "mcp_url=https%3A%2F%2Fuser%3Asecret%40example.test%2Fmcp"},
+		{name: "fragment", query: "mcp_url=https%3A%2F%2Fexample.test%2Fmcp%23fragment"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, _, err := parseMCPProxyTarget(test.query); err == nil {
+				t.Fatal("parseMCPProxyTarget() error = nil, want error")
+			}
+		})
+	}
+}
+
+func TestMCPProxyAuthorizationRejectsURLNotInSession(t *testing.T) {
+	snapshot := json.RawMessage(`{"mcp_servers":[{"type":"http","url":"https://configured.example/mcp"}]}`)
+	policy, err := networkpolicy.ParseMCPProxyPolicy(json.RawMessage(`{"type":"cloud","networking":{"type":"unrestricted"}}`), snapshot)
+	if err != nil {
+		t.Fatalf("parse policy: %v", err)
+	}
+	handler := &Handler{
+		logger: slog.Default(),
+		loadMCPPolicyContext: func(context.Context, upstreamProxyIdentity) (mcpProxyPolicyContext, error) {
+			return mcpProxyPolicyContext{policy: policy}, nil
+		},
+	}
+	target, err := url.Parse("https://other.example/mcp")
+	if err != nil {
+		t.Fatalf("parse target: %v", err)
+	}
+	if handler.authorizeMCPProxyTarget(context.Background(), testUpstreamProxyIdentity(), target, target.String()) {
+		t.Fatal("unconfigured MCP URL must be denied")
+	}
+}
+
+func TestMCPProxyForwardsProtocolHeadersAndUsesCredentialInjector(t *testing.T) {
+	type capturedRequest struct {
+		method  string
+		uri     string
+		host    string
+		headers http.Header
+		body    string
+	}
+	captured := make(chan capturedRequest, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured <- capturedRequest{method: r.Method, uri: r.URL.RequestURI(), host: r.Host, headers: r.Header.Clone(), body: string(body)}
+		w.Header().Set("Mcp-Session-Id", "upstream-session")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","result":{}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	targetURL := upstream.URL + "/api/mcp?tenant=one"
+	snapshot, err := json.Marshal(map[string]any{"mcp_servers": []any{map[string]any{"type": "http", "url": targetURL}}})
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	policy, err := networkpolicy.ParseMCPProxyPolicy(json.RawMessage(`{"type":"cloud","networking":{"type":"unrestricted"}}`), snapshot)
+	if err != nil {
+		t.Fatalf("parse policy: %v", err)
+	}
+	credentials, err := NewSessionCredentials(config.Config{})
+	if err != nil {
+		t.Fatalf("create credentials: %v", err)
+	}
+	service := NewServiceWithCredentials(nil, credentials, nil)
+	var logOutput bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logOutput, nil))
+	handler := NewHandler(config.Config{}, service, nil, logger)
+	handler.mcpProxyTransport = http.DefaultTransport
+	handler.loadMCPPolicyContext = func(context.Context, upstreamProxyIdentity) (mcpProxyPolicyContext, error) {
+		return mcpProxyPolicyContext{
+			policy: policy,
+			proxyPolicyScope: proxyPolicyScope{
+				organizationUUID:      "00000000-0000-0000-0000-000000000001",
+				workspaceUUID:         "00000000-0000-0000-0000-000000000002",
+				environmentExternalID: "env_test",
+			},
+		}, nil
+	}
+	handler.injectMCPProxyHeaders = func(_ context.Context, claims SessionCredentialClaims, target *url.URL, headers http.Header) error {
+		if claims.SessionID != "cse_test" || target.String() != targetURL {
+			t.Errorf("credential injector context = session %q target %q", claims.SessionID, target)
+		}
+		headers.Set("Authorization", "Bearer upstream-secret")
+		headers.Set("X-MCP-Key", "vault-secret")
+		return nil
+	}
+	token, err := credentials.Issue(SessionCredentialIdentity{
+		SessionID:        "cse_test",
+		PublicSessionID:  "sesn_test",
+		AgentID:          "agent_test",
+		AgentVersion:     1,
+		OrganizationUUID: "00000000-0000-0000-0000-000000000001",
+		WorkspaceUUID:    "00000000-0000-0000-0000-000000000002",
+	})
+	if err != nil {
+		t.Fatalf("issue session token: %v", err)
+	}
+
+	router := chi.NewRouter()
+	router.Route("/v2", handler.RegisterV2Routes)
+	proxyServer := httptest.NewServer(router)
+	t.Cleanup(proxyServer.Close)
+	proxyURL := proxyServer.URL + "/v2/ccr-sessions/cse_test/mcp?" + url.Values{"mcp_url": {targetURL}}.Encode()
+	request, err := http.NewRequest(http.MethodPost, proxyURL, bytes.NewBufferString(`{"jsonrpc":"2.0","method":"initialize"}`))
+	if err != nil {
+		t.Fatalf("create proxy request: %v", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json, text/event-stream")
+	request.Header.Set("Mcp-Session-Id", "client-session")
+	request.Header.Set("Proxy-Authorization", "must-not-leak")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read proxy response: %v", err)
+	}
+	if response.StatusCode != http.StatusAccepted || response.Header.Get("Mcp-Session-Id") != "upstream-session" || !strings.Contains(string(responseBody), `"result"`) {
+		t.Fatalf("proxy response = status %d headers %#v body %s", response.StatusCode, response.Header, responseBody)
+	}
+
+	got := <-captured
+	if got.method != http.MethodPost || got.uri != "/api/mcp?tenant=one" || got.host != strings.TrimPrefix(upstream.URL, "http://") || !strings.Contains(got.body, `"initialize"`) {
+		t.Fatalf("upstream request = %#v", got)
+	}
+	if got.headers.Get("Authorization") != "Bearer upstream-secret" || got.headers.Get("X-MCP-Key") != "vault-secret" {
+		t.Fatalf("upstream credentials = %#v", got.headers)
+	}
+	if got.headers.Get("Proxy-Authorization") != "" || got.headers.Get("Mcp-Session-Id") != "client-session" {
+		t.Fatalf("upstream protocol headers = %#v", got.headers)
+	}
+
+	var requestLog map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(logOutput.String()), "\n") {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("decode log entry: %v", err)
+		}
+		if entry["msg"] == "MCP proxy request received" {
+			requestLog = entry
+			break
+		}
+	}
+	if requestLog == nil {
+		t.Fatal("MCP proxy request log not found")
+	}
+	if requestLog["code_session_id"] != "cse_test" || requestLog["method"] != http.MethodPost || requestLog["mcp_url"] != upstream.URL+"/api/mcp" || requestLog["content_type"] != "application/json" {
+		t.Fatalf("MCP proxy request log = %#v", requestLog)
+	}
+	if strings.Contains(logOutput.String(), "tenant=one") || strings.Contains(logOutput.String(), "upstream-secret") {
+		t.Fatalf("MCP proxy request log leaked sensitive data: %s", logOutput.String())
+	}
+}

--- a/internal/codesessions/routes.go
+++ b/internal/codesessions/routes.go
@@ -21,6 +21,7 @@ func (h *Handler) RegisterV1Routes(router chi.Router) {
 func (h *Handler) RegisterV2Routes(router chi.Router) {
 	h.registerSessionIngressRoutes(router)
 	router.Get("/sessions/{code_session_id}", h.handleSessionContext)
+	router.Handle("/ccr-sessions/{code_session_id}/mcp", http.HandlerFunc(h.handleMCPProxy))
 }
 
 func (h *Handler) registerRuntimeRoutes(router chi.Router) {

--- a/internal/codesessions/upstream_proxy.go
+++ b/internal/codesessions/upstream_proxy.go
@@ -239,11 +239,15 @@ func upstreamProxyCredentialsMatch(request upstreamProxyConnectRequest, expected
 func resolveUpstreamProxyTarget(ctx context.Context, target string, disableSSRFProtection bool) (string, error) {
 	// 即使临时关闭 SSRF 地址过滤，也继续限制为 443：当前协议只支持 HTTPS CONNECT，
 	// 不能把该开关扩展成任意端口的通用 TCP 转发器。
+	return resolveProxyTarget(ctx, target, disableSSRFProtection, true)
+}
+
+func resolveProxyTarget(ctx context.Context, target string, disableSSRFProtection bool, httpsOnly bool) (string, error) {
 	host, port, err := net.SplitHostPort(target)
 	if err != nil || strings.TrimSpace(host) == "" {
 		return "", &upstreamProxyTargetError{status: http.StatusBadRequest, cause: errors.New("invalid CONNECT target")}
 	}
-	if port != "443" {
+	if strings.TrimSpace(port) == "" || (httpsOnly && port != "443") {
 		return "", &upstreamProxyTargetError{status: http.StatusForbidden, cause: errors.New("only HTTPS targets are allowed")}
 	}
 	// IP 字面量无需 DNS；默认必须是公网地址，临时开关开启时才原样放行。

--- a/internal/codesessions/upstream_proxy_policy.go
+++ b/internal/codesessions/upstream_proxy_policy.go
@@ -7,13 +7,22 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/networkpolicy"
 )
 
-// upstreamProxyPolicyContext 是一次 CONNECT 授权所需的策略上下文：
-// Policy 供纯策略模块决策，其余字段只用于服务端审计日志。
-type upstreamProxyPolicyContext struct {
-	policy                networkpolicy.Policy
+type proxyPolicyScope struct {
 	organizationUUID      string
 	workspaceUUID         string
 	environmentExternalID string
+}
+
+// upstreamProxyPolicyContext 是一次 CONNECT 授权所需的编译后策略与审计作用域。
+type upstreamProxyPolicyContext struct {
+	policy networkpolicy.Policy
+	proxyPolicyScope
+}
+
+// mcpProxyPolicyContext 是一次 MCP HTTP proxy 授权所需的编译后策略与审计作用域。
+type mcpProxyPolicyContext struct {
+	policy networkpolicy.MCPProxyPolicy
+	proxyPolicyScope
 }
 
 // upstreamProxyIdentity 只由已验签的 session-ingress JWT claims 构造，作为
@@ -43,10 +52,38 @@ func (h *Handler) loadUpstreamProxyPolicyContext(ctx context.Context, identity u
 		return upstreamProxyPolicyContext{}, err
 	}
 	return upstreamProxyPolicyContext{
-		organizationUUID:      record.OrganizationUUID,
-		workspaceUUID:         record.WorkspaceUUID,
-		environmentExternalID: record.EnvironmentExternalID,
-		policy:                policy,
+		policy: policy,
+		proxyPolicyScope: proxyPolicyScope{
+			organizationUUID:      record.OrganizationUUID,
+			workspaceUUID:         record.WorkspaceUUID,
+			environmentExternalID: record.EnvironmentExternalID,
+		},
+	}, nil
+}
+
+// loadMCPProxyPolicyContext 为 MCP HTTP proxy 编译精确 URL 与 Environment
+// host 策略；原始 Agent Snapshot 不会越过该加载边界。
+func (h *Handler) loadMCPProxyPolicyContext(ctx context.Context, identity upstreamProxyIdentity) (mcpProxyPolicyContext, error) {
+	record, err := h.db.GetCodeSessionNetworkPolicyContext(
+		ctx,
+		identity.codeSessionExternalID,
+		identity.organizationUUID,
+		identity.workspaceUUID,
+	)
+	if err != nil {
+		return mcpProxyPolicyContext{}, err
+	}
+	policy, err := networkpolicy.ParseMCPProxyPolicy(record.EnvironmentConfig, record.AgentSnapshot)
+	if err != nil {
+		return mcpProxyPolicyContext{}, err
+	}
+	return mcpProxyPolicyContext{
+		policy: policy,
+		proxyPolicyScope: proxyPolicyScope{
+			organizationUUID:      record.OrganizationUUID,
+			workspaceUUID:         record.WorkspaceUUID,
+			environmentExternalID: record.EnvironmentExternalID,
+		},
 	}, nil
 }
 
@@ -54,7 +91,7 @@ func (h *Handler) loadUpstreamProxyPolicyContext(ctx context.Context, identity u
 // Environment networking 策略。拒绝时只向 relay 返回通用 framed 403，reason 与
 // 维度标识只进服务端审计日志；不记录 credential、query、header 或 body。
 func (h *Handler) authorizeUpstreamProxyTarget(ctx context.Context, identity upstreamProxyIdentity, target string) bool {
-	policyContext, err := h.loadPolicyContext(ctx, identity)
+	policyContext, err := h.loadUpstreamPolicyContext(ctx, identity)
 	attrs := []any{
 		"event", "upstream_proxy_policy",
 		"organization_uuid", identity.organizationUUID,

--- a/internal/codesessions/upstream_proxy_policy_test.go
+++ b/internal/codesessions/upstream_proxy_policy_test.go
@@ -82,7 +82,7 @@ func stubUnrestrictedPolicyContext(t *testing.T, handler *Handler) {
 	if err != nil {
 		t.Fatalf("ParsePolicy() error = %v", err)
 	}
-	handler.loadPolicyContext = func(context.Context, upstreamProxyIdentity) (upstreamProxyPolicyContext, error) {
+	handler.loadUpstreamPolicyContext = func(context.Context, upstreamProxyIdentity) (upstreamProxyPolicyContext, error) {
 		return upstreamProxyPolicyContext{policy: policy}, nil
 	}
 }
@@ -90,12 +90,14 @@ func stubUnrestrictedPolicyContext(t *testing.T, handler *Handler) {
 func policyTestHandler(t *testing.T, policy networkpolicy.Policy, err error) *Handler {
 	t.Helper()
 	handler := NewHandler(config.Config{}, newTestService(t, nil), nil, nil)
-	handler.loadPolicyContext = func(context.Context, upstreamProxyIdentity) (upstreamProxyPolicyContext, error) {
+	handler.loadUpstreamPolicyContext = func(context.Context, upstreamProxyIdentity) (upstreamProxyPolicyContext, error) {
 		return upstreamProxyPolicyContext{
-			policy:                policy,
-			organizationUUID:      "00000000-0000-0000-0000-000000000001",
-			workspaceUUID:         "00000000-0000-0000-0000-000000000002",
-			environmentExternalID: "env_test",
+			policy: policy,
+			proxyPolicyScope: proxyPolicyScope{
+				organizationUUID:      "00000000-0000-0000-0000-000000000001",
+				workspaceUUID:         "00000000-0000-0000-0000-000000000002",
+				environmentExternalID: "env_test",
+			},
 		}, err
 	}
 	return handler

--- a/internal/environments/environment_manager.go
+++ b/internal/environments/environment_manager.go
@@ -3,10 +3,12 @@ package environments
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	urlpkg "net/url"
 	"path"
 	"strings"
 
+	"github.com/superduck-ai/open-managed-agents/internal/common/collections"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 )
@@ -90,6 +92,53 @@ func managedAgentMCPConfigFile(mcpConfig map[string]any) map[string]any {
 		"content": base64.StdEncoding.EncodeToString(content),
 		"mode":    0o600,
 	}
+}
+
+func proxyManagedAgentMCPConfig(startupContext map[string]any, apiBaseURL string, codeSessionID string, sessionIngressToken string) error {
+	rawConfig, ok := startupContext["mcp_config"]
+	if !ok {
+		return nil
+	}
+	mcpConfig, ok := rawConfig.(map[string]any)
+	if !ok {
+		return errors.New("managed agent mcp_config must be an object")
+	}
+	servers, ok := mcpConfig["mcpServers"].(map[string]any)
+	if !ok {
+		return errors.New("managed agent mcpServers must be an object")
+	}
+	for name, rawServer := range servers {
+		server, ok := rawServer.(map[string]any)
+		if !ok {
+			return errors.New("managed agent MCP server " + name + " must be an object")
+		}
+		upstreamURL := stringFromMap(server, "url")
+		proxyURL, err := codeSessionMCPProxyURL(apiBaseURL, codeSessionID, upstreamURL)
+		if err != nil {
+			return err
+		}
+		server["url"] = proxyURL
+		headers := mapStringAnyValue(server["headers"])
+		headers["Authorization"] = "Bearer " + sessionIngressToken
+		server["headers"] = headers
+	}
+	startupContext["mcp_config"] = mcpConfig
+	startupContext["mcp_config_file"] = managedAgentMCPConfigFile(mcpConfig)
+	return nil
+}
+
+func codeSessionMCPProxyURL(apiBaseURL string, codeSessionID string, upstreamURL string) (string, error) {
+	base, err := urlpkg.Parse(strings.TrimSpace(apiBaseURL))
+	if err != nil || base.Scheme == "" || base.Host == "" || (base.Scheme != "http" && base.Scheme != "https") {
+		return "", errors.New("code_session.sandbox_api_base_url must be an absolute HTTP(S) URL for MCP proxying")
+	}
+	if collections.IsBlank(codeSessionID) || collections.IsBlank(upstreamURL) {
+		return "", errors.New("managed agent MCP proxy requires a code session ID and upstream URL")
+	}
+	base.RawQuery = ""
+	base.Fragment = ""
+	proxyURL := strings.TrimRight(base.String(), "/") + "/v2/ccr-sessions/" + urlpkg.PathEscape(codeSessionID) + "/mcp"
+	return proxyURL + "?" + urlpkg.Values{"mcp_url": {upstreamURL}}.Encode(), nil
 }
 
 func mcpToolsetsByServer(tools []any) map[string]map[string]any {
@@ -223,7 +272,11 @@ func buildEnvironmentManagerV0Payload(codeSessionID string, sessionIngressToken 
 			return nil, err
 		}
 	}
-	startupContext["api_base_url"] = codeSessionSandboxAPIBaseURL(cfg)
+	apiBaseURL := codeSessionSandboxAPIBaseURL(cfg)
+	startupContext["api_base_url"] = apiBaseURL
+	if err := proxyManagedAgentMCPConfig(startupContext, apiBaseURL, codeSessionID, sessionIngressToken); err != nil {
+		return nil, err
+	}
 	startupContext["use_code_sessions"] = true
 	startupContext["session_id"] = codeSessionID
 	environmentVariables := mapStringAnyValue(startupContext["environment_variables"])

--- a/internal/environments/environment_manager_test.go
+++ b/internal/environments/environment_manager_test.go
@@ -31,6 +31,25 @@ func TestCodeSessionSandboxAPIBaseURLUsesConfiguredValue(t *testing.T) {
 	}
 }
 
+func TestCodeSessionMCPProxyURLRejectsIncompleteInputs(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		apiBaseURL  string
+		sessionID   string
+		upstreamURL string
+	}{
+		{name: "relative API base", apiBaseURL: "/api", sessionID: "cse_test", upstreamURL: "https://mcp.example/mcp"},
+		{name: "missing session", apiBaseURL: "https://api.example", upstreamURL: "https://mcp.example/mcp"},
+		{name: "missing upstream", apiBaseURL: "https://api.example", sessionID: "cse_test"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := codeSessionMCPProxyURL(test.apiBaseURL, test.sessionID, test.upstreamURL); err == nil {
+				t.Fatal("codeSessionMCPProxyURL() error = nil, want error")
+			}
+		})
+	}
+}
+
 func managedAgentRuntimeSourceValues(
 	t *testing.T,
 	sources []json.RawMessage,
@@ -343,6 +362,45 @@ func TestBuildEnvironmentManagerPayloadAndCommand(t *testing.T) {
 	if strings.Contains(allCommands, "installed managed agent skills") ||
 		strings.Contains(allCommands, "$HOME/.claude/skills") {
 		t.Fatalf("command should not install managed agent skills directly:\n%s", allCommands)
+	}
+}
+
+func TestBuildEnvironmentManagerPayloadProxiesMCPConfig(t *testing.T) {
+	cfg := config.Config{CodeSession: config.CodeSessionConfig{SandboxAPIBaseURL: "http://host.docker.internal:18081/"}}
+	sessionConfig := json.RawMessage(`{
+		"mcp_config":{"mcpServers":{"ms-api":{"type":"http","url":"https://learn.microsoft.com/api/mcp?view=azure"}}},
+		"mcp_config_file":{"path":"/tmp/stale.json","content":"stale","mode":384}
+	}`)
+	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", "", sessionConfig, cfg)
+	if err != nil {
+		t.Fatalf("build payload: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	startup := body["startup_context"].(map[string]any)
+	mcpConfig := startup["mcp_config"].(map[string]any)
+	server := mcpConfig["mcpServers"].(map[string]any)["ms-api"].(map[string]any)
+	wantURL := "http://host.docker.internal:18081/v2/ccr-sessions/cse_test/mcp?mcp_url=https%3A%2F%2Flearn.microsoft.com%2Fapi%2Fmcp%3Fview%3Dazure"
+	if server["url"] != wantURL || server["type"] != "http" {
+		t.Fatalf("proxied MCP server = %#v, want url %q", server, wantURL)
+	}
+	headers := server["headers"].(map[string]any)
+	if headers["Authorization"] != "Bearer sk-ant-si-test-token" {
+		t.Fatalf("MCP proxy headers = %#v", headers)
+	}
+	mcpConfigFile := startup["mcp_config_file"].(map[string]any)
+	content, err := base64.StdEncoding.DecodeString(mcpConfigFile["content"].(string))
+	if err != nil {
+		t.Fatalf("decode MCP config file: %v", err)
+	}
+	var fileConfig map[string]any
+	if err := json.Unmarshal(content, &fileConfig); err != nil {
+		t.Fatalf("decode MCP config file JSON: %v", err)
+	}
+	if !reflect.DeepEqual(fileConfig, mcpConfig) {
+		t.Fatalf("MCP config file = %#v, want %#v", fileConfig, mcpConfig)
 	}
 }
 

--- a/internal/networkpolicy/hosts.go
+++ b/internal/networkpolicy/hosts.go
@@ -140,12 +140,27 @@ func NormalizeHost(raw string) (string, error) {
 	return ascii, nil
 }
 
-// hostMatcher 是编译后的 allowlist 只读索引：只在 newHostMatcher 构造阶段
-// 写入，构造完成后可供多个 goroutine 并发读取。
+// hostMatcher 是按 DNS label 倒序存储的 trie。例如 api.example.com 的路径是
+// root → com → example → api，这样遍历到 example 节点时即可判断
+// *.example.com。索引只在 newHostMatcher 构造阶段写入，构造完成后可供多个
+// goroutine 并发读取。
 type hostMatcher struct {
 	root *hostMatcherNode
 }
 
+// 每个节点的 children map 只表达下一层域名 label，保留完整的父子路径；不能按
+// 整棵树的深度共用 map，否则 example.com 与 example.org 下的同名子节点会冲突。
+// rules 只存在于一条规则的终止节点：key 为空表示任意有效端口，非空 key 表示
+// 指定端口；value 分开标记 apex exact 与子域 wildcard，避免二者借用彼此的端口。
+// 例如 example.com:443、*.example.com:8443、api.example.com:9443 会编译为：
+//
+//	root
+//	└── children["com"]
+//	    └── children["example"]
+//	        ├── rules["443"]  = exact
+//	        ├── rules["8443"] = wildcard
+//	        └── children["api"]
+//	            └── rules["9443"] = exact
 type hostMatcherNode struct {
 	children map[string]*hostMatcherNode
 	rules    map[string]hostMatchRule
@@ -176,10 +191,13 @@ func (m hostMatcher) match(host string, port string) bool {
 			return false
 		}
 		node = next
+		// 仍有 label 未消费时，当前节点只允许匹配 wildcard；因此
+		// *.example.com 可以匹配 api.example.com，但不会匹配 apex example.com。
 		if index > 0 && node.matchesWildcard(port) {
 			return true
 		}
 	}
+	// 所有 label 都已消费，只有终止节点的 exact 规则可以匹配 apex。
 	return node.matchesExact(port)
 }
 

--- a/internal/networkpolicy/hosts.go
+++ b/internal/networkpolicy/hosts.go
@@ -143,66 +143,78 @@ func NormalizeHost(raw string) (string, error) {
 // hostMatcher 是编译后的 allowlist 只读索引：只在 newHostMatcher 构造阶段
 // 写入，构造完成后可供多个 goroutine 并发读取。
 type hostMatcher struct {
-	exact        map[string]struct{}
-	wildcardRoot *hostMatcherNode
+	root *hostMatcherNode
 }
 
 type hostMatcherNode struct {
 	children map[string]*hostMatcherNode
+	rules    map[string]hostMatchRule
+}
+
+type hostMatchRule struct {
+	exact    bool
 	wildcard bool
 }
 
 func newHostMatcher(entries []allowedHost) hostMatcher {
-	matcher := hostMatcher{
-		exact:        make(map[string]struct{}, len(entries)),
-		wildcardRoot: &hostMatcherNode{children: map[string]*hostMatcherNode{}},
-	}
+	matcher := hostMatcher{root: newHostMatcherNode()}
 	for _, entry := range entries {
-		if entry.port != "" && entry.port != "443" {
-			continue
-		}
-		if entry.wildcard {
-			matcher.addWildcard(entry.host)
-			continue
-		}
-		matcher.exact[entry.host] = struct{}{}
+		matcher.add(entry)
 	}
 	return matcher
 }
 
-func (m hostMatcher) match(host string) bool {
-	if _, ok := m.exact[host]; ok {
-		return true
-	}
-	labels := strings.Split(host, ".")
-	node := m.wildcardRoot
+func (m hostMatcher) match(host string, port string) bool {
+	node := m.root
 	if node == nil {
 		return false
 	}
+	labels := strings.Split(host, ".")
 	for index := len(labels) - 1; index >= 0; index-- {
 		next, ok := node.children[labels[index]]
 		if !ok {
 			return false
 		}
 		node = next
-		if node.wildcard && index > 0 {
+		if index > 0 && node.matchesWildcard(port) {
 			return true
 		}
 	}
-	return false
+	return node.matchesExact(port)
 }
 
-func (m hostMatcher) addWildcard(host string) {
-	node := m.wildcardRoot
-	labels := strings.Split(host, ".")
+func newHostMatcherNode() *hostMatcherNode {
+	return &hostMatcherNode{children: map[string]*hostMatcherNode{}}
+}
+
+func (m hostMatcher) add(entry allowedHost) {
+	node := m.root
+	labels := strings.Split(entry.host, ".")
 	for index := len(labels) - 1; index >= 0; index-- {
 		label := labels[index]
 		next, ok := node.children[label]
 		if !ok {
-			next = &hostMatcherNode{children: map[string]*hostMatcherNode{}}
+			next = newHostMatcherNode()
 			node.children[label] = next
 		}
 		node = next
 	}
-	node.wildcard = true
+	if node.rules == nil {
+		node.rules = map[string]hostMatchRule{}
+	}
+	rule := node.rules[entry.port]
+	if entry.wildcard {
+		rule.wildcard = true
+	} else {
+		rule.exact = true
+	}
+	node.rules[entry.port] = rule
+}
+
+func (n *hostMatcherNode) matchesExact(port string) bool {
+	return n.rules[""].exact || n.rules[port].exact
+}
+
+func (n *hostMatcherNode) matchesWildcard(port string) bool {
+	return n.rules[""].wildcard || n.rules[port].wildcard
 }

--- a/internal/networkpolicy/hosts_test.go
+++ b/internal/networkpolicy/hosts_test.go
@@ -38,8 +38,39 @@ func TestValidateAllowedHostRejectsInvalidEntries(t *testing.T) {
 }
 
 func TestHostMatcherZeroValueDoesNotMatch(t *testing.T) {
-	if (hostMatcher{}).match("api.example.com") {
+	if (hostMatcher{}).match("api.example.com", "443") {
 		t.Fatal("zero hostMatcher must not match")
+	}
+}
+
+func TestHostMatcherRequiresConfiguredPort(t *testing.T) {
+	entries, err := parseConfigAllowedHosts([]string{"api.example.com:8443", "*.example.org:9443", "public.example.net"})
+	if err != nil {
+		t.Fatalf("parseConfigAllowedHosts() error = %v", err)
+	}
+	matcher := newHostMatcher(entries)
+	if matcher.match("api.example.com", "443") || matcher.match("service.example.org", "443") {
+		t.Fatal("port-specific entries must not match a different port")
+	}
+	if !matcher.match("api.example.com", "8443") || !matcher.match("service.example.org", "9443") {
+		t.Fatal("port-specific entries must match their configured port")
+	}
+	if !matcher.match("public.example.net", "8080") {
+		t.Fatal("host-only entries must match any valid target port")
+	}
+}
+
+func TestHostMatcherSeparatesExactAndWildcardRulesAtSameNode(t *testing.T) {
+	entries, err := parseConfigAllowedHosts([]string{"example.com:443", "*.example.com:8443"})
+	if err != nil {
+		t.Fatalf("parseConfigAllowedHosts() error = %v", err)
+	}
+	matcher := newHostMatcher(entries)
+	if matcher.match("example.com", "8443") || matcher.match("api.example.com", "443") {
+		t.Fatal("exact and wildcard rules must not borrow each other's ports")
+	}
+	if !matcher.match("example.com", "443") || !matcher.match("api.example.com", "8443") {
+		t.Fatal("exact and wildcard rules must match their own ports")
 	}
 }
 
@@ -75,9 +106,9 @@ func TestHostMatcherSupportsConcurrentReads(t *testing.T) {
 		group.Add(1)
 		go func() {
 			defer group.Done()
-			results <- matcher.match("api.example.com") &&
-				matcher.match("storage.googleapis.com") &&
-				!matcher.match("example.org")
+			results <- matcher.match("api.example.com", "443") &&
+				matcher.match("storage.googleapis.com", "443") &&
+				!matcher.match("example.org", "443")
 		}()
 	}
 	group.Wait()

--- a/internal/networkpolicy/mcp.go
+++ b/internal/networkpolicy/mcp.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ErrMalformedAgentSnapshot 表示 Session AgentSnapshot 或其中的 MCP URL
-// 无法安全解析；allow_mcp_servers 开启时调用方必须 fail closed。
+// 无法安全解析；MCP 授权依赖 snapshot 时调用方必须 fail closed。
 var ErrMalformedAgentSnapshot = errors.New("malformed session agent snapshot")
 
 type agentSnapshotSchema struct {
@@ -25,6 +25,11 @@ type mcpServerSchema struct {
 }
 
 type mcpServerListSchema []mcpServerSchema
+
+type mcpServerTargets struct {
+	hosts []string
+	urls  []string
+}
 
 func (s *mcpServerListSchema) UnmarshalJSON(raw []byte) error {
 	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
@@ -43,28 +48,51 @@ func (s *mcpServerListSchema) UnmarshalJSON(raw []byte) error {
 // 自然排除；畸形 snapshot 或非空但不可解析的 URL 返回错误。runner 写入 work
 // metadata 与 proxy 授权共用本函数，保证两处语义不漂移。
 func MCPAllowedHosts(agentSnapshot json.RawMessage) ([]string, error) {
-	var snapshot agentSnapshotSchema
-	trimmed := bytes.TrimSpace(agentSnapshot)
-	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
-		return nil, ErrMalformedAgentSnapshot
+	targets, err := parseMCPServerTargets(agentSnapshot)
+	if err != nil {
+		return nil, err
 	}
-	if err := json.Unmarshal(trimmed, &snapshot); err != nil {
-		if errors.Is(err, ErrMalformedAgentSnapshot) {
-			return nil, err
-		}
-		return nil, fmt.Errorf("%w: invalid JSON", ErrMalformedAgentSnapshot)
+	return targets.hosts, nil
+}
+
+func parseMCPServerTargets(agentSnapshot json.RawMessage) (mcpServerTargets, error) {
+	snapshot, err := parseAgentSnapshotMCPServers(agentSnapshot)
+	if err != nil {
+		return mcpServerTargets{}, err
 	}
 	var hosts []string
+	var urls []string
 	for _, server := range snapshot.MCPServers {
 		host, err := mcpServerHost(server)
 		if err != nil {
-			return nil, err
+			return mcpServerTargets{}, err
 		}
 		if host != "" {
 			hosts = append(hosts, host)
 		}
+		if rawURL := strings.TrimSpace(server.URL); rawURL != "" {
+			urls = append(urls, rawURL)
+		}
 	}
-	return collections.UniqueTrimmedStrings(hosts), nil
+	return mcpServerTargets{
+		hosts: collections.UniqueTrimmedStrings(hosts),
+		urls:  collections.UniqueTrimmedStrings(urls),
+	}, nil
+}
+
+func parseAgentSnapshotMCPServers(agentSnapshot json.RawMessage) (agentSnapshotSchema, error) {
+	var snapshot agentSnapshotSchema
+	trimmed := bytes.TrimSpace(agentSnapshot)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return agentSnapshotSchema{}, ErrMalformedAgentSnapshot
+	}
+	if err := json.Unmarshal(trimmed, &snapshot); err != nil {
+		if errors.Is(err, ErrMalformedAgentSnapshot) {
+			return agentSnapshotSchema{}, err
+		}
+		return agentSnapshotSchema{}, fmt.Errorf("%w: invalid JSON", ErrMalformedAgentSnapshot)
+	}
+	return snapshot, nil
 }
 
 func mcpServerHost(server mcpServerSchema) (string, error) {

--- a/internal/networkpolicy/mcp_test.go
+++ b/internal/networkpolicy/mcp_test.go
@@ -94,3 +94,19 @@ func TestMCPAllowedHostsAcceptsCanonicalAndTransportRemoteServerTypes(t *testing
 		t.Fatalf("hosts = %v, want %v", hosts, want)
 	}
 }
+
+func TestParseMCPServerTargetsPreservesConfiguredURLs(t *testing.T) {
+	snapshot := json.RawMessage(`{"mcp_servers":[
+		{"type":"url","url":"https://example.test/mcp?tenant=one"},
+		{"type":"http","url":"http://streamable.example/mcp"},
+		{"type":"stdio","command":"npx"}
+	]}`)
+	targets, err := parseMCPServerTargets(snapshot)
+	if err != nil {
+		t.Fatalf("parse MCP targets: %v", err)
+	}
+	want := []string{"https://example.test/mcp?tenant=one", "http://streamable.example/mcp"}
+	if !slices.Equal(targets.urls, want) {
+		t.Fatalf("urls = %v, want %v", targets.urls, want)
+	}
+}

--- a/internal/networkpolicy/policy.go
+++ b/internal/networkpolicy/policy.go
@@ -2,6 +2,8 @@ package networkpolicy
 
 import (
 	"net"
+	"net/url"
+	"strings"
 
 	"github.com/superduck-ai/open-managed-agents/internal/common/collections"
 )
@@ -19,20 +21,27 @@ const (
 	ReasonPolicyUnavailable  Reason = "policy_unavailable"
 )
 
-// Decision 是单个已归一化 HTTPS target 的授权结果。
+// Decision 是单个已归一化网络 target 的授权结果。
 type Decision struct {
 	Allow  bool
 	Reason Reason
 	Host   string
 }
 
-// Policy 是解析并编译后的 Environment 网络策略。原始 JSON 只存在于
-// ParsePolicy 边界，授权逻辑仅处理类型化状态。
+// Policy 是解析并编译后的 Environment 网络策略。原始 JSON 只存在于策略
+// 解析边界，授权逻辑仅处理类型化状态。
 type Policy struct {
 	policyType           Type
 	explicitHosts        hostMatcher
 	mcpHosts             map[string]struct{}
 	allowPackageManagers bool
+}
+
+// MCPProxyPolicy 是 MCP HTTP proxy 的编译后授权策略，同时约束 Session
+// 配置的精确 URL 与 Environment 网络策略。
+type MCPProxyPolicy struct {
+	policy    Policy
+	mcpURLSet map[string]struct{}
 }
 
 // ParsePolicy 在策略加载边界解析数据库 JSON，并编译归一化的 host 索引。
@@ -42,20 +51,51 @@ func ParsePolicy(configRaw, agentSnapshotRaw []byte) (Policy, error) {
 	if err != nil {
 		return Policy{}, err
 	}
-	policy := Policy{policyType: config.Type}
-	if config.Type == TypeUnrestricted {
-		return policy, nil
-	}
-	policy.explicitHosts = newHostMatcher(config.allowedHosts)
-	policy.allowPackageManagers = config.AllowPackageManagers
+	var mcpHosts []string
 	if config.AllowMCPServers {
-		hosts, err := MCPAllowedHosts(agentSnapshotRaw)
+		targets, err := parseMCPServerTargets(agentSnapshotRaw)
 		if err != nil {
 			return Policy{}, err
 		}
-		policy.mcpHosts = collections.StringSet(hosts)
+		mcpHosts = targets.hosts
 	}
-	return policy, nil
+	return compilePolicy(config, mcpHosts), nil
+}
+
+// ParseMCPProxyPolicy 在 MCP proxy 的策略加载边界一次性解析 Environment
+// 配置与 Session Agent Snapshot，并编译精确 URL 集合和 host matcher。
+func ParseMCPProxyPolicy(configRaw, agentSnapshotRaw []byte) (MCPProxyPolicy, error) {
+	config, err := ParseConfig(configRaw)
+	if err != nil {
+		return MCPProxyPolicy{}, err
+	}
+	targets, err := parseMCPServerTargets(agentSnapshotRaw)
+	if err != nil {
+		return MCPProxyPolicy{}, err
+	}
+	var mcpHosts []string
+	if config.AllowMCPServers {
+		mcpHosts = targets.hosts
+	}
+	mcpURLSet := make(map[string]struct{}, len(targets.urls))
+	for _, rawURL := range targets.urls {
+		mcpURLSet[rawURL] = struct{}{}
+	}
+	return MCPProxyPolicy{
+		policy:    compilePolicy(config, mcpHosts),
+		mcpURLSet: mcpURLSet,
+	}, nil
+}
+
+func compilePolicy(config Config, mcpHosts []string) Policy {
+	policy := Policy{policyType: config.Type}
+	if config.Type == TypeUnrestricted {
+		return policy
+	}
+	policy.explicitHosts = newHostMatcher(config.allowedHosts)
+	policy.allowPackageManagers = config.AllowPackageManagers
+	policy.mcpHosts = collections.StringSet(mcpHosts)
+	return policy
 }
 
 // AuthorizeHTTPS 授权 host:443 形式的 target。SSRF、公网地址与 DNS rebinding
@@ -69,19 +109,54 @@ func (p Policy) AuthorizeHTTPS(target string) Decision {
 	if err != nil {
 		return Decision{Reason: ReasonInvalidTarget}
 	}
+	return p.authorizeEndpoint(normalized, "https", port)
+}
+
+// AuthorizeMCPURL 授权原始 MCP HTTP(S) URL。调用方不得改写 scheme、host 或 port。
+func (p MCPProxyPolicy) AuthorizeMCPURL(rawURL string) Decision {
+	target, err := url.Parse(rawURL)
+	if err != nil || !target.IsAbs() || target.Host == "" || target.Hostname() == "" || target.User != nil || target.Fragment != "" {
+		return Decision{Reason: ReasonInvalidTarget}
+	}
+	scheme := strings.ToLower(target.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return Decision{Reason: ReasonInvalidTarget}
+	}
+	host, err := NormalizeHost(target.Hostname())
+	if err != nil {
+		return Decision{Reason: ReasonInvalidTarget}
+	}
+	if _, ok := p.mcpURLSet[rawURL]; !ok {
+		return Decision{Reason: ReasonHostNotAllowed, Host: host}
+	}
+	port := target.Port()
+	if port == "" {
+		if scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	if !validAllowedPort(port) {
+		return Decision{Reason: ReasonInvalidTarget, Host: host}
+	}
+	return p.policy.authorizeEndpoint(host, scheme, port)
+}
+
+func (p Policy) authorizeEndpoint(normalized string, scheme string, port string) Decision {
 	if p.policyType != TypeUnrestricted && p.policyType != TypeLimited {
 		return Decision{Reason: ReasonPolicyUnavailable, Host: normalized}
 	}
 	if p.policyType == TypeUnrestricted {
 		return Decision{Allow: true, Reason: ReasonUnrestricted, Host: normalized}
 	}
-	if p.explicitHosts.match(normalized) {
+	if p.explicitHosts.match(normalized, port) {
 		return Decision{Allow: true, Reason: ReasonExplicitHost, Host: normalized}
 	}
 	if _, ok := p.mcpHosts[normalized]; ok {
 		return Decision{Allow: true, Reason: ReasonMCPHost, Host: normalized}
 	}
-	if p.allowPackageManagers && isPackageManagerHost(normalized) {
+	if scheme == "https" && port == "443" && p.allowPackageManagers && isPackageManagerHost(normalized) {
 		return Decision{Allow: true, Reason: ReasonPackageManagerHost, Host: normalized}
 	}
 	return Decision{Reason: ReasonHostNotAllowed, Host: normalized}

--- a/internal/networkpolicy/policy_test.go
+++ b/internal/networkpolicy/policy_test.go
@@ -22,6 +22,15 @@ func authorizeHTTPSFixture(t *testing.T, fixture rawPolicyFixture, target string
 	return policy.AuthorizeHTTPS(target)
 }
 
+func authorizeMCPURLFixture(t *testing.T, fixture rawPolicyFixture, target string) Decision {
+	t.Helper()
+	policy, err := ParseMCPProxyPolicy(fixture.Config, fixture.AgentSnapshot)
+	if err != nil {
+		t.Fatalf("ParseMCPProxyPolicy() error = %v", err)
+	}
+	return policy.AuthorizeMCPURL(target)
+}
+
 func limitedConfig(t *testing.T, networking string) json.RawMessage {
 	t.Helper()
 	return json.RawMessage(`{"type":"cloud","networking":` + networking + `}`)
@@ -170,6 +179,16 @@ func TestParsePolicyRejectsMalformedAgentSnapshotWhenMCPAllowed(t *testing.T) {
 	}
 }
 
+func TestParseMCPProxyPolicyRejectsMalformedSnapshotWhenUnrestricted(t *testing.T) {
+	_, err := ParseMCPProxyPolicy(
+		limitedConfig(t, `{"type":"unrestricted"}`),
+		json.RawMessage(`{"mcp_servers":[`),
+	)
+	if !errors.Is(err, ErrMalformedAgentSnapshot) {
+		t.Fatalf("expected ErrMalformedAgentSnapshot, got %v", err)
+	}
+}
+
 func TestParsePolicyRejectsMalformedMCPURL(t *testing.T) {
 	_, err := ParsePolicy(
 		limitedConfig(t, `{"type":"limited","allowed_hosts":["api.example.com"],"allow_mcp_servers":true,"allow_package_managers":false}`),
@@ -204,6 +223,33 @@ func TestAuthorizeHTTPSDeniesNonCatalogHostWhenPackageSwitchOn(t *testing.T) {
 	decision := authorizeHTTPSFixture(t, fixture, "evil-packages.example.com:443")
 	if decision.Allow {
 		t.Fatal("non-catalog host must be denied")
+	}
+}
+
+func TestAuthorizeMCPURLDeniesURLNotConfiguredForSession(t *testing.T) {
+	fixture := rawPolicyFixture{
+		Config:        limitedConfig(t, `{"type":"unrestricted"}`),
+		AgentSnapshot: snapshotWithMCP(t, "https://configured.example/mcp"),
+	}
+	decision := authorizeMCPURLFixture(t, fixture, "https://other.example/mcp")
+	if decision.Allow || decision.Reason != ReasonHostNotAllowed {
+		t.Fatalf("unconfigured MCP URL decision = %+v, want host_not_allowed denial", decision)
+	}
+}
+
+func TestAuthorizeMCPURLDeniesDifferentActualPort(t *testing.T) {
+	for _, target := range []string{
+		"http://api.example.com/mcp",
+		"https://api.example.com:8443/mcp",
+	} {
+		fixture := rawPolicyFixture{
+			Config:        limitedConfig(t, `{"type":"limited","allowed_hosts":["api.example.com:443"],"allow_mcp_servers":false,"allow_package_managers":false}`),
+			AgentSnapshot: snapshotWithMCP(t, target),
+		}
+		decision := authorizeMCPURLFixture(t, fixture, target)
+		if decision.Allow || decision.Reason != ReasonHostNotAllowed {
+			t.Fatalf("target %q decision = %+v, want actual-port denial", target, decision)
+		}
 	}
 }
 
@@ -299,6 +345,37 @@ func TestAuthorizeHTTPSAllowsMCPHostWhenSwitchOn(t *testing.T) {
 	}
 	if decision.Reason != ReasonMCPHost {
 		t.Fatalf("expected reason %q, got %q", ReasonMCPHost, decision.Reason)
+	}
+}
+
+func TestAuthorizeMCPURLAllowsActualHTTPAndCustomHTTPSPorts(t *testing.T) {
+	for _, test := range []struct {
+		target      string
+		allowedHost string
+	}{
+		{target: "http://api.example.com/mcp", allowedHost: "api.example.com:80"},
+		{target: "https://api.example.com:8443/mcp", allowedHost: "api.example.com:8443"},
+	} {
+		fixture := rawPolicyFixture{
+			Config:        limitedConfig(t, `{"type":"limited","allowed_hosts":["`+test.allowedHost+`"],"allow_mcp_servers":false,"allow_package_managers":false}`),
+			AgentSnapshot: snapshotWithMCP(t, test.target),
+		}
+		decision := authorizeMCPURLFixture(t, fixture, test.target)
+		if !decision.Allow || decision.Reason != ReasonExplicitHost {
+			t.Fatalf("target %q decision = %+v, want explicit_host allow", test.target, decision)
+		}
+	}
+}
+
+func TestAuthorizeMCPURLAllowsConfiguredPortWhenMCPSwitchOn(t *testing.T) {
+	const target = "http://mcp.example.com:8080/mcp"
+	fixture := rawPolicyFixture{
+		Config:        limitedConfig(t, `{"type":"limited","allowed_hosts":[],"allow_mcp_servers":true,"allow_package_managers":false}`),
+		AgentSnapshot: snapshotWithMCP(t, target),
+	}
+	decision := authorizeMCPURLFixture(t, fixture, target)
+	if !decision.Allow || decision.Reason != ReasonMCPHost {
+		t.Fatalf("MCP URL decision = %+v, want mcp_host allow", decision)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add MCP HTTP proxy routing and request handling for code sessions.
- Introduce upstream proxy policy evaluation for managed-agent model runtimes.
- Extend network policy and environment management for MCP and host access controls.
- Document the upstream proxy, model runtime, and Claude Code permission bridge design.
- Add unit tests covering MCP proxy behavior, policy evaluation, host rules, and environment management.

## Testing

- Added and updated unit tests across code sessions, network policy, and environment management components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure MCP server proxying for code sessions.
  - Managed agent configurations now route MCP connections through the session proxy automatically.
  - Supports approved credentials and protocol headers while preserving streaming responses.
  - Added support for port-specific MCP and network access rules.

- **Bug Fixes**
  - Invalid, unauthorized, malformed, or unsafe MCP targets are rejected.
  - Sensitive proxy credentials are removed from forwarded requests and logs.
  - Policy validation now fails closed when configuration is invalid.

- **Tests**
  - Added coverage for authorization, URL validation, credential handling, port matching, and configuration generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->