### PR TITLE
Set Claude launcher settings in environment manager payload

### DIFF
--- a/docs/design/be/ccrv2/upstream-proxy-and-model-runtime.md
+++ b/docs/design/be/ccrv2/upstream-proxy-and-model-runtime.md
@@ -67,6 +67,8 @@ CLAUDE_CODE_WORKER_EPOCH=1
 
 `startup_context.api_base_url` 是 sandbox 可访问的 Open Managed Agents API 地址。payload 不再注入上游 `ANTHROPIC_BASE_URL` 或 `ANTHROPIC_API_KEY`；environment-manager 使用 `api_base_url` 作为 Claude 的 `ANTHROPIC_BASE_URL` fallback。
 
+payload 始终在 `startup_context.claude_code_args` 中设置 `settings=/root/.claude/launcher-settings.json`，由 environment-manager 展开为 Claude Code 的 `--settings /root/.claude/launcher-settings.json` 启动参数；已有的 `mcp-config` 等参数保持不变。
+
 environment-manager 启动 Claude 时还会根据 executor 的 session ID 设置 `CLAUDE_CODE_SESSION_ID` 与 `CLAUDE_CODE_REMOTE_SESSION_ID`。后者是 relay 的必要条件；缺失时 Claude 会记录 `CLAUDE_CODE_REMOTE_SESSION_ID unset; proxy disabled`，即使 token 文件和其他开关都存在也不会注入代理环境。
 
 payload 同时提供两种用途独立的 auth：

--- a/internal/environments/environment_manager.go
+++ b/internal/environments/environment_manager.go
@@ -18,6 +18,7 @@ const (
 	defaultClaudeAgentVersion     = "2.1.120"
 	defaultClaudePath             = "/opt/claude-code/bin/claude"
 	defaultEnvironmentWorkDir     = "/home/user"
+	launcherSettingsPath          = "/root/.claude/launcher-settings.json"
 	managedAgentMCPConfigPath     = "/tmp/managed-agent-mcp-config.json"
 )
 
@@ -279,6 +280,9 @@ func buildEnvironmentManagerV0Payload(codeSessionID string, sessionIngressToken 
 	}
 	startupContext["use_code_sessions"] = true
 	startupContext["session_id"] = codeSessionID
+	claudeCodeArgs := mapStringAnyValue(startupContext["claude_code_args"])
+	claudeCodeArgs["settings"] = launcherSettingsPath
+	startupContext["claude_code_args"] = claudeCodeArgs
 	environmentVariables := mapStringAnyValue(startupContext["environment_variables"])
 	environmentVariables["CLAUDE_CODE_REMOTE"] = "true" // 进入 remote-session 路径并初始化 CCR relay。
 	environmentVariables["CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2"] = "1"

--- a/internal/environments/environment_manager_test.go
+++ b/internal/environments/environment_manager_test.go
@@ -275,6 +275,10 @@ func TestBuildEnvironmentManagerPayloadAndCommand(t *testing.T) {
 	if startup["api_base_url"] != "http://host.docker.internal:18081" || startup["session_id"] != "cse_test" || startup["use_code_sessions"] != true {
 		t.Fatalf("unexpected startup context: %#v", startup)
 	}
+	claudeArgs := startup["claude_code_args"].(map[string]any)
+	if claudeArgs["settings"] != launcherSettingsPath {
+		t.Fatalf("unexpected Claude args: %#v", claudeArgs)
+	}
 	startupEnv := startup["environment_variables"].(map[string]any)
 	if startupEnv["CLAUDE_CODE_REMOTE"] != "true" ||
 		startupEnv["CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2"] != "1" ||
@@ -369,7 +373,8 @@ func TestBuildEnvironmentManagerPayloadProxiesMCPConfig(t *testing.T) {
 	cfg := config.Config{CodeSession: config.CodeSessionConfig{SandboxAPIBaseURL: "http://host.docker.internal:18081/"}}
 	sessionConfig := json.RawMessage(`{
 		"mcp_config":{"mcpServers":{"ms-api":{"type":"http","url":"https://learn.microsoft.com/api/mcp?view=azure"}}},
-		"mcp_config_file":{"path":"/tmp/stale.json","content":"stale","mode":384}
+		"mcp_config_file":{"path":"/tmp/stale.json","content":"stale","mode":384},
+		"claude_code_args":{"mcp-config":"/tmp/managed-agent-mcp-config.json"}
 	}`)
 	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", "", sessionConfig, cfg)
 	if err != nil {
@@ -380,6 +385,10 @@ func TestBuildEnvironmentManagerPayloadProxiesMCPConfig(t *testing.T) {
 		t.Fatalf("decode payload: %v", err)
 	}
 	startup := body["startup_context"].(map[string]any)
+	claudeArgs := startup["claude_code_args"].(map[string]any)
+	if claudeArgs["settings"] != launcherSettingsPath || claudeArgs["mcp-config"] != managedAgentMCPConfigPath {
+		t.Fatalf("unexpected Claude args: %#v", claudeArgs)
+	}
 	mcpConfig := startup["mcp_config"].(map[string]any)
 	server := mcpConfig["mcpServers"].(map[string]any)["ms-api"].(map[string]any)
 	wantURL := "http://host.docker.internal:18081/v2/ccr-sessions/cse_test/mcp?mcp_url=https%3A%2F%2Flearn.microsoft.com%2Fapi%2Fmcp%3Fview%3Dazure"


### PR DESCRIPTION
## Summary

- Add the launcher settings file to Claude Code startup arguments.
- Preserve existing arguments such as the managed MCP configuration.
- Document the settings expansion behavior in the CCR v2 runtime design.

## Testing

- Updated environment manager payload tests to verify launcher settings and MCP arguments are retained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Claude Code now consistently starts with the correct launcher settings applied.
  - Existing startup options, including MCP configuration, are preserved when settings are added.
  - MCP proxy environments now correctly include and validate the managed MCP configuration, improving reliable tool connectivity.
- **Documentation**
  - Updated technical documentation to reflect the launcher settings behavior and startup configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->