### PR TITLE
feat(codesessions): 支持 session.usage 事件（累计用量快照 + budget 回显，#249）

### DIFF
--- a/docs/design/be/session-usage-event.md
+++ b/docs/design/be/session-usage-event.md
@@ -1,0 +1,65 @@
+# session.usage 事件（累计用量快照 + budget 回显）
+
+> Issue: #249
+> 日期: 2026-08-16
+> 分支: `feat/session-usage-event`
+
+## 背景
+
+官方 Claude Managed Agents 的事件类型表里有 `session.usage` 事件：会话**累计用量**快照，携带 usage 对象 + budget（无预算时 null）。**触发时机**：idle 转换时（每次 session 进入 idle 前发一个；预算暂停时的额外发送属 #244 后续）——`https://platform.claude.com/docs/en/managed-agents/events-and-streaming.md`。
+
+OMA 当前无此事件：用量只在 `span.model_request_end`（`mapper.go:392-441`）有单次请求的用量，session 级累计存在 DB 快照（`sessions.usage`），从不作为事件发出。
+
+## 方案
+
+### 1. `publicSessionStatusPayloads` 同时产生 `session.usage`
+
+`internal/codesessions/status.go:45-90`：构造 `session.status_idle` 时，**额外产生 `session.usage` 事件**：
+- `usage`：session 的 `Usage` 字段（DB 快照的累计用量）
+- `budget`：当前固定为 `null`（`db.Session` 尚无 `Budget` 字段；#244 引入后改为读取 `session.Budget`，见「对抗性 review 修正」的合并检查清单）
+- 触发条件：eventType 为 `session.status_idle` 时（idle 转换）
+
+顺序保证：`session.usage` 的 `created_at`/`processed_at` 取 `idle 时间 - 1µs`（`publicEventOrderingGap`）。共用同一时间戳时，两个事件的相对顺序会退化为按 ID 排序：
+
+- 发布排序 `sessions.PublishCodeSessionEvents`：`ProcessedAt → CreatedAt → ExternalID`，最终 tie-break 落到 SHA-256 派生的 `sevt_` ID
+- 历史读取 `ListSessionEventsPage`：`ORDER BY created_at ASC, uuid ASC`，`uuid` 是 `gen_random_uuid()` 随机值
+
+`session_events.created_at`/`processed_at` 是 PostgreSQL `timestamptz`（微秒精度），因此差值必须 ≥ 1µs，纳秒级差值会被截断成同一时刻。取 1µs 后顺序在实时 SSE 与落库历史中都严格成立。
+
+排序相关的纯逻辑抽为 `statusTransitionPayloads(record, session, eventType, status, now)`，`publicSessionStatusPayloads` 只负责查库与去重判断，单测可直接断言最终事件序。
+
+### 2. `session.usage` 事件类型注册
+
+`internal/managedagentsevents/events.go`：`CategoryFor` 注册 `session.usage`（CategorySessionStatus），确保事件可持久化/进历史。
+
+## 明确不做
+
+- 用量**累计逻辑**本身（`span.model_request_end` → session.usage 聚合）依赖 #62 用量采集，本实现用 DB 快照现有值
+- `budget_reached` 精确暂停语义（#244 后续）
+- list cost 计算
+
+## 测试
+
+- `statusTransitionPayloads`：idle 时产生 `[session.usage, session.status_idle]`，且 usage 时间戳严格早于 idle 且差值 ≥ 1µs（落库后保序）
+- `statusTransitionPayloads`：非 idle 状态只产生状态事件，不带 usage
+- `sessionUsagePayload`：事件结构（type/usage/budget），无 usage 时回显 `{}`
+- `CategoryFor("session.usage")` 返回 CategorySessionStatus
+
+## 验收
+
+- session 进入 idle 时，事件流出现 `session.usage`（携带累计用量 + budget/null）
+- `session.usage` 在实时流与历史列表中都紧邻 `session.status_idle` 之前
+- 官方 SDK 的 `session.usage` 处理分支可正常工作
+
+## 对抗性 review 修正（2026-08-16）
+
+**跨分支合并检查清单（#249 ↔ #244）**：
+- [ ] **必须**：`sessionUsagePayload`（status.go）的 `budget` 从硬编码 `null` 改为读取 `session.Budget`（#244 给 db.Session 加了 Budget 字段）。当前硬编码 null 与「无预算」现状一致，但合并 #244 后不会自动生效——这是跨 PR 契约缺口，**必须在合并时手动修改**（无 CI 能捕获）
+- [ ] #244 的 `sessionUpdatedEvent` 已带 budget ✅（无需改）
+- [ ] 合并后补集成测试：带 budget 的 session idle 时，`session.usage` 事件回显真实 budget
+
+**事件 ID 去重提示**：`stablePublicEventID(..., session.UpdatedAt)` 种子在同一秒内连续 idle 可能重复（频率极低，不阻塞）。
+
+## Review 修正（2026-08-19）
+
+**usage/idle 顺序在落库后不成立**：初版让 usage 与 idle 共用同一个 `now`，两者 `created_at`/`processed_at` 完全相同，顺序退化为按 `ExternalID`（SHA-256 派生）/ `uuid`（随机）排序，实测随 `UpdatedAt` 翻转。修正为 usage 取 `idle - 1µs`（见「顺序保证」），并把排序逻辑抽成 `statusTransitionPayloads` 纯函数，单测直接断言生产代码产出的事件序与时间差。

--- a/internal/codesessions/status.go
+++ b/internal/codesessions/status.go
@@ -9,6 +9,8 @@ import (
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 )
 
+const publicEventOrderingGap = time.Microsecond
+
 func (s *Service) syncPublicSessionFromWorker(ctx context.Context, record db.CodeSession, workerStatus string) error {
 	if record.SessionExternalID == "" {
 		return nil
@@ -70,7 +72,16 @@ func (s *Service) publicSessionStatusPayloads(ctx context.Context, record db.Cod
 		}
 	}
 	//
-	now := time.Now().UTC()
+	return statusTransitionPayloads(record, session, eventType, status, time.Now().UTC())
+}
+
+func statusTransitionPayloads(
+	record db.CodeSession,
+	session db.Session,
+	eventType string,
+	status string,
+	now time.Time,
+) ([]json.RawMessage, error) {
 	eventID := stablePublicEventID(record.ExternalID, "worker_status_"+status+"\x00"+session.UpdatedAt.UTC().Format(time.RFC3339Nano))
 	payload, err := marshalRaw(map[string]any{
 		"id":           eventID,
@@ -81,5 +92,28 @@ func (s *Service) publicSessionStatusPayloads(ctx context.Context, record db.Cod
 	if err != nil {
 		return nil, err
 	}
-	return []json.RawMessage{payload}, nil
+	if status != "idle" {
+		return []json.RawMessage{payload}, nil
+	}
+	usagePayload, err := sessionUsagePayload(record, session, now.Add(-publicEventOrderingGap))
+	if err != nil {
+		return nil, err
+	}
+	return []json.RawMessage{usagePayload, payload}, nil
+}
+
+func sessionUsagePayload(record db.CodeSession, session db.Session, at time.Time) (json.RawMessage, error) {
+	eventID := stablePublicEventID(record.ExternalID, "session_usage\x00"+session.UpdatedAt.UTC().Format(time.RFC3339Nano))
+	usage := json.RawMessage(`{}`)
+	if len(session.Usage) > 0 {
+		usage = session.Usage
+	}
+	return marshalRaw(map[string]any{
+		"id":           eventID,
+		"type":         "session.usage",
+		"created_at":   formatTime(at),
+		"processed_at": formatTime(at),
+		"usage":        usage,
+		"budget":       json.RawMessage(`null`),
+	})
 }

--- a/internal/codesessions/status_test.go
+++ b/internal/codesessions/status_test.go
@@ -1,0 +1,112 @@
+package codesessions
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+)
+
+func TestSessionUsagePayload(t *testing.T) {
+	now := time.Date(2026, time.August, 16, 12, 0, 0, 0, time.UTC)
+	record := db.CodeSession{ExternalID: "csev_test"}
+
+	session := db.Session{
+		Usage: json.RawMessage(`{"input_tokens":100,"output_tokens":50}`),
+	}
+	payload, err := sessionUsagePayload(record, session, now)
+	if err != nil {
+		t.Fatalf("sessionUsagePayload: %v", err)
+	}
+	object := decodePayload(t, payload)
+	if object["type"] != "session.usage" {
+		t.Fatalf("type = %v, want session.usage", object["type"])
+	}
+	usage, ok := object["usage"].(map[string]any)
+	if !ok || usage["input_tokens"] != float64(100) {
+		t.Fatalf("usage = %v, want 含 input_tokens", object["usage"])
+	}
+	if object["budget"] != nil {
+		t.Fatalf("budget = %v, want null", object["budget"])
+	}
+
+	empty := db.Session{}
+	payload, err = sessionUsagePayload(record, empty, now)
+	if err != nil {
+		t.Fatalf("sessionUsagePayload: %v", err)
+	}
+	object = decodePayload(t, payload)
+	if usage, ok := object["usage"].(map[string]any); !ok || len(usage) != 0 {
+		t.Fatalf("无 usage 应为空对象, got %v", object["usage"])
+	}
+}
+
+func TestStatusTransitionPayloadsUsagePrecedesIdle(t *testing.T) {
+	// 官方契约：usage 紧邻 idle 之前，且落库后（timestamptz 微秒精度）顺序仍成立。
+	now := time.Date(2026, time.August, 16, 12, 0, 0, 0, time.UTC)
+	record := db.CodeSession{ExternalID: "csev_test"}
+	session := db.Session{Usage: json.RawMessage(`{"input_tokens":1}`), UpdatedAt: now}
+
+	payloads, err := statusTransitionPayloads(record, session, "session.status_idle", "idle", now)
+	if err != nil {
+		t.Fatalf("statusTransitionPayloads: %v", err)
+	}
+	if len(payloads) != 2 {
+		t.Fatalf("payloads 数量 = %d, want 2", len(payloads))
+	}
+	first := decodePayload(t, payloads[0])
+	second := decodePayload(t, payloads[1])
+	if first["type"] != "session.usage" || second["type"] != "session.status_idle" {
+		t.Fatalf("顺序错误: %v then %v, want usage then idle", first["type"], second["type"])
+	}
+	usageAt := parsePayloadTime(t, first, "created_at")
+	idleAt := parsePayloadTime(t, second, "created_at")
+	if !usageAt.Before(idleAt) {
+		t.Fatalf("usage created_at = %s, 应严格早于 idle created_at = %s", usageAt, idleAt)
+	}
+	if idleAt.Sub(usageAt) < time.Microsecond {
+		t.Fatalf("时间差 = %s, 至少需要 1µs 以在 timestamptz 落库后保序", idleAt.Sub(usageAt))
+	}
+	if parsePayloadTime(t, first, "processed_at") != usageAt {
+		t.Fatalf("usage processed_at 应与 created_at 一致")
+	}
+}
+
+func TestStatusTransitionPayloadsNonIdleOmitsUsage(t *testing.T) {
+	now := time.Date(2026, time.August, 16, 12, 0, 0, 0, time.UTC)
+	record := db.CodeSession{ExternalID: "csev_test"}
+
+	payloads, err := statusTransitionPayloads(record, db.Session{UpdatedAt: now}, "session.status_running", "running", now)
+	if err != nil {
+		t.Fatalf("statusTransitionPayloads: %v", err)
+	}
+	if len(payloads) != 1 {
+		t.Fatalf("payloads 数量 = %d, want 1", len(payloads))
+	}
+	if payload := decodePayload(t, payloads[0]); payload["type"] != "session.status_running" {
+		t.Fatalf("type = %v, want session.status_running", payload["type"])
+	}
+}
+
+func decodePayload(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	return object
+}
+
+func parsePayloadTime(t *testing.T, payload map[string]any, field string) time.Time {
+	t.Helper()
+	value, ok := payload[field].(string)
+	if !ok {
+		t.Fatalf("%s = %v, want 字符串", field, payload[field])
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		t.Fatalf("parse %s: %v", field, err)
+	}
+	return parsed.UTC()
+}

--- a/internal/managedagentsevents/events.go
+++ b/internal/managedagentsevents/events.go
@@ -29,7 +29,7 @@ func CategoryFor(eventType string) Category {
 		return CategoryThreadCoordination
 	case "session.status_running", "session.status_idle", "session.status_rescheduled", "session.status_terminated",
 		"session.status_run_started", "session.status_idled", "session.running", "session.idled", "session.requires_action",
-		"session.deleted", "session.updated", "session.error":
+		"session.deleted", "session.updated", "session.error", "session.usage":
 		return CategorySessionStatus
 	case "session.thread_status_running", "session.thread_status_idle", "session.thread_status_rescheduled", "session.thread_status_terminated",
 		"session.thread_idled", "session.thread_terminated":

--- a/internal/managedagentsevents/events_test.go
+++ b/internal/managedagentsevents/events_test.go
@@ -27,6 +27,7 @@ func TestReferencePersistedEventCategories(t *testing.T) {
 		"session.deleted":                   CategorySessionStatus,
 		"session.updated":                   CategorySessionStatus,
 		"session.error":                     CategorySessionStatus,
+		"session.usage":                     CategorySessionStatus,
 		"session.thread_created":            CategoryThreadCoordination,
 		"session.thread_status_running":     CategoryThreadStatus,
 		"session.thread_status_idle":        CategoryThreadStatus,


### PR DESCRIPTION
## 背景

官方 Claude Managed Agents 事件类型表里有 `session.usage` 事件：会话**累计用量**快照，携带 usage 对象 + budget（无预算时为 `null`）。它是观测与成本归因的基础，前端用量展示、成本统计都依赖它。官方契约：`session.usage` 在 **idle 转换时**发出，且**总是紧邻 `session.status_idle` 之前**。

OMA 现状：`session.usage` 事件类型不存在（`CategoryFor` 落入 `CategoryUnknown`）；会话累计用量只存 DB 快照字段（`sessions.usage`，创建时 `{}`），从不作为事件发出；用量只在 `span.model_request_end`（`internal/codesessions/mapper.go:404-421`）有单次请求的用量，没有会话级累计。

## 改动

### 事件注册（`internal/managedagentsevents`）
- `CategoryFor` 注册 `session.usage` → `CategorySessionStatus`（事件可持久化/进历史）

### 事件发出（`internal/codesessions`）
- `publicSessionStatusPayloads` 在构造 `session.status_idle` 时，**额外产生 `session.usage` 事件**，并保证顺序：`[session.usage, session.status_idle]`（官方契约：usage 紧邻 idle 之前）
- **顺序在落库后依然成立**：usage 的 `created_at`/`processed_at` 取 `idle - 1µs`（`publicEventOrderingGap`）。共用同一时间戳时顺序会退化为按 ID 排序——发布排序 `PublishCodeSessionEvents` 的 tie-break 落到 SHA-256 派生的 `sevt_` ID，历史读取 `ListSessionEventsPage` 按随机 `uuid` 排序，实测顺序随 `session.UpdatedAt` 翻转。`session_events.created_at` 是 `timestamptz`（微秒精度），因此差值必须 ≥ 1µs
- 排序逻辑抽为纯函数 `statusTransitionPayloads(record, session, eventType, status, now)`，`publicSessionStatusPayloads` 只保留查库与去重判断
- `sessionUsagePayload` 构造事件：
  - `usage`：session 的 `Usage` 字段（DB 快照的累计用量）
  - `budget`：当前硬编码 `null`（无预算；#244 合并后读取 `session.Budget`，见设计文档对抗性 review）
  - 事件 ID 复用项目既有 `stablePublicEventID` 确定性 ID 模式（`session_usage\x00+updated_at` 作 seed，幂等去重）

### 测试
- `TestSessionUsagePayload`：事件结构（type/usage/budget）断言，无 usage 时回显 `{}`
- `TestStatusTransitionPayloadsUsagePrecedesIdle`：**调用生产函数**断言事件序，并校验 usage 时间戳严格早于 idle 且差值 ≥ 1µs
- `TestStatusTransitionPayloadsNonIdleOmitsUsage`：非 idle 状态只产生状态事件
- `TestReferencePersistedEventCategories`：`session.usage` → `CategorySessionStatus`

### 设计文档
- 新增 `docs/design/be/session-usage-event.md`：方案、顺序保证（两个排序退化点与微秒精度约束）、明确不做（累计聚合依赖 #62、budget_reached 语义依赖 #244）、验收、对抗性 review（#249 ↔ #244 跨分支合并检查清单）

## 验收

- [x] **事件类型注册**：`CategoryFor("session.usage")` 返回 `CategorySessionStatus`
- [x] **idle 转换时发出**：session 进入 idle 时事件流出现 `session.usage`（携带累计用量）
- [x] **顺序对齐官方**：`session.usage` 紧邻 `session.status_idle` 之前，且在实时 SSE 与落库历史中都成立（单测断言生产代码产出的事件序与时间差）
- [x] **无预算回显 null**：无 budget 的 session 回显 `budget: null`
- [x] **事件 ID 幂等**：复用 `stablePublicEventID`，同一 usage 快照重复投递产生同一 `sevt_xxx`，下游可去重

## 测试

- ✅ `just test`：相关包全绿（`internal/codesessions`、`internal/managedagentsevents`）
- ✅ `just lint` / `dead-code` / `duplicates` / `complexity` / `large-files` 全过

## 关联

- Part of #249（本 PR 交付 session.usage 事件本身；budget 回显依赖 #244，合入后按 #249 合并检查清单补齐）
- 依赖 #244（budget 回显，本 PR 先置 null）

## Review 修正

- **Pullfrog（Main）：usage/idle 顺序在落库/发布/历史读取后不保证** — 已修复。原因与修法见上文「顺序在落库后依然成立」。补充一点：Pullfrog 建议的 `now.Add(-time.Nanosecond)` 不可行，`timestamptz` 只保留微秒，1ns 差值会被截断成同一时刻，因此取 1µs
- **Pullfrog / CodeRabbit（Nitpick）：测试没测生产代码** — 已修复。旧测试自己拼 `{usagePayload, idlePayload}` 再断言自己拼的顺序，生产代码写反也会通过；现在直接调用 `statusTransitionPayloads`
- **CodeRabbit（Linked Issues warning）：budget 回显 / 累计聚合 / budget 暂停顺序未实现** — 有意不在本 PR 范围内，[已回复](https://github.com/superduck-ai/open-managed-agents/pull/268#issuecomment-5350644735)。`db.Session` 目前没有 `Budget` 字段（由 #244 引入），字段不存在时 `budget: null` 是唯一正确表现；累计聚合依赖 #62 的用量采集。设计文档已登记 #249 ↔ #244 的合并检查清单


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added usage events when sessions enter an idle state.
  * Usage snapshots include session usage and available budget information.
  * Usage events are persisted and included in session history.
  * Events appear before the corresponding idle status update for consistent ordering.

* **Bug Fixes**
  * Preserved existing behavior for non-idle status transitions.
  * Improved timestamp precision for reliable real-time and historical event ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
