### PR TITLE
Use task-run's native stdin behavior

### DIFF
--- a/internal/environments/environment_manager.go
+++ b/internal/environments/environment_manager.go
@@ -406,7 +406,6 @@ func buildEnvironmentManagerCommand(codeSessionID string, cfg config.Config, pay
 		// E2B 负责把该命令作为后台进程启动；payload 通过进程 stdin 发送，不进入命令行或沙箱文件系统。
 		"exec " + shellQuote(managerPath) +
 			" task-run" +
-			" --stdin" +
 			" --session " + shellQuote(codeSessionID) +
 			" --session-mode resume-cached" +
 			" --claude-agent-version " + shellQuote("current") +

--- a/internal/environments/environment_manager_test.go
+++ b/internal/environments/environment_manager_test.go
@@ -324,7 +324,7 @@ func TestBuildEnvironmentManagerPayloadAndCommand(t *testing.T) {
 	for _, want := range []string{
 		"environment-manager binary missing or not executable: /opt/env manager/bin/environment-manager",
 		"Claude binary missing or not executable: /opt/claude path/bin/claude",
-		"task-run --stdin --session 'cse_session with '\"'\"'quote'\"'\"'/and/slash'",
+		"task-run --session 'cse_session with '\"'\"'quote'\"'\"'/and/slash'",
 		"--session-mode resume-cached",
 		"--claude-agent-version 'current'",
 		"--claude-path '/opt/claude path/bin/claude'",
@@ -338,6 +338,9 @@ func TestBuildEnvironmentManagerPayloadAndCommand(t *testing.T) {
 	}
 	if strings.Contains(allCommands, "sk-ant-test-secret") {
 		t.Fatalf("command leaked anthropic api key:\n%s", allCommands)
+	}
+	if strings.Contains(allCommands, "task-run --stdin") {
+		t.Fatalf("command should use task-run's native clap stdin behavior:\n%s", allCommands)
 	}
 	if strings.Contains(allCommands, "nohup") ||
 		strings.Contains(allCommands, "environment-manager.v0.json") ||


### PR DESCRIPTION
## Summary

- Remove the obsolete `--stdin` flag from the environment manager command.
- Update command-generation tests to verify native Clap stdin handling and prevent regressions.

## Testing

- Updated the environment manager command-generation test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment task execution by removing the unnecessary standard-input option from generated commands.
  * Preserved task payload handling separately, ensuring commands continue to run as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->