### PR TITLE
Align worker session lifecycle and request schemas

### DIFF
--- a/docs/design/be/ccrv2/ccr-v2-api-worker-state.md
+++ b/docs/design/be/ccrv2/ccr-v2-api-worker-state.md
@@ -187,9 +187,11 @@ final worker_status != requires_action  => 一律保存为 null
 | `idle` | `idle` |
 | `requires_action` | `idle` |
 
-同步发生在 worker state DB 更新提交之后。`running` 不再直接修改 public session/thread 行，而是先持久化 `session.status_running`，再由统一的 session event effect 更新状态并广播 SSE、投递 webhook。事件在 PUT 返回成功前完成发布，因此 worker 应等待 PUT 成功后再开始模型请求或发送 `span.model_request_start`。同一 public running 状态下重复上报不会生成重复事件；session 先回到 idle 后再次上报 running 会生成新的事件。
+同步发生在 worker state DB 更新提交之后。`running`、`idle` 和 `requires_action` 都通过同一条 public event 管道同步：先持久化 `session.status_running` 或 `session.status_idle`，再由 session event projection 更新 public session 与 primary thread，随后广播 SSE，并且只为首次创建的事件投递 webhook。同一 public 状态下重复上报不会生成重复事件；状态发生转换后再次上报会生成新的事件。
 
-`idle` 和 `requires_action` 暂时保留直接状态同步；其中 `requires_action` 不是 public session status enum，阻塞语义仍由 worker state、metadata 以及工具权限路径产生的 `session.status_idle.stop_reason` 表达。同步时忽略 `ErrNotFound`；其它 DB 错误会让请求返回 `500 api_error`，此时 worker state 已经持久化，但 handler 不返回成功响应，避免调用方误以为 public 状态也同步完成。
+`requires_action` 不是 public session status enum，因此 worker 状态只映射为不带 `stop_reason` 的普通 `session.status_idle`。工具阻塞语义仍由 worker state、metadata 以及工具权限路径产生的 `session.status_idle.stop_reason` 表达。
+
+如果事件已经持久化但状态 projection 失败，PUT 返回 `500 api_error`。worker 使用相同状态重试时会命中同一个稳定事件 ID；服务端会重新执行已存在事件的 projection，但不会重复广播 SSE 或投递 webhook。Session 状态最后写入，作为 primary thread projection 已完成的标记，避免部分成功让后续重试被提前跳过。
 
 如果请求没有显式 `worker_status`，不会触发 public session/thread 状态同步。details-only update 会保留当前 public status。
 

--- a/docs/design/be/ccrv2/ccr-v2-api-worker-state.md
+++ b/docs/design/be/ccrv2/ccr-v2-api-worker-state.md
@@ -115,7 +115,7 @@ DB 行为：
 |---|---|---:|---|
 | `worker_epoch` | JSON number | 是 | 必须是正 int64；`0`、负数、小数、字符串、`null` 都是 400 |
 | `worker_status` | string 或 `null` | 否 | 非空时必须精确为 `idle`、`running`、`requires_action`；缺省、空字符串或 `null` 不更新状态 |
-| `requires_action_details` | object 或 `null` | 否 | 按客户端 schema 解析 `tool_name`、`action_description`、`request_id`；未知字段忽略；最终 status 不是 `requires_action` 时会被清空 |
+| `requires_action_details` | object 或 `null` | 否 | 按客户端 schema 解析 `tool_name`、`action_description`、`tool_use_id`、`request_id`、`input`；未知字段忽略；最终 status 不是 `requires_action` 时会被清空 |
 | `external_metadata` | object 或 `null` | 否 | object 按一层 merge patch 应用；顶层 `null` 不更新 metadata；object 内的 value 为 JSON `null` 时删除该 key |
 
 未知字段当前会被忽略。

--- a/docs/design/be/ccrv2/ccr-v2-api-worker-state.md
+++ b/docs/design/be/ccrv2/ccr-v2-api-worker-state.md
@@ -113,10 +113,10 @@ DB 行为：
 
 | 字段 | 类型 | 必填 | 当前实现 |
 |---|---|---:|---|
-| `worker_epoch` | JSON number 或 string integer | 是 | 必须是正 int64；`0`、负数、小数、非数字字符串、`null` 都是 400 |
-| `worker_status` | string | 否 | trim 后必须是 `idle`、`running`、`requires_action` |
-| `requires_action_details` | object 或 `null` | 否 | object 会先作为候选 details；最终 status 不是 `requires_action` 时会被清空 |
-| `external_metadata` | object | 否 | 按一层 merge patch 应用；value 为 JSON `null` 时删除该 key |
+| `worker_epoch` | JSON number | 是 | 必须是正 int64；`0`、负数、小数、字符串、`null` 都是 400 |
+| `worker_status` | string 或 `null` | 否 | 非空时必须精确为 `idle`、`running`、`requires_action`；缺省、空字符串或 `null` 不更新状态 |
+| `requires_action_details` | object 或 `null` | 否 | 按客户端 schema 解析 `tool_name`、`action_description`、`request_id`；未知字段忽略；最终 status 不是 `requires_action` 时会被清空 |
+| `external_metadata` | object 或 `null` | 否 | object 按一层 merge patch 应用；顶层 `null` 不更新 metadata；object 内的 value 为 JSON `null` 时删除该 key |
 
 未知字段当前会被忽略。
 
@@ -132,7 +132,7 @@ DB 行为：
 
 ### Patch 语义
 
-`worker_status` 未提供时保留当前 `worker_status`。
+`worker_status` 未提供、为空字符串或为 `null` 时保留当前 `worker_status`。`requires_action_details` 和 `external_metadata` 未提供或为顶层 `null` 时也按零值处理，不单独更新对应字段。worker status 最终不是 `requires_action` 时，DB 不变量仍会清空已有 details。
 
 `requires_action_details` 的最终不变量：
 
@@ -187,7 +187,9 @@ final worker_status != requires_action  => 一律保存为 null
 | `idle` | `idle` |
 | `requires_action` | `idle` |
 
-同步发生在 worker state DB 更新提交之后。同步时忽略 `ErrNotFound`；其它 DB 错误会让请求返回 `500 api_error`，此时 worker state 已经持久化，但 handler 不返回成功响应，避免调用方误以为 public status 也同步完成。`requires_action` 不是 public session status enum；阻塞语义由 worker state 和 metadata 表达。
+同步发生在 worker state DB 更新提交之后。`running` 不再直接修改 public session/thread 行，而是先持久化 `session.status_running`，再由统一的 session event effect 更新状态并广播 SSE、投递 webhook。事件在 PUT 返回成功前完成发布，因此 worker 应等待 PUT 成功后再开始模型请求或发送 `span.model_request_start`。同一 public running 状态下重复上报不会生成重复事件；session 先回到 idle 后再次上报 running 会生成新的事件。
+
+`idle` 和 `requires_action` 暂时保留直接状态同步；其中 `requires_action` 不是 public session status enum，阻塞语义仍由 worker state、metadata 以及工具权限路径产生的 `session.status_idle.stop_reason` 表达。同步时忽略 `ErrNotFound`；其它 DB 错误会让请求返回 `500 api_error`，此时 worker state 已经持久化，但 handler 不返回成功响应，避免调用方误以为 public 状态也同步完成。
 
 如果请求没有显式 `worker_status`，不会触发 public session/thread 状态同步。details-only update 会保留当前 public status。
 
@@ -316,7 +318,8 @@ GET 不返回 `ok`、`session_id`、`status`、`worker_epoch`、`worker_status`�
 - `requires_action` 保存 details 和 `external_metadata.pending_action`。
 - `running` / `idle` 清空 `requires_action_details`。
 - 当前 status 为 `running` 时，details-only PUT 不保存 details，且 public session/thread 保持 `running`。
-- `worker_status=running` 同步 public session/thread 为 `running`。
+- `worker_status=running` 持久化一个 `session.status_running`，并通过该事件同步 public session/thread 为 `running`。
+- 同一 running 状态的重复 PUT 不重复生成事件；经过 idle 后的新一轮 running 会生成新事件。
 - `worker_status=idle` 或 `requires_action` 同步 public session/thread 为 `idle`。
 - GET `/worker` 用最小 response 读回 PUT 后的 non-empty `external_metadata`。
 - GET `/worker` metadata 为空时返回 `{ "worker": {} }`，且不刷新 connected/activity。

--- a/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
+++ b/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
@@ -45,8 +45,8 @@ Content-Type: application/json
 字段规则：
 
 - `session_id` 必须存在，必须是非空字符串，并且必须等于 path 中的 `{code_session_id}`。
-- `worker_epoch` 必须存在，接受正整数 JSON number 或数字字符串。
-- `worker_epoch` 拒绝 `0`、负数、浮点、空字符串、非数字、`null` 和 `int64` 溢出值。
+- `worker_epoch` 必须存在，并且必须是正整数 JSON number。
+- `worker_epoch` 拒绝 `0`、负数、浮点、字符串、`null` 和 `int64` 溢出值。
 - 空 body、malformed JSON、数组 body 都返回 `400 invalid_request_error`。
 
 ### 成功响应

--- a/internal/codesessions/errors.go
+++ b/internal/codesessions/errors.go
@@ -1,0 +1,19 @@
+package codesessions
+
+import (
+	"errors"
+
+	"github.com/superduck-ai/open-managed-agents/internal/apperr"
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+)
+
+func codeSessionNotFound(cause error) error {
+	return apperr.New(apperr.NotFound, "Code session not found", cause)
+}
+
+func mapCodeSessionLoadError(err error) error {
+	if errors.Is(err, db.ErrNotFound) {
+		return codeSessionNotFound(err)
+	}
+	return apperr.New(apperr.Internal, "Could not load code session", err)
+}

--- a/internal/codesessions/errors.go
+++ b/internal/codesessions/errors.go
@@ -12,12 +12,34 @@ func codeSessionNotFound(cause error) error {
 	return apperr.New(apperr.NotFound, "Code session not found", cause)
 }
 
+func internalError(message string, cause error) error {
+	return apperr.New(apperr.Internal, message, cause)
+}
+
+func codeSessionRouteNotFound() error {
+	return apperr.New(apperr.NotFound, "Not found", nil)
+}
+
+func sessionIngressTokenRequired() error {
+	return apperr.New(apperr.Unauthenticated, "Missing session ingress token", nil)
+}
+
+func sessionIngressTokenInvalid(cause error) error {
+	return apperr.New(apperr.Unauthenticated, "Invalid session ingress token", cause)
+}
+
+func codeSessionEventsLoadError(err error, codeSessionID string) error {
+	return internalError(
+		"Could not list code session events",
+		fmt.Errorf("list code session %q events: %w", codeSessionID, err),
+	)
+}
+
 func mapCodeSessionLoadError(err error, codeSessionID string) error {
 	if errors.Is(err, db.ErrNotFound) {
 		return codeSessionNotFound(err)
 	}
-	return apperr.New(
-		apperr.Internal,
+	return internalError(
 		"Could not load code session",
 		fmt.Errorf("load code session %q: %w", codeSessionID, err),
 	)

--- a/internal/codesessions/errors.go
+++ b/internal/codesessions/errors.go
@@ -2,6 +2,7 @@ package codesessions
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/superduck-ai/open-managed-agents/internal/apperr"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
@@ -11,9 +12,13 @@ func codeSessionNotFound(cause error) error {
 	return apperr.New(apperr.NotFound, "Code session not found", cause)
 }
 
-func mapCodeSessionLoadError(err error) error {
+func mapCodeSessionLoadError(err error, codeSessionID string) error {
 	if errors.Is(err, db.ErrNotFound) {
 		return codeSessionNotFound(err)
 	}
-	return apperr.New(apperr.Internal, "Could not load code session", err)
+	return apperr.New(
+		apperr.Internal,
+		"Could not load code session",
+		fmt.Errorf("load code session %q: %w", codeSessionID, err),
+	)
 }

--- a/internal/codesessions/errors_test.go
+++ b/internal/codesessions/errors_test.go
@@ -20,7 +20,7 @@ func TestMapCodeSessionLoadError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mapped := mapCodeSessionLoadError(test.cause)
+			mapped := mapCodeSessionLoadError(test.cause, "code_session_test")
 			appErr, ok := errors.AsType[*apperr.Error](mapped)
 			if !ok {
 				t.Fatalf("error type = %T, want *apperr.Error", mapped)

--- a/internal/codesessions/errors_test.go
+++ b/internal/codesessions/errors_test.go
@@ -1,0 +1,36 @@
+package codesessions
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/superduck-ai/open-managed-agents/internal/apperr"
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+)
+
+func TestMapCodeSessionLoadError(t *testing.T) {
+	tests := []struct {
+		name    string
+		cause   error
+		kind    apperr.Kind
+		message string
+	}{
+		{name: "unexpected failure", cause: errors.New("database failed"), kind: apperr.Internal, message: "Could not load code session"},
+		{name: "not found", cause: db.ErrNotFound, kind: apperr.NotFound, message: "Code session not found"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mapped := mapCodeSessionLoadError(test.cause)
+			appErr, ok := errors.AsType[*apperr.Error](mapped)
+			if !ok {
+				t.Fatalf("error type = %T, want *apperr.Error", mapped)
+			}
+			if appErr.Kind != test.kind || appErr.PublicMessage != test.message {
+				t.Fatalf("error = (%v, %q), want (%v, %q)", appErr.Kind, appErr.PublicMessage, test.kind, test.message)
+			}
+			if !errors.Is(mapped, test.cause) {
+				t.Fatalf("errors.Is(%v, cause) = false", mapped)
+			}
+		})
+	}
+}

--- a/internal/codesessions/handler.go
+++ b/internal/codesessions/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
 	"github.com/superduck-ai/open-managed-agents/internal/logging"
 	"github.com/superduck-ai/open-managed-agents/internal/secrets"
 	"github.com/superduck-ai/open-managed-agents/internal/vaults"
@@ -22,6 +23,7 @@ type Handler struct {
 	db                     *db.DB
 	service                *Service
 	logger                 *slog.Logger
+	errorAdapter           *httpapi.ErrorAdapter
 	sandboxTimeoutExtender SandboxTimeoutExtender
 	upstreamProxy          upstreamProxyRuntime
 	mcpProxyTransport      http.RoundTripper
@@ -50,6 +52,7 @@ func NewHandler(cfg config.Config, service *Service, sandboxTimeoutExtender Sand
 		db:                     service.db,
 		service:                service,
 		logger:                 logger,
+		errorAdapter:           httpapi.NewErrorAdapter(logger),
 		sandboxTimeoutExtender: sandboxTimeoutExtender,
 		upstreamProxy:          newUpstreamProxyRuntime(),
 		mcpProxyTransport:      newMCPProxyTransport(cfg.CodeSession.UpstreamProxyDisableSSRFProtection),

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -95,12 +95,11 @@ func (h *Handler) handlePutCodeSessionWorker(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	if input.WorkerStatus != nil {
-		if err := h.service.syncPublicSessionStatusFromWorker(r.Context(), updated, *input.WorkerStatus); err != nil {
+		if err := h.service.syncPublicSessionFromWorker(r.Context(), updated, *input.WorkerStatus); err != nil {
 			h.logger.ErrorContext(r.Context(), "sync public session status from worker", "code_session_id", codeSessionID, "session_id", updated.SessionExternalID, "worker_status", *input.WorkerStatus, "error", err)
 			httpapi.WriteError(w, r, httpapi.NewError(http.StatusInternalServerError, "api_error", "Could not sync code session worker status"))
 			return
 		}
-		h.service.reconcileSubagentEvents(r.Context(), codeSessionID)
 	}
 	httpapi.WriteJSON(w, http.StatusOK, h.codeSessionWorkerState(updated, r, input.WorkerEpoch))
 }

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -48,7 +48,7 @@ func (h *Handler) handleCodeSessionHTTPPoll(w http.ResponseWriter, r *http.Reque
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
+	if _, err := h.requireCodeSession(r.Context(), codeSessionID); err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
 	}
@@ -124,7 +124,7 @@ func (h *Handler) handleGetCodeSessionWorker(w http.ResponseWriter, r *http.Requ
 	if _, _, ok := h.validateOptionalWorkerEpochRequest(w, r, codeSessionID); !ok {
 		return
 	}
-	record, err := h.getCodeSession(r.Context(), codeSessionID)
+	record, err := h.requireCodeSession(r.Context(), codeSessionID)
 	if err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
@@ -137,7 +137,7 @@ func (h *Handler) handleCodeSessionWorkerInternalEvents(w http.ResponseWriter, r
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	record, err := h.getCodeSession(r.Context(), codeSessionID)
+	record, err := h.requireCodeSession(r.Context(), codeSessionID)
 	if err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
@@ -222,7 +222,7 @@ func (h *Handler) handleCodeSessionWorkerEventsStream(w http.ResponseWriter, r *
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
+	if _, err := h.requireCodeSession(r.Context(), codeSessionID); err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
 	}
@@ -523,7 +523,7 @@ func (h *Handler) handleCodeSessionWorkerOTLP(w http.ResponseWriter, r *http.Req
 		// 上报启动与安装指标；该 exporter 只携带 session bearer token。无 epoch
 		// telemetry 只确认 session 仍存在，不刷新 worker activity 或 lease，避免旧
 		// exporter 借遥测请求维持已经失效的 worker 所有权。
-		if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
+		if _, err := h.requireCodeSession(r.Context(), codeSessionID); err != nil {
 			h.logCodeSessionWorkerOTLPRequest(r, codeSessionID, body, 0, false, "", "", "session_load_error", err)
 			h.writeIngressLoadError(w, r, err)
 			return
@@ -546,7 +546,7 @@ func (h *Handler) handleSessionIngressEvents(w http.ResponseWriter, r *http.Requ
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
+	if _, err := h.requireCodeSession(r.Context(), codeSessionID); err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
 	}
@@ -574,7 +574,7 @@ func (h *Handler) handleSessionIngressDiagLogs(w http.ResponseWriter, r *http.Re
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
+	if _, err := h.requireCodeSession(r.Context(), codeSessionID); err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
 	}
@@ -602,7 +602,7 @@ func (h *Handler) handleSessionIngressPersistence(w http.ResponseWriter, r *http
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
+	if _, err := h.requireCodeSession(r.Context(), codeSessionID); err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
 	}
@@ -634,7 +634,7 @@ func (h *Handler) handleSessionContext(w http.ResponseWriter, r *http.Request) {
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	record, err := h.getCodeSession(r.Context(), codeSessionID)
+	record, err := h.requireCodeSession(r.Context(), codeSessionID)
 	if err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
@@ -781,19 +781,19 @@ func objectConfigValue(value any) map[string]any {
 	return object
 }
 
-func (h *Handler) getCodeSession(ctx context.Context, codeSessionID string) (db.CodeSession, error) {
+func (h *Handler) requireCodeSession(ctx context.Context, codeSessionID string) (db.CodeSession, error) {
 	record, found, err := h.db.GetCodeSession(ctx, codeSessionID)
 	if err != nil {
-		return db.CodeSession{}, err
+		return db.CodeSession{}, mapCodeSessionLoadError(err, codeSessionID)
 	}
 	if !found {
-		return db.CodeSession{}, db.ErrNotFound
+		return db.CodeSession{}, mapCodeSessionLoadError(db.ErrNotFound, codeSessionID)
 	}
 	return record, nil
 }
 
 func (h *Handler) writeIngressLoadError(w http.ResponseWriter, r *http.Request, err error) {
-	h.errorAdapter.Write(w, r, mapCodeSessionLoadError(err))
+	h.errorAdapter.Write(w, r, err)
 }
 
 type codeSessionWorkerEpochBody struct {
@@ -871,7 +871,7 @@ func (h *Handler) validateWorkerEpochValue(w http.ResponseWriter, r *http.Reques
 
 func (h *Handler) writeWorkerEpochDBError(w http.ResponseWriter, r *http.Request, codeSessionID string, err error, internalMessage string) {
 	if errors.Is(err, db.ErrNotFound) {
-		h.writeIngressLoadError(w, r, err)
+		h.writeIngressLoadError(w, r, mapCodeSessionLoadError(err, codeSessionID))
 		return
 	}
 	if errors.Is(err, db.ErrWorkerEpochMismatch) {

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -812,9 +812,11 @@ type codeSessionWorkerHeartbeatBody struct {
 }
 
 type codeSessionWorkerRequiresActionDetails struct {
-	ToolName          *string `json:"tool_name,omitempty"`
-	ActionDescription *string `json:"action_description,omitempty"`
-	RequestID         *string `json:"request_id,omitempty"`
+	ToolName          *string                    `json:"tool_name,omitempty"`
+	ActionDescription *string                    `json:"action_description,omitempty"`
+	ToolUseID         *string                    `json:"tool_use_id,omitempty"`
+	RequestID         *string                    `json:"request_id,omitempty"`
+	Input             map[string]json.RawMessage `json:"input,omitempty"`
 }
 
 type codeSessionWorkerStateBody struct {

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -100,6 +100,7 @@ func (h *Handler) handlePutCodeSessionWorker(w http.ResponseWriter, r *http.Requ
 			httpapi.WriteError(w, r, httpapi.NewError(http.StatusInternalServerError, "api_error", "Could not sync code session worker status"))
 			return
 		}
+		h.service.reconcileSubagentEvents(r.Context(), codeSessionID)
 	}
 	httpapi.WriteJSON(w, http.StatusOK, h.codeSessionWorkerState(updated, r, input.WorkerEpoch))
 }

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -787,7 +787,7 @@ func (h *Handler) requireCodeSession(ctx context.Context, codeSessionID string) 
 		return db.CodeSession{}, mapCodeSessionLoadError(err, codeSessionID)
 	}
 	if !found {
-		return db.CodeSession{}, mapCodeSessionLoadError(db.ErrNotFound, codeSessionID)
+		return db.CodeSession{}, codeSessionNotFound(nil)
 	}
 	return record, nil
 }

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -793,12 +793,7 @@ func (h *Handler) getCodeSession(ctx context.Context, codeSessionID string) (db.
 }
 
 func (h *Handler) writeIngressLoadError(w http.ResponseWriter, r *http.Request, err error) {
-	if errors.Is(err, db.ErrNotFound) {
-		httpapi.WriteError(w, r, httpapi.NewError(http.StatusNotFound, "not_found_error", "Code session not found"))
-		return
-	}
-	h.logger.ErrorContext(r.Context(), "load code session", "error", err)
-	httpapi.WriteError(w, r, httpapi.NewError(http.StatusInternalServerError, "api_error", "Could not load code session"))
+	h.errorAdapter.Write(w, r, mapCodeSessionLoadError(err))
 }
 
 type codeSessionWorkerEpochBody struct {

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -29,28 +29,18 @@ const (
 	internalEventsPageSize      = 500
 )
 
-func (h *Handler) handleCodeSession(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodGet {
-		// legacy WebSocket ingress 已移除。必须在请求进入旧的 30 秒 HTTP poll
-		// 之前拒绝 WebSocket upgrade，避免退化成长轮询请求。
-		if strings.EqualFold(strings.TrimSpace(r.Header.Get("Upgrade")), "websocket") {
-			httpapi.WriteError(w, r, httpapi.NewError(http.StatusNotFound, "not_found_error", "Not found"))
-			return
-		}
-		h.handleCodeSessionHTTPPoll(w, r)
-		return
-	}
-	h.handleSessionIngressPersistence(w, r)
-}
-
-func (h *Handler) handleCodeSessionHTTPPoll(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) handleCodeSessionHTTPPoll(w http.ResponseWriter, r *http.Request) error {
 	codeSessionID := chi.URLParam(r, "code_session_id")
-	if !h.authorizeSessionIngress(w, r, codeSessionID) {
-		return
+	// legacy WebSocket ingress 已移除。必须在请求进入旧的 30 秒 HTTP poll
+	// 之前拒绝 WebSocket upgrade，避免退化成长轮询请求。
+	if strings.EqualFold(strings.TrimSpace(r.Header.Get("Upgrade")), "websocket") {
+		return codeSessionRouteNotFound()
+	}
+	if err := h.authorizeSessionIngressRequest(r, codeSessionID); err != nil {
+		return err
 	}
 	if _, err := h.requireCodeSession(r.Context(), codeSessionID); err != nil {
-		h.writeIngressLoadError(w, r, err)
-		return
+		return err
 	}
 	if err := h.db.MarkCodeSessionWorkerConnected(r.Context(), codeSessionID); err != nil && !errors.Is(err, db.ErrNotFound) {
 		h.logger.ErrorContext(r.Context(), "mark code session http poll connected", "code_session_id", codeSessionID, "error", err)
@@ -63,9 +53,7 @@ func (h *Handler) handleCodeSessionHTTPPoll(w http.ResponseWriter, r *http.Reque
 	for {
 		events, err := h.db.ListQueuedCodeSessionInboundEvents(r.Context(), codeSessionID)
 		if err != nil {
-			h.logger.ErrorContext(r.Context(), "list queued code session http poll events", "code_session_id", codeSessionID, "error", err)
-			httpapi.WriteError(w, r, httpapi.NewError(http.StatusInternalServerError, "api_error", "Could not list code session events"))
-			return
+			return codeSessionEventsLoadError(err, codeSessionID)
 		}
 		if len(events) > 0 {
 			payloads := make([]json.RawMessage, 0, len(events))
@@ -78,14 +66,14 @@ func (h *Handler) handleCodeSessionHTTPPoll(w http.ResponseWriter, r *http.Reque
 					h.logger.ErrorContext(r.Context(), "mark code session http poll event sent", "code_session_id", codeSessionID, "event_id", event.ExternalID, "error", err)
 				}
 			}
-			return
+			return nil
 		}
 		select {
 		case <-r.Context().Done():
-			return
+			return nil
 		case <-deadline.C:
 			httpapi.WriteJSON(w, http.StatusOK, map[string]any{"events": []any{}})
-			return
+			return nil
 		case <-ticker.C:
 		}
 	}

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -48,7 +48,7 @@ func (h *Handler) handleCodeSessionHTTPPoll(w http.ResponseWriter, r *http.Reque
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	if _, err := h.db.GetCodeSession(r.Context(), codeSessionID); err != nil {
+	if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
 	}
@@ -124,7 +124,7 @@ func (h *Handler) handleGetCodeSessionWorker(w http.ResponseWriter, r *http.Requ
 	if _, _, ok := h.validateOptionalWorkerEpochRequest(w, r, codeSessionID); !ok {
 		return
 	}
-	record, err := h.db.GetCodeSession(r.Context(), codeSessionID)
+	record, err := h.getCodeSession(r.Context(), codeSessionID)
 	if err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
@@ -137,7 +137,7 @@ func (h *Handler) handleCodeSessionWorkerInternalEvents(w http.ResponseWriter, r
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	record, err := h.db.GetCodeSession(r.Context(), codeSessionID)
+	record, err := h.getCodeSession(r.Context(), codeSessionID)
 	if err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
@@ -222,7 +222,7 @@ func (h *Handler) handleCodeSessionWorkerEventsStream(w http.ResponseWriter, r *
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	if _, err := h.db.GetCodeSession(r.Context(), codeSessionID); err != nil {
+	if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
 	}
@@ -446,12 +446,7 @@ func (h *Handler) handleCodeSessionWorkerHeartbeat(w http.ResponseWriter, r *htt
 	}
 	input, err := decodeCodeSessionWorkerHeartbeatBody(w, r, codeSessionID)
 	if err != nil {
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
-			writeCodeSessionWorkerBodyReadError(w, r, err)
-			return
-		}
-		httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", err.Error()))
+		writeCodeSessionWorkerBodyReadError(w, r, err)
 		return
 	}
 	expiresAt, err := h.db.RecordCodeSessionWorkerHeartbeat(r.Context(), codeSessionID, input.WorkerEpoch, codeSessionWorkerLeaseTTL, codeSessionWorkerLeaseGrace)
@@ -528,7 +523,7 @@ func (h *Handler) handleCodeSessionWorkerOTLP(w http.ResponseWriter, r *http.Req
 		// 上报启动与安装指标；该 exporter 只携带 session bearer token。无 epoch
 		// telemetry 只确认 session 仍存在，不刷新 worker activity 或 lease，避免旧
 		// exporter 借遥测请求维持已经失效的 worker 所有权。
-		if _, err := h.db.GetCodeSession(r.Context(), codeSessionID); err != nil {
+		if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
 			h.logCodeSessionWorkerOTLPRequest(r, codeSessionID, body, 0, false, "", "", "session_load_error", err)
 			h.writeIngressLoadError(w, r, err)
 			return
@@ -551,7 +546,7 @@ func (h *Handler) handleSessionIngressEvents(w http.ResponseWriter, r *http.Requ
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	if _, err := h.db.GetCodeSession(r.Context(), codeSessionID); err != nil {
+	if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
 	}
@@ -579,7 +574,7 @@ func (h *Handler) handleSessionIngressDiagLogs(w http.ResponseWriter, r *http.Re
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	if _, err := h.db.GetCodeSession(r.Context(), codeSessionID); err != nil {
+	if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
 	}
@@ -607,7 +602,7 @@ func (h *Handler) handleSessionIngressPersistence(w http.ResponseWriter, r *http
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	if _, err := h.db.GetCodeSession(r.Context(), codeSessionID); err != nil {
+	if _, err := h.getCodeSession(r.Context(), codeSessionID); err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
 	}
@@ -639,7 +634,7 @@ func (h *Handler) handleSessionContext(w http.ResponseWriter, r *http.Request) {
 	if !h.authorizeSessionIngress(w, r, codeSessionID) {
 		return
 	}
-	record, err := h.db.GetCodeSession(r.Context(), codeSessionID)
+	record, err := h.getCodeSession(r.Context(), codeSessionID)
 	if err != nil {
 		h.writeIngressLoadError(w, r, err)
 		return
@@ -786,6 +781,17 @@ func objectConfigValue(value any) map[string]any {
 	return object
 }
 
+func (h *Handler) getCodeSession(ctx context.Context, codeSessionID string) (db.CodeSession, error) {
+	record, found, err := h.db.GetCodeSession(ctx, codeSessionID)
+	if err != nil {
+		return db.CodeSession{}, err
+	}
+	if !found {
+		return db.CodeSession{}, db.ErrNotFound
+	}
+	return record, nil
+}
+
 func (h *Handler) writeIngressLoadError(w http.ResponseWriter, r *http.Request, err error) {
 	if errors.Is(err, db.ErrNotFound) {
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusNotFound, "not_found_error", "Code session not found"))
@@ -800,9 +806,22 @@ type codeSessionWorkerEpochBody struct {
 	epoch int64
 }
 
-type codeSessionWorkerHeartbeatInput struct {
-	SessionID   string
-	WorkerEpoch int64
+type codeSessionWorkerHeartbeatBody struct {
+	SessionID   string `json:"session_id"`
+	WorkerEpoch int64  `json:"worker_epoch"`
+}
+
+type codeSessionWorkerRequiresActionDetails struct {
+	ToolName          *string `json:"tool_name,omitempty"`
+	ActionDescription *string `json:"action_description,omitempty"`
+	RequestID         *string `json:"request_id,omitempty"`
+}
+
+type codeSessionWorkerStateBody struct {
+	WorkerEpoch           int64                                   `json:"worker_epoch"`
+	WorkerStatus          string                                  `json:"worker_status"`
+	RequiresActionDetails *codeSessionWorkerRequiresActionDetails `json:"requires_action_details"`
+	ExternalMetadata      map[string]json.RawMessage              `json:"external_metadata"`
 }
 
 func (h *Handler) requireWorkerEpochBody(w http.ResponseWriter, r *http.Request, codeSessionID string) (codeSessionWorkerEpochBody, bool) {
@@ -1158,103 +1177,57 @@ func validateCodeSessionWorkerRegisterBody(w http.ResponseWriter, r *http.Reques
 	return nil
 }
 
-func decodeCodeSessionWorkerHeartbeatBody(w http.ResponseWriter, r *http.Request, codeSessionID string) (codeSessionWorkerHeartbeatInput, error) {
-	body, err := readCodeSessionWorkerBody(w, r)
+func decodeCodeSessionWorkerHeartbeatBody(w http.ResponseWriter, r *http.Request, codeSessionID string) (codeSessionWorkerHeartbeatBody, error) {
+	request, err := httpapi.DecodeObjectBodyAs[codeSessionWorkerHeartbeatBody](w, r, maxIngressBodySize)
 	if err != nil {
-		return codeSessionWorkerHeartbeatInput{}, err
+		return codeSessionWorkerHeartbeatBody{}, err
 	}
-	body = bytes.TrimSpace(body)
-	if len(body) == 0 {
-		return codeSessionWorkerHeartbeatInput{}, errors.New("heartbeat body is required")
+	if request.SessionID == "" {
+		return codeSessionWorkerHeartbeatBody{}, errors.New("session_id is required")
 	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(body, &fields); err != nil || fields == nil {
-		return codeSessionWorkerHeartbeatInput{}, errors.New("heartbeat body must be a JSON object")
+	if request.SessionID != codeSessionID {
+		return codeSessionWorkerHeartbeatBody{}, errors.New("session_id does not match code session id")
 	}
-
-	rawSessionID, ok := fields["session_id"]
-	if !ok {
-		return codeSessionWorkerHeartbeatInput{}, errors.New("session_id is required")
+	if request.WorkerEpoch <= 0 {
+		return codeSessionWorkerHeartbeatBody{}, errors.New("worker_epoch must be a positive integer")
 	}
-	var sessionID string
-	if err := json.Unmarshal(rawSessionID, &sessionID); err != nil {
-		return codeSessionWorkerHeartbeatInput{}, errors.New("session_id must be a string")
-	}
-	sessionID = strings.TrimSpace(sessionID)
-	if sessionID == "" {
-		return codeSessionWorkerHeartbeatInput{}, errors.New("session_id is required")
-	}
-	if sessionID != codeSessionID {
-		return codeSessionWorkerHeartbeatInput{}, errors.New("session_id does not match code session id")
-	}
-
-	rawEpoch, ok := fields["worker_epoch"]
-	if !ok {
-		return codeSessionWorkerHeartbeatInput{}, errors.New("worker_epoch is required")
-	}
-	epoch, err := parseWorkerEpochRaw(rawEpoch)
-	if err != nil {
-		return codeSessionWorkerHeartbeatInput{}, err
-	}
-	return codeSessionWorkerHeartbeatInput{SessionID: sessionID, WorkerEpoch: epoch}, nil
+	return *request, nil
 }
 
 func decodeCodeSessionWorkerStateBody(w http.ResponseWriter, r *http.Request) (db.UpdateCodeSessionWorkerStateInput, error) {
-	body, err := readCodeSessionWorkerBody(w, r)
+	request, err := httpapi.DecodeObjectBodyAs[codeSessionWorkerStateBody](w, r, maxIngressBodySize)
 	if err != nil {
 		return db.UpdateCodeSessionWorkerStateInput{}, err
 	}
-	body = bytes.TrimSpace(body)
-	if len(body) == 0 {
-		return db.UpdateCodeSessionWorkerStateInput{}, errors.New("worker body is required")
-	}
-	var fields map[string]json.RawMessage
-	if err := json.Unmarshal(body, &fields); err != nil || fields == nil {
-		return db.UpdateCodeSessionWorkerStateInput{}, errors.New("worker body must be a JSON object")
-	}
 
-	rawEpoch, ok := fields["worker_epoch"]
-	if !ok {
-		return db.UpdateCodeSessionWorkerStateInput{}, errors.New("worker_epoch is required")
+	if request.WorkerEpoch <= 0 {
+		return db.UpdateCodeSessionWorkerStateInput{}, errors.New("worker_epoch must be a positive integer")
 	}
-	epoch, err := parseWorkerEpochRaw(rawEpoch)
-	if err != nil {
-		return db.UpdateCodeSessionWorkerStateInput{}, err
-	}
-	input := db.UpdateCodeSessionWorkerStateInput{WorkerEpoch: epoch}
+	input := db.UpdateCodeSessionWorkerStateInput{WorkerEpoch: request.WorkerEpoch}
 
-	if rawStatus, ok := fields["worker_status"]; ok {
-		var status string
-		if err := json.Unmarshal(rawStatus, &status); err != nil {
-			return db.UpdateCodeSessionWorkerStateInput{}, errors.New("worker_status must be a string")
-		}
-		status = strings.TrimSpace(status)
-		if !validWorkerStatus(status) {
+	if request.WorkerStatus != "" {
+		if !validWorkerStatus(request.WorkerStatus) {
 			return db.UpdateCodeSessionWorkerStateInput{}, errors.New("worker_status must be one of: idle, running, requires_action")
 		}
-		input.WorkerStatus = &status
+		input.WorkerStatus = &request.WorkerStatus
 	}
 
-	if rawDetails, ok := fields["requires_action_details"]; ok {
-		rawDetails = bytes.TrimSpace(rawDetails)
-		if !rawJSONIsNull(rawDetails) && !rawJSONObject(rawDetails) {
-			return db.UpdateCodeSessionWorkerStateInput{}, errors.New("requires_action_details must be an object or null")
+	if request.RequiresActionDetails != nil {
+		details, err := json.Marshal(request.RequiresActionDetails)
+		if err != nil {
+			return db.UpdateCodeSessionWorkerStateInput{}, errors.New("requires_action_details must be an object")
 		}
 		input.RequiresActionDetailsSet = true
-		if rawJSONIsNull(rawDetails) {
-			input.RequiresActionDetails = json.RawMessage(`null`)
-		} else {
-			input.RequiresActionDetails = copyRawMessage(rawDetails)
-		}
+		input.RequiresActionDetails = details
 	}
 
-	if rawMetadata, ok := fields["external_metadata"]; ok {
-		rawMetadata = bytes.TrimSpace(rawMetadata)
-		if !rawJSONObject(rawMetadata) {
+	if request.ExternalMetadata != nil {
+		metadata, err := json.Marshal(request.ExternalMetadata)
+		if err != nil {
 			return db.UpdateCodeSessionWorkerStateInput{}, errors.New("external_metadata must be an object")
 		}
 		input.ExternalMetadataSet = true
-		input.ExternalMetadata = copyRawMessage(rawMetadata)
+		input.ExternalMetadata = metadata
 	}
 
 	return input, nil
@@ -1267,20 +1240,6 @@ func validWorkerStatus(status string) bool {
 	default:
 		return false
 	}
-}
-
-func rawJSONIsNull(raw json.RawMessage) bool {
-	raw = bytes.TrimSpace(raw)
-	return len(raw) == 0 || bytes.Equal(raw, []byte("null"))
-}
-
-func rawJSONObject(raw json.RawMessage) bool {
-	raw = bytes.TrimSpace(raw)
-	if len(raw) == 0 || raw[0] != '{' {
-		return false
-	}
-	var object map[string]json.RawMessage
-	return json.Unmarshal(raw, &object) == nil && object != nil
 }
 
 func copyRawMessage(raw json.RawMessage) json.RawMessage {

--- a/internal/codesessions/ingress_test.go
+++ b/internal/codesessions/ingress_test.go
@@ -2,10 +2,29 @@ package codesessions
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
+
+	"github.com/go-chi/chi/v5"
 )
+
+func TestCodeSessionHTTPPollReturnsErrorsThroughAdapter(t *testing.T) {
+	handler := NewHandler(config.Config{}, newTestService(t, nil), nil, nil)
+	router := chi.NewRouter()
+	handler.RegisterV1Routes(router)
+
+	request := httptest.NewRequest(http.MethodGet, "/code/sessions/cse_test/", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusUnauthorized, response.Body.String())
+	}
+}
 
 func TestSessionContextFromCodeSessionUsesStoredConfig(t *testing.T) {
 	record := db.CodeSession{

--- a/internal/codesessions/routes.go
+++ b/internal/codesessions/routes.go
@@ -35,9 +35,9 @@ func (h *Handler) registerCodeSessionRoutes(router chi.Router) {
 	// code-session ID 只在资源根路径声明一次；worker 作为该 session 的子资源注册，
 	// 避免通过字符串拼接重复完整路径，并让后续资源级中间件可以挂载在明确的 chi 子路由上。
 	router.Route("/code/sessions/{code_session_id}", func(sessionRouter chi.Router) {
-		sessionRouter.Get("/", h.handleCodeSession)
-		sessionRouter.Post("/", h.handleCodeSession)
-		sessionRouter.Put("/", h.handleCodeSession)
+		sessionRouter.Get("/", h.errorAdapter.Wrap(h.handleCodeSessionHTTPPoll))
+		sessionRouter.Post("/", h.handleSessionIngressPersistence)
+		sessionRouter.Put("/", h.handleSessionIngressPersistence)
 		sessionRouter.Route("/worker", func(workerRouter chi.Router) {
 			workerRouter.Get("/", h.handleGetCodeSessionWorker)
 			workerRouter.Put("/", h.handlePutCodeSessionWorker)

--- a/internal/codesessions/runtime_auth.go
+++ b/internal/codesessions/runtime_auth.go
@@ -23,19 +23,24 @@ func (h *Handler) authenticateRuntimeSession(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *Handler) authorizeSessionIngress(w http.ResponseWriter, r *http.Request, codeSessionID string) bool {
-	// 校验 URL 中的 codeSessionID，为空时返回 404，避免处理没有明确 session 归属的请求。
-	if strings.TrimSpace(codeSessionID) == "" {
-		httpapi.WriteError(w, r, httpapi.NewError(http.StatusNotFound, "not_found_error", "Not found"))
-		return false
-	}
-	token := auth.ExtractAPIKey(r)
-	if token == "" {
-		httpapi.WriteError(w, r, httpapi.NewError(http.StatusUnauthorized, "authentication_error", "Missing session ingress token"))
-		return false
-	}
-	if _, err := h.service.AuthenticateSessionIngress(token, codeSessionID); err != nil {
-		httpapi.WriteError(w, r, httpapi.NewError(http.StatusUnauthorized, "authentication_error", "Invalid session ingress token"))
+	if err := h.authorizeSessionIngressRequest(r, codeSessionID); err != nil {
+		h.errorAdapter.Write(w, r, err)
 		return false
 	}
 	return true
+}
+
+func (h *Handler) authorizeSessionIngressRequest(r *http.Request, codeSessionID string) error {
+	// 校验 URL 中的 codeSessionID，为空时返回 404，避免处理没有明确 session 归属的请求。
+	if strings.TrimSpace(codeSessionID) == "" {
+		return codeSessionRouteNotFound()
+	}
+	token := auth.ExtractAPIKey(r)
+	if token == "" {
+		return sessionIngressTokenRequired()
+	}
+	if _, err := h.service.AuthenticateSessionIngress(token, codeSessionID); err != nil {
+		return sessionIngressTokenInvalid(err)
+	}
+	return nil
 }

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -205,10 +205,9 @@ func (s *Service) AppendWorkerOutputEventsForEpoch(ctx context.Context, codeSess
 		if !ok {
 			continue
 		}
-		if err := s.publishPublicPayloads(ctx, codeSessionID, publicPayloads); err != nil {
+		if err := s.publishWorkerPublicPayloads(ctx, codeSessionID, publicPayloads); err != nil {
 			return err
 		}
-		s.reconcileSubagentEvents(ctx, codeSessionID)
 	}
 	return nil
 }
@@ -272,11 +271,7 @@ func (s *Service) appendWorkerEvent(ctx context.Context, codeSessionID string, r
 	if !ok {
 		return nil
 	}
-	if err := s.publishPublicPayloads(ctx, codeSessionID, publicPayloads); err != nil {
-		return err
-	}
-	s.reconcileSubagentEvents(ctx, codeSessionID)
-	return nil
+	return s.publishWorkerPublicPayloads(ctx, codeSessionID, publicPayloads)
 }
 
 func (s *Service) queueInitialize(ctx context.Context, codeSession db.CodeSession, configRaw json.RawMessage, now time.Time) error {
@@ -337,6 +332,14 @@ func newInboundEventInput(codeSessionID string, payload json.RawMessage, source 
 		Source:         strings.TrimSpace(source),
 		CreatedAt:      time.Now().UTC(),
 	}, nil
+}
+
+func (s *Service) publishWorkerPublicPayloads(ctx context.Context, codeSessionID string, payloads []json.RawMessage) error {
+	if err := s.publishPublicPayloads(ctx, codeSessionID, payloads); err != nil {
+		return err
+	}
+	s.reconcileSubagentEvents(ctx, codeSessionID)
+	return nil
 }
 
 func (s *Service) publishPublicPayloads(ctx context.Context, codeSessionID string, payloads []json.RawMessage) error {

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -208,6 +208,9 @@ func (s *Service) AppendWorkerOutputEventsForEpoch(ctx context.Context, codeSess
 		if err := s.publishPublicPayloads(ctx, codeSessionID, publicPayloads); err != nil {
 			return err
 		}
+		if event.EventType == "session.thread_created" {
+			s.backfillSubagentEvents(ctx, codeSessionID)
+		}
 	}
 	return nil
 }
@@ -271,7 +274,13 @@ func (s *Service) appendWorkerEvent(ctx context.Context, codeSessionID string, r
 	if !ok {
 		return nil
 	}
-	return s.publishPublicPayloads(ctx, codeSessionID, publicPayloads)
+	if err := s.publishPublicPayloads(ctx, codeSessionID, publicPayloads); err != nil {
+		return err
+	}
+	if meta.EventType == "session.thread_created" {
+		s.backfillSubagentEvents(ctx, codeSessionID)
+	}
+	return nil
 }
 
 func (s *Service) queueInitialize(ctx context.Context, codeSession db.CodeSession, configRaw json.RawMessage, now time.Time) error {
@@ -335,37 +344,33 @@ func newInboundEventInput(codeSessionID string, payload json.RawMessage, source 
 }
 
 func (s *Service) publishPublicPayloads(ctx context.Context, codeSessionID string, payloads []json.RawMessage) error {
-	codeSession, err := s.publishPublicPayloadsToSink(ctx, codeSessionID, payloads)
-	if err != nil {
-		return err
-	}
-	if codeSession.ExternalID == "" {
-		return nil
-	}
-	if err := s.publishSubagentInternalEvents(ctx, codeSession); err != nil {
-		s.logger.ErrorContext(ctx, "publish subagent internal events", "code_session_id", codeSession.ExternalID, "session_id", codeSession.SessionExternalID, "error", err)
-	}
-	return nil
-}
-
-func (s *Service) publishPublicPayloadsToSink(ctx context.Context, codeSessionID string, payloads []json.RawMessage) (db.CodeSession, error) {
 	if len(payloads) == 0 {
-		return db.CodeSession{}, nil
+		return nil
 	}
 	codeSession, found, err := s.db.GetCodeSession(ctx, codeSessionID)
 	if err != nil {
-		return db.CodeSession{}, err
+		return err
 	}
 	if !found {
-		return db.CodeSession{}, db.ErrNotFound
+		return db.ErrNotFound
 	}
 	s.sinkMu.Lock()
 	sink := s.sink
 	s.sinkMu.Unlock()
 	if sink == nil {
-		return codeSession, nil
+		return nil
 	}
-	return codeSession, sink.PublishCodeSessionEvents(ctx, codeSession, payloads)
+	return sink.PublishCodeSessionEvents(ctx, codeSession, payloads)
+}
+
+func (s *Service) backfillSubagentEvents(ctx context.Context, codeSessionID string) {
+	codeSession, found, err := s.db.GetCodeSession(ctx, codeSessionID)
+	if err == nil && found {
+		err = s.publishSubagentInternalEvents(ctx, codeSession)
+	}
+	if err != nil {
+		s.logger.ErrorContext(ctx, "publish subagent internal events", "code_session_id", codeSessionID, "error", err)
+	}
 }
 
 func (s *Service) publishSubagentInternalEvents(ctx context.Context, codeSession db.CodeSession) error {
@@ -410,8 +415,7 @@ func (s *Service) publishSubagentInternalEvents(ctx context.Context, codeSession
 	if len(payloads) == 0 {
 		return nil
 	}
-	_, err = s.publishPublicPayloadsToSink(ctx, codeSession.ExternalID, payloads)
-	return err
+	return s.publishPublicPayloads(ctx, codeSession.ExternalID, payloads)
 }
 
 func (s *Service) PublishSubagentInternalEvents(ctx context.Context, codeSession db.CodeSession) error {

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -208,9 +208,7 @@ func (s *Service) AppendWorkerOutputEventsForEpoch(ctx context.Context, codeSess
 		if err := s.publishPublicPayloads(ctx, codeSessionID, publicPayloads); err != nil {
 			return err
 		}
-		if event.EventType == "session.thread_created" {
-			s.backfillSubagentEvents(ctx, codeSessionID)
-		}
+		s.reconcileSubagentEvents(ctx, codeSessionID)
 	}
 	return nil
 }
@@ -277,9 +275,7 @@ func (s *Service) appendWorkerEvent(ctx context.Context, codeSessionID string, r
 	if err := s.publishPublicPayloads(ctx, codeSessionID, publicPayloads); err != nil {
 		return err
 	}
-	if meta.EventType == "session.thread_created" {
-		s.backfillSubagentEvents(ctx, codeSessionID)
-	}
+	s.reconcileSubagentEvents(ctx, codeSessionID)
 	return nil
 }
 
@@ -363,7 +359,7 @@ func (s *Service) publishPublicPayloads(ctx context.Context, codeSessionID strin
 	return sink.PublishCodeSessionEvents(ctx, codeSession, payloads)
 }
 
-func (s *Service) backfillSubagentEvents(ctx context.Context, codeSessionID string) {
+func (s *Service) reconcileSubagentEvents(ctx context.Context, codeSessionID string) {
 	codeSession, found, err := s.db.GetCodeSession(ctx, codeSessionID)
 	if err == nil && found {
 		err = s.publishSubagentInternalEvents(ctx, codeSession)

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -352,9 +352,12 @@ func (s *Service) publishPublicPayloadsToSink(ctx context.Context, codeSessionID
 	if len(payloads) == 0 {
 		return db.CodeSession{}, nil
 	}
-	codeSession, err := s.db.GetCodeSession(ctx, codeSessionID)
+	codeSession, found, err := s.db.GetCodeSession(ctx, codeSessionID)
 	if err != nil {
 		return db.CodeSession{}, err
+	}
+	if !found {
+		return db.CodeSession{}, db.ErrNotFound
 	}
 	s.sinkMu.Lock()
 	sink := s.sink
@@ -488,7 +491,7 @@ func requestIDString(requestID *string) string {
 }
 
 func stablePublicEventID(codeSessionID, seed string) string {
-	sum := sha256.Sum256([]byte(strings.TrimSpace(codeSessionID) + "\x00public\x00" + strings.TrimSpace(seed)))
+	sum := sha256.Sum256([]byte(codeSessionID + "\x00public\x00" + seed))
 	return "sevt_" + hex.EncodeToString(sum[:16])
 }
 

--- a/internal/codesessions/status.go
+++ b/internal/codesessions/status.go
@@ -2,8 +2,9 @@ package codesessions
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-	"strings"
+	"time"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 )
@@ -11,11 +12,16 @@ import (
 func (s *Service) syncPublicSessionStatusFromWorker(ctx context.Context, record db.CodeSession, workerStatus string) error {
 	// worker 状态属于内部执行协议；这里只把可公开表达的状态同步到 session 和主线程。
 	// 找不到公开 session/thread 代表旧数据或尚未完成初始化，不应让 worker 上报失败。
-	publicStatus, ok := publicSessionStatusFromWorkerStatus(workerStatus)
-	if !ok || strings.TrimSpace(record.SessionExternalID) == "" {
+	if record.SessionExternalID == "" {
 		return nil
 	}
-	if err := s.db.SetSessionStatus(ctx, record.WorkspaceUUID, record.SessionExternalID, publicStatus); err != nil && !errors.Is(err, db.ErrNotFound) {
+	if workerStatus == "running" {
+		return s.publishPublicRunningStatus(ctx, record)
+	}
+	if workerStatus != "idle" && workerStatus != "requires_action" {
+		return nil
+	}
+	if err := s.db.SetSessionStatus(ctx, record.WorkspaceUUID, record.SessionExternalID, "idle"); err != nil && !errors.Is(err, db.ErrNotFound) {
 		return err
 	}
 	thread, err := s.db.GetPrimarySessionThread(ctx, record.WorkspaceUUID, record.SessionExternalID)
@@ -25,20 +31,33 @@ func (s *Service) syncPublicSessionStatusFromWorker(ctx context.Context, record 
 		}
 		return err
 	}
-	if err := s.db.SetSessionThreadStatus(ctx, record.WorkspaceUUID, record.SessionExternalID, thread.ExternalID, publicStatus); err != nil && !errors.Is(err, db.ErrNotFound) {
+	if err := s.db.SetSessionThreadStatus(ctx, record.WorkspaceUUID, record.SessionExternalID, thread.ExternalID, "idle"); err != nil && !errors.Is(err, db.ErrNotFound) {
 		return err
 	}
 	return nil
 }
 
-func publicSessionStatusFromWorkerStatus(workerStatus string) (string, bool) {
-	// requires_action 对公开 API 表示“等待用户输入”，因此映射为 idle；其余内部状态不外泄。
-	switch workerStatus {
-	case "running":
-		return "running", true
-	case "idle", "requires_action":
-		return "idle", true
-	default:
-		return "", false
+func (s *Service) publishPublicRunningStatus(ctx context.Context, record db.CodeSession) error {
+	session, found, err := s.db.GetSession(ctx, record.WorkspaceUUID, record.SessionExternalID)
+	if err != nil {
+		return err
 	}
+	if !found {
+		return nil
+	}
+	if session.Status == "running" {
+		return nil
+	}
+	now := time.Now().UTC()
+	eventID := stablePublicEventID(record.ExternalID, "worker_status_running\x00"+session.UpdatedAt.UTC().Format(time.RFC3339Nano))
+	payload, err := marshalRaw(map[string]any{
+		"id":           eventID,
+		"type":         "session.status_running",
+		"created_at":   formatTime(now),
+		"processed_at": formatTime(now),
+	})
+	if err != nil {
+		return err
+	}
+	return s.publishPublicPayloads(ctx, record.ExternalID, []json.RawMessage{payload})
 }

--- a/internal/codesessions/status.go
+++ b/internal/codesessions/status.go
@@ -9,7 +9,7 @@ import (
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 )
 
-func (s *Service) syncPublicSessionStatusFromWorker(ctx context.Context, record db.CodeSession, workerStatus string) error {
+func (s *Service) syncPublicSessionFromWorker(ctx context.Context, record db.CodeSession, workerStatus string) error {
 	if record.SessionExternalID == "" {
 		return nil
 	}
@@ -17,7 +17,11 @@ func (s *Service) syncPublicSessionStatusFromWorker(ctx context.Context, record 
 	if !ok {
 		return nil
 	}
-	return s.publishPublicSessionStatus(ctx, record, eventType)
+	if err := s.publishPublicSessionStatus(ctx, record, eventType); err != nil {
+		return err
+	}
+	s.reconcileSubagentEvents(ctx, record.ExternalID)
+	return nil
 }
 
 func publicEventTypeFromWorkerStatus(status string) (string, bool) {

--- a/internal/codesessions/status.go
+++ b/internal/codesessions/status.go
@@ -17,11 +17,11 @@ func (s *Service) syncPublicSessionFromWorker(ctx context.Context, record db.Cod
 	if !ok {
 		return nil
 	}
-	if err := s.publishPublicSessionStatus(ctx, record, eventType); err != nil {
+	payloads, err := s.publicSessionStatusPayloads(ctx, record, eventType)
+	if err != nil {
 		return err
 	}
-	s.reconcileSubagentEvents(ctx, record.ExternalID)
-	return nil
+	return s.publishWorkerPublicPayloads(ctx, record.ExternalID, payloads)
 }
 
 func publicEventTypeFromWorkerStatus(status string) (string, bool) {
@@ -35,28 +35,28 @@ func publicEventTypeFromWorkerStatus(status string) (string, bool) {
 	}
 }
 
-func (s *Service) publishPublicSessionStatus(ctx context.Context, record db.CodeSession, eventType string) error {
+func (s *Service) publicSessionStatusPayloads(ctx context.Context, record db.CodeSession, eventType string) ([]json.RawMessage, error) {
 	status, ok := maevents.SessionStatus(eventType)
 	if !ok {
-		return nil
+		return nil, nil
 	}
 	session, found, err := s.db.GetSession(ctx, record.WorkspaceUUID, record.SessionExternalID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !found {
-		return nil
+		return nil, nil
 	}
 	if session.Status == status {
 		thread, found, err := s.db.GetPrimarySessionThread(ctx, record.WorkspaceUUID, record.SessionExternalID)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if !found {
-			return nil
+			return nil, nil
 		}
 		if thread.Status == status {
-			return nil
+			return nil, nil
 		}
 	}
 	now := time.Now().UTC()
@@ -68,7 +68,7 @@ func (s *Service) publishPublicSessionStatus(ctx context.Context, record db.Code
 		"processed_at": formatTime(now),
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return s.publishPublicPayloads(ctx, record.ExternalID, []json.RawMessage{payload})
+	return []json.RawMessage{payload}, nil
 }

--- a/internal/codesessions/status.go
+++ b/internal/codesessions/status.go
@@ -3,7 +3,6 @@ package codesessions
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"time"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
@@ -45,12 +44,12 @@ func (s *Service) publishPublicSessionStatus(ctx context.Context, record db.Code
 		return nil
 	}
 	if session.Status == status {
-		thread, err := s.db.GetPrimarySessionThread(ctx, record.WorkspaceUUID, record.SessionExternalID)
+		thread, found, err := s.db.GetPrimarySessionThread(ctx, record.WorkspaceUUID, record.SessionExternalID)
 		if err != nil {
-			if errors.Is(err, db.ErrNotFound) {
-				return nil
-			}
 			return err
+		}
+		if !found {
+			return nil
 		}
 		if thread.Status == status {
 			return nil

--- a/internal/codesessions/status.go
+++ b/internal/codesessions/status.go
@@ -7,37 +7,36 @@ import (
 	"time"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
+	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 )
 
 func (s *Service) syncPublicSessionStatusFromWorker(ctx context.Context, record db.CodeSession, workerStatus string) error {
-	// worker 状态属于内部执行协议；这里只把可公开表达的状态同步到 session 和主线程。
-	// 找不到公开 session/thread 代表旧数据或尚未完成初始化，不应让 worker 上报失败。
 	if record.SessionExternalID == "" {
 		return nil
 	}
-	if workerStatus == "running" {
-		return s.publishPublicRunningStatus(ctx, record)
-	}
-	if workerStatus != "idle" && workerStatus != "requires_action" {
+	eventType, ok := publicEventTypeFromWorkerStatus(workerStatus)
+	if !ok {
 		return nil
 	}
-	if err := s.db.SetSessionStatus(ctx, record.WorkspaceUUID, record.SessionExternalID, "idle"); err != nil && !errors.Is(err, db.ErrNotFound) {
-		return err
-	}
-	thread, err := s.db.GetPrimarySessionThread(ctx, record.WorkspaceUUID, record.SessionExternalID)
-	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			return nil
-		}
-		return err
-	}
-	if err := s.db.SetSessionThreadStatus(ctx, record.WorkspaceUUID, record.SessionExternalID, thread.ExternalID, "idle"); err != nil && !errors.Is(err, db.ErrNotFound) {
-		return err
-	}
-	return nil
+	return s.publishPublicSessionStatus(ctx, record, eventType)
 }
 
-func (s *Service) publishPublicRunningStatus(ctx context.Context, record db.CodeSession) error {
+func publicEventTypeFromWorkerStatus(status string) (string, bool) {
+	switch status {
+	case "running":
+		return "session.status_running", true
+	case "idle", "requires_action":
+		return "session.status_idle", true
+	default:
+		return "", false
+	}
+}
+
+func (s *Service) publishPublicSessionStatus(ctx context.Context, record db.CodeSession, eventType string) error {
+	status, ok := maevents.SessionStatus(eventType)
+	if !ok {
+		return nil
+	}
 	session, found, err := s.db.GetSession(ctx, record.WorkspaceUUID, record.SessionExternalID)
 	if err != nil {
 		return err
@@ -45,14 +44,23 @@ func (s *Service) publishPublicRunningStatus(ctx context.Context, record db.Code
 	if !found {
 		return nil
 	}
-	if session.Status == "running" {
-		return nil
+	if session.Status == status {
+		thread, err := s.db.GetPrimarySessionThread(ctx, record.WorkspaceUUID, record.SessionExternalID)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				return nil
+			}
+			return err
+		}
+		if thread.Status == status {
+			return nil
+		}
 	}
 	now := time.Now().UTC()
-	eventID := stablePublicEventID(record.ExternalID, "worker_status_running\x00"+session.UpdatedAt.UTC().Format(time.RFC3339Nano))
+	eventID := stablePublicEventID(record.ExternalID, "worker_status_"+status+"\x00"+session.UpdatedAt.UTC().Format(time.RFC3339Nano))
 	payload, err := marshalRaw(map[string]any{
 		"id":           eventID,
-		"type":         "session.status_running",
+		"type":         eventType,
 		"created_at":   formatTime(now),
 		"processed_at": formatTime(now),
 	})

--- a/internal/codesessions/tool_permissions.go
+++ b/internal/codesessions/tool_permissions.go
@@ -51,13 +51,19 @@ func (s *Service) handleToolPermissionRequest(ctx context.Context, codeSessionID
 }
 
 func (s *Service) resolveToolPermission(ctx context.Context, codeSessionID string, claudeToolName string) (resolvedToolPermission, toolIdentity, error) {
-	codeSession, err := s.db.GetCodeSession(ctx, codeSessionID)
+	codeSession, found, err := s.db.GetCodeSession(ctx, codeSessionID)
 	if err != nil {
 		return resolvedToolPermissionAsk, parseClaudeToolIdentity(claudeToolName), err
 	}
-	session, err := s.db.GetSession(ctx, codeSession.WorkspaceUUID, codeSession.SessionExternalID)
+	if !found {
+		return resolvedToolPermissionAsk, parseClaudeToolIdentity(claudeToolName), db.ErrNotFound
+	}
+	session, found, err := s.db.GetSession(ctx, codeSession.WorkspaceUUID, codeSession.SessionExternalID)
 	if err != nil {
 		return resolvedToolPermissionAsk, parseClaudeToolIdentity(claudeToolName), err
+	}
+	if !found {
+		return resolvedToolPermissionAsk, parseClaudeToolIdentity(claudeToolName), db.ErrNotFound
 	}
 	return resolveToolPermissionFromAgentSnapshot(session.AgentSnapshot, claudeToolName), parseClaudeToolIdentity(claudeToolName), nil
 }

--- a/internal/codesessions/tool_permissions.go
+++ b/internal/codesessions/tool_permissions.go
@@ -423,5 +423,9 @@ func (s *Service) publishToolPermissionRequiresAction(ctx context.Context, codeS
 		}
 		payloads = append(payloads, raw)
 	}
-	return s.publishPublicPayloads(ctx, codeSessionID, payloads)
+	if err := s.publishPublicPayloads(ctx, codeSessionID, payloads); err != nil {
+		return err
+	}
+	s.reconcileSubagentEvents(ctx, codeSessionID)
+	return nil
 }

--- a/internal/codesessions/tool_permissions.go
+++ b/internal/codesessions/tool_permissions.go
@@ -423,9 +423,5 @@ func (s *Service) publishToolPermissionRequiresAction(ctx context.Context, codeS
 		}
 		payloads = append(payloads, raw)
 	}
-	if err := s.publishPublicPayloads(ctx, codeSessionID, payloads); err != nil {
-		return err
-	}
-	s.reconcileSubagentEvents(ctx, codeSessionID)
-	return nil
+	return s.publishWorkerPublicPayloads(ctx, codeSessionID, payloads)
 }

--- a/internal/db/code_session_mapper.go
+++ b/internal/db/code_session_mapper.go
@@ -137,7 +137,7 @@ type CodeSessionMapper interface {
 	FindCredentialForIssue(ctx context.Context, organizationUUID, workspaceUUID, codeSessionExternalID string) (codeSessionCredentialContextRow, error)
 	FindNetworkPolicyContext(ctx context.Context, organizationUUID, workspaceUUID, codeSessionExternalID string) (codeSessionNetworkPolicyContextRow, error)
 	FindVaultIDs(ctx context.Context, organizationUUID, workspaceUUID, codeSessionExternalID string) (codeSessionVaultIDsRow, bool, error)
-	FindByExternalID(ctx context.Context, codeSessionExternalID string) (codeSessionRow, error)
+	FindByExternalID(ctx context.Context, codeSessionExternalID string) (codeSessionRow, bool, error)
 	FindLatestBySessionExternalID(ctx context.Context, workspaceUUID, sessionExternalID string) (codeSessionRow, error)
 	LockCodeSessionByExternalID(ctx context.Context, codeSessionExternalID string) (codeSessionRow, bool, error)
 	LockInitializingCodeSession(ctx context.Context, workspaceUUID, codeSessionUUID string) (codeSessionRow, bool, error)

--- a/internal/db/code_session_mapper_test.go
+++ b/internal/db/code_session_mapper_test.go
@@ -8,6 +8,21 @@ import (
 	"github.com/superduck-ai/yourbatis"
 )
 
+func TestCodeSessionMapperFindByExternalIDNotFound(t *testing.T) {
+	executor := newMapperTestExecutor(t, mapperTestResponse{columns: []string{"uuid"}})
+	row, found, err := NewCodeSessionMapper(executor).FindByExternalID(context.Background(), "codeses_missing")
+	if err != nil || found || row.UUID != "" {
+		t.Fatalf("FindByExternalID() = (%+v, %t, %v), want zero, false, nil", row, found, err)
+	}
+	assertMapperTestExecution(
+		t,
+		executor,
+		"CodeSessionMapper.FindByExternalID",
+		yourbatis.StatementSelect,
+		[]any{"codeses_missing"},
+	)
+}
+
 func TestCodeSessionMapperFindVaultIDsNotFound(t *testing.T) {
 	executor := newMapperTestExecutor(t, mapperTestResponse{columns: []string{"vault_ids"}})
 	row, found, err := NewCodeSessionMapper(executor).FindVaultIDs(

--- a/internal/db/code_sessions.go
+++ b/internal/db/code_sessions.go
@@ -547,16 +547,13 @@ func decodeVaultIDList(raw []byte) ([]string, error) {
 	return ids, nil
 }
 
-func (d *DB) GetCodeSession(ctx context.Context, externalID string) (CodeSession, error) {
+func (d *DB) GetCodeSession(ctx context.Context, externalID string) (CodeSession, bool, error) {
 	mapper := NewCodeSessionMapper(d.mapperDB)
-	row, err := mapper.FindByExternalID(ctx, externalID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return CodeSession{}, ErrNotFound
+	row, found, err := mapper.FindByExternalID(ctx, externalID)
+	if err != nil || !found {
+		return CodeSession{}, found, err
 	}
-	if err != nil {
-		return CodeSession{}, err
-	}
-	return row.session(), nil
+	return row.session(), true, nil
 }
 
 func (d *DB) GetCodeSessionBySessionExternalID(ctx context.Context, workspaceUUID string, sessionExternalID string) (CodeSession, error) {
@@ -1266,9 +1263,12 @@ func (d *DB) TouchCodeSessionWorkerActivityForActiveLease(ctx context.Context, c
 		return nil
 	}
 	// 条件更新未命中后再读取当前状态，以便把 takeover 与 lease 过期映射为不同 HTTP 错误。
-	record, err := d.GetCodeSession(ctx, codeSessionExternalID)
+	record, found, err := d.GetCodeSession(ctx, codeSessionExternalID)
 	if err != nil {
 		return err
+	}
+	if !found {
+		return ErrNotFound
 	}
 	if record.CurrentWorkerEpoch != epoch {
 		return ErrWorkerEpochMismatch

--- a/internal/db/session_mapper.go
+++ b/internal/db/session_mapper.go
@@ -94,7 +94,7 @@ type sessionPageMapperParams struct {
 // SessionMapper contains queries whose primary table is sessions.
 type SessionMapper interface {
 	Insert(ctx context.Context, params sessionWriteParams) (sessionRow, error)
-	FindByExternalID(ctx context.Context, workspaceUUID, sessionExternalID string) (sessionRow, error)
+	FindByExternalID(ctx context.Context, workspaceUUID, sessionExternalID string) (sessionRow, bool, error)
 	UpdateByExternalID(ctx context.Context, params sessionUpdateParams) (sessionRow, error)
 	PatchMetadata(ctx context.Context, workspaceUUID, sessionExternalID string, metadataPatch []byte) (sessionRow, error)
 	SetOutcomeEvaluations(ctx context.Context, workspaceUUID, sessionExternalID string, evaluations []byte) (sessionRow, error)

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -214,10 +214,13 @@ func (d *DB) CreateSession(ctx context.Context, input CreateSessionInput) (Sessi
 	return session, thread, resources, work, err
 }
 
-func (d *DB) GetSession(ctx context.Context, workspaceUUID string, externalID string) (Session, error) {
+func (d *DB) GetSession(ctx context.Context, workspaceUUID string, externalID string) (Session, bool, error) {
 	mapper := NewSessionMapper(d.mapperDB)
-	row, err := mapper.FindByExternalID(ctx, workspaceUUID, externalID)
-	return row.session(), mapNoRows(err)
+	row, found, err := mapper.FindByExternalID(ctx, workspaceUUID, externalID)
+	if err != nil || !found {
+		return Session{}, found, err
+	}
+	return row.session(), true, nil
 }
 
 func (d *DB) UpdateSession(ctx context.Context, workspaceUUID string, externalID string, next Session) (Session, error) {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -339,10 +341,16 @@ func (d *DB) ListSessionsPage(ctx context.Context, params ListSessionsPageParams
 	return sessions, hasMore, nil
 }
 
-func (d *DB) GetPrimarySessionThread(ctx context.Context, workspaceUUID string, sessionExternalID string) (SessionThread, error) {
+func (d *DB) GetPrimarySessionThread(ctx context.Context, workspaceUUID string, sessionExternalID string) (SessionThread, bool, error) {
 	mapper := NewSessionThreadMapper(d.mapperDB)
 	row, err := mapper.FindPrimary(ctx, workspaceUUID, sessionExternalID)
-	return row.thread(), mapNoRows(err)
+	if errors.Is(err, sql.ErrNoRows) {
+		return SessionThread{}, false, nil
+	}
+	if err != nil {
+		return SessionThread{}, false, err
+	}
+	return row.thread(), true, nil
 }
 
 func (d *DB) GetSessionThread(ctx context.Context, workspaceUUID string, sessionExternalID, threadExternalID string) (SessionThread, error) {

--- a/internal/db/sessions_mapper_test.go
+++ b/internal/db/sessions_mapper_test.go
@@ -8,6 +8,25 @@ import (
 	"github.com/superduck-ai/yourbatis"
 )
 
+func TestSessionMapperFindByExternalIDNotFound(t *testing.T) {
+	executor := newMapperTestExecutor(t, mapperTestResponse{columns: []string{"uuid"}})
+	row, found, err := NewSessionMapper(executor).FindByExternalID(
+		context.Background(),
+		"workspace-uuid",
+		"ses_missing",
+	)
+	if err != nil || found || row.UUID != "" {
+		t.Fatalf("FindByExternalID() = (%+v, %t, %v), want zero, false, nil", row, found, err)
+	}
+	assertMapperTestExecution(
+		t,
+		executor,
+		"SessionMapper.FindByExternalID",
+		yourbatis.StatementSelect,
+		[]any{"workspace-uuid", "ses_missing"},
+	)
+}
+
 func TestSessionTableMapperWriteBuilderContracts(t *testing.T) {
 	now := time.Date(2026, time.August, 5, 12, 0, 0, 0, time.UTC)
 	sessionParams := sessionWriteParams{

--- a/internal/environments/runner.go
+++ b/internal/environments/runner.go
@@ -474,9 +474,12 @@ func (r *Runner) prepareManagedAgentLaunch(
 	if !ok || !cloudEnvironment(env) {
 		return nil, nil
 	}
-	session, err := r.db.GetSession(ctx, work.WorkspaceUUID, sessionID)
+	session, found, err := r.db.GetSession(ctx, work.WorkspaceUUID, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("load managed agent Session: %w", err)
+	}
+	if !found {
+		return nil, fmt.Errorf("load managed agent Session: %w", db.ErrNotFound)
 	}
 	resources, err := r.db.ListSessionResources(ctx, session.WorkspaceUUID, session.ExternalID)
 	if err != nil {
@@ -719,9 +722,12 @@ func (r *Runner) prepareManagedAgentNetworkMetadata(ctx context.Context, env db.
 		if !ok {
 			return fmt.Errorf("limited managed-agent MCP policy requires session work identity")
 		}
-		session, err := r.db.GetSession(ctx, work.WorkspaceUUID, sessionID)
+		session, found, err := r.db.GetSession(ctx, work.WorkspaceUUID, sessionID)
 		if err != nil {
 			return err
+		}
+		if !found {
+			return db.ErrNotFound
 		}
 		hosts, err = networkpolicy.MCPAllowedHosts(session.AgentSnapshot)
 		if err != nil {

--- a/internal/sessions/access.go
+++ b/internal/sessions/access.go
@@ -24,9 +24,12 @@ func (h *Handler) authorizeSession(r *http.Request, sessionID string, access ses
 	if h.isOfficialSDKFixturePrincipal(principal) && sessionID == h.cfg.SDKFixtures.SessionID {
 		return h.fixtureDBSession(principal), nil
 	}
-	session, err := h.db.GetSession(r.Context(), principal.WorkspaceUUID, sessionID)
+	session, found, err := h.db.GetSession(r.Context(), principal.WorkspaceUUID, sessionID)
 	if err != nil {
 		return db.Session{}, mapSessionLoadError(err, sessionID)
+	}
+	if !found {
+		return db.Session{}, mapSessionLoadError(db.ErrNotFound, sessionID)
 	}
 	if isSessionManagerCredential(principal) {
 		return session, nil

--- a/internal/sessions/code_event_bridge.go
+++ b/internal/sessions/code_event_bridge.go
@@ -72,10 +72,26 @@ func (h *Handler) PublishCodeSessionEvents(ctx context.Context, codeSession db.C
 		}
 		return err
 	}
+	persisted := make(map[string]db.SessionEvent, len(created))
 	for _, event := range created {
-		h.applySessionEventEffects(ctx, event)
+		persisted[event.ExternalID] = event
+	}
+	// Idempotent retries reapply stored state projections; only newly inserted events leave the process.
+	var projectionErr error
+	for _, event := range events {
+		stored, ok := persisted[event.ExternalID]
+		var eventErr error
+		if !ok {
+			stored, eventErr = h.db.GetSessionEvent(ctx, session.WorkspaceUUID, session.ExternalID, event.ExternalID)
+		}
+		if eventErr == nil {
+			eventErr = h.applySessionEventProjection(ctx, stored)
+		}
+		projectionErr = errors.Join(projectionErr, eventErr)
+	}
+	for _, event := range created {
 		h.broadcast(event)
 	}
 	h.enqueueWebhooksForSessionEvents(ctx, session.WorkspaceUUID, session.ExternalID, created)
-	return nil
+	return projectionErr
 }

--- a/internal/sessions/code_event_bridge.go
+++ b/internal/sessions/code_event_bridge.go
@@ -27,9 +27,12 @@ func (h *Handler) PublishCodeSessionEvents(ctx context.Context, codeSession db.C
 	if h == nil || len(payloads) == 0 {
 		return nil
 	}
-	session, err := h.db.GetSession(ctx, codeSession.WorkspaceUUID, codeSession.SessionExternalID)
+	session, found, err := h.db.GetSession(ctx, codeSession.WorkspaceUUID, codeSession.SessionExternalID)
 	if err != nil {
 		return err
+	}
+	if !found {
+		return db.ErrNotFound
 	}
 	var events []db.SessionEvent
 	now := time.Now().UTC()

--- a/internal/sessions/event_effects.go
+++ b/internal/sessions/event_effects.go
@@ -58,13 +58,14 @@ func (h *Handler) applySessionEventProjection(ctx context.Context, event db.Sess
 	if !ok {
 		return nil
 	}
-	thread, err := h.db.GetPrimarySessionThread(ctx, event.WorkspaceUUID, event.SessionExternalID)
-	if err == nil {
+	thread, found, err := h.db.GetPrimarySessionThread(ctx, event.WorkspaceUUID, event.SessionExternalID)
+	if err != nil {
+		return err
+	}
+	if found {
 		if err := h.db.SetSessionThreadStatus(ctx, event.WorkspaceUUID, event.SessionExternalID, thread.ExternalID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
 			return err
 		}
-	} else if !errors.Is(err, db.ErrNotFound) {
-		return err
 	}
 	if err := h.db.SetSessionStatus(ctx, event.WorkspaceUUID, event.SessionExternalID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
 		return err

--- a/internal/sessions/event_effects.go
+++ b/internal/sessions/event_effects.go
@@ -17,11 +17,12 @@ import (
 
 func (h *Handler) applySessionEventEffects(ctx context.Context, event db.SessionEvent) {
 	if event.EventType == "session.thread_created" {
-		session, err := h.db.GetSession(ctx, event.WorkspaceUUID, event.SessionExternalID)
+		session, found, err := h.db.GetSession(ctx, event.WorkspaceUUID, event.SessionExternalID)
 		if err != nil {
-			if !errors.Is(err, db.ErrNotFound) {
-				h.logger.ErrorContext(ctx, "load session for thread_created", "session_id", event.SessionExternalID, "error", err)
-			}
+			h.logger.ErrorContext(ctx, "load session for thread_created", "session_id", event.SessionExternalID, "error", err)
+			return
+		}
+		if !found {
 			return
 		}
 		if threadID := sessionThreadIDFromEvent(event); threadID != nil {
@@ -38,14 +39,14 @@ func (h *Handler) applySessionEventEffects(ctx context.Context, event db.Session
 		if threadID == nil {
 			return
 		}
-		session, err := h.db.GetSession(ctx, event.WorkspaceUUID, event.SessionExternalID)
-		if err == nil {
+		session, found, err := h.db.GetSession(ctx, event.WorkspaceUUID, event.SessionExternalID)
+		if err == nil && found {
 			var payload map[string]any
 			_ = json.Unmarshal(event.Payload, &payload)
 			if err := h.ensureSessionThread(ctx, session, *threadID, payload, event.CreatedAt); err != nil && !errors.Is(err, db.ErrNotFound) {
 				h.logger.ErrorContext(ctx, "ensure session thread for status", "session_id", event.SessionExternalID, "thread_id", *threadID, "error", err)
 			}
-		} else if !errors.Is(err, db.ErrNotFound) {
+		} else if err != nil {
 			h.logger.ErrorContext(ctx, "load session for thread status", "session_id", event.SessionExternalID, "error", err)
 		}
 		if err := h.db.SetSessionThreadStatus(ctx, event.WorkspaceUUID, event.SessionExternalID, *threadID, status); err != nil && !errors.Is(err, db.ErrNotFound) {

--- a/internal/sessions/event_effects.go
+++ b/internal/sessions/event_effects.go
@@ -15,61 +15,61 @@ import (
 	"github.com/google/uuid"
 )
 
-func (h *Handler) applySessionEventEffects(ctx context.Context, event db.SessionEvent) {
+func (h *Handler) applySessionEventProjection(ctx context.Context, event db.SessionEvent) error {
 	if event.EventType == "session.thread_created" {
 		session, found, err := h.db.GetSession(ctx, event.WorkspaceUUID, event.SessionExternalID)
 		if err != nil {
-			h.logger.ErrorContext(ctx, "load session for thread_created", "session_id", event.SessionExternalID, "error", err)
-			return
+			return err
 		}
 		if !found {
-			return
+			return nil
 		}
 		if threadID := sessionThreadIDFromEvent(event); threadID != nil {
 			var payload map[string]any
 			_ = json.Unmarshal(event.Payload, &payload)
 			if err := h.ensureSessionThread(ctx, session, *threadID, payload, event.CreatedAt); err != nil && !errors.Is(err, db.ErrNotFound) {
-				h.logger.ErrorContext(ctx, "ensure session thread", "session_id", event.SessionExternalID, "thread_id", *threadID, "error", err)
+				return err
 			}
 		}
-		return
+		return nil
 	}
 	if status, ok := threadStatusFromEventType(event.EventType); ok {
 		threadID := sessionThreadIDFromEvent(event)
 		if threadID == nil {
-			return
+			return nil
 		}
 		session, found, err := h.db.GetSession(ctx, event.WorkspaceUUID, event.SessionExternalID)
-		if err == nil && found {
+		if err != nil {
+			return err
+		}
+		if found {
 			var payload map[string]any
 			_ = json.Unmarshal(event.Payload, &payload)
 			if err := h.ensureSessionThread(ctx, session, *threadID, payload, event.CreatedAt); err != nil && !errors.Is(err, db.ErrNotFound) {
-				h.logger.ErrorContext(ctx, "ensure session thread for status", "session_id", event.SessionExternalID, "thread_id", *threadID, "error", err)
+				return err
 			}
-		} else if err != nil {
-			h.logger.ErrorContext(ctx, "load session for thread status", "session_id", event.SessionExternalID, "error", err)
 		}
 		if err := h.db.SetSessionThreadStatus(ctx, event.WorkspaceUUID, event.SessionExternalID, *threadID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
-			h.logger.ErrorContext(ctx, "update session thread status from event", "session_id", event.SessionExternalID, "thread_id", *threadID, "event_type", event.EventType, "error", err)
-			return
+			return err
 		}
-		h.updateAggregatedSessionStatus(ctx, event.WorkspaceUUID, event.SessionExternalID)
-		return
+		return h.projectAggregatedSessionStatus(ctx, event.WorkspaceUUID, event.SessionExternalID)
 	}
 	status, ok := sessionStatusFromEventType(event.EventType)
 	if !ok {
-		return
-	}
-	if err := h.db.SetSessionStatus(ctx, event.WorkspaceUUID, event.SessionExternalID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
-		h.logger.ErrorContext(ctx, "update session status from event", "session_id", event.SessionExternalID, "event_type", event.EventType, "error", err)
+		return nil
 	}
 	thread, err := h.db.GetPrimarySessionThread(ctx, event.WorkspaceUUID, event.SessionExternalID)
-	if err != nil {
-		return
+	if err == nil {
+		if err := h.db.SetSessionThreadStatus(ctx, event.WorkspaceUUID, event.SessionExternalID, thread.ExternalID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
+			return err
+		}
+	} else if !errors.Is(err, db.ErrNotFound) {
+		return err
 	}
-	if err := h.db.SetSessionThreadStatus(ctx, event.WorkspaceUUID, event.SessionExternalID, thread.ExternalID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
-		h.logger.ErrorContext(ctx, "update primary session thread status from event", "session_id", event.SessionExternalID, "thread_id", thread.ExternalID, "event_type", event.EventType, "error", err)
+	if err := h.db.SetSessionStatus(ctx, event.WorkspaceUUID, event.SessionExternalID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
+		return err
 	}
+	return nil
 }
 
 func sessionStatusFromEventType(eventType string) (string, bool) {
@@ -80,16 +80,16 @@ func threadStatusFromEventType(eventType string) (string, bool) {
 	return maevents.ThreadStatus(eventType)
 }
 
-func (h *Handler) updateAggregatedSessionStatus(ctx context.Context, workspaceUUID string, sessionID string) {
+func (h *Handler) projectAggregatedSessionStatus(ctx context.Context, workspaceUUID string, sessionID string) error {
 	threads, err := h.db.ListSessionThreads(ctx, workspaceUUID, sessionID)
 	if err != nil {
-		if !errors.Is(err, db.ErrNotFound) {
-			h.logger.ErrorContext(ctx, "list session threads for aggregate", "session_id", sessionID, "error", err)
+		if errors.Is(err, db.ErrNotFound) {
+			return nil
 		}
-		return
+		return err
 	}
 	if len(threads) == 0 {
-		return
+		return nil
 	}
 	status := "terminated"
 	for _, thread := range threads {
@@ -97,9 +97,9 @@ func (h *Handler) updateAggregatedSessionStatus(ctx context.Context, workspaceUU
 		case "running":
 			status = "running"
 			if err := h.db.SetSessionStatus(ctx, workspaceUUID, sessionID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
-				h.logger.ErrorContext(ctx, "aggregate session status", "session_id", sessionID, "error", err)
+				return err
 			}
-			return
+			return nil
 		case "rescheduling":
 			if status != "running" {
 				status = "rescheduling"
@@ -111,8 +111,9 @@ func (h *Handler) updateAggregatedSessionStatus(ctx context.Context, workspaceUU
 		}
 	}
 	if err := h.db.SetSessionStatus(ctx, workspaceUUID, sessionID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
-		h.logger.ErrorContext(ctx, "aggregate session status", "session_id", sessionID, "error", err)
+		return err
 	}
+	return nil
 }
 
 func (h *Handler) sessionUpdatedEvent(session db.Session) (db.SessionEvent, error) {

--- a/internal/sessions/event_mapper.go
+++ b/internal/sessions/event_mapper.go
@@ -58,9 +58,12 @@ func (h *Handler) streamDeltaEventFromCodeSessionPayload(ctx context.Context, se
 	delete(payload, "owner_session_thread_id")
 	delete(payload, "_owner_session_thread_id")
 	if threadID == "" {
-		primary, err := h.db.GetPrimarySessionThread(ctx, session.WorkspaceUUID, session.ExternalID)
+		primary, found, err := h.db.GetPrimarySessionThread(ctx, session.WorkspaceUUID, session.ExternalID)
 		if err != nil {
 			return db.SessionEvent{}, err
+		}
+		if !found {
+			return db.SessionEvent{}, errors.New("primary session thread not found")
 		}
 		threadID = primary.ExternalID
 	}
@@ -384,12 +387,12 @@ func firstSessionPayloadString(payload map[string]any, fields ...string) string 
 }
 
 func (h *Handler) ensurePrimarySessionThread(ctx context.Context, session db.Session) (db.SessionThread, error) {
-	thread, err := h.db.GetPrimarySessionThread(ctx, session.WorkspaceUUID, session.ExternalID)
-	if err == nil {
-		return thread, nil
-	}
-	if !errors.Is(err, db.ErrNotFound) {
+	thread, found, err := h.db.GetPrimarySessionThread(ctx, session.WorkspaceUUID, session.ExternalID)
+	if err != nil {
 		return db.SessionThread{}, err
+	}
+	if found {
+		return thread, nil
 	}
 	threadID, err := ids.New("sthr_")
 	if err != nil {
@@ -435,13 +438,14 @@ func (h *Handler) ensureSessionThread(ctx context.Context, session db.Session, t
 	var parentThreadExternalID *string
 	parentExternalID := sessionPayloadString(payload, "parent_session_thread_id")
 	var parent db.SessionThread
+	parentFound := true
 	var err error
 	if parentExternalID != "" {
 		parent, err = h.db.GetSessionThread(ctx, session.WorkspaceUUID, session.ExternalID, parentExternalID)
 	} else {
-		parent, err = h.db.GetPrimarySessionThread(ctx, session.WorkspaceUUID, session.ExternalID)
+		parent, parentFound, err = h.db.GetPrimarySessionThread(ctx, session.WorkspaceUUID, session.ExternalID)
 	}
-	if err == nil && parent.ExternalID != threadID {
+	if err == nil && parentFound && parent.ExternalID != threadID {
 		parentThreadUUID = &parent.UUID
 		value := parent.ExternalID
 		parentThreadExternalID = &value

--- a/internal/sessions/service.go
+++ b/internal/sessions/service.go
@@ -264,9 +264,12 @@ func (h *Handler) updateRoute(w http.ResponseWriter, r *http.Request) error {
 		httpapi.WriteJSON(w, http.StatusOK, h.fixtureSession(time.Now().UTC(), false))
 		return nil
 	}
-	current, err := h.db.GetSession(r.Context(), principal.WorkspaceUUID, sessionID)
+	current, found, err := h.db.GetSession(r.Context(), principal.WorkspaceUUID, sessionID)
 	if err != nil {
 		return mapSessionLoadError(err, sessionID)
+	}
+	if !found {
+		return mapSessionLoadError(db.ErrNotFound, sessionID)
 	}
 	if current.ArchivedAt != nil || current.Status != "idle" {
 		return invalidRequest(errors.New("session must be idle and unarchived to update"))
@@ -324,9 +327,12 @@ func (h *Handler) archiveRoute(w http.ResponseWriter, r *http.Request) error {
 		httpapi.WriteJSON(w, http.StatusOK, h.fixtureSession(time.Now().UTC(), true))
 		return nil
 	}
-	current, err := h.db.GetSession(r.Context(), principal.WorkspaceUUID, sessionID)
+	current, found, err := h.db.GetSession(r.Context(), principal.WorkspaceUUID, sessionID)
 	if err != nil {
 		return mapSessionLoadError(err, sessionID)
+	}
+	if !found {
+		return mapSessionLoadError(db.ErrNotFound, sessionID)
 	}
 	if current.Status == "running" || current.Status == "rescheduling" {
 		return invalidRequest(errors.New("running sessions cannot be archived"))
@@ -354,9 +360,12 @@ func (h *Handler) deleteRoute(w http.ResponseWriter, r *http.Request) error {
 		httpapi.WriteJSON(w, http.StatusOK, deleteResponse{ID: sessionID, Type: "session_deleted"})
 		return nil
 	}
-	current, err := h.db.GetSession(r.Context(), principal.WorkspaceUUID, sessionID)
+	current, found, err := h.db.GetSession(r.Context(), principal.WorkspaceUUID, sessionID)
 	if err != nil {
 		return mapSessionLoadError(err, sessionID)
+	}
+	if !found {
+		return mapSessionLoadError(db.ErrNotFound, sessionID)
 	}
 	if current.Status == "running" || current.Status == "rescheduling" {
 		return invalidRequest(errors.New("running sessions cannot be deleted"))
@@ -784,9 +793,12 @@ func (h *Handler) archiveThreadRoute(w http.ResponseWriter, r *http.Request) err
 		httpapi.WriteJSON(w, http.StatusOK, h.fixtureThread(time.Now().UTC(), true))
 		return nil
 	}
-	session, err := h.db.GetSession(r.Context(), principal.WorkspaceUUID, sessionID)
+	session, found, err := h.db.GetSession(r.Context(), principal.WorkspaceUUID, sessionID)
 	if err != nil {
 		return mapSessionLoadError(err, sessionID)
+	}
+	if !found {
+		return mapSessionLoadError(db.ErrNotFound, sessionID)
 	}
 	thread, err := h.db.ArchiveSessionThread(r.Context(), principal.WorkspaceUUID, session.ExternalID, threadID)
 	if err != nil {

--- a/tests/ccrv2_upstream_proxy_test.go
+++ b/tests/ccrv2_upstream_proxy_test.go
@@ -386,13 +386,13 @@ func TestCCRV2UpstreamProxyPolicyChainFailures(t *testing.T) {
 	})
 
 	t.Run("failure malformed MCP contract fails closed before explicit host matching", func(t *testing.T) {
-		codeSession, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+		codeSession, err := getCodeSession(app, context.Background(), codeSessionID)
 		if err != nil {
 			t.Fatalf("load code session scope: %v", err)
 		}
-		originalSession, err := app.db.GetSession(context.Background(), codeSession.WorkspaceUUID, session.ID)
-		if err != nil {
-			t.Fatalf("load original session snapshot: %v", err)
+		originalSession, found, err := app.db.GetSession(context.Background(), codeSession.WorkspaceUUID, session.ID)
+		if err != nil || !found {
+			t.Fatalf("load original session snapshot = (%t, %v), want found", found, err)
 		}
 		if _, err := app.pool.Exec(context.Background(), `
 			update environments
@@ -542,7 +542,7 @@ func codeSessionIngressTokenWithScope(
 	workspaceUUID string,
 ) string {
 	t.Helper()
-	record, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	record, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("get code session: %v", err)
 	}

--- a/tests/environments_runner_cloud_test.go
+++ b/tests/environments_runner_cloud_test.go
@@ -307,9 +307,9 @@ func TestEnvironmentRunnerLaunchesManagedAgentCloudSession(t *testing.T) {
 		t.Fatalf("rclone config does not mount /uploads at the managed-agents root: %#v", rcloneConfig.Mounts)
 	}
 
-	stored, err := app.db.GetSession(ctx, apiKey.WorkspaceUUID.String(), session.ID)
-	if err != nil {
-		t.Fatalf("load stored session: %v", err)
+	stored, found, err := app.db.GetSession(ctx, apiKey.WorkspaceUUID.String(), session.ID)
+	if err != nil || !found {
+		t.Fatalf("load stored session = (%t, %v), want found", found, err)
 	}
 	var metadata map[string]any
 	if err := json.Unmarshal(stored.Metadata, &metadata); err != nil {
@@ -627,9 +627,9 @@ func runPackageEnvironment(t *testing.T, testCase packageRunnerCase) (*recording
 		t.Fatalf("list package runner work count/error = %d/%v, want one work", len(works), workErr)
 	}
 	provider.workHasRuntimeMetadata = hasJSONKey(works[0].Metadata, "claude_code_session_id")
-	storedSession, sessionErr := app.db.GetSession(inspectionCtx, ids.WorkspaceUUID, session.ID)
-	if sessionErr != nil {
-		t.Fatalf("load package runner session: %v", sessionErr)
+	storedSession, sessionFound, sessionErr := app.db.GetSession(inspectionCtx, ids.WorkspaceUUID, session.ID)
+	if sessionErr != nil || !sessionFound {
+		t.Fatalf("load package runner session = (%t, %v), want found", sessionFound, sessionErr)
 	}
 	provider.sessionHasRuntimeMetadata = hasJSONKey(storedSession.Metadata, "claude_code_session_id")
 	if err := app.pool.QueryRow(inspectionCtx, `
@@ -788,9 +788,9 @@ func TestEnvironmentRunnerRevokesCodeSessionWhenManagerStartFails(t *testing.T) 
 	if codeSession.Status != "terminated" || codeSession.ConnectionStatus != "disconnected" || codeSession.WorkerLeaseExpiresAt != nil {
 		t.Fatalf("compensated code session = %#v", codeSession)
 	}
-	storedSession, err := app.db.GetSession(ctx, ids.WorkspaceUUID, session.ID)
-	if err != nil {
-		t.Fatalf("load Session after manager failure: %v", err)
+	storedSession, found, err := app.db.GetSession(ctx, ids.WorkspaceUUID, session.ID)
+	if err != nil || !found {
+		t.Fatalf("load Session after manager failure = (%t, %v), want found", found, err)
 	}
 	if hasJSONKey(storedSession.Metadata, "claude_code_session_id") {
 		t.Fatalf("failed runtime was published in Session metadata: %s", storedSession.Metadata)

--- a/tests/filestore_db_test.go
+++ b/tests/filestore_db_test.go
@@ -88,12 +88,12 @@ func TestCreateSessionRejectsFileResourcesAboveDBLimit(t *testing.T) {
 		t.Fatalf("CreateSession() error = %v, want file resource limit %d", err, db.MaxSessionFileResources)
 	}
 
-	if _, err := app.db.GetSession(
+	if _, found, err := app.db.GetSession(
 		context.Background(),
 		workspaceUUID,
 		input.Session.ExternalID,
-	); !errors.Is(err, db.ErrNotFound) {
-		t.Fatalf("GetSession() after rollback error = %v, want ErrNotFound", err)
+	); err != nil || found {
+		t.Fatalf("GetSession() after rollback = (%t, %v), want false, nil", found, err)
 	}
 }
 

--- a/tests/sessions_api_test.go
+++ b/tests/sessions_api_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
+	sessionsapi "github.com/superduck-ai/open-managed-agents/internal/sessions"
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
 	"github.com/superduck-ai/open-managed-agents/internal/webhooks"
 
@@ -1349,6 +1350,33 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 	if len(runningEvents.Data) != 1 {
 		t.Fatalf("duplicate running state produced %d events, want 1: %+v", len(runningEvents.Data), runningEvents.Data)
 	}
+	codeSession, err := getCodeSession(app, context.Background(), codeSessionID)
+	if err != nil {
+		t.Fatalf("load code session for projection retry: %v", err)
+	}
+	sessionRecord := mustSessionRecord(t, app, session.ID)
+	if err := app.db.SetSessionThreadStatus(context.Background(), sessionRecord.WorkspaceUUID, session.ID, threads.Data[0].ID, "idle"); err != nil {
+		t.Fatalf("make primary thread projection stale: %v", err)
+	}
+	if err := app.db.SetSessionStatus(context.Background(), sessionRecord.WorkspaceUUID, session.ID, "idle"); err != nil {
+		t.Fatalf("make session projection stale: %v", err)
+	}
+	retryService := codesessions.NewServiceWithCredentials(app.db, app.credentials, nil)
+	retrySink := sessionsapi.NewHandler(app.cfg, app.db, retryService, nil, nil)
+	if err := retrySink.PublishCodeSessionEvents(context.Background(), codeSession, runningEvents.Data); err != nil {
+		t.Fatalf("retry existing running event projection: %v", err)
+	}
+	if got := retrieveSession(t, app, session.ID, defaultTestKey).Status; got != "running" {
+		t.Fatalf("public session status after projection retry = %q, want running", got)
+	}
+	threads = listSessionThreads(t, app, session.ID, defaultTestKey)
+	if len(threads.Data) != 1 || threads.Data[0].Status != "running" {
+		t.Fatalf("primary thread status after projection retry = %+v, want running", threads.Data)
+	}
+	runningEvents = listSessionEvents(t, app, session.ID, "types[]=session.status_running", defaultTestKey)
+	if len(runningEvents.Data) != 1 {
+		t.Fatalf("projection retry produced %d running events, want 1: %+v", len(runningEvents.Data), runningEvents.Data)
+	}
 	runningDetailsOnlyState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"requires_action_details":{"tool_name":"Bash"}}`)
 	if runningDetailsOnlyState.Worker.WorkerStatus != "running" || !rawMessageIsJSONNull(runningDetailsOnlyState.Worker.RequiresActionDetails) {
 		t.Fatalf("running details-only worker state = %+v, details=%s; want running with cleared details", runningDetailsOnlyState.Worker, runningDetailsOnlyState.Worker.RequiresActionDetails)
@@ -1361,7 +1389,6 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 		t.Fatalf("primary thread status after details-only update = %+v, want running", threads.Data)
 	}
 
-	sessionRecord := mustSessionRecord(t, app, session.ID)
 	filesystem, err := app.db.GetFilestoreFilesystemBySession(
 		context.Background(),
 		sessionRecord.WorkspaceUUID,
@@ -1427,6 +1454,7 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 		t.Fatalf("download output = %q, want %q", got, outputContent)
 	}
 
+	idleEventsBefore := listSessionEvents(t, app, session.ID, "types[]=session.status_idle", defaultTestKey)
 	idleState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"idle","external_metadata":{"pending_action":null}}`)
 	if idleState.Worker.WorkerStatus != "idle" || !rawMessageIsJSONNull(idleState.Worker.RequiresActionDetails) {
 		t.Fatalf("idle worker state = %+v, details=%s; want idle with cleared details", idleState.Worker, idleState.Worker.RequiresActionDetails)
@@ -1440,6 +1468,19 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 	threads = listSessionThreads(t, app, session.ID, defaultTestKey)
 	if len(threads.Data) != 1 || threads.Data[0].Status != "idle" {
 		t.Fatalf("primary thread status after idle = %+v, want idle", threads.Data)
+	}
+	idleEvents := listSessionEvents(t, app, session.ID, "types[]=session.status_idle", defaultTestKey)
+	if len(idleEvents.Data) != len(idleEventsBefore.Data)+1 {
+		t.Fatalf("worker idle produced %d total idle events, want %d: %+v", len(idleEvents.Data), len(idleEventsBefore.Data)+1, idleEvents.Data)
+	}
+	idleEvent := sessionEventObjectByType(t, idleEvents, "session.status_idle")
+	if _, ok := idleEvent["stop_reason"]; ok {
+		t.Fatalf("worker session.status_idle unexpectedly contains stop_reason: %#v", idleEvent)
+	}
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"idle"}`)
+	duplicateIdleEvents := listSessionEvents(t, app, session.ID, "types[]=session.status_idle", defaultTestKey)
+	if len(duplicateIdleEvents.Data) != len(idleEvents.Data) {
+		t.Fatalf("duplicate idle state produced %d events, want %d: %+v", len(duplicateIdleEvents.Data), len(idleEvents.Data), duplicateIdleEvents.Data)
 	}
 	afterIdleFiles := listFiles(t, app, "scope_id="+session.ID)
 	var outputFileAfterIdle *metadataResponse

--- a/tests/sessions_api_test.go
+++ b/tests/sessions_api_test.go
@@ -1298,12 +1298,16 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 		t.Fatalf("metadata merge did not preserve persisted key: %+v", initState.Worker.ExternalMetadata)
 	}
 
-	requiresState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"requires_action","requires_action_details":{"tool_name":"Bash","action_description":"Running npm test","request_id":"req_worker_state"},"external_metadata":{"pending_action":{"tool_name":"Bash"},"persisted":{"kept":true}}}`)
+	requiresState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"requires_action","requires_action_details":{"tool_name":"Bash","action_description":"Running npm test","tool_use_id":"tool_worker_state","request_id":"req_worker_state","input":{"command":"npm test"}},"external_metadata":{"pending_action":{"tool_name":"Bash"},"persisted":{"kept":true}}}`)
 	if requiresState.Worker.WorkerStatus != "requires_action" {
 		t.Fatalf("requires action worker status = %q, want requires_action", requiresState.Worker.WorkerStatus)
 	}
-	var actionDetails map[string]string
-	if err := json.Unmarshal(requiresState.Worker.RequiresActionDetails, &actionDetails); err != nil || actionDetails["tool_name"] != "Bash" {
+	var actionDetails struct {
+		ToolName  string                     `json:"tool_name"`
+		ToolUseID string                     `json:"tool_use_id"`
+		Input     map[string]json.RawMessage `json:"input"`
+	}
+	if err := json.Unmarshal(requiresState.Worker.RequiresActionDetails, &actionDetails); err != nil || actionDetails.ToolName != "Bash" || actionDetails.ToolUseID != "tool_worker_state" || string(actionDetails.Input["command"]) != `"npm test"` {
 		t.Fatalf("requires_action_details = %s, err=%v", requiresState.Worker.RequiresActionDetails, err)
 	}
 	var pendingAction map[string]string

--- a/tests/sessions_api_test.go
+++ b/tests/sessions_api_test.go
@@ -256,15 +256,26 @@ func TestArchivedSessionResourceMutationsReturnInvalidState(t *testing.T) {
 
 func mustSessionRecord(t *testing.T, app *testApp, sessionExternalID string) db.Session {
 	t.Helper()
-	session, err := app.db.GetSession(
+	session, found, err := app.db.GetSession(
 		context.Background(),
 		getDefaultDBIDs(t, app.pool).WorkspaceUUID,
 		sessionExternalID,
 	)
-	if err != nil {
-		t.Fatalf("load Session %q: %v", sessionExternalID, err)
+	if err != nil || !found {
+		t.Fatalf("load Session %q = (%t, %v), want found", sessionExternalID, found, err)
 	}
 	return session
+}
+
+func getCodeSession(app *testApp, ctx context.Context, codeSessionID string) (db.CodeSession, error) {
+	record, found, err := app.db.GetCodeSession(ctx, codeSessionID)
+	if err != nil {
+		return db.CodeSession{}, err
+	}
+	if !found {
+		return db.CodeSession{}, db.ErrNotFound
+	}
+	return record, nil
 }
 
 func TestSessionsEnvironmentKeyAccess(t *testing.T) {
@@ -706,7 +717,7 @@ func TestManagedAgentActivationReplaysStartupHistory(t *testing.T) {
 		t.Fatalf("set code session initializing: %v", err)
 	}
 
-	codeSession, err := app.db.GetCodeSession(ctx, codeSessionID)
+	codeSession, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load initializing code session: %v", err)
 	}
@@ -723,7 +734,7 @@ func TestManagedAgentActivationReplaysStartupHistory(t *testing.T) {
 	if err := codeSessionService.ActivateManagedAgentCodeSession(ctx, codeSession); err != nil {
 		t.Fatalf("activate with startup history: %v", err)
 	}
-	codeSession, err = app.db.GetCodeSession(ctx, codeSessionID)
+	codeSession, err = getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("reload activated code session: %v", err)
 	}
@@ -769,11 +780,11 @@ func TestManagedAgentActivationPreservesLargeHistoryOrder(t *testing.T) {
 		t.Fatalf("set Code Session initializing: %v", err)
 	}
 
-	session, err := app.db.GetSession(ctx, getDefaultDBIDs(t, app.pool).WorkspaceUUID, sessionResponse.ID)
-	if err != nil {
-		t.Fatalf("load Session: %v", err)
+	session, found, err := app.db.GetSession(ctx, getDefaultDBIDs(t, app.pool).WorkspaceUUID, sessionResponse.ID)
+	if err != nil || !found {
+		t.Fatalf("load Session = (%t, %v), want found", found, err)
 	}
-	codeSession, err := app.db.GetCodeSession(ctx, codeSessionID)
+	codeSession, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load Code Session: %v", err)
 	}
@@ -839,11 +850,11 @@ func TestManagedAgentActivationRollsBackOnHistoryConversionFailure(t *testing.T)
 		t.Fatalf("set rollback code session initializing: %v", err)
 	}
 	sendSessionEvents(t, app, sessionResponse.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"history must remain durable"}]}]}`, defaultTestKey)
-	session, err := app.db.GetSession(ctx, getDefaultDBIDs(t, app.pool).WorkspaceUUID, sessionResponse.ID)
-	if err != nil {
-		t.Fatalf("load rollback Session: %v", err)
+	session, found, err := app.db.GetSession(ctx, getDefaultDBIDs(t, app.pool).WorkspaceUUID, sessionResponse.ID)
+	if err != nil || !found {
+		t.Fatalf("load rollback Session = (%t, %v), want found", found, err)
 	}
-	codeSession, err := app.db.GetCodeSession(ctx, codeSessionID)
+	codeSession, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load rollback Code Session: %v", err)
 	}
@@ -870,7 +881,7 @@ func TestManagedAgentActivationRollsBackOnHistoryConversionFailure(t *testing.T)
 	if listErr != nil || len(after) != 1 {
 		t.Fatalf("rollback inbound after delivery = (%#v, %v), want unchanged initialize", after, listErr)
 	}
-	reloaded, err := app.db.GetCodeSession(ctx, codeSessionID)
+	reloaded, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("reload rollback Code Session: %v", err)
 	}
@@ -1269,11 +1280,11 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 		t.Fatalf("initial worker read metadata = %+v, want nil", metadata)
 	}
 
-	seedState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(workerEpoch)+`,"external_metadata":{"pending_action":{"tool_name":"OldTool"},"task_summary":"stale","persisted":true}}`)
+	seedState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"external_metadata":{"pending_action":{"tool_name":"OldTool"},"task_summary":"stale","persisted":true}}`)
 	if _, ok := seedState.Worker.ExternalMetadata["persisted"]; !ok {
 		t.Fatalf("seed worker metadata missing persisted key: %+v", seedState.Worker.ExternalMetadata)
 	}
-	initState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(workerEpoch)+`,"worker_status":"idle","requires_action_details":null,"external_metadata":{"pending_action":null,"task_summary":null}}`)
+	initState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"idle","requires_action_details":null,"external_metadata":{"pending_action":null,"task_summary":null}}`)
 	if initState.Worker.WorkerStatus != "idle" {
 		t.Fatalf("init worker status = %q, want idle", initState.Worker.WorkerStatus)
 	}
@@ -1287,7 +1298,7 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 		t.Fatalf("metadata merge did not preserve persisted key: %+v", initState.Worker.ExternalMetadata)
 	}
 
-	requiresState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(workerEpoch)+`,"worker_status":"requires_action","requires_action_details":{"tool_name":"Bash","action_description":"Running npm test","request_id":"req_worker_state"},"external_metadata":{"pending_action":{"tool_name":"Bash"},"persisted":{"kept":true}}}`)
+	requiresState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"requires_action","requires_action_details":{"tool_name":"Bash","action_description":"Running npm test","request_id":"req_worker_state"},"external_metadata":{"pending_action":{"tool_name":"Bash"},"persisted":{"kept":true}}}`)
 	if requiresState.Worker.WorkerStatus != "requires_action" {
 		t.Fatalf("requires action worker status = %q, want requires_action", requiresState.Worker.WorkerStatus)
 	}
@@ -1307,7 +1318,7 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 		t.Fatalf("primary thread status after requires_action = %+v, want idle", threads.Data)
 	}
 
-	runningState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(workerEpoch)+`,"worker_status":"running","requires_action_details":{"tool_name":"Bash"}}`)
+	runningState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"running","requires_action_details":{"tool_name":"Bash"}}`)
 	if runningState.Worker.WorkerStatus != "running" || !rawMessageIsJSONNull(runningState.Worker.RequiresActionDetails) {
 		t.Fatalf("running worker state = %+v, details=%s; want running with cleared details", runningState.Worker, runningState.Worker.RequiresActionDetails)
 	}
@@ -1318,7 +1329,23 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 	if len(threads.Data) != 1 || threads.Data[0].Status != "running" {
 		t.Fatalf("primary thread status after running = %+v, want running", threads.Data)
 	}
-	runningDetailsOnlyState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(workerEpoch)+`,"requires_action_details":{"tool_name":"Bash"}}`)
+	runningEvents := listSessionEvents(t, app, session.ID, "types[]=session.status_running", defaultTestKey)
+	if len(runningEvents.Data) != 1 {
+		t.Fatalf("session.status_running events = %d, want 1: %+v", len(runningEvents.Data), runningEvents.Data)
+	}
+	runningEvent := sessionEventObjectByType(t, runningEvents, "session.status_running")
+	if runningEvent["id"] == "" || runningEvent["processed_at"] == "" {
+		t.Fatalf("session.status_running missing persisted fields: %#v", runningEvent)
+	}
+	if _, ok := runningEvent["stop_reason"]; ok {
+		t.Fatalf("session.status_running unexpectedly contains stop_reason: %#v", runningEvent)
+	}
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"running"}`)
+	runningEvents = listSessionEvents(t, app, session.ID, "types[]=session.status_running", defaultTestKey)
+	if len(runningEvents.Data) != 1 {
+		t.Fatalf("duplicate running state produced %d events, want 1: %+v", len(runningEvents.Data), runningEvents.Data)
+	}
+	runningDetailsOnlyState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"requires_action_details":{"tool_name":"Bash"}}`)
 	if runningDetailsOnlyState.Worker.WorkerStatus != "running" || !rawMessageIsJSONNull(runningDetailsOnlyState.Worker.RequiresActionDetails) {
 		t.Fatalf("running details-only worker state = %+v, details=%s; want running with cleared details", runningDetailsOnlyState.Worker, runningDetailsOnlyState.Worker.RequiresActionDetails)
 	}
@@ -1396,7 +1423,7 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 		t.Fatalf("download output = %q, want %q", got, outputContent)
 	}
 
-	idleState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(workerEpoch)+`,"worker_status":"idle","external_metadata":{"pending_action":null}}`)
+	idleState := putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"idle","external_metadata":{"pending_action":null}}`)
 	if idleState.Worker.WorkerStatus != "idle" || !rawMessageIsJSONNull(idleState.Worker.RequiresActionDetails) {
 		t.Fatalf("idle worker state = %+v, details=%s; want idle with cleared details", idleState.Worker, idleState.Worker.RequiresActionDetails)
 	}
@@ -1467,6 +1494,12 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 	if eventPageContains(diagEvents, "diag from ccr worker") {
 		t.Fatalf("worker diagnostics leaked into public session events: %+v", diagEvents.Data)
 	}
+
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"running"}`)
+	runningEvents = listSessionEvents(t, app, session.ID, "types[]=session.status_running", defaultTestKey)
+	if len(runningEvents.Data) != 2 {
+		t.Fatalf("second idle-to-running transition produced %d events, want 2: %+v", len(runningEvents.Data), runningEvents.Data)
+	}
 }
 
 func TestSessionEventsListHidesLegacyEnvManagerLog(t *testing.T) {
@@ -1483,9 +1516,9 @@ func TestSessionEventsListHidesLegacyEnvManagerLog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get api key: %v", err)
 	}
-	storedSession, err := app.db.GetSession(ctx, apiKey.WorkspaceUUID.String(), session.ID)
-	if err != nil {
-		t.Fatalf("get stored session: %v", err)
+	storedSession, found, err := app.db.GetSession(ctx, apiKey.WorkspaceUUID.String(), session.ID)
+	if err != nil || !found {
+		t.Fatalf("get stored session = (%t, %v), want found", found, err)
 	}
 	eventSuffix := strings.TrimPrefix(session.ID, "sesn_")
 	hiddenEventID := "sevt_legacy_env_manager_log_" + eventSuffix
@@ -1754,13 +1787,13 @@ func TestCodeSessionWorkerEventsAppendContract(t *testing.T) {
 	workerEpoch := registerCodeSessionWorker(t, app, codeSessionID)
 	ctx := context.Background()
 
-	beforeKeepAlive, err := app.db.GetCodeSession(ctx, codeSessionID)
+	beforeKeepAlive, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load before keep_alive: %v", err)
 	}
 	time.Sleep(5 * time.Millisecond)
 	postCodeSessionWorkerEvents(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(workerEpoch)+`,"events":[{"payload":{"type":"keep_alive"}}]}`)
-	afterKeepAlive, err := app.db.GetCodeSession(ctx, codeSessionID)
+	afterKeepAlive, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load after keep_alive: %v", err)
 	}
@@ -2320,7 +2353,7 @@ func TestCodeSessionWorkerRegisterEpochsAreSessionScopedAndConcurrent(t *testing
 	if !seen["2"] || !seen["3"] || len(seen) != 2 {
 		t.Fatalf("concurrent register epochs = %+v, want 2 and 3", seen)
 	}
-	record, err := app.db.GetCodeSession(context.Background(), codeSessionA)
+	record, err := getCodeSession(app, context.Background(), codeSessionA)
 	if err != nil {
 		t.Fatalf("load code session A: %v", err)
 	}
@@ -2441,7 +2474,7 @@ func TestCodeSessionEventAppendPreservesIdempotencyAndDirectionSequences(t *test
 	codeSessionID := launchLocalCodeSession(t, app, session.ID)
 	ctx := context.Background()
 
-	before, err := app.db.GetCodeSession(ctx, codeSessionID)
+	before, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load Code Session before append: %v", err)
 	}
@@ -2486,7 +2519,7 @@ func TestCodeSessionEventAppendPreservesIdempotencyAndDirectionSequences(t *test
 		t.Fatalf("duplicate outbound event = (%+v, duplicate=%v, err=%v), want UUID %q", duplicateOutbound, duplicate, err, outbound.UUID)
 	}
 
-	after, err := app.db.GetCodeSession(ctx, codeSessionID)
+	after, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load Code Session after append: %v", err)
 	}
@@ -2533,7 +2566,7 @@ func TestCodeSessionWorkerConnectionStateUpdatesAreEpochScoped(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("get worker without epoch status = %d, want 200: %s", resp.StatusCode, readAll(t, resp.Body))
 	}
-	afterNoEpoch, err := app.db.GetCodeSession(ctx, codeSessionID)
+	afterNoEpoch, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load code session after no-epoch get: %v", err)
 	}
@@ -2543,7 +2576,7 @@ func TestCodeSessionWorkerConnectionStateUpdatesAreEpochScoped(t *testing.T) {
 
 	resp = doCodeSessionWorkerRequestWithMethod(t, app, http.MethodGet, codeSessionID, "?worker_epoch="+url.QueryEscape(epoch1), "")
 	assertError(t, resp, http.StatusConflict, "conflict_error")
-	afterStaleGet, err := app.db.GetCodeSession(ctx, codeSessionID)
+	afterStaleGet, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load code session after stale get: %v", err)
 	}
@@ -2552,7 +2585,7 @@ func TestCodeSessionWorkerConnectionStateUpdatesAreEpochScoped(t *testing.T) {
 	}
 
 	getCodeSessionWorkerReadStateResponse(t, app, codeSessionID, epoch2)
-	afterCurrentGet, err := app.db.GetCodeSession(ctx, codeSessionID)
+	afterCurrentGet, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load code session after current get: %v", err)
 	}
@@ -2563,7 +2596,7 @@ func TestCodeSessionWorkerConnectionStateUpdatesAreEpochScoped(t *testing.T) {
 	if err := app.db.MarkCodeSessionWorkerConnectedForEpoch(ctx, codeSessionID, 1); !errors.Is(err, db.ErrWorkerEpochMismatch) {
 		t.Fatalf("stale epoch connect error = %v, want worker epoch mismatch", err)
 	}
-	afterStaleConnect, err := app.db.GetCodeSession(ctx, codeSessionID)
+	afterStaleConnect, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load code session after stale connect: %v", err)
 	}
@@ -2573,7 +2606,7 @@ func TestCodeSessionWorkerConnectionStateUpdatesAreEpochScoped(t *testing.T) {
 	if err := app.db.MarkCodeSessionWorkerConnectedForEpoch(ctx, codeSessionID, 2); err != nil {
 		t.Fatalf("current epoch connect: %v", err)
 	}
-	afterCurrentConnect, err := app.db.GetCodeSession(ctx, codeSessionID)
+	afterCurrentConnect, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load code session after current connect: %v", err)
 	}
@@ -2584,7 +2617,7 @@ func TestCodeSessionWorkerConnectionStateUpdatesAreEpochScoped(t *testing.T) {
 	if err := app.db.MarkCodeSessionWorkerDisconnectedForEpoch(ctx, codeSessionID, 1); !errors.Is(err, db.ErrWorkerEpochMismatch) {
 		t.Fatalf("stale epoch disconnect error = %v, want worker epoch mismatch", err)
 	}
-	afterStaleDisconnect, err := app.db.GetCodeSession(ctx, codeSessionID)
+	afterStaleDisconnect, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load code session after stale disconnect: %v", err)
 	}
@@ -2594,7 +2627,7 @@ func TestCodeSessionWorkerConnectionStateUpdatesAreEpochScoped(t *testing.T) {
 	if err := app.db.MarkCodeSessionWorkerDisconnectedForEpoch(ctx, codeSessionID, 2); err != nil {
 		t.Fatalf("current epoch disconnect: %v", err)
 	}
-	afterCurrentDisconnect, err := app.db.GetCodeSession(ctx, codeSessionID)
+	afterCurrentDisconnect, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load code session after current disconnect: %v", err)
 	}
@@ -2662,8 +2695,9 @@ func TestCodeSessionWorkerEpochValidationRejectsInvalidValues(t *testing.T) {
 		`[]`,
 		`{`,
 		`{"session_id":` + quoteJSON(codeSessionID) + `}`,
-		`{"session_id":123,"worker_epoch":` + quoteJSON(workerEpoch) + `}`,
-		`{"session_id":"other","worker_epoch":` + quoteJSON(workerEpoch) + `}`,
+		`{"session_id":123,"worker_epoch":` + workerEpoch + `}`,
+		`{"session_id":"other","worker_epoch":` + workerEpoch + `}`,
+		`{"session_id":` + quoteJSON(codeSessionID) + `,"worker_epoch":` + quoteJSON(workerEpoch) + `}`,
 		`{"session_id":` + quoteJSON(codeSessionID) + `,"worker_epoch":"abc"}`,
 		`{"session_id":` + quoteJSON(codeSessionID) + `,"worker_epoch":1.2}`,
 		`{"session_id":` + quoteJSON(codeSessionID) + `,"worker_epoch":-1}`,
@@ -2677,15 +2711,20 @@ func TestCodeSessionWorkerEpochValidationRejectsInvalidValues(t *testing.T) {
 	assertError(t, resp, http.StatusBadRequest, "invalid_request_error")
 
 	badStateBodies := []string{
-		`{"worker_epoch":` + quoteJSON(workerEpoch) + `,"worker_status":"connected"}`,
-		`{"worker_epoch":` + quoteJSON(workerEpoch) + `,"worker_status":123}`,
-		`{"worker_epoch":` + quoteJSON(workerEpoch) + `,"external_metadata":null}`,
-		`{"worker_epoch":` + quoteJSON(workerEpoch) + `,"external_metadata":[]}`,
-		`{"worker_epoch":` + quoteJSON(workerEpoch) + `,"requires_action_details":[]}`,
+		`{"worker_epoch":` + workerEpoch + `,"worker_status":"connected"}`,
+		`{"worker_epoch":` + workerEpoch + `,"worker_status":123}`,
+		`{"worker_epoch":` + workerEpoch + `,"external_metadata":[]}`,
+		`{"worker_epoch":` + workerEpoch + `,"requires_action_details":[]}`,
+		`{"worker_epoch":` + quoteJSON(workerEpoch) + `}`,
 	}
 	for _, body := range badStateBodies {
 		resp := doCodeSessionWorkerRequestWithMethod(t, app, http.MethodPut, codeSessionID, "", body)
 		assertError(t, resp, http.StatusBadRequest, "invalid_request_error")
+	}
+	nullStateResp := doCodeSessionWorkerRequestWithMethod(t, app, http.MethodPut, codeSessionID, "", `{"worker_epoch":`+workerEpoch+`,"worker_status":null,"requires_action_details":null,"external_metadata":null}`)
+	defer nullStateResp.Body.Close()
+	if nullStateResp.StatusCode != http.StatusOK {
+		t.Fatalf("null worker state fields status = %d, want 200: %s", nullStateResp.StatusCode, readAll(t, nullStateResp.Body))
 	}
 
 	resp = doCodeSessionWorkerOTLPRequest(t, app, codeSessionID, "metrics", "abc", "application/x-protobuf", nil)
@@ -2702,7 +2741,7 @@ func TestCodeSessionWorkerOTLPAcceptsMissingEpochWithoutWorkerActivity(t *testin
 	defer cleanupEnvironmentRows(t, app.pool, env.ID)
 	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
 	codeSessionID := launchLocalCodeSession(t, app, session.ID)
-	before, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	before, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load code session before OTLP: %v", err)
 	}
@@ -2721,7 +2760,7 @@ func TestCodeSessionWorkerOTLPAcceptsMissingEpochWithoutWorkerActivity(t *testin
 		}
 	}
 
-	after, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	after, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load code session after OTLP: %v", err)
 	}
@@ -2874,7 +2913,7 @@ func TestCodeSessionWorkerHeartbeatReportsSandboxTimeoutFailure(t *testing.T) {
 	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
 	codeSessionID := launchLocalCodeSession(t, app, session.ID)
 	workerEpoch := registerCodeSessionWorker(t, app, codeSessionID)
-	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(workerEpoch)+`,"worker_status":"running"}`)
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"running"}`)
 	app.sandboxTimeouts.setError(errors.New("provider unavailable"))
 
 	resp := doCodeSessionWorkerRequest(t, app, codeSessionID, "heartbeat", workerHeartbeatBody(codeSessionID, workerEpoch))
@@ -2897,7 +2936,7 @@ func TestCodeSessionWorkerHeartbeatSkipsSandboxTimeoutWhenNotRunning(t *testing.
 	codeSessionID := launchLocalCodeSession(t, app, session.ID)
 	workerEpoch := registerCodeSessionWorker(t, app, codeSessionID)
 
-	beforeIdle, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	beforeIdle, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load before idle heartbeat: %v", err)
 	}
@@ -2910,7 +2949,7 @@ func TestCodeSessionWorkerHeartbeatSkipsSandboxTimeoutWhenNotRunning(t *testing.
 		t.Fatalf("idle heartbeat sandbox timeout calls = %d, want 0", len(calls))
 	}
 
-	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(workerEpoch)+`,"worker_status":"requires_action"}`)
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"requires_action"}`)
 	time.Sleep(5 * time.Millisecond)
 	requiresActionExpiresAt := assertCodeSessionWorkerHeartbeat(t, app, codeSessionID, workerEpoch)
 	if !requiresActionExpiresAt.After(idleExpiresAt) {
@@ -2933,8 +2972,8 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	codeSessionID := launchLocalCodeSession(t, app, session.ID)
 
 	epoch1 := registerCodeSessionWorker(t, app, codeSessionID)
-	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+quoteJSON(epoch1)+`,"worker_status":"running"}`)
-	before, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+epoch1+`,"worker_status":"running"}`)
+	before, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load before heartbeat: %v", err)
 	}
@@ -2942,14 +2981,14 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 		t.Fatalf("register did not set worker lease/register timestamps: %+v", before)
 	}
 	time.Sleep(5 * time.Millisecond)
-	stringExpiresAt := assertCodeSessionWorkerHeartbeat(t, app, codeSessionID, epoch1)
-	if !stringExpiresAt.After(*before.WorkerLeaseExpiresAt) {
-		t.Fatalf("string heartbeat lease expiry = %s, want after %s", stringExpiresAt, before.WorkerLeaseExpiresAt)
+	firstExpiresAt := assertCodeSessionWorkerHeartbeat(t, app, codeSessionID, epoch1)
+	if !firstExpiresAt.After(*before.WorkerLeaseExpiresAt) {
+		t.Fatalf("first heartbeat lease expiry = %s, want after %s", firstExpiresAt, before.WorkerLeaseExpiresAt)
 	}
 	time.Sleep(5 * time.Millisecond)
-	numberExpiresAt := assertCodeSessionWorkerHeartbeatBody(t, app, codeSessionID, `{"session_id":`+quoteJSON(codeSessionID)+`,"worker_epoch":`+epoch1+`}`)
-	if !numberExpiresAt.After(stringExpiresAt) {
-		t.Fatalf("number heartbeat lease expiry = %s, want after %s", numberExpiresAt, stringExpiresAt)
+	secondExpiresAt := assertCodeSessionWorkerHeartbeat(t, app, codeSessionID, epoch1)
+	if !secondExpiresAt.After(firstExpiresAt) {
+		t.Fatalf("second heartbeat lease expiry = %s, want after %s", secondExpiresAt, firstExpiresAt)
 	}
 	timeoutCalls := app.sandboxTimeouts.snapshotCalls()
 	if len(timeoutCalls) != 2 {
@@ -2967,7 +3006,7 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 			t.Fatalf("sandbox timeout call = %+v, want sandbox %q timeout %s", call, *sandbox.ProviderSandboxID, app.cfg.E2B.SandboxTimeout)
 		}
 	}
-	after, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	after, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load after heartbeat: %v", err)
 	}
@@ -2978,7 +3017,7 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 		t.Fatalf("heartbeat lease expiry = %s, want after %s", after.WorkerLeaseExpiresAt, before.WorkerLeaseExpiresAt)
 	}
 
-	beforeFutureMismatch, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	beforeFutureMismatch, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load before future mismatch heartbeat: %v", err)
 	}
@@ -2987,7 +3026,7 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	if calls := app.sandboxTimeouts.snapshotCalls(); len(calls) != 2 {
 		t.Fatalf("future epoch sandbox timeout calls = %d, want 2", len(calls))
 	}
-	afterFutureMismatch, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	afterFutureMismatch, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load after future mismatch heartbeat: %v", err)
 	}
@@ -2997,7 +3036,7 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	if epoch2 != "2" {
 		t.Fatalf("second register epoch = %q, want 2", epoch2)
 	}
-	beforeMismatch, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	beforeMismatch, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load before mismatch heartbeat: %v", err)
 	}
@@ -3006,7 +3045,7 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	if calls := app.sandboxTimeouts.snapshotCalls(); len(calls) != 2 {
 		t.Fatalf("stale epoch sandbox timeout calls = %d, want 2", len(calls))
 	}
-	afterMismatch, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	afterMismatch, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load after mismatch heartbeat: %v", err)
 	}
@@ -3015,7 +3054,7 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	if _, err := app.pool.Exec(context.Background(), `update code_sessions set worker_lease_expires_at = now() - interval '5 seconds' where external_id = $1`, codeSessionID); err != nil {
 		t.Fatalf("expire worker lease inside grace: %v", err)
 	}
-	graceBefore, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	graceBefore, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load grace lease record: %v", err)
 	}
@@ -3023,7 +3062,7 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	if calls := app.sandboxTimeouts.snapshotCalls(); len(calls) != 3 {
 		t.Fatalf("grace heartbeat sandbox timeout calls = %d, want 3", len(calls))
 	}
-	graceAfter, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	graceAfter, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load after grace heartbeat: %v", err)
 	}
@@ -3034,7 +3073,7 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	if _, err := app.pool.Exec(context.Background(), `update code_sessions set worker_lease_expires_at = now() - interval '15 seconds' where external_id = $1`, codeSessionID); err != nil {
 		t.Fatalf("expire worker lease beyond grace: %v", err)
 	}
-	expired, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	expired, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load expired lease record: %v", err)
 	}
@@ -3048,7 +3087,7 @@ func TestCodeSessionWorkerHeartbeatUpdatesLeaseForCurrentEpoch(t *testing.T) {
 	}
 	resp = doCodeSessionWorkerOTLPRequest(t, app, codeSessionID, "metrics", epoch2, "application/x-protobuf", nil)
 	assertError(t, resp, http.StatusGone, "session_expired")
-	afterExpiredHeartbeat, err := app.db.GetCodeSession(context.Background(), codeSessionID)
+	afterExpiredHeartbeat, err := getCodeSession(app, context.Background(), codeSessionID)
 	if err != nil {
 		t.Fatalf("load after expired heartbeat: %v", err)
 	}
@@ -3217,7 +3256,7 @@ func TestCodeSessionWorkerEventsStreamRejectsInvalidReplayCursorWithoutConnectin
 	resp := doCodeSessionWorkerRequestWithMethod(t, app, http.MethodGet, codeSessionID, "events/stream?worker_epoch="+url.QueryEscape(workerEpoch)+"&from_sequence_num=bad-cursor", "")
 	assertError(t, resp, http.StatusBadRequest, "invalid_request_error")
 
-	after, err := app.db.GetCodeSession(ctx, codeSessionID)
+	after, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		t.Fatalf("load code session after invalid stream cursor: %v", err)
 	}
@@ -4041,7 +4080,7 @@ func codeSessionIngressToken(t *testing.T, app *testApp, codeSessionID string) s
 
 func codeSessionIngressTokenNoFatal(app *testApp, codeSessionID string) (string, error) {
 	ctx := context.Background()
-	record, err := app.db.GetCodeSession(ctx, codeSessionID)
+	record, err := getCodeSession(app, ctx, codeSessionID)
 	if err != nil {
 		return "", err
 	}
@@ -4397,7 +4436,7 @@ func codeSessionEventsContainPayloadUUID(events []db.CodeSessionEvent, payloadUU
 
 func assertCodeSessionWorkerHeartbeat(t *testing.T, app *testApp, codeSessionID string, workerEpoch string) time.Time {
 	t.Helper()
-	return assertCodeSessionWorkerHeartbeatBody(t, app, codeSessionID, `{"session_id":`+quoteJSON(codeSessionID)+`,"worker_epoch":`+quoteJSON(workerEpoch)+`}`)
+	return assertCodeSessionWorkerHeartbeatBody(t, app, codeSessionID, `{"session_id":`+quoteJSON(codeSessionID)+`,"worker_epoch":`+workerEpoch+`}`)
 }
 
 func assertCodeSessionWorkerHeartbeatBody(t *testing.T, app *testApp, codeSessionID string, body string) time.Time {
@@ -4522,11 +4561,11 @@ func assertCodeSessionWorkerWriteStatus(t *testing.T, app *testApp, method strin
 }
 
 func workerStateBody(codeSessionID string, workerEpoch string) string {
-	return `{"session_id":` + quoteJSON(codeSessionID) + `,"worker_epoch":` + quoteJSON(workerEpoch) + `}`
+	return `{"session_id":` + quoteJSON(codeSessionID) + `,"worker_epoch":` + workerEpoch + `}`
 }
 
 func workerHeartbeatBody(codeSessionID string, workerEpoch string) string {
-	return `{"session_id":` + quoteJSON(codeSessionID) + `,"worker_epoch":` + quoteJSON(workerEpoch) + `}`
+	return `{"session_id":` + quoteJSON(codeSessionID) + `,"worker_epoch":` + workerEpoch + `}`
 }
 
 func workerDeliveryBody(workerEpoch string) string {

--- a/tests/sessions_api_test.go
+++ b/tests/sessions_api_test.go
@@ -937,6 +937,17 @@ func TestSessionClaudeCodeSubagentInternalEventsPublishToChildThread(t *testing.
 	`, session.ID, child.ID); err != nil {
 		t.Fatalf("delete child session events before backfill: %v", err)
 	}
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"running"}`)
+	sessionRecord := mustSessionRecord(t, app, session.ID)
+	storedChildEvents, _, err := app.db.ListSessionEventsPage(context.Background(), db.ListSessionEventsPageParams{
+		WorkspaceUUID:     sessionRecord.WorkspaceUUID,
+		SessionExternalID: session.ID,
+		ThreadExternalID:  child.ID,
+		Limit:             100,
+	})
+	if err != nil || len(storedChildEvents) == 0 {
+		t.Fatalf("child events after worker state reconciliation = (%d, %v), want restored events", len(storedChildEvents), err)
+	}
 
 	childEvents := listThreadEvents(t, app, session.ID, child.ID, defaultTestKey)
 	for _, want := range []string{


### PR DESCRIPTION
## Summary

- decode worker state and heartbeat payloads through typed request schemas
- publish `session.status_running` through the public event pipeline before worker execution proceeds
- represent optional Session and CodeSession lookups with explicit `found` results instead of `sql.ErrNoRows`

## Why

This aligns worker-driven status changes with the managed-agent session lifecycle, keeps public event/SSE/webhook behavior consistent, and moves known HTTP payload fields out of raw JSON handling.

## Impact

Worker epoch values are now accepted only as positive JSON numbers. Running transitions produce a durable public status event, while idle and requires-action updates retain their existing public idle mapping. Internal DB callers now distinguish missing rows from query errors explicitly.

## Validation

- `just hooks-run` (passed with the embedded `web/node_modules/flatted/golang` fixture excluded from Go package discovery)
- `just large-files`
- `just lint`
- `just dead-code`
- `just duplicates`
- `just complexity`
- `go test ./internal/db ./internal/codesessions ./internal/sessions ./internal/environments -count=1`
- `go test ./tests -run "^$" -count=1`

`just test` still reports pre-existing failures involving the config example contract and shared filestore/vault/deployment test database state; the affected internal packages above pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worker heartbeat requests now require a positive JSON number for the worker epoch.
  * Worker state updates support nullable fields and preserve status when omitted, empty, or null.
  * Running and idle status changes now produce synchronized public events with duplicate suppression.

* **Bug Fixes**
  * Missing sessions are handled consistently across session, thread, worker, and permission operations.
  * Invalid heartbeat and worker-state payloads now receive consistent validation errors.
  * Event projections are safely retried without duplicating broadcasts or webhooks.
  * Code-session polling now returns consistent authentication errors.

* **Documentation**
  * Updated API documentation for revised validation and event behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->