### PR TITLE
改用全进程 HTTPS_PROXY 代理 Managed Agent MCP 请求

### DIFF
--- a/docs/design/be/ccrv2/upstream-proxy-and-model-runtime.md
+++ b/docs/design/be/ccrv2/upstream-proxy-and-model-runtime.md
@@ -1,8 +1,8 @@
-# CCRv2 子进程 HTTPS 代理与模型运行时
+# CCRv2 全进程 HTTPS 代理与模型运行时
 
 ## 目标
 
-Managed Agent 启动 Claude Code 后，Claude 创建的 Bash、MCP、LSP 和 hook 子进程需要继承 `HTTPS_PROXY`。当前 Claude Code 内置的 CCRv2 relay 已经负责在容器内监听本地 CONNECT 代理，但只有以下条件同时成立时才会启用：
+Managed Agent 启动 Claude Code 后，Claude 主进程及其创建的 Bash、MCP、LSP 和 hook 子进程都会使用 `HTTPS_PROXY`。当前 Claude Code 内置的 CCRv2 relay 已经负责在容器内监听本地 CONNECT 代理，但只有以下条件同时成立时才会启用：
 
 - `CLAUDE_CODE_REMOTE=true`
 - `CLAUDE_CODE_REMOTE_SESSION_ID` 是当前 code session ID
@@ -41,7 +41,9 @@ sequenceDiagram
     Claude->>API: GET /v1/code/upstreamproxy/ca-cert
     Claude->>Relay: start 127.0.0.1 ephemeral CONNECT listener
     Claude->>Claude: unlink /run/ccr/session_token after relay is ready
-    Claude->>Child: HTTPS_PROXY=http://127.0.0.1:{port}
+    Claude->>Claude: use HTTPS_PROXY=http://127.0.0.1:{port}
+    Claude->>Child: inherit HTTPS_PROXY
+    Claude->>Relay: CONNECT MCP and other public hosts
     Child->>Relay: CONNECT public-host:443
     Relay->>API: WebSocket /v1/code/upstreamproxy/ws
     alt MITM disabled
@@ -153,7 +155,9 @@ Proxy-Authorization: Basic base64(code_session_id:session_ingress_jwt)
 
 ### `GET|POST|DELETE /v2/ccr-sessions/{code_session_id}/mcp`
 
-Managed Agent 的远程 MCP 不再由 Sandbox 直接访问。Runner 在 environment-manager payload 边界把 Agent Snapshot 中的真实 URL 编码到 `mcp_url`，并将 MCP config 的连接地址改成此 session 级代理，同时通过 config header 携带 session-ingress JWT。
+Runner 不再把 Managed Agent MCP URL 改写到该接口。MCP config 保留 Agent Snapshot 中的原始 URL，Claude 主进程通过 `HTTPS_PROXY` 将请求交给 CCRv2 CONNECT relay；配置中也不再为该接口注入 session-ingress header。
+
+该接口作为显式调用的兼容入口继续保留，其边界如下：
 
 代理执行以下边界：
 
@@ -276,4 +280,4 @@ Go 官方 module proxy 对较大的 module zip（例如 `github.com/aws/aws-sdk-
 - Go module redirect 合同测试覆盖 `proxy.golang.org` 到 `storage.googleapis.com` 的 host 链；设置 `TEST_GO_MODULE_PROXY_REDIRECT=1` 可额外对真实大 module zip 运行 live redirect 验证。
 - `internal/codesessions` 与 DB-backed proxy 集成测试覆盖策略上下文边界：JWT org/workspace 作用域、Code Session 与 Environment/Session 绑定、不能借用另一 Environment allowlist、Environment/Session 缺失与持久化配置畸形时 fail-closed。
 - proxy 集成测试证明：limited 下授权目标能进入拨号路径、未授权目标在 DNS/拨号前收到 framed `403`、unrestricted 行为与现状兼容、Environment 更新对存活 Code Session 的下一次 CONNECT 即时生效。
-- linux/amd64 镜像验收通过真实 Claude CLI 和 Bash tool call 确认：relay 从 `/run/ccr/session_token` 读取 token 并启动，Claude 子进程同时具有指向同一 `127.0.0.1` relay 的 `HTTPS_PROXY`、`https_proxy`，以及 `NODE_EXTRA_CA_CERTS`、`SSL_CERT_FILE`。
+- linux/amd64 镜像验收通过真实 Claude CLI 和 Bash tool call 确认：relay 从 `/run/ccr/session_token` 读取 token 并启动，Claude 主进程与子进程同时具有指向同一 `127.0.0.1` relay 的 `HTTPS_PROXY`、`https_proxy`，以及 `NODE_EXTRA_CA_CERTS`、`SSL_CERT_FILE`。

--- a/docs/design/be/managed-agent-claude-code-permission-bridge.md
+++ b/docs/design/be/managed-agent-claude-code-permission-bridge.md
@@ -29,17 +29,14 @@ Claude Code 运行在 `environment-manager` 中，它通过 MCP config 加载 MC
 
 ### 2.1 连接层
 
-`managedAgentSessionConfig` 继续从 agent snapshot 中读取 `mcp_servers`。Runner 创建 Code Session 后，在写入 environment-manager v0 payload 前把每个真实 MCP URL 放入 `mcp_url`，并把 Claude Code 实际连接地址改成 session 级 OMA proxy：
+`managedAgentSessionConfig` 继续从 agent snapshot 中读取 `mcp_servers`，并把真实 MCP URL 原样写入 Claude Code 的 MCP config。Claude 主进程与子进程都使用 CCRv2 提供的 `HTTPS_PROXY`，因此不需要把 URL 改成 session 级 OMA MCP proxy：
 
 ```json
 {
   "mcpServers": {
     "weather_service": {
       "type": "http",
-      "url": "http://host.docker.internal:38080/v2/ccr-sessions/cse_123/mcp?mcp_url=https%3A%2F%2Fmcp.example.com%2Fmcp",
-      "headers": {
-        "Authorization": "Bearer sk-ant-si-<JWT>"
-      }
+      "url": "https://mcp.example.com/mcp"
     }
   }
 }
@@ -60,7 +57,7 @@ session config 继续通过现有字段传给 `environment-manager`：
 }
 ```
 
-`environment-manager` 已经会把 `claude_code_args` 展开成 Claude Code CLI 参数，因此本设计不改变 v0 stdin schema，也不修改 `environment-manager` 代码。MCP config file 保持 `0600`；代理验证 session-ingress JWT 与路径中的 Code Session ID，并要求 `mcp_url` 精确匹配该 Session Agent Snapshot 中的 MCP URL。转发前删除 OMA 的 `Authorization` / `X-Api-Key`，保留 `Mcp-Session-Id`、`Last-Event-ID`、content negotiation 等端到端 header。服务端凭证注入集中在 `injectMCPProxyHeaders`：`WithVaultSecrets` 接到 `vaults.Injector`，按真实 `mcp_url` 匹配 `static_bearer` 并写入上游 `Authorization`（详见 `docs/design/be/vault-runtime.md`）。
+`environment-manager` 已经会把 `claude_code_args` 展开成 Claude Code CLI 参数，因此本设计不改变 v0 stdin schema，也不修改 `environment-manager` 代码。MCP config file 保持 `0600`；Runner 不改写其中的 URL，也不附加 session-ingress header。MCP 请求与其他 HTTPS 请求一样通过主进程继承的 CCRv2 CONNECT proxy 出站。
 
 ### 2.2 静态提示层
 
@@ -284,7 +281,7 @@ Claude Code 可能通过 `/worker/events` batch endpoint 上报 `can_use_tool`�
 
 实现应集中在 `claude-api-server`：
 
-- Managed Agent session config 继续生成 MCP config file 和 `claude_code_args["mcp-config"]`；environment-manager payload 边界将其中的真实 URL 重写为 session 级代理 URL。
+- Managed Agent session config 继续生成 MCP config file 和 `claude_code_args["mcp-config"]`；environment-manager payload 边界保留其中的真实 URL。
 - Code Session handler 负责 MCP proxy 的 JWT/path 绑定；加载边界通过 `ParseMCPProxyPolicy` 一次性把 Agent Snapshot 的精确 URL set 与 Environment host/port policy 编译为单一授权对象，handler 只调用 `AuthorizeMCPURL`，不保存或重解析原始 snapshot。授权后再执行拨号期 SSRF 防护、流式转发和凭证 header 注入边界。
 - Code session service 新增 policy-aware permission handler。
 - Session events 接收 `user.tool_confirmation` 后，将 public blocking event id 解析为 worker `tool_use_id`，补齐到 Claude Code `control_response` 的路由；旧 worker `tool_use_id` 作为兼容输入继续支持。
@@ -367,7 +364,7 @@ tools:
 期望：
 
 - 新 session 的 agent snapshot 包含 `weather_service` 和 `mcp_toolset`。
-- `/tmp/managed-agent-mcp-config.json` 包含 `weather_service`，其连接地址为 `/v2/ccr-sessions/{code_session_id}/mcp`，原始 URL 只出现在 `mcp_url`。
+- `/tmp/managed-agent-mcp-config.json` 包含 `weather_service`，其连接地址保持 Agent Snapshot 中的原始 URL，且不附加 OMA session-ingress header。
 - Claude Code init event 显示 MCP server connected。
 - 调用 `mcp__weather_service__get_weather` 时不再卡在 permission prompt。
 - DB 中能看到 `can_use_tool` outbound 和对应 auto `control_response` inbound。

--- a/docs/design/be/vault-runtime.md
+++ b/docs/design/be/vault-runtime.md
@@ -11,7 +11,7 @@
 
 ## 背景
 
-Vault CRUD 和 OAuth 注册已经有了；存库侧已切到信封加密。运行时注入挂在 Session MCP HTTP proxy（`/v2/ccr-sessions/{id}/mcp`），对真实 `mcp_url` 注入 static_bearer。
+Vault CRUD 和 OAuth 注册已经有了；存库侧已切到信封加密。Session MCP HTTP proxy（`/v2/ccr-sessions/{id}/mcp`）仍支持对显式传入的真实 `mcp_url` 注入 static_bearer，但 Managed Agent Runner 不再自动把 MCP config URL 改写到该接口。
 ## 威胁模型（加密管到哪）
 
 | 场景 | 加密能否挡住 |
@@ -155,11 +155,11 @@ KEK 不做强制退役的原因：config.yaml 模式下旧 key 很难干净销�
 
 ## 运行时注入（static_bearer MVP）
 
-> **状态：已实现。** 存库加密已完成；MCP HTTP proxy 路径仅注入 static_bearer。
+> **状态：已实现但不再由 Runner 自动接入。** 存库加密已完成；MCP HTTP proxy 路径仅注入 static_bearer。
 
-目标：Sandbox 调需认证的 MCP 时，由 OMA 在 MCP HTTP proxy 转发前注入凭证；Sandbox 只看到改写后的 proxy URL，看不到 token。
+目标：显式调用 OMA MCP HTTP proxy 时，由 OMA 在转发前注入凭证；调用方只看到 proxy URL，不看到 token。
 
-注入点：`/v2/ccr-sessions/{code_session_id}/mcp`。Runner 把真实 MCP URL 放进 `mcp_url`，Claude Code 只连 session 级 proxy。Proxy 验 JWT、按 Agent Snapshot + Environment 策略授权后，对真实 `mcp_url` 做 Credential URL match，再注入 `Authorization` 并转发。不依赖 upstream CONNECT MITM。
+注入点：`/v2/ccr-sessions/{code_session_id}/mcp`。显式调用方把真实 MCP URL 放进 `mcp_url`；Proxy 验 JWT、按 Agent Snapshot + Environment 策略授权后，对真实 `mcp_url` 做 Credential URL match，再注入 `Authorization` 并转发。不依赖 upstream CONNECT MITM。Managed Agent 当前保留原始 MCP URL 并通过 `HTTPS_PROXY` 走 CONNECT，因此不会经过此注入点；如需恢复自动 static_bearer 注入，应在 CONNECT MITM 边界单独实现。
 
 ### MVP 决策（grilling 已确认）
 
@@ -190,7 +190,7 @@ KEK 不做强制退役的原因：config.yaml 模式下旧 key 很难干净销�
 - **environment_variable**：环境占位符 / 出口替换（E2B 上另议）
 - Credential 级 `networking.allowed_hosts` 门控
 
-Sandbox 拿到的 `mcp_config` 只有 proxy URL + session JWT，没有上游 token。真 token 只在 OMA proxy 里瞬态出现。日志不记录明文。
+显式 MCP proxy 调用方只持有 proxy URL + session JWT，没有上游 token。真 token 只在 OMA proxy 里瞬态出现。日志不记录明文。Runner 生成的 `mcp_config` 则保留原始 URL，不携带 session JWT 或上游 token。
 
 ## 实施阶段
 
@@ -214,7 +214,7 @@ Sandbox 拿到的 `mcp_config` 只有 proxy URL + session JWT，没有上游 tok
 
 ## 验收（运行时注入 MVP：已完成）
 
-- Managed Agent MCP 走 `/v2/ccr-sessions/{id}/mcp`；vault 注入接在该 proxy，不依赖 MITM。
+- 显式 MCP proxy 请求走 `/v2/ccr-sessions/{id}/mcp`；vault 注入接在该 proxy，不依赖 MITM。Managed Agent Runner 不再自动生成该 URL。
 - static_bearer：path 前缀命中后注入 Bearer；沙箱 / `mcp_config` / 日志不见 token。
 - host 未覆盖 → passthrough；同 host path 不配 → 拒绝（502）；命中后 Open 失败 → 拒绝（502）。
 - 不自动跟随跨 origin redirect 携带注入头。

--- a/internal/environments/environment_manager.go
+++ b/internal/environments/environment_manager.go
@@ -3,12 +3,10 @@ package environments
 import (
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	urlpkg "net/url"
 	"path"
 	"strings"
 
-	"github.com/superduck-ai/open-managed-agents/internal/common/collections"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 )
@@ -93,53 +91,6 @@ func managedAgentMCPConfigFile(mcpConfig map[string]any) map[string]any {
 		"content": base64.StdEncoding.EncodeToString(content),
 		"mode":    0o600,
 	}
-}
-
-func proxyManagedAgentMCPConfig(startupContext map[string]any, apiBaseURL string, codeSessionID string, sessionIngressToken string) error {
-	rawConfig, ok := startupContext["mcp_config"]
-	if !ok {
-		return nil
-	}
-	mcpConfig, ok := rawConfig.(map[string]any)
-	if !ok {
-		return errors.New("managed agent mcp_config must be an object")
-	}
-	servers, ok := mcpConfig["mcpServers"].(map[string]any)
-	if !ok {
-		return errors.New("managed agent mcpServers must be an object")
-	}
-	for name, rawServer := range servers {
-		server, ok := rawServer.(map[string]any)
-		if !ok {
-			return errors.New("managed agent MCP server " + name + " must be an object")
-		}
-		upstreamURL := stringFromMap(server, "url")
-		proxyURL, err := codeSessionMCPProxyURL(apiBaseURL, codeSessionID, upstreamURL)
-		if err != nil {
-			return err
-		}
-		server["url"] = proxyURL
-		headers := mapStringAnyValue(server["headers"])
-		headers["Authorization"] = "Bearer " + sessionIngressToken
-		server["headers"] = headers
-	}
-	startupContext["mcp_config"] = mcpConfig
-	startupContext["mcp_config_file"] = managedAgentMCPConfigFile(mcpConfig)
-	return nil
-}
-
-func codeSessionMCPProxyURL(apiBaseURL string, codeSessionID string, upstreamURL string) (string, error) {
-	base, err := urlpkg.Parse(strings.TrimSpace(apiBaseURL))
-	if err != nil || base.Scheme == "" || base.Host == "" || (base.Scheme != "http" && base.Scheme != "https") {
-		return "", errors.New("code_session.sandbox_api_base_url must be an absolute HTTP(S) URL for MCP proxying")
-	}
-	if collections.IsBlank(codeSessionID) || collections.IsBlank(upstreamURL) {
-		return "", errors.New("managed agent MCP proxy requires a code session ID and upstream URL")
-	}
-	base.RawQuery = ""
-	base.Fragment = ""
-	proxyURL := strings.TrimRight(base.String(), "/") + "/v2/ccr-sessions/" + urlpkg.PathEscape(codeSessionID) + "/mcp"
-	return proxyURL + "?" + urlpkg.Values{"mcp_url": {upstreamURL}}.Encode(), nil
 }
 
 func mcpToolsetsByServer(tools []any) map[string]map[string]any {
@@ -275,9 +226,6 @@ func buildEnvironmentManagerV0Payload(codeSessionID string, sessionIngressToken 
 	}
 	apiBaseURL := codeSessionSandboxAPIBaseURL(cfg)
 	startupContext["api_base_url"] = apiBaseURL
-	if err := proxyManagedAgentMCPConfig(startupContext, apiBaseURL, codeSessionID, sessionIngressToken); err != nil {
-		return nil, err
-	}
 	startupContext["use_code_sessions"] = true
 	startupContext["session_id"] = codeSessionID
 	claudeCodeArgs := mapStringAnyValue(startupContext["claude_code_args"])

--- a/internal/environments/environment_manager_test.go
+++ b/internal/environments/environment_manager_test.go
@@ -31,25 +31,6 @@ func TestCodeSessionSandboxAPIBaseURLUsesConfiguredValue(t *testing.T) {
 	}
 }
 
-func TestCodeSessionMCPProxyURLRejectsIncompleteInputs(t *testing.T) {
-	for _, test := range []struct {
-		name        string
-		apiBaseURL  string
-		sessionID   string
-		upstreamURL string
-	}{
-		{name: "relative API base", apiBaseURL: "/api", sessionID: "cse_test", upstreamURL: "https://mcp.example/mcp"},
-		{name: "missing session", apiBaseURL: "https://api.example", upstreamURL: "https://mcp.example/mcp"},
-		{name: "missing upstream", apiBaseURL: "https://api.example", sessionID: "cse_test"},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			if _, err := codeSessionMCPProxyURL(test.apiBaseURL, test.sessionID, test.upstreamURL); err == nil {
-				t.Fatal("codeSessionMCPProxyURL() error = nil, want error")
-			}
-		})
-	}
-}
-
 func managedAgentRuntimeSourceValues(
 	t *testing.T,
 	sources []json.RawMessage,
@@ -369,7 +350,7 @@ func TestBuildEnvironmentManagerPayloadAndCommand(t *testing.T) {
 	}
 }
 
-func TestBuildEnvironmentManagerPayloadProxiesMCPConfig(t *testing.T) {
+func TestBuildEnvironmentManagerPayloadPreservesMCPConfig(t *testing.T) {
 	cfg := config.Config{CodeSession: config.CodeSessionConfig{SandboxAPIBaseURL: "http://host.docker.internal:18081/"}}
 	sessionConfig := json.RawMessage(`{
 		"mcp_config":{"mcpServers":{"ms-api":{"type":"http","url":"https://learn.microsoft.com/api/mcp?view=azure"}}},
@@ -391,25 +372,16 @@ func TestBuildEnvironmentManagerPayloadProxiesMCPConfig(t *testing.T) {
 	}
 	mcpConfig := startup["mcp_config"].(map[string]any)
 	server := mcpConfig["mcpServers"].(map[string]any)["ms-api"].(map[string]any)
-	wantURL := "http://host.docker.internal:18081/v2/ccr-sessions/cse_test/mcp?mcp_url=https%3A%2F%2Flearn.microsoft.com%2Fapi%2Fmcp%3Fview%3Dazure"
+	wantURL := "https://learn.microsoft.com/api/mcp?view=azure"
 	if server["url"] != wantURL || server["type"] != "http" {
-		t.Fatalf("proxied MCP server = %#v, want url %q", server, wantURL)
+		t.Fatalf("MCP server = %#v, want original url %q", server, wantURL)
 	}
-	headers := server["headers"].(map[string]any)
-	if headers["Authorization"] != "Bearer sk-ant-si-test-token" {
-		t.Fatalf("MCP proxy headers = %#v", headers)
+	if _, ok := server["headers"]; ok {
+		t.Fatalf("MCP server unexpectedly contains proxy headers: %#v", server)
 	}
 	mcpConfigFile := startup["mcp_config_file"].(map[string]any)
-	content, err := base64.StdEncoding.DecodeString(mcpConfigFile["content"].(string))
-	if err != nil {
-		t.Fatalf("decode MCP config file: %v", err)
-	}
-	var fileConfig map[string]any
-	if err := json.Unmarshal(content, &fileConfig); err != nil {
-		t.Fatalf("decode MCP config file JSON: %v", err)
-	}
-	if !reflect.DeepEqual(fileConfig, mcpConfig) {
-		t.Fatalf("MCP config file = %#v, want %#v", fileConfig, mcpConfig)
+	if mcpConfigFile["path"] != "/tmp/stale.json" || mcpConfigFile["content"] != "stale" {
+		t.Fatalf("MCP config file was unexpectedly rewritten: %#v", mcpConfigFile)
 	}
 }
 


### PR DESCRIPTION
## Summary

- 停止在 environment-manager payload 中将 MCP URL 改写为 session 级代理地址
- 保留 Agent Snapshot 中的原始 MCP URL，不再注入 session-ingress header
- 更新 CCRv2、权限桥接与 Vault 运行时设计文档，明确主进程和子进程均通过 HTTPS_PROXY 出站
- 调整环境管理器测试，验证 MCP 配置保持不变

## Testing

- 未运行（未请求）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managed agent MCP configurations now preserve their original server URLs and settings.
  * Claude processes access MCP services through the configured HTTPS proxy.
  * Proxy and CA environment settings are consistently available to both primary and child processes.

* **Documentation**
  * Updated runtime and integration guidance to reflect HTTPS CONNECT proxy behavior and current MCP configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->