### PR TITLE
Align managed agent session files and resources

### DIFF
--- a/docs/design/be/filestore.md
+++ b/docs/design/be/filestore.md
@@ -136,6 +136,8 @@ filesystem 的数据库 namespace 在 Session/resource 写事务完成时已经�
 
 五个挂载统一使用 `vfs_cache_mode=full`、`vfs_cache_max_size=1G`、`uid=999`、`gid=1000`、目录权限 `0755` 和文件权限 `0644`。`/outputs` 使用读写 Token，其余四个 source 共享只读 Token 并设置 `readonly=true`；两类 Token 都绑定当前 public Session 唯一 filesystem 的 external ID，`service_url` 直接取 `code_session.sandbox_api_base_url`。
 
+OMA 在 Managed Agent 的 `appendSystemPrompt` 中同步声明这组公开路径与 sandbox 路径的映射：上传输入使用 `/mnt/session/uploads/<relative-path>`，用户可下载的输出使用 `/mnt/user-data/outputs/<relative-path>`。提示词为用户提到的文件名或相对路径规定固定查找顺序：先尝试 `/mnt/session/uploads/<relative-path>`，必要时调用显式设置 `path=/mnt/session/uploads` 的 Glob 递归查找，只有 uploads 未命中后才搜索工作目录；两处都检查前不得报告文件不存在。Claude 只能使用实际命中的上传路径，不截断、改名或从 `file_id` 推断文件名；写入输出挂载的文件会投影为 `/outputs/<relative-path>` 并进入该 Session 的 Files API Catalog。普通仓库编辑仍留在工作目录，只有用户交付物写入 outputs。
+
 Runner 不执行独立的 mount preparation；`rclone-filestore multimount` 在内部对每个 destination 执行 `MkdirAll`。镜像和 Environment Manager 不得创建 skill 软链，也不会复制或解压 archive；destination 无法创建时，由 multimount 启动或 ready 阶段失败并进入统一 Sandbox 清理。
 
 Runner 先通过 E2B Files API 完整写入强类型 JSON，再将 `/tmp/rclone-mount-config.json` 权限设置为 `0600`。文件写入完成后才直接执行固定镜像命令，不使用 stdin bootstrap、临时文件或 shell trap：

--- a/docs/design/be/messages-proxy.md
+++ b/docs/design/be/messages-proxy.md
@@ -80,6 +80,8 @@ sequenceDiagram
 
 `environment-manager` 的 `auth[type=anthropic_oauth]` 使用 lifecycle-bound OAuth-compatible token；`auth[type=session_ingress]` 使用自包含的 `sk-ant-si-<JWT>`。前者只访问 `/v1/messages`，后者供 worker、relay 与 upstream proxy 使用。启动 payload 不再包含 `auth[type=anthropic_api]` 或 `CLAUDE_CODE_SESSION_ACCESS_TOKEN`，避免环境变量遮蔽 WebSocket FD。Runner 创建 Cloud Session Sandbox 后，先等待固定 rclone-filestore 四挂载 ready，并最多重试三次删除临时 Token 配置；其中 `/uploads` namespace 已整体只读挂载到 `/mnt/session/uploads`，不执行逐文件 projection。随后把 sandbox 标记为 `running`、建立首个 environment work heartbeat，才创建 local Code Session 并通过 E2B 后台进程 API 启动 environment-manager、按 PID 直接发送并关闭 stdin。environment-manager 启动失败时 Runner 立即终止该 Code Session；启动成功后才以一个数据库事务把 runtime metadata 发布到 Session 和 Environment Work。environment-manager 在启动 Claude 前 register CCR worker。work heartbeat 只维护 environment 租约，不参与 code-session token 鉴权。payload 不写入沙箱文件系统，发送或关闭失败时终止未完整初始化的进程。
 
+Managed Agent 的 initialize 控制事件把 Agent snapshot 中的 `system` 原样映射为 `systemPrompt`，并通过 `appendSystemPrompt` 追加 OMA 管理的 sandbox 文件合同。追加提示只描述环境，不替代 Agent 角色；它告诉 Claude 使用真实 sandbox 路径访问上传文件、把用户交付物写入输出挂载，并明确禁止根据 `file_id` 猜测或重建文件路径。该合同是所有 Session 共用的静态文本，不拼接资源清单、文件 ID 或其他 Session 数据，以保持稳定的 prompt cache 前缀；它由 OMA 的 Session 启动配置统一注入，不依赖 CCRv2 模式切换。
+
 ## 错误语义
 
 - 未配置上游 key：`503 api_error`；
@@ -95,4 +97,5 @@ sequenceDiagram
 - `tests/messages_api_test.go`：缺少上游 key、跨资源使用、未 register、lease 过期、public session 终止、长时间运行、普通 API key、平台 cookie、header 清洗与响应 header 透传；
 - `tests/platform_proxy_directory_api_test.go`：管理后台原有独立路径的 JSON 与 SSE 转发；
 - `internal/environments/environment_manager_test.go`：沙箱 payload 不含上游 key 或 Claude 凭证环境变量，api base URL 和 lifecycle-bound token auth 正确，启动 payload 会被删除；
-- `tests/environments_runner_cloud_test.go`：真实 runner 组装出的 runtime payload 使用 session-scoped token。
+- `tests/environments_runner_cloud_test.go`：真实 runner 组装出的 runtime payload 使用 session-scoped token，并在 initialize 事件中携带 Agent system prompt 与 OMA append system prompt；
+- `tests/environments_full_e2b_bridge_integration_test.go`：真实 E2B 中验证 Files API 上传、只读 uploads 挂载、Agent 生成 outputs、session 文件 Catalog 和 Files API 下载闭环。

--- a/docs/design/fe/sessions/session-conversation-workspace.md
+++ b/docs/design/fe/sessions/session-conversation-workspace.md
@@ -9,7 +9,7 @@ Session 详情页同时承担两个职责：继续与运行中的智能体对话
 会话摘要下方提供五个一级页签：
 
 1. **事件**：复用现有 transcript/debug、事件筛选、搜索、线程 lane、minimap 和事件详情面板。
-2. **资源**：展示真实 `session.resources.list` 返回的挂载项。
+2. **资源**：展示 Session retrieve 响应中 `resources` 返回的挂载项。
 3. **智能体**：展示会话固定的 Agent 版本、模型、系统提示词和工具类型。
 4. **环境**：展示 Session 引用的 Environment、状态和网络模式。
 5. **凭据**：展示 Session 关联的凭据保险库和凭据元数据。页面不得读取或展示 credential 的 secret 值。
@@ -18,16 +18,18 @@ Session 详情页同时承担两个职责：继续与运行中的智能体对话
 
 ## 数据来源
 
-| 区域     | 数据来源                    | 说明                                                    |
-| -------- | --------------------------- | ------------------------------------------------------- |
-| 会话摘要 | Session retrieve            | 状态、Agent 引用、Environment ID、Vault IDs、用量和时间 |
-| 事件     | Session/Thread events + SSE | 保留现有缓存、补帧和实时状态机                          |
-| 资源     | Session resources list      | 只展示 API 实际返回的资源，不虚构环境变量等类型         |
-| 智能体   | Agent retrieve              | 按 `session.agent` 中的 ID 和固定版本读取               |
-| 环境     | Environment retrieve        | 按 `environment_id` 读取                                |
-| 凭据     | Vault + credential list     | 按 `vault_ids` 读取元数据，禁止请求 credential secret   |
+| 区域     | 数据来源                    | 说明                                                     |
+| -------- | --------------------------- | -------------------------------------------------------- |
+| 会话摘要 | Session retrieve            | 状态、Agent 引用、Environment ID、Vault IDs、用量和时间  |
+| 事件     | Session/Thread events + SSE | 保留现有缓存、补帧和实时状态机                           |
+| 资源     | Session retrieve            | 只展示 `resources` 实际返回的资源，不拼接 Files API 数据 |
+| 智能体   | Agent retrieve              | 按 `session.agent` 中的 ID 和固定版本读取                |
+| 环境     | Environment retrieve        | 按 `environment_id` 读取                                 |
+| 凭据     | Vault + credential list     | 按 `vault_ids` 读取元数据，禁止请求 credential secret    |
 
 关联实体并行加载；一类关联实体失败时保留其余可用数据并显示不可用状态，不影响事件与对话。
+
+进入资源页签时重新请求 Session retrieve，以获取后端最新的 `resources`。事件流不触发资源刷新；前端不调用 Session resources list 或 Files API 补齐资源字段。
 
 ## 对话和停止行为
 

--- a/docs/design/fe/sessions/session-conversation-workspace.md
+++ b/docs/design/fe/sessions/session-conversation-workspace.md
@@ -18,18 +18,18 @@ Session 详情页同时承担两个职责：继续与运行中的智能体对话
 
 ## 数据来源
 
-| 区域     | 数据来源                    | 说明                                                     |
-| -------- | --------------------------- | -------------------------------------------------------- |
-| 会话摘要 | Session retrieve            | 状态、Agent 引用、Environment ID、Vault IDs、用量和时间  |
-| 事件     | Session/Thread events + SSE | 保留现有缓存、补帧和实时状态机                           |
-| 资源     | Session retrieve            | 只展示 `resources` 实际返回的资源，不拼接 Files API 数据 |
-| 智能体   | Agent retrieve              | 按 `session.agent` 中的 ID 和固定版本读取                |
-| 环境     | Environment retrieve        | 按 `environment_id` 读取                                 |
-| 凭据     | Vault + credential list     | 按 `vault_ids` 读取元数据，禁止请求 credential secret    |
+| 区域     | 数据来源                         | 说明                                                         |
+| -------- | -------------------------------- | ------------------------------------------------------------ |
+| 会话摘要 | Session retrieve                 | 状态、Agent 引用、Environment ID、Vault IDs、用量和时间      |
+| 事件     | Session/Thread events + SSE      | 保留现有缓存、补帧和实时状态机                               |
+| 资源     | Session retrieve + File metadata | Session 返回挂载关系；文件名按 `file_id` 获取 Files metadata |
+| 智能体   | Agent retrieve                   | 按 `session.agent` 中的 ID 和固定版本读取                    |
+| 环境     | Environment retrieve             | 按 `environment_id` 读取                                     |
+| 凭据     | Vault + credential list          | 按 `vault_ids` 读取元数据，禁止请求 credential secret        |
 
 关联实体并行加载；一类关联实体失败时保留其余可用数据并显示不可用状态，不影响事件与对话。
 
-进入资源页签时重新请求 Session retrieve，以获取后端最新的 `resources`。事件流不触发资源刷新；前端不调用 Session resources list 或 Files API 补齐资源字段。
+进入资源页签时重新请求 Session retrieve，以获取后端最新的 `resources`。文件资源再按 `file_id` 请求 File metadata 获取文件名；不从 `mount_path` 推断名称，也不调用 Session resources list 或 Files list。事件流不触发资源刷新。
 
 ## 对话和停止行为
 

--- a/internal/environments/environment_manager.go
+++ b/internal/environments/environment_manager.go
@@ -18,6 +18,26 @@ const (
 	defaultEnvironmentWorkDir     = "/home/user"
 	launcherSettingsPath          = "/root/.claude/launcher-settings.json"
 	managedAgentMCPConfigPath     = "/tmp/managed-agent-mcp-config.json"
+	managedAgentEnvironmentPrompt = `# Managed-agent environment
+
+These rules describe the current sandbox environment and do not replace your assigned role.
+
+## Uploaded inputs
+
+- A public/API path /uploads/<relative-path> is available inside the sandbox at /mnt/session/uploads/<relative-path>. Use the sandbox path when accessing the file; do not try to open /uploads/... inside the sandbox.
+- /mnt/session/uploads is read-only. Do not modify files under this directory.
+- Mandatory lookup order: for every filename or relative file path mentioned by the user, check /mnt/session/uploads before the working directory, even if the user does not say the file was uploaded. Never run a working-directory-only search first.
+- First try the exact sandbox path /mnt/session/uploads/<user-provided-relative-path>. If only a filename is known or that exact path is absent, search recursively with Glob using path /mnt/session/uploads and pattern **/<filename>. Omitting path searches only the working directory and does not satisfy this rule.
+- Search the working directory only after the uploads check finds no match. Do not report a file missing until both locations have been checked in this order.
+- Uploaded filenames and paths are authoritative. Use an exact path when provided; otherwise, use only a path returned by inspecting /mnt/session/uploads. If multiple files match, ask the user which one to use.
+- Never guess, truncate, rename, or reconstruct an uploaded input path. Do not infer an upload path from metadata such as a file ID.
+
+## Output deliverables
+
+- /mnt/user-data/outputs is read-write. Write every file intended as a user-facing session output to /mnt/user-data/outputs/<relative-path>.
+- A file written there is surfaced at the corresponding public/API path /outputs/<relative-path>. Do not write to /outputs/... inside the sandbox.
+- Files written outside /mnt/user-data/outputs are working files and are not surfaced as session outputs.
+- Keep normal repository and source-code edits in the repository working directory. Do not redirect them to /mnt/user-data/outputs; only exported, user-facing deliverables belong there.`
 )
 
 func managedAgentSessionConfig(
@@ -28,10 +48,14 @@ func managedAgentSessionConfig(
 	mcpServers := arrayValue(agentSnapshot["mcp_servers"])
 	tools := arrayValue(agentSnapshot["tools"])
 	body := map[string]any{
-		"origin":   "managed_agents_api",
-		"model":    modelIDFromAgentSnapshot(session.AgentSnapshot),
-		"sources":  runtimeResources.sources,
-		"outcomes": []any{},
+		"origin":               "managed_agents_api",
+		"model":                modelIDFromAgentSnapshot(session.AgentSnapshot),
+		"sources":              runtimeResources.sources,
+		"outcomes":             []any{},
+		"append_system_prompt": managedAgentEnvironmentPrompt,
+	}
+	if system, ok := agentSnapshot["system"].(string); ok && system != "" {
+		body["system_prompt"] = system
 	}
 	if len(mcpServers) > 0 {
 		body["mcp_servers"] = mcpServers

--- a/internal/environments/environment_manager.go
+++ b/internal/environments/environment_manager.go
@@ -25,6 +25,7 @@ These rules describe the current sandbox environment and do not replace your ass
 ## Uploaded inputs
 
 - A public/API path /uploads/<relative-path> is available inside the sandbox at /mnt/session/uploads/<relative-path>. Use the sandbox path when accessing the file; do not try to open /uploads/... inside the sandbox.
+- If the user provides a public/API path /uploads/<relative-path>, use /mnt/session/uploads/<relative-path> inside the sandbox. Never form /mnt/session/uploads/uploads/<relative-path>.
 - /mnt/session/uploads is read-only. Do not modify files under this directory.
 - Mandatory lookup order: for every filename or relative file path mentioned by the user, check /mnt/session/uploads before the working directory, even if the user does not say the file was uploaded. Never run a working-directory-only search first.
 - First try the exact sandbox path /mnt/session/uploads/<user-provided-relative-path>. If only a filename is known or that exact path is absent, search recursively with Glob using path /mnt/session/uploads and pattern **/<filename>. Omitting path searches only the working directory and does not satisfy this rule.

--- a/tests/environments_full_e2b_bridge_integration_test.go
+++ b/tests/environments_full_e2b_bridge_integration_test.go
@@ -4,6 +4,7 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -18,8 +19,6 @@ import (
 	e2b "github.com/superduck-ai/e2b-go-sdk"
 )
 
-const fullE2BManagedAgentSandboxImage = "ghcr.io/superduck-ai/managed-agent-sandbox:latest"
-
 func TestE2BManagedAgentBridgeEnvironmentManagerIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping real E2B managed-agent bridge integration test in short mode")
@@ -32,7 +31,6 @@ func TestE2BManagedAgentBridgeEnvironmentManagerIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load config: %v", err)
 	}
-	cfg.E2B.Template = fullE2BManagedAgentSandboxImage
 	requireFullE2BBridgeConfig(t, cfg)
 	t.Logf("Testing managed-agent sandbox image %s", cfg.E2B.Template)
 	if cfg.E2B.RequestTimeout < 2*time.Minute {
@@ -46,6 +44,9 @@ func TestE2BManagedAgentBridgeEnvironmentManagerIntegration(t *testing.T) {
 	// so the test app and that ingress must share the configured object store.
 	app := newTestApp(t, &cfg)
 	defer app.close()
+	if quickstartLooksLikeLoopbackURL(cfg.E2B.APIURL) {
+		app.cfg.CodeSession.SandboxAPIBaseURL = ""
+	}
 	quickstartEnsureSandboxIngress(t, app)
 	cfg = app.cfg
 
@@ -108,14 +109,14 @@ func TestE2BManagedAgentBridgeEnvironmentManagerIntegration(t *testing.T) {
 		}
 	}()
 
-	file := uploadFile(t, app, "e2b-data.csv", "text/csv", []byte("name,value\nalpha,1\n"))
+	file := uploadFile(t, app, "config.example.yaml", "text/yaml", []byte("value=41\n"))
 	uploadedFileID = file.ID
 	resourceResponse := doSessionRequest(
 		t,
 		app,
 		http.MethodPost,
 		"/v1/sessions/"+session.ID+"/resources?beta=true",
-		strings.NewReader(fmt.Sprintf(`{"type":"file","file_id":%q,"mount_path":"/workspace/data.csv"}`, file.ID)),
+		strings.NewReader(fmt.Sprintf(`{"type":"file","file_id":%q,"mount_path":"/config.example.yaml"}`, file.ID)),
 		defaultTestKey,
 		true,
 	)
@@ -124,16 +125,42 @@ func TestE2BManagedAgentBridgeEnvironmentManagerIntegration(t *testing.T) {
 		t.Fatalf("add E2B file resource status = %d: %s", resourceResponse.StatusCode, readAll(t, resourceResponse.Body))
 	}
 
+	sendText := func(text string) string {
+		t.Helper()
+		response, err := client.Beta.Sessions.Events.Send(ctx, session.ID, anthropic.BetaSessionEventSendParams{
+			Events: []anthropic.BetaManagedAgentsEventParamsUnion{{
+				OfUserMessage: &anthropic.BetaManagedAgentsUserMessageEventParams{
+					Type: anthropic.BetaManagedAgentsUserMessageEventParamsTypeUserMessage,
+					Content: []anthropic.BetaManagedAgentsUserMessageEventParamsContentUnion{{
+						OfText: &anthropic.BetaManagedAgentsTextBlockParam{
+							Type: anthropic.BetaManagedAgentsTextBlockTypeText,
+							Text: text,
+						},
+					}},
+				},
+			}},
+		})
+		if err != nil {
+			t.Fatalf("send E2B file task: %v", err)
+		}
+		if len(response.Data) != 1 {
+			t.Fatalf("sent session events = %d, want 1", len(response.Data))
+		}
+		return response.Data[0].ID
+	}
+	firstMessageID := sendText("帮我看下 config.example.yaml 都有什么内容？")
+
 	workID := quickstartFindSessionEnvironmentWorkID(t, app, environment.ID, session.ID)
 
 	provider := e2bruntime.NewProvider(cfg.E2B)
 	var providerSandboxID string
 	stopped := false
 	defer func() {
-		if providerSandboxID != "" && !stopped {
-			killCtx, cancelKill := context.WithTimeout(context.Background(), 2*time.Minute)
-			defer cancelKill()
-			_ = provider.Kill(killCtx, providerSandboxID)
+		if !stopped {
+			stopCtx, cancelStop := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancelStop()
+			quickstartStopEnvironmentWork(t, stopCtx, app, environment.ID, workID)
+			stopped = true
 		}
 	}()
 
@@ -160,18 +187,18 @@ func TestE2BManagedAgentBridgeEnvironmentManagerIntegration(t *testing.T) {
 	}
 	sandboxRecord, err := app.db.GetActiveEnvironmentSandboxForWork(
 		ctx,
-		getDefaultDBIDs(t, app.pool).WorkspaceID,
+		getDefaultDBIDs(t, app.pool).WorkspaceUUID,
 		environment.ID,
 		workID,
 	)
 	if err != nil {
 		t.Fatalf("load active E2B sandbox record: %v", err)
 	}
-	if sandboxRecord.Template != fullE2BManagedAgentSandboxImage {
+	if sandboxRecord.Template != cfg.E2B.Template {
 		t.Fatalf(
 			"E2B sandbox template = %q, want %q",
 			sandboxRecord.Template,
-			fullE2BManagedAgentSandboxImage,
+			cfg.E2B.Template,
 		)
 	}
 
@@ -185,6 +212,22 @@ func TestE2BManagedAgentBridgeEnvironmentManagerIntegration(t *testing.T) {
 	assertE2BFilestoreMounts(t, ctx, sandbox)
 	probe := waitForEnvironmentManagerProcess(t, ctx, sandbox, codeSessionID)
 	t.Logf("environment-manager started for code session %s in sandbox %s:\n%s", codeSessionID, providerSandboxID, probe)
+	waitForAgentMessageContaining(t, ctx, app, session.ID, firstMessageID, "value=41")
+	sendText("把刚才读取到的 value 值加 1，只把结果和一个换行写到用户可下载的 result.txt。")
+	waitForManagedAgentOutput(t, ctx, sandbox, "/mnt/user-data/outputs/result.txt")
+	output := waitForSessionOutputFile(t, ctx, app, session.ID, "result.txt")
+	if !output.Downloadable {
+		t.Fatalf("output file %s is not downloadable: %+v", output.ID, output)
+	}
+	response := app.do(t, http.MethodGet, "/v1/files/"+output.ID+"/content?beta=true", nil, defaultTestKey, true, "")
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("download output status = %d: %s", response.StatusCode, readAll(t, response.Body))
+	}
+	if downloaded := readAll(t, response.Body); string(downloaded) != "42\n" {
+		t.Fatalf("downloaded output = %q, want %q", downloaded, "42\\n")
+	}
+	t.Logf("Agent output %s was cataloged as %s and downloaded successfully", output.Filename, output.ID)
 
 	quickstartStopEnvironmentWork(t, ctx, app, environment.ID, workID)
 	stopped = true
@@ -196,15 +239,14 @@ func assertE2BFilestoreMounts(t *testing.T, ctx context.Context, sandbox *e2b.Sa
 set -eu
 test -x /opt/rclone/rclone-filestore
 test ! -e /tmp/rclone-mount-config.json
-test "$(cat /mnt/session/uploads/workspace/data.csv)" = "name,value
-alpha,1"
+test "$(cat /mnt/session/uploads/config.example.yaml)" = "value=41"
 printf 'output-ok\n' > /mnt/user-data/outputs/e2b-output.txt
 test "$(cat /mnt/user-data/outputs/e2b-output.txt)" = "output-ok"
 for target in \
 	/mnt/session/uploads/e2b-readonly-test \
 	/mnt/transcripts/e2b-readonly-test \
 	/mnt/user-data/tool_results/e2b-readonly-test \
-	/mnt/session/uploads/workspace/data.csv
+	/mnt/session/uploads/config.example.yaml
 do
 	if printf 'must-fail\n' > "$target"; then
 		echo "readonly write unexpectedly succeeded: $target" >&2
@@ -219,6 +261,107 @@ printf 'e2b-filestore-ok\n'
 	}
 	if !strings.Contains(stdout, "e2b-filestore-ok") {
 		t.Fatalf("real E2B filestore probe did not finish:\nstdout=%s\nstderr=%s", stdout, stderr)
+	}
+}
+
+func waitForManagedAgentOutput(t *testing.T, ctx context.Context, sandbox *e2b.Sandbox, outputPath string) {
+	t.Helper()
+	command := "test -f " + shellPath(outputPath)
+	deadline := time.Now().Add(4 * time.Minute)
+	var lastErr error
+	for {
+		_, _, lastErr = runE2BCommand(ctx, sandbox, command, 30*time.Second)
+		if lastErr == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("managed agent did not create %s: %v", outputPath, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("waiting for managed agent output %s: %v", outputPath, ctx.Err())
+		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+func waitForAgentMessageContaining(t *testing.T, ctx context.Context, app *testApp, sessionID, afterEventID, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Minute)
+	for {
+		page := listSessionEvents(t, app, sessionID, "order=asc&limit=1000", defaultTestKey)
+		var messages []string
+		boundarySeen := false
+		started := false
+		finished := false
+		for _, raw := range page.Data {
+			var event map[string]any
+			if err := json.Unmarshal(raw, &event); err != nil {
+				t.Fatalf("decode session event: %v", err)
+			}
+			if event["id"] == afterEventID {
+				boundarySeen = true
+				continue
+			}
+			if !boundarySeen {
+				continue
+			}
+			switch event["type"] {
+			case "agent.message":
+				started = true
+				text := rawAgentMessageText(event)
+				messages = append(messages, text)
+				if strings.Contains(text, want) {
+					return
+				}
+			case "agent.thinking", "agent.tool_use", "agent.tool_result", "agent.mcp_tool_use", "agent.mcp_tool_result":
+				started = true
+			case "session.status_idle":
+				finished = started && event["stop_reason"] != nil
+			}
+		}
+		if finished {
+			t.Fatalf("agent messages = %q, want one to contain %q", messages, want)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("managed agent did not answer with %q; messages = %q", want, messages)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("waiting for managed agent response: %v", ctx.Err())
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+func rawAgentMessageText(event map[string]any) string {
+	texts := make([]string, 0)
+	for _, block := range quickstartContentBlocks(event) {
+		if block["type"] == "text" {
+			texts = append(texts, quickstartStringValue(block["text"]))
+		}
+	}
+	return strings.Join(texts, "\n")
+}
+
+func waitForSessionOutputFile(t *testing.T, ctx context.Context, app *testApp, sessionID, filename string) metadataResponse {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		page := listFiles(t, app, "scope_id="+sessionID+"&limit=100")
+		for _, file := range page.Data {
+			if file.Filename == filename {
+				return file
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("session output %q did not enter the Files API catalog: %+v", filename, page.Data)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("waiting for session output %q in Files API: %v", filename, ctx.Err())
+		case <-time.After(time.Second):
+		}
 	}
 }
 

--- a/tests/environments_runner_cloud_test.go
+++ b/tests/environments_runner_cloud_test.go
@@ -198,6 +198,37 @@ func TestEnvironmentRunnerLaunchesManagedAgentCloudSession(t *testing.T) {
 	if len(queued) != 2 || queued[0].EventType != "control_request" || queued[0].EventSubtype != "initialize" || queued[1].EventType != "user" {
 		t.Fatalf("unexpected queued inbound events: %#v", queued)
 	}
+	var initialize map[string]any
+	if err := json.Unmarshal(queued[0].Payload, &initialize); err != nil {
+		t.Fatalf("decode initialize worker event: %v", err)
+	}
+	initializeRequest := initialize["request"].(map[string]any)
+	if initializeRequest["systemPrompt"] != "You are a concise coding assistant." {
+		t.Fatalf("initialize systemPrompt = %q", initializeRequest["systemPrompt"])
+	}
+	const expectedManagedAgentEnvironmentPrompt = `# Managed-agent environment
+
+These rules describe the current sandbox environment and do not replace your assigned role.
+
+## Uploaded inputs
+
+- A public/API path /uploads/<relative-path> is available inside the sandbox at /mnt/session/uploads/<relative-path>. Use the sandbox path when accessing the file; do not try to open /uploads/... inside the sandbox.
+- /mnt/session/uploads is read-only. Do not modify files under this directory.
+- Mandatory lookup order: for every filename or relative file path mentioned by the user, check /mnt/session/uploads before the working directory, even if the user does not say the file was uploaded. Never run a working-directory-only search first.
+- First try the exact sandbox path /mnt/session/uploads/<user-provided-relative-path>. If only a filename is known or that exact path is absent, search recursively with Glob using path /mnt/session/uploads and pattern **/<filename>. Omitting path searches only the working directory and does not satisfy this rule.
+- Search the working directory only after the uploads check finds no match. Do not report a file missing until both locations have been checked in this order.
+- Uploaded filenames and paths are authoritative. Use an exact path when provided; otherwise, use only a path returned by inspecting /mnt/session/uploads. If multiple files match, ask the user which one to use.
+- Never guess, truncate, rename, or reconstruct an uploaded input path. Do not infer an upload path from metadata such as a file ID.
+
+## Output deliverables
+
+- /mnt/user-data/outputs is read-write. Write every file intended as a user-facing session output to /mnt/user-data/outputs/<relative-path>.
+- A file written there is surfaced at the corresponding public/API path /outputs/<relative-path>. Do not write to /outputs/... inside the sandbox.
+- Files written outside /mnt/user-data/outputs are working files and are not surfaced as session outputs.
+- Keep normal repository and source-code edits in the repository working directory. Do not redirect them to /mnt/user-data/outputs; only exported, user-facing deliverables belong there.`
+	if initializeRequest["appendSystemPrompt"] != expectedManagedAgentEnvironmentPrompt {
+		t.Fatalf("initialize appendSystemPrompt = %q", initializeRequest["appendSystemPrompt"])
+	}
 	var initial map[string]any
 	if err := json.Unmarshal(queued[1].Payload, &initial); err != nil {
 		t.Fatalf("decode initial worker event: %v", err)

--- a/tests/environments_runner_cloud_test.go
+++ b/tests/environments_runner_cloud_test.go
@@ -213,6 +213,7 @@ These rules describe the current sandbox environment and do not replace your ass
 ## Uploaded inputs
 
 - A public/API path /uploads/<relative-path> is available inside the sandbox at /mnt/session/uploads/<relative-path>. Use the sandbox path when accessing the file; do not try to open /uploads/... inside the sandbox.
+- If the user provides a public/API path /uploads/<relative-path>, use /mnt/session/uploads/<relative-path> inside the sandbox. Never form /mnt/session/uploads/uploads/<relative-path>.
 - /mnt/session/uploads is read-only. Do not modify files under this directory.
 - Mandatory lookup order: for every filename or relative file path mentioned by the user, check /mnt/session/uploads before the working directory, even if the user does not say the file was uploaded. Never run a working-directory-only search first.
 - First try the exact sandbox path /mnt/session/uploads/<user-provided-relative-path>. If only a filename is known or that exact path is absent, search recursively with Glob using path /mnt/session/uploads and pattern **/<filename>. Omitting path searches only the working directory and does not satisfy this rule.

--- a/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
@@ -613,13 +613,18 @@ export function registerManagedAgentsResourceTests() {
     const workspaceTabs = screen.getByRole('tablist', { name: 'Session workspace' });
     fireEvent.click(within(workspaceTabs).getByRole('tab', { name: /Resources/ }));
     expect((await screen.findByText('Mounted resources')).closest('[data-session-workspace-card]')).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeTruthy();
     expect(screen.getByRole('columnheader', { name: 'Type' })).toBeTruthy();
-    expect(screen.getByRole('columnheader', { name: 'Resource ID' })).toBeTruthy();
     expect(screen.getByRole('columnheader', { name: 'File ID' })).toBeTruthy();
     expect(screen.getByRole('columnheader', { name: 'Mount path' })).toBeTruthy();
-    expect(screen.getByText('sesrsc_orders123456')).toBeTruthy();
+    expect(await screen.findByText('source-orders.zip')).toBeTruthy();
     expect(screen.getByText('file_orders123456')).toBeTruthy();
     expect(screen.getByText('/uploads/orders.zip')).toBeTruthy();
+    expect(
+      api.requests.some(
+        (request) => request.url === '/v1/files/file_orders123456?beta=true' && request.method === 'GET',
+      ),
+    ).toBe(true);
     expect(api.requests.some((request) => request.url.startsWith('/v1/files?'))).toBe(false);
     expect(
       api.requests.some(

--- a/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
@@ -750,6 +750,52 @@ export function registerManagedAgentsResourceTests() {
     }
   });
 
+  test('preserves live session state and reports Get Session failures when refreshing resources', async () => {
+    resetTestDom('https://oma.duck.ai/workspaces/default/sessions/sesn_one123456');
+    const api = mockManagedResourceApi();
+    api.resources.sessionEvents = api.resources.sessionEvents.filter((event) => event.type !== 'session.status_idle');
+    const baseFetch = globalThis.fetch;
+    let failResourceRefresh = false;
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (
+        failResourceRefresh &&
+        requestUrl(input) === '/v1/sessions/sesn_one123456?beta=true' &&
+        requestMethod(input, init) === 'GET'
+      ) {
+        return new Response(JSON.stringify({ error: { message: 'resource refresh failed' } }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return baseFetch(input, init);
+    }) as typeof fetch;
+
+    try {
+      renderManagedAgentsPage('sessions');
+
+      expect((await screen.findAllByText('Running')).length).toBeGreaterThan(0);
+      api.resources.sessions[0].status = 'idle';
+      api.resources.sessions[0].resources.push({
+        id: 'sesrsc_new_output123456',
+        type: 'file',
+        created_at: new Date().toISOString(),
+        file_id: 'file_new_output123456',
+        mount_path: '/outputs/new-output.txt',
+      });
+      const resourcesTab = screen.getByRole('tab', { name: /Resources/ });
+      fireEvent.click(resourcesTab);
+
+      expect(await screen.findByText('file_new_output123456')).toBeTruthy();
+      expect(screen.getAllByText('Running').length).toBeGreaterThan(0);
+
+      failResourceRefresh = true;
+      fireEvent.click(resourcesTab);
+      expect(await screen.findByText('resource refresh failed')).toBeTruthy();
+    } finally {
+      globalThis.fetch = baseFetch;
+    }
+  });
+
   test('renders transcript idle gaps with the original striped separator', async () => {
     resetTestDom('https://oma.duck.ai/workspaces/default/sessions/sesn_one123456');
     window.localStorage.removeItem('oma.sessionDetail.showArchivedLanes');

--- a/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
@@ -610,7 +610,13 @@ export function registerManagedAgentsResourceTests() {
     const workspaceTabs = screen.getByRole('tablist', { name: 'Session workspace' });
     fireEvent.click(within(workspaceTabs).getByRole('tab', { name: /Resources/ }));
     expect((await screen.findByText('Mounted resources')).closest('[data-session-workspace-card]')).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'Type' })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'File ID' })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'Mount path' })).toBeTruthy();
     expect(screen.getByText('orders.zip')).toBeTruthy();
+    expect(screen.getByText('file_orders123456')).toBeTruthy();
+    expect(screen.getByText('/uploads/orders.zip')).toBeTruthy();
 
     fireEvent.click(within(workspaceTabs).getByRole('tab', { name: 'Agent' }));
     const agentHeadings = await screen.findAllByText('Ecommerce Basket Analysis Agent');

--- a/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
@@ -407,7 +407,10 @@ export function registerManagedAgentsResourceTests() {
     await waitFor(() =>
       expect(api.requests.some((request) => request.url === '/v1/sessions/sesn_one123456?beta=true')).toBe(true),
     );
-    expect(api.requests.some((request) => request.url.startsWith('/v1/sessions/sesn_one123456/resources?'))).toBe(true);
+    expect(api.requests.some((request) => request.url.startsWith('/v1/files?'))).toBe(false);
+    expect(api.requests.some((request) => request.url.startsWith('/v1/sessions/sesn_one123456/resources?'))).toBe(
+      false,
+    );
     expect(api.requests.some((request) => request.url.startsWith('/v1/sessions/sesn_one123456/threads?'))).toBe(true);
     expect(api.requests.some((request) => request.url.startsWith('/v1/sessions/sesn_one123456/events?'))).toBe(true);
     expect(
@@ -610,13 +613,19 @@ export function registerManagedAgentsResourceTests() {
     const workspaceTabs = screen.getByRole('tablist', { name: 'Session workspace' });
     fireEvent.click(within(workspaceTabs).getByRole('tab', { name: /Resources/ }));
     expect((await screen.findByText('Mounted resources')).closest('[data-session-workspace-card]')).toBeTruthy();
-    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeTruthy();
     expect(screen.getByRole('columnheader', { name: 'Type' })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'Resource ID' })).toBeTruthy();
     expect(screen.getByRole('columnheader', { name: 'File ID' })).toBeTruthy();
     expect(screen.getByRole('columnheader', { name: 'Mount path' })).toBeTruthy();
-    expect(screen.getByText('orders.zip')).toBeTruthy();
+    expect(screen.getByText('sesrsc_orders123456')).toBeTruthy();
     expect(screen.getByText('file_orders123456')).toBeTruthy();
     expect(screen.getByText('/uploads/orders.zip')).toBeTruthy();
+    expect(api.requests.some((request) => request.url.startsWith('/v1/files?'))).toBe(false);
+    expect(
+      api.requests.some(
+        (request) => request.url.startsWith('/v1/sessions/sesn_one123456/resources?') && request.method === 'GET',
+      ),
+    ).toBe(false);
 
     fireEvent.click(within(workspaceTabs).getByRole('tab', { name: 'Agent' }));
     const agentHeadings = await screen.findAllByText('Ecommerce Basket Analysis Agent');
@@ -639,7 +648,7 @@ export function registerManagedAgentsResourceTests() {
     expect(screen.getByText(/Secret values are never shown here/)).toBeTruthy();
   });
 
-  test('shows a sent message without refreshing an idle session page', async () => {
+  test('refreshes session resources from Get Session only when the Resources tab is clicked', async () => {
     resetTestDom('https://oma.duck.ai/workspaces/default/sessions/sesn_one123456');
     const api = mockManagedResourceApi();
     api.resources.sessions[0].status = 'idle';
@@ -664,6 +673,7 @@ export function registerManagedAgentsResourceTests() {
     const fetchSessionEvents = globalThis.fetch;
     let staleReadAfterPost = false;
     let messagePosted = false;
+    let outputAdded = false;
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = requestUrl(input);
       const method = requestMethod(input, init);
@@ -675,6 +685,16 @@ export function registerManagedAgentsResourceTests() {
       }
       if (messagePosted && url.startsWith('/v1/sessions/sesn_one123456/events/stream?') && method === 'GET') {
         const now = new Date().toISOString();
+        if (!outputAdded) {
+          api.resources.sessions[0].resources.push({
+            id: 'sesrsc_report123456',
+            type: 'file',
+            created_at: now,
+            file_id: 'file_report123456',
+            mount_path: '/outputs/report.csv',
+          });
+          outputAdded = true;
+        }
         const frames = [
           { id: 'evt_running_after_send', type: 'session.status_running', created_at: now },
           {
@@ -707,6 +727,8 @@ export function registerManagedAgentsResourceTests() {
       renderManagedAgentsPage('sessions');
 
       expect(await screen.findByText('Existing message.')).toBeTruthy();
+      const sessionURL = '/v1/sessions/sesn_one123456?beta=true';
+      const initialSessionRequestCount = api.requests.filter((request) => request.url === sessionURL).length;
       const composer = await screen.findByRole('textbox', { name: 'Message' });
       fireEvent.change(composer, { target: { value: 'Render this message immediately.' } });
       fireEvent.keyDown(composer, { key: 'Enter', shiftKey: false });
@@ -714,6 +736,15 @@ export function registerManagedAgentsResourceTests() {
       await waitFor(() => expect((composer as HTMLTextAreaElement).value).toBe(''));
       expect(await screen.findByText('Render this message immediately.')).toBeTruthy();
       expect(await screen.findByText('Agent reply arrived live.')).toBeTruthy();
+      expect(api.requests.filter((request) => request.url === sessionURL)).toHaveLength(initialSessionRequestCount);
+      const workspaceTabs = screen.getByRole('tablist', { name: 'Session workspace' });
+      fireEvent.click(within(workspaceTabs).getByRole('tab', { name: /Resources/ }));
+      expect(await screen.findByText('file_report123456')).toBeTruthy();
+      expect(await screen.findByText('/outputs/report.csv')).toBeTruthy();
+      expect(api.requests.filter((request) => request.url === sessionURL).length).toBeGreaterThan(
+        initialSessionRequestCount,
+      );
+      expect(api.requests.some((request) => request.url.startsWith('/v1/files?'))).toBe(false);
     } finally {
       globalThis.fetch = fetchSessionEvents;
     }

--- a/web/src/features/managed-agents/ManagedAgentsPage.test-utils.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.test-utils.tsx
@@ -868,10 +868,11 @@ export function mockManagedResourceApi() {
     ],
     sessionResources: [
       {
-        id: 'file_orders123456',
+        id: 'sesrsc_orders123456',
         type: 'file',
         created_at: new Date(Date.now() - 80_000).toISOString(),
-        filename: 'orders.zip',
+        file_id: 'file_orders123456',
+        mount_path: '/uploads/orders.zip',
       },
     ],
     sessionThreads: [

--- a/web/src/features/managed-agents/ManagedAgentsPage.test-utils.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.test-utils.tsx
@@ -845,6 +845,15 @@ export function mockAgentsApi(initialAgents: AgentFixture[], options: MockAgents
 export function mockManagedResourceApi() {
   const now = new Date().toISOString();
   const requests: RecordedRequest[] = [];
+  const sessionResources = [
+    {
+      id: 'sesrsc_orders123456',
+      type: 'file',
+      created_at: new Date(Date.now() - 80_000).toISOString(),
+      file_id: 'file_orders123456',
+      mount_path: '/uploads/orders.zip',
+    },
+  ];
   const resources = {
     agents: [
       agentResponse({
@@ -864,17 +873,10 @@ export function mockManagedResourceApi() {
         type: 'session',
         updated_at: now,
         vault_ids: ['vlt_one123456'],
+        resources: sessionResources,
       },
     ],
-    sessionResources: [
-      {
-        id: 'sesrsc_orders123456',
-        type: 'file',
-        created_at: new Date(Date.now() - 80_000).toISOString(),
-        file_id: 'file_orders123456',
-        mount_path: '/uploads/orders.zip',
-      },
-    ],
+    sessionResources,
     sessionThreads: [
       {
         id: 'sthr_reporter123456',

--- a/web/src/features/managed-agents/ManagedAgentsPage.test-utils.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.test-utils.tsx
@@ -1391,6 +1391,21 @@ export function mockManagedResourceApi() {
       const session = resources.sessions.find((item) => item.id === sessionId);
       return session ? jsonResponse(session) : jsonResponse({ error: { message: 'not found' } }, 404);
     }
+    const fileMetadataMatch = url.match(/^\/v1\/files\/([^/?]+)\?beta=true$/);
+    if (fileMetadataMatch && method === 'GET') {
+      const fileId = decodeURIComponent(fileMetadataMatch[1]);
+      return jsonResponse({
+        id: fileId,
+        type: 'file',
+        filename: 'source-orders.zip',
+        size_bytes: 2_048,
+        mime_type: 'application/zip',
+        created_at: new Date(Date.now() - 100_000).toISOString(),
+        downloadable: true,
+        scope: null,
+        metadata: {},
+      });
+    }
     const sessionResourcesMatch = url.match(/^\/v1\/sessions\/([^/?]+)\/resources\?/);
     if (sessionResourcesMatch && method === 'GET') {
       return jsonResponse({ data: resources.sessionResources, next_page: null });

--- a/web/src/features/managed-agents/api.ts
+++ b/web/src/features/managed-agents/api.ts
@@ -607,12 +607,6 @@ export async function listAllSessionThreads(sessionId: string, workspaceId: stri
   });
 }
 
-export function listSessionResourcesForDetail(sessionId: string, workspaceId: string) {
-  return sessionDetailSingleFlight(`resources:${workspaceId}:${sessionId}`, () =>
-    listSessionResources(sessionId, workspaceId),
-  );
-}
-
 export function listSessionEvents(
   sessionId: string,
   workspaceId: string,

--- a/web/src/features/managed-agents/api.ts
+++ b/web/src/features/managed-agents/api.ts
@@ -23,6 +23,7 @@ import {
   type DeploymentRunApiResponse,
   type EnvironmentApiResponse,
   type EnvironmentWorkApiResponse,
+  type FileMetadataApiResponse,
   type ManagedEntityApiResponse,
   type ManagedEntityFormValues,
   type ManagedEntityListFilters,
@@ -553,6 +554,10 @@ export function listSessionResources(sessionId: string, workspaceId: string) {
   return anthropicBetaApi.sessions.resources.list<SessionResourceApiResponse>(sessionId, {}, workspaceId) as Promise<
     PageResponse<SessionResourceApiResponse>
   >;
+}
+
+export function retrieveFileMetadata(fileId: string, workspaceId: string) {
+  return anthropicBetaApi.files.retrieveMetadata<FileMetadataApiResponse>(fileId, workspaceId);
 }
 
 export const SESSION_DETAIL_EVENT_PAGE_LIMIT = 500;

--- a/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
+++ b/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
@@ -105,6 +105,7 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [metadataError, setMetadataError] = useState<string | null>(null);
+  const [resourceRefreshError, setResourceRefreshError] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
   const [eventRefreshKey, setEventRefreshKey] = useState(0);
@@ -154,9 +155,10 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
       return;
     }
     const activeSessionId = session.id;
+    setResourceRefreshError(null);
     void retrieveSessionDetailSession(activeSessionId, activeWorkspaceId)
-      .then((updatedSession) => setSession(updatedSession))
-      .catch(() => undefined);
+      .then((updatedSession) => setSession((currentSession) => mergeSessionResources(currentSession, updatedSession)))
+      .catch((error) => setResourceRefreshError(errorMessage(error)));
   }, [activeWorkspaceId, session?.id]);
   const activeSessionId = session?.id ?? null;
   const handlePrimaryStreamEvent = useCallback(
@@ -190,6 +192,7 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
     setLoading(true);
     setLoadError(null);
     setMetadataError(null);
+    setResourceRefreshError(null);
     setThreads([]);
     setMetadataLoaded(false);
     void (async () => {
@@ -558,6 +561,7 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
 
   const archived = Boolean(session.archived_at);
   const conversationState = sessionConversationState(session);
+  const warningError = [resourceRefreshError, metadataError, eventError].find(Boolean);
 
   return (
     <TooltipProvider>
@@ -689,9 +693,7 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
         </header>
 
         {mutationError ? <ManagedErrorAlert className="mb-4 max-w-xl">{mutationError}</ManagedErrorAlert> : null}
-        {metadataError || eventError ? (
-          <ManagedWarningAlert className="mb-4 max-w-xl">{metadataError || eventError}</ManagedWarningAlert>
-        ) : null}
+        {warningError ? <ManagedWarningAlert className="mb-4 max-w-xl">{warningError}</ManagedWarningAlert> : null}
 
         <Tabs defaultValue="events" className="min-h-0 flex-1 gap-0">
           <div className="border-b border-border">
@@ -808,6 +810,12 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
 
 export function EventsTab(props: EventsTabProps) {
   return <EventsTabInner {...props} />;
+}
+
+function mergeSessionResources(currentSession: SessionApiResponse | null, updatedSession: SessionApiResponse) {
+  return currentSession?.id === updatedSession.id
+    ? { ...currentSession, resources: updatedSession.resources }
+    : currentSession;
 }
 
 function sessionConversationState(session: SessionApiResponse) {

--- a/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
+++ b/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
@@ -16,7 +16,6 @@ import {
   archiveManagedEntity,
   deleteManagedEntity,
   listAllSessionThreads,
-  listSessionResourcesForDetail,
   retrieveSessionDetailSession,
   SESSION_DETAIL_CHILD_REFETCH_INTERVAL_MS,
   sessionThreadListSignature,
@@ -31,7 +30,6 @@ import {
   type SessionApiResponse,
   type SessionDebugDetailTab,
   type SessionEventListEntry,
-  type SessionResourceApiResponse,
   type SessionThreadApiResponse,
   type SessionTraceFilterOption,
   type SessionTraceView,
@@ -103,7 +101,6 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
   const listHref = managedEntityListHref(activeWorkspaceId, 'sessions');
   const listLabel = resourceTitle(config, msg);
   const [session, setSession] = useState<SessionApiResponse | null>(null);
-  const [resources, setResources] = useState<SessionResourceApiResponse[]>([]);
   const [threads, setThreads] = useState<SessionThreadApiResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -152,7 +149,7 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
       })().catch(() => undefined);
     }, 600);
   }, [activeWorkspaceId, session?.id]);
-  const refreshSessionMetadata = useCallback(() => {
+  const refreshSessionResources = useCallback(() => {
     if (!session?.id) {
       return;
     }
@@ -183,11 +180,9 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
       }
       if (type === 'session.thread_created') {
         refreshSessionThreads();
-      } else if (type === 'session.updated') {
-        refreshSessionMetadata();
       }
     },
-    [activeSessionId, refreshSessionMetadata, refreshSessionThreads],
+    [activeSessionId, refreshSessionThreads],
   );
 
   useEffect(() => {
@@ -195,7 +190,6 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
     setLoading(true);
     setLoadError(null);
     setMetadataError(null);
-    setResources([]);
     setThreads([]);
     setMetadataLoaded(false);
     void (async () => {
@@ -207,26 +201,20 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
         setSession(loadedSession);
         setLoading(false);
 
-        const [resourcesResult, threadsResult] = await Promise.allSettled([
-          listSessionResourcesForDetail(loadedSession.id, activeWorkspaceId),
-          listAllSessionThreads(loadedSession.id, activeWorkspaceId),
-        ]);
-        if (!active) {
-          return;
+        try {
+          const threadsPage = await listAllSessionThreads(loadedSession.id, activeWorkspaceId);
+          if (active) {
+            setThreads(threadsPage.data ?? []);
+          }
+        } catch (error) {
+          if (active) {
+            setMetadataError(errorMessage(error));
+          }
+        } finally {
+          if (active) {
+            setMetadataLoaded(true);
+          }
         }
-        const loadedThreads = threadsResult.status === 'fulfilled' ? (threadsResult.value.data ?? []) : [];
-        if (resourcesResult.status === 'fulfilled') {
-          setResources(resourcesResult.value.data ?? []);
-        }
-        if (threadsResult.status === 'fulfilled') {
-          setThreads(loadedThreads);
-        }
-        setMetadataLoaded(true);
-        const settledResults = [resourcesResult, threadsResult] as PromiseSettledResult<unknown>[];
-        const firstRejected = settledResults.find(
-          (result): result is PromiseRejectedResult => result.status === 'rejected',
-        );
-        setMetadataError(firstRejected ? errorMessage(firstRejected.reason) : null);
       } catch (error) {
         if (active) {
           setSession(null);
@@ -379,8 +367,8 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
     [activeLane, entriesByLaneId, filteredEntries, query, selectedTypes, timeline, view],
   );
   const summary = useMemo(
-    () => (session ? buildSessionDetailSummary(session, resources, sortedEvents, formatters, msg) : null),
-    [formatters, msg, resources, session, sortedEvents],
+    () => (session ? buildSessionDetailSummary(session, session.resources, sortedEvents, formatters, msg) : null),
+    [formatters, msg, session, sortedEvents],
   );
   const copyPayload = useMemo(() => sessionDetailEventCopyPayload(filteredEntries, view), [filteredEntries, view]);
 
@@ -716,7 +704,7 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
                 <ListTree className="size-4" aria-hidden />
                 {msg('managedAgents.sessions.detail.eventsTab', 'Events')}
               </TabsTrigger>
-              <TabsTrigger value="resources" className="h-10 flex-none gap-2 px-1">
+              <TabsTrigger value="resources" className="h-10 flex-none gap-2 px-1" onClick={refreshSessionResources}>
                 <FolderOpen className="size-4" aria-hidden />
                 {msg('managedAgents.sessions.detail.resourcesTab', 'Resources')}
               </TabsTrigger>
@@ -811,12 +799,7 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
               />
             </SessionDetailDeltaFramesContext.Provider>
           </TabsContent>
-          <SessionEntityPanels
-            refreshKey={refreshKey}
-            resources={resources}
-            session={session}
-            workspaceId={activeWorkspaceId}
-          />
+          <SessionEntityPanels refreshKey={refreshKey} session={session} workspaceId={activeWorkspaceId} />
         </Tabs>
       </section>
     </TooltipProvider>

--- a/web/src/features/managed-agents/sessions/SessionEntityPanels.tsx
+++ b/web/src/features/managed-agents/sessions/SessionEntityPanels.tsx
@@ -38,12 +38,10 @@ const emptyRelatedEntities: RelatedEntities = {
 
 export function SessionEntityPanels({
   refreshKey,
-  resources,
   session,
   workspaceId,
 }: {
   refreshKey: number;
-  resources: SessionResourceApiResponse[];
   session: SessionApiResponse;
   workspaceId: string;
 }) {
@@ -67,8 +65,8 @@ export function SessionEntityPanels({
             'Files, repositories, and memory stores available inside this session.',
           )}
         >
-          {resources.length ? (
-            <ResourceTable resources={resources} />
+          {session.resources.length ? (
+            <ResourceTable resources={session.resources} />
           ) : (
             <EmptyText>{msg('managedAgents.sessions.nested.noResources', 'No resources mounted')}</EmptyText>
           )}
@@ -361,41 +359,47 @@ function ResourceTable({ resources }: { resources: SessionResourceApiResponse[] 
 
   return (
     <div className="overflow-hidden rounded-lg border border-border">
-      <Table className="min-w-[860px] table-fixed text-left">
+      <Table className="min-w-[760px] table-fixed text-left">
+        <colgroup>
+          <col className="w-[18%]" />
+          <col className="w-[27%]" />
+          <col className="w-[27%]" />
+          <col className="w-[28%]" />
+        </colgroup>
         <TableHeader className="bg-card-raised text-muted-foreground">
           <TableRow className="hover:bg-transparent">
-            <TableHead className="w-[24%] px-4 text-muted-foreground">{msg('common.name', 'Name')}</TableHead>
-            <TableHead className="w-[120px] px-4 text-muted-foreground">
+            <TableHead className="px-5 text-muted-foreground">
               {msg('managedAgents.sessions.trace.type', 'Type')}
             </TableHead>
-            <TableHead className="w-[220px] px-4 text-muted-foreground">
+            <TableHead className="px-5 text-muted-foreground">
+              {msg('managedAgents.sessions.resources.resourceId', 'Resource ID')}
+            </TableHead>
+            <TableHead className="px-5 text-muted-foreground">
               {msg('managedAgents.sessions.resources.fileId', 'File ID')}
             </TableHead>
-            <TableHead className="px-4 text-muted-foreground">
+            <TableHead className="px-5 text-muted-foreground">
               {msg('managedAgents.sessions.resources.mountPath', 'Mount path')}
             </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {resources.map((resource, index) => {
-            const name = resourceName(resource);
-            const fileId = typeof resource.file_id === 'string' && resource.file_id ? resource.file_id : '—';
-            const path = resourcePath(resource) || '—';
+            const resourceId = resource.id ?? '—';
+            const fileId = resource.file_id ?? '—';
+            const mountPath = resource.mount_path ?? '—';
             return (
-              <TableRow key={String(resource.id ?? index)} className="bg-card text-foreground">
-                <TableCell className="h-12 truncate px-4 font-medium" title={name}>
-                  {name}
+              <TableRow key={resource.id ?? index} className="bg-card text-foreground">
+                <TableCell className="h-14 px-5">
+                  <Badge variant="secondary">{titleCase((resource.type ?? 'resource').replaceAll('_', ' '))}</Badge>
                 </TableCell>
-                <TableCell className="h-12 px-4">
-                  <Badge variant="secondary">
-                    {titleCase(String(resource.type ?? 'resource').replaceAll('_', ' '))}
-                  </Badge>
+                <TableCell className="h-14 truncate px-5 font-mono text-xs text-muted-foreground" title={resourceId}>
+                  {resourceId}
                 </TableCell>
-                <TableCell className="h-12 truncate px-4 font-mono text-xs text-muted-foreground" title={fileId}>
+                <TableCell className="h-14 truncate px-5 font-mono text-xs text-muted-foreground" title={fileId}>
                   {fileId}
                 </TableCell>
-                <TableCell className="h-12 truncate px-4 font-mono text-xs text-muted-foreground" title={path}>
-                  {path}
+                <TableCell className="h-14 truncate px-5 font-mono text-xs text-muted-foreground" title={mountPath}>
+                  {mountPath}
                 </TableCell>
               </TableRow>
             );
@@ -408,19 +412,6 @@ function ResourceTable({ resources }: { resources: SessionResourceApiResponse[] 
 
 function EmptyText({ children }: { children: React.ReactNode }) {
   return <div className="py-12 text-center text-sm text-muted-foreground">{children}</div>;
-}
-
-function resourceName(resource: SessionResourceApiResponse) {
-  for (const key of ['filename', 'name']) if (typeof resource[key] === 'string' && resource[key]) return resource[key];
-  const basename = resourcePath(resource).split('/').filter(Boolean).at(-1);
-  if (basename) return basename;
-  return String(resource.id ?? 'Resource');
-}
-
-function resourcePath(resource: SessionResourceApiResponse) {
-  for (const key of ['mount_path', 'path', 'repository', 'url'])
-    if (typeof resource[key] === 'string' && resource[key]) return resource[key];
-  return '';
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/web/src/features/managed-agents/sessions/SessionEntityPanels.tsx
+++ b/web/src/features/managed-agents/sessions/SessionEntityPanels.tsx
@@ -4,7 +4,7 @@ import { Badge } from '../../../shared/ui/badge';
 import { CardContent, CardDescription, CardHeader, CardTitle } from '../../../shared/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../../shared/ui/table';
 import { TabsContent } from '../../../shared/ui/tabs';
-import { listVaultCredentials, retrieveAgent, retrieveManagedEntity } from '../api';
+import { listVaultCredentials, retrieveAgent, retrieveFileMetadata, retrieveManagedEntity } from '../api';
 import { agentModelName } from '../agents/model';
 import { environmentPackageRows, credentialAuthLabel } from '../resources/model';
 import {
@@ -50,6 +50,7 @@ export function SessionEntityPanels({
   const agentVersion = typeof agentReference.version === 'number' ? agentReference.version : null;
   const vaultKey = (Array.isArray(session.vault_ids) ? session.vault_ids.filter(isNonEmptyString) : []).join('\0');
   const related = useRelatedEntities(agentId, agentVersion, session.environment_id, vaultKey, workspaceId, refreshKey);
+  const filenamesByFileId = useSessionFileNames(session.resources, workspaceId);
   const { msg } = useI18n();
   const emptyText = related.loading
     ? msg('common.loading', 'Loading...')
@@ -66,7 +67,7 @@ export function SessionEntityPanels({
           )}
         >
           {session.resources.length ? (
-            <ResourceTable resources={session.resources} />
+            <ResourceTable filenamesByFileId={filenamesByFileId} resources={session.resources} />
           ) : (
             <EmptyText>{msg('managedAgents.sessions.nested.noResources', 'No resources mounted')}</EmptyText>
           )}
@@ -82,6 +83,42 @@ export function SessionEntityPanels({
       />
     </>
   );
+}
+
+function useSessionFileNames(resources: SessionResourceApiResponse[], workspaceId: string) {
+  const [filenamesByFileId, setFilenamesByFileId] = useState<Record<string, string>>({});
+  useEffect(() => {
+    let active = true;
+    const fileIds = [
+      ...new Set(
+        resources
+          .filter((resource) => resource.type === 'file')
+          .map((resource) => resource.file_id)
+          .filter(isNonEmptyString),
+      ),
+    ];
+    void Promise.allSettled(
+      fileIds.map(async (fileId) => {
+        const file = await retrieveFileMetadata(fileId, workspaceId);
+        return [fileId, file.filename] as const;
+      }),
+    ).then((results) => {
+      if (!active) return;
+      setFilenamesByFileId(
+        Object.fromEntries(
+          results
+            .filter(
+              (result): result is PromiseFulfilledResult<readonly [string, string]> => result.status === 'fulfilled',
+            )
+            .map((result) => result.value),
+        ),
+      );
+    });
+    return () => {
+      active = false;
+    };
+  }, [resources, workspaceId]);
+  return filenamesByFileId;
 }
 
 function useRelatedEntities(
@@ -354,25 +391,29 @@ function DetailSection({ children, empty, title }: { children: React.ReactNode; 
   );
 }
 
-function ResourceTable({ resources }: { resources: SessionResourceApiResponse[] }) {
+function ResourceTable({
+  filenamesByFileId,
+  resources,
+}: {
+  filenamesByFileId: Record<string, string>;
+  resources: SessionResourceApiResponse[];
+}) {
   const { msg } = useI18n();
 
   return (
     <div className="overflow-hidden rounded-lg border border-border">
       <Table className="min-w-[760px] table-fixed text-left">
         <colgroup>
-          <col className="w-[18%]" />
-          <col className="w-[27%]" />
-          <col className="w-[27%]" />
-          <col className="w-[28%]" />
+          <col className="w-[26%]" />
+          <col className="w-[16%]" />
+          <col className="w-[29%]" />
+          <col className="w-[29%]" />
         </colgroup>
         <TableHeader className="bg-card-raised text-muted-foreground">
           <TableRow className="hover:bg-transparent">
+            <TableHead className="px-5 text-muted-foreground">{msg('common.name', 'Name')}</TableHead>
             <TableHead className="px-5 text-muted-foreground">
               {msg('managedAgents.sessions.trace.type', 'Type')}
-            </TableHead>
-            <TableHead className="px-5 text-muted-foreground">
-              {msg('managedAgents.sessions.resources.resourceId', 'Resource ID')}
             </TableHead>
             <TableHead className="px-5 text-muted-foreground">
               {msg('managedAgents.sessions.resources.fileId', 'File ID')}
@@ -384,16 +425,16 @@ function ResourceTable({ resources }: { resources: SessionResourceApiResponse[] 
         </TableHeader>
         <TableBody>
           {resources.map((resource, index) => {
-            const resourceId = resource.id ?? '—';
             const fileId = resource.file_id ?? '—';
+            const filename = resource.file_id ? (filenamesByFileId[resource.file_id] ?? '—') : '—';
             const mountPath = resource.mount_path ?? '—';
             return (
               <TableRow key={resource.id ?? index} className="bg-card text-foreground">
+                <TableCell className="h-14 truncate px-5" title={filename}>
+                  {filename}
+                </TableCell>
                 <TableCell className="h-14 px-5">
                   <Badge variant="secondary">{titleCase((resource.type ?? 'resource').replaceAll('_', ' '))}</Badge>
-                </TableCell>
-                <TableCell className="h-14 truncate px-5 font-mono text-xs text-muted-foreground" title={resourceId}>
-                  {resourceId}
                 </TableCell>
                 <TableCell className="h-14 truncate px-5 font-mono text-xs text-muted-foreground" title={fileId}>
                   {fileId}

--- a/web/src/features/managed-agents/sessions/SessionEntityPanels.tsx
+++ b/web/src/features/managed-agents/sessions/SessionEntityPanels.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useI18n } from '../../../shared/i18n';
 import { Badge } from '../../../shared/ui/badge';
 import { CardContent, CardDescription, CardHeader, CardTitle } from '../../../shared/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../../shared/ui/table';
 import { TabsContent } from '../../../shared/ui/tabs';
 import { listVaultCredentials, retrieveAgent, retrieveManagedEntity } from '../api';
 import { agentModelName } from '../agents/model';
@@ -67,7 +68,7 @@ export function SessionEntityPanels({
           )}
         >
           {resources.length ? (
-            <ResourceGrid resources={resources} />
+            <ResourceTable resources={resources} />
           ) : (
             <EmptyText>{msg('managedAgents.sessions.nested.noResources', 'No resources mounted')}</EmptyText>
           )}
@@ -355,18 +356,52 @@ function DetailSection({ children, empty, title }: { children: React.ReactNode; 
   );
 }
 
-function ResourceGrid({ resources }: { resources: SessionResourceApiResponse[] }) {
+function ResourceTable({ resources }: { resources: SessionResourceApiResponse[] }) {
+  const { msg } = useI18n();
+
   return (
-    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-      {resources.map((resource, index) => (
-        <div key={String(resource.id ?? index)} className="rounded-lg border border-border p-4">
-          <div className="font-medium">{resourceName(resource)}</div>
-          <div className="mt-1 font-mono text-xs text-muted-foreground">{String(resource.id ?? '—')}</div>
-          <Badge variant="secondary" className="mt-3">
-            {titleCase(String(resource.type ?? 'resource').replaceAll('_', ' '))}
-          </Badge>
-        </div>
-      ))}
+    <div className="overflow-hidden rounded-lg border border-border">
+      <Table className="min-w-[860px] table-fixed text-left">
+        <TableHeader className="bg-card-raised text-muted-foreground">
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="w-[24%] px-4 text-muted-foreground">{msg('common.name', 'Name')}</TableHead>
+            <TableHead className="w-[120px] px-4 text-muted-foreground">
+              {msg('managedAgents.sessions.trace.type', 'Type')}
+            </TableHead>
+            <TableHead className="w-[220px] px-4 text-muted-foreground">
+              {msg('managedAgents.sessions.resources.fileId', 'File ID')}
+            </TableHead>
+            <TableHead className="px-4 text-muted-foreground">
+              {msg('managedAgents.sessions.resources.mountPath', 'Mount path')}
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {resources.map((resource, index) => {
+            const name = resourceName(resource);
+            const fileId = typeof resource.file_id === 'string' && resource.file_id ? resource.file_id : '—';
+            const path = resourcePath(resource) || '—';
+            return (
+              <TableRow key={String(resource.id ?? index)} className="bg-card text-foreground">
+                <TableCell className="h-12 truncate px-4 font-medium" title={name}>
+                  {name}
+                </TableCell>
+                <TableCell className="h-12 px-4">
+                  <Badge variant="secondary">
+                    {titleCase(String(resource.type ?? 'resource').replaceAll('_', ' '))}
+                  </Badge>
+                </TableCell>
+                <TableCell className="h-12 truncate px-4 font-mono text-xs text-muted-foreground" title={fileId}>
+                  {fileId}
+                </TableCell>
+                <TableCell className="h-12 truncate px-4 font-mono text-xs text-muted-foreground" title={path}>
+                  {path}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
     </div>
   );
 }
@@ -376,9 +411,16 @@ function EmptyText({ children }: { children: React.ReactNode }) {
 }
 
 function resourceName(resource: SessionResourceApiResponse) {
-  for (const key of ['filename', 'name', 'path', 'repository', 'url'])
-    if (typeof resource[key] === 'string' && resource[key]) return resource[key];
+  for (const key of ['filename', 'name']) if (typeof resource[key] === 'string' && resource[key]) return resource[key];
+  const basename = resourcePath(resource).split('/').filter(Boolean).at(-1);
+  if (basename) return basename;
   return String(resource.id ?? 'Resource');
+}
+
+function resourcePath(resource: SessionResourceApiResponse) {
+  for (const key of ['mount_path', 'path', 'repository', 'url'])
+    if (typeof resource[key] === 'string' && resource[key]) return resource[key];
+  return '';
 }
 
 function isNonEmptyString(value: unknown): value is string {

--- a/web/src/features/managed-agents/sessions/sessionDetailModel.ts
+++ b/web/src/features/managed-agents/sessions/sessionDetailModel.ts
@@ -492,10 +492,8 @@ export function sessionResourcesLabel(resources: SessionResourceApiResponse[], m
   if (!resources.length) {
     return '';
   }
-  const fileCount = resources.filter((resource) =>
-    String(resource.type || resource.resource_type || '').includes('file'),
-  ).length;
-  if (fileCount > 0 && fileCount === resources.length) {
+  const fileCount = resources.filter((resource) => resource.type === 'file').length;
+  if (fileCount === resources.length) {
     return msg('managedAgents.sessions.detail.fileCount', '{count, plural, one {# file} other {# files}}', {
       count: fileCount,
     });

--- a/web/src/features/managed-agents/types.ts
+++ b/web/src/features/managed-agents/types.ts
@@ -308,6 +308,17 @@ export type SessionResourceApiResponse = {
   [key: string]: unknown;
 };
 
+export type FileMetadataApiResponse = {
+  id: string;
+  created_at: string;
+  downloadable?: boolean;
+  filename: string;
+  mime_type: string;
+  scope?: unknown;
+  size_bytes: number;
+  type: 'file';
+};
+
 export type SessionThreadApiResponse = {
   id: string;
   archived_at?: string | null;

--- a/web/src/features/managed-agents/types.ts
+++ b/web/src/features/managed-agents/types.ts
@@ -169,6 +169,7 @@ export type SessionApiResponse = {
   created_at: string;
   deployment_id?: string | null;
   environment_id: string;
+  resources: SessionResourceApiResponse[];
   stats?: unknown;
   status: string;
   title?: string | null;
@@ -301,6 +302,8 @@ export type EnvironmentWorkApiResponse = {
 export type SessionResourceApiResponse = {
   id?: string;
   created_at?: string;
+  file_id?: string;
+  mount_path?: string;
   type?: string;
   [key: string]: unknown;
 };


### PR DESCRIPTION
## What changed

- add the managed-agent `append_system_prompt` that maps public `/uploads` and `/outputs` paths to their sandbox locations and defines the uploaded-file lookup order
- render Session resources from the Get Session `resources` field with resource ID, file ID, type, and mount path
- refresh Get Session only when the Resources tab is opened, without merging Files API or Session resources-list responses
- update focused frontend, runner, and real E2B coverage plus the related design documentation

## Why

Managed agents need one explicit filesystem contract for uploaded inputs and downloadable outputs. The Session UI should use the complete resource records returned by Session retrieve and should refresh them on demand without maintaining a second resource-list data path.

## Impact

- uploaded files are described to the agent as readable under `/mnt/session/uploads`
- user-facing outputs are directed to `/mnt/user-data/outputs`
- Session resources show the backend-provided IDs and mount paths and refresh when the user opens the Resources tab

## Validation

- `just hooks-run`
- `just large-files`
- `just web-test` (423 passed)
- `just web-build`
- `go test ./internal/environments -count=1`
- `go test ./tests -run '^TestEnvironmentRunnerLaunchesManagedAgentCloudSession$' -count=1 -v`

`just test` is not fully green in the current local integration environment. The failures are outside this PR's changed paths and include an old Vault database schema (`vault_credentials.ciphertext` missing), the current `config.example.yaml` contract mismatch, and unrelated Deployments, Skills, Files, and Vault integration assertions. The focused tests above pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Managed Agent sessions now provide clearer file handling: uploaded files are located from the designated upload area, while generated deliverables are saved and exposed through the outputs area and Files catalog.
  - Session resources now show resource types, IDs, associated file IDs, mount paths, and retrieved filenames.
  - Newly generated output files can be viewed and downloaded from session resources.

- **Improvements**
  - The Resources tab refreshes current session data when opened, without unnecessary refreshes during conversation updates.
  - Resource refresh errors are displayed while preserving existing session information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->