### PR TITLE
Log sanitized MITM upstream proxy request metadata

### DIFF
--- a/docs/design/be/ccrv2/upstream-proxy-and-model-runtime.md
+++ b/docs/design/be/ccrv2/upstream-proxy-and-model-runtime.md
@@ -188,6 +188,7 @@ upstream proxy 是 code-session 级公开网络出口，不是任意 SSRF 转发
 - 域名先解析，服务端只拨号已验证的 public IP，避免校验后再次解析造成 DNS rebinding。
 - 不记录 bearer token、Basic header、上游 API key 或隧道内容。
 - MITM 默认关闭；开启后只解密通过 code-session 双重鉴权且通过 SSRF 校验的 CONNECT 流量。
+- MITM 解密并完成 Host 校验后，为每条 HTTP 请求记录结构化的 `host`、`port` 和去除 query 的 `url`；不记录 header 或 body。
 - 即使开启 MITM，也不会信任动态 CA 作为真实上游根证书；服务端到目标网站始终使用系统信任链。
 
 本地 fake-IP/TUN DNS 可能把公网域名解析到 `198.18.0.0/15`，从而触发上述保护。仅用于临时排障时，可以设置 `code_session.upstream_proxy_disable_ssrf_protection: true` 关闭目标 IP 过滤；默认值为 `false`。该开关仍然只允许端口 `443`，但会允许 loopback、私网、link-local 与 fake-IP，因此不得在生产环境启用。

--- a/internal/codesessions/upstream_proxy_mitm.go
+++ b/internal/codesessions/upstream_proxy_mitm.go
@@ -64,7 +64,7 @@ func (h *Handler) serveUpstreamProxyMITM(connection *websocket.Conn, target stri
 	if err := clientConnection.HandshakeContext(handshakeContext); err != nil {
 		return
 	}
-	_ = serveUpstreamProxyMITMHTTP(clientConnection, transport, target, targetHost)
+	_ = h.serveUpstreamProxyMITMHTTP(clientConnection, transport, target, targetHost)
 }
 
 func newUpstreamProxyMITMServerTLSConfig(authority *upstreamProxyCertificateAuthority, targetHost string, now time.Time) (*tls.Config, error) {
@@ -156,7 +156,7 @@ func newUpstreamProxyMITMTransport(dialer *upstreamProxyMITMTLSDialer) *http.Tra
 	}
 }
 
-func serveUpstreamProxyMITMHTTP(connection net.Conn, transport http.RoundTripper, target string, targetHost string) error {
+func (h *Handler) serveUpstreamProxyMITMHTTP(connection net.Conn, transport http.RoundTripper, target string, targetHost string) error {
 	targetURL := &url.URL{Scheme: "https", Host: target}
 	proxy := &httputil.ReverseProxy{
 		Transport:     transport,
@@ -181,6 +181,14 @@ func serveUpstreamProxyMITMHTTP(connection net.Conn, transport http.RoundTripper
 			http.Error(w, "request host does not match CONNECT target", http.StatusMisdirectedRequest)
 			return
 		}
+		logURL := *targetURL
+		logURL.Path = request.URL.Path
+		logURL.RawPath = request.URL.RawPath
+		h.logger.InfoContext(request.Context(), "upstream proxy request received",
+			"host", targetHost,
+			"port", targetURL.Port(),
+			"url", logURL.String(),
+		)
 		proxy.ServeHTTP(w, request)
 	})
 	listener := newUpstreamProxySingleConnectionListener(connection)

--- a/internal/codesessions/upstream_proxy_mitm_test.go
+++ b/internal/codesessions/upstream_proxy_mitm_test.go
@@ -11,8 +11,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -281,7 +283,9 @@ func TestUpstreamProxyMITMDecryptsAndForwardsHTTPRequest(t *testing.T) {
 	files := writeTestUpstreamProxyCA(t, "tunnel")
 	upstreamRequests := make(chan *http.Request, 1)
 	dialTargets := make(chan string, 1)
-	handler := NewHandler(files.config(), newTestService(t, nil), nil, nil)
+	var logOutput bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logOutput, nil))
+	handler := NewHandler(files.config(), newTestService(t, nil), nil, logger)
 	stubUnrestrictedPolicyContext(t, handler)
 	authority, err := handler.loadUpstreamProxyCA()
 	if err != nil {
@@ -360,6 +364,26 @@ func TestUpstreamProxyMITMDecryptsAndForwardsHTTPRequest(t *testing.T) {
 	}
 	if captured.Header.Get("Proxy-Authorization") != "" {
 		t.Fatal("Proxy-Authorization leaked to upstream")
+	}
+	var requestLog map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(logOutput.String()), "\n") {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("decode log entry: %v", err)
+		}
+		if entry["msg"] == "upstream proxy request received" {
+			requestLog = entry
+			break
+		}
+	}
+	if requestLog == nil {
+		t.Fatal("upstream proxy request log not found")
+	}
+	if requestLog["host"] != "1.1.1.1" || requestLog["port"] != "443" || requestLog["url"] != "https://1.1.1.1:443/robots.txt" {
+		t.Fatalf("upstream proxy request log = %#v", requestLog)
+	}
+	if strings.Contains(logOutput.String(), "source=mitm") {
+		t.Fatalf("upstream proxy request log leaked query parameters: %s", logOutput.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add structured logging for MITM-decrypted upstream HTTP requests.
- Record the validated host, port, and query-free URL path.
- Preserve sensitive-data protections by excluding headers, bodies, and query parameters.
- Document the new logging behavior.

## Testing

- Extended the MITM proxy integration test to verify forwarded requests and sanitized structured logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured logging for proxied HTTP requests in MITM mode, including the destination host, port, and URL path.
  * Query parameters, request headers, and request bodies are excluded from these logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->