### PR TITLE
Upgrade Go and golangci-lint toolchains

### DIFF
--- a/.github/workflows/complexity.yml
+++ b/.github/workflows/complexity.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Check Go complexity
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.2
+          version: v2.13.0
           args: --config=.golangci-complexity.yml --timeout=5m ./...
 
   typescript-complexity:

--- a/.github/workflows/dead-code.yml
+++ b/.github/workflows/dead-code.yml
@@ -52,5 +52,5 @@ jobs:
       - name: Detect unreachable Go declarations
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.2
+          version: v2.13.0
           args: --config=.golangci-dead-code.yml --timeout=5m ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.2
+          version: v2.13.0
           args: --config=.golangci.yml --timeout=5m ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 ARG REGISTRY=docker.io/library
 
 # ---- Go 后端编译 ------------------------------------------------------------
-FROM ${REGISTRY}/golang:1.26.2 AS go-builder
+FROM ${REGISTRY}/golang:1.27.0 AS go-builder
 
 ARG GOPROXY=https://goproxy.cn,direct
 ENV GOPROXY=${GOPROXY}

--- a/README.cn.md
+++ b/README.cn.md
@@ -12,7 +12,7 @@ Open Managed Agents 是一个用 Go 实现的本地优先 Managed Agents API 服
 
 ## 技术栈
 
-- 后端：Go `1.26.2`、`chi`、`pgx`、`goose`、AWS SDK for Go v2、Redis、Anthropic Go SDK。
+- 后端：Go `1.27.0`、`chi`、`pgx`、`goose`、AWS SDK for Go v2、Redis、Anthropic Go SDK。
 - 前端：Bun、Vite、React、TypeScript、Tailwind CSS、TanStack Router/Query/Table、Base UI、shadcn/ui 风格组件。
 - 存储：PostgreSQL、Redis、S3 兼容对象存储，默认本地使用 MinIO。
 - 沙箱：E2B 相关能力通过 `config/config.yaml` 的 `e2b` 节点启用；没有配置时，多数 API/单元测试仍可在 fake store 或非真实沙箱路径下运行。

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/superduck-ai/open-managed-agents
 
-go 1.26.2
+go 1.27.0
 
 tool github.com/superduck-ai/yourbatis/cmd/sqlmapgen
 

--- a/internal/vaults/credential_auth.go
+++ b/internal/vaults/credential_auth.go
@@ -185,15 +185,15 @@ func normalizeMCPOAuthRefreshForCreate(input mcpOAuthRefreshCreateInput) (mcpOAu
 		return mcpOAuthRefresh{}, mcpOAuthRefreshSecret{}, err
 	}
 	return mcpOAuthRefresh{
-			TokenEndpoint:     tokenEndpoint,
-			ClientID:          clientID,
-			TokenEndpointAuth: publicTokenAuth,
-			Scope:             input.Scope,
-			Resource:          input.Resource,
-		}, mcpOAuthRefreshSecret{
-			RefreshToken:      refreshToken,
-			TokenEndpointAuth: &secretTokenAuth,
-		}, nil
+		TokenEndpoint:     tokenEndpoint,
+		ClientID:          clientID,
+		TokenEndpointAuth: publicTokenAuth,
+		Scope:             input.Scope,
+		Resource:          input.Resource,
+	}, mcpOAuthRefreshSecret{
+		RefreshToken:      refreshToken,
+		TokenEndpointAuth: &secretTokenAuth,
+	}, nil
 }
 
 func normalizeTokenEndpointAuth(input *tokenEndpointAuthInput) (tokenEndpointAuth, tokenEndpointAuthSecret, error) {

--- a/tests/vaults_encryption_test.go
+++ b/tests/vaults_encryption_test.go
@@ -268,12 +268,12 @@ func readVaultCredentialEnvelope(t *testing.T, app *testApp, credentialID string
 		t.Fatalf("read credential envelope: %v", err)
 	}
 	return secrets.Envelope{
-			Ciphertext: ciphertext, Nonce: nonce, WrappedDEK: wrappedDEK,
-			FormatVersion: int(formatVersion.Int32), KeyProvider: keyProvider.String, KeyVersion: keyVersion.Int64,
-		}, secrets.Binding{
-			OrganizationUUID: orgUUID, WorkspaceUUID: wsUUID,
-			VaultExternalID: vaultExt, CredentialExternalID: credExt,
-		}
+		Ciphertext: ciphertext, Nonce: nonce, WrappedDEK: wrappedDEK,
+		FormatVersion: int(formatVersion.Int32), KeyProvider: keyProvider.String, KeyVersion: keyVersion.Int64,
+	}, secrets.Binding{
+		OrganizationUUID: orgUUID, WorkspaceUUID: wsUUID,
+		VaultExternalID: vaultExt, CredentialExternalID: credExt,
+	}
 }
 
 func insertEnvelopeLessCredential(t *testing.T, app *testApp, vaultID, credentialKey string) string {


### PR DESCRIPTION
## Summary

- Upgrade the Go toolchain and module version to 1.27.0
- Update golangci-lint CI checks to v2.13.0
- Refresh the documented Go version
- Apply gofmt-compatible formatting updates

## Testing

- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the application’s Go runtime and build environment to version 1.27.0.
  - Refreshed automated code-quality checks to use the latest linting workflow version.
  - Updated the technical stack information in the Chinese README.

- **Bug Fixes**
  - Credential encryption handling now preserves the credential’s external identifier when reading stored vault data.

- **Maintenance**
  - Applied minor formatting improvements without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->