### PR TITLE
Simplify public event sink setup

### DIFF
--- a/internal/codesessions/public_event_sink.go
+++ b/internal/codesessions/public_event_sink.go
@@ -13,13 +13,11 @@ type PublicEventSink interface {
 	PublishCodeSessionEvents(ctx context.Context, codeSession db.CodeSession, payloads []json.RawMessage) error
 }
 
-// SetPublicEventSink 在服务组装阶段注入事件接收端。Service 发布事件时会在锁内取得 sink 快照、
-// 在锁外执行 I/O；这既避免装配或测试替换 sink 时与 worker 发布发生 data race，也不会让慢投递长期占锁。
+// SetPublicEventSink 在服务组装阶段注入事件接收端。
+// 必须在 Service 开始处理请求或 worker 事件前调用，运行期不得替换。
 func (s *Service) SetPublicEventSink(sink PublicEventSink) {
 	if s == nil {
 		return
 	}
-	s.sinkMu.Lock()
-	defer s.sinkMu.Unlock()
 	s.sink = sink
 }

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"log/slog"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
@@ -25,7 +24,6 @@ type Service struct {
 	db          *db.DB
 	credentials *SessionCredentials
 	logger      *slog.Logger
-	sinkMu      sync.Mutex
 	sink        PublicEventSink
 }
 
@@ -353,13 +351,10 @@ func (s *Service) publishPublicPayloads(ctx context.Context, codeSessionID strin
 	if !found {
 		return db.ErrNotFound
 	}
-	s.sinkMu.Lock()
-	sink := s.sink
-	s.sinkMu.Unlock()
-	if sink == nil {
+	if s.sink == nil {
 		return nil
 	}
-	return sink.PublishCodeSessionEvents(ctx, codeSession, payloads)
+	return s.sink.PublishCodeSessionEvents(ctx, codeSession, payloads)
 }
 
 func (s *Service) reconcileSubagentEvents(ctx context.Context, codeSessionID string) {

--- a/internal/codesessions/status.go
+++ b/internal/codesessions/status.go
@@ -35,11 +35,19 @@ func publicEventTypeFromWorkerStatus(status string) (string, bool) {
 	}
 }
 
+// 把 worker 内部状态同步成外部可消费的 session 状态事件，并在 session 和主 thread 都已经处于目标状态时跳过重复发布。
+// worker 报告 running，需要发布事件
+//
+//	比如：
+//	- workerStatus = "running"
+//	- publicEventTypeFromWorkerStatus 把它映射为 eventType = "session.status_running"
+//	- maevents.SessionStatus("session.status_running") 返回 status = "running"
 func (s *Service) publicSessionStatusPayloads(ctx context.Context, record db.CodeSession, eventType string) ([]json.RawMessage, error) {
 	status, ok := maevents.SessionStatus(eventType)
 	if !ok {
 		return nil, nil
 	}
+	// 从 db 查 session status
 	session, found, err := s.db.GetSession(ctx, record.WorkspaceUUID, record.SessionExternalID)
 	if err != nil {
 		return nil, err
@@ -47,6 +55,7 @@ func (s *Service) publicSessionStatusPayloads(ctx context.Context, record db.Cod
 	if !found {
 		return nil, nil
 	}
+	// 状态相同，则查主 Agent 的状态
 	if session.Status == status {
 		thread, found, err := s.db.GetPrimarySessionThread(ctx, record.WorkspaceUUID, record.SessionExternalID)
 		if err != nil {
@@ -55,10 +64,12 @@ func (s *Service) publicSessionStatusPayloads(ctx context.Context, record db.Cod
 		if !found {
 			return nil, nil
 		}
+		// 如果主 Agent 也状态相同，则不需要重复发布
 		if thread.Status == status {
 			return nil, nil
 		}
 	}
+	//
 	now := time.Now().UTC()
 	eventID := stablePublicEventID(record.ExternalID, "worker_status_"+status+"\x00"+session.UpdatedAt.UTC().Format(time.RFC3339Nano))
 	payload, err := marshalRaw(map[string]any{

--- a/internal/managedagentsevents/events.go
+++ b/internal/managedagentsevents/events.go
@@ -97,7 +97,7 @@ func IsWorkerOutputEvent(eventType string) bool {
 }
 
 func SessionStatus(eventType string) (string, bool) {
-	switch strings.TrimSpace(eventType) {
+	switch eventType {
 	case "session.status_run_started", "session.status_running", "session.running":
 		return "running", true
 	case "session.status_rescheduled":


### PR DESCRIPTION
## What changed

- Treat the public event sink as an assembly-time dependency and remove its runtime mutex.
- Document the worker-to-public status mapping flow.
- Require exact managed-agent session event type matching.

## Why

These changes were left out when #239 was merged. The sink is installed before request handling starts and is not replaced at runtime, so synchronization around every publish is unnecessary.

## Validation

- `go test -race ./internal/codesessions ./internal/sessions ./internal/managedagentsevents -count=1`
- package-scoped `golangci-lint`
- `just dead-code`
- `just duplicates`
- `just complexity`
- `just large-files`