### PR TITLE
feat(sessions): Session Budget 支持（max_list_cost 费用上限，#244）

### DIFF
--- a/docs/design/be/session-budget.md
+++ b/docs/design/be/session-budget.md
@@ -1,0 +1,110 @@
+# Session Budget（max_list_cost 费用上限）
+
+> Issue: #244
+> 日期: 2026-08-16
+> 分支: `feat/session-budget`
+
+## 背景
+
+官方 Claude Managed Agents 支持 session 级费用预算：创建 session 时传 `budget: {type: "limit", max_list_cost: {amount: "125", currency: "USD"}}`（amount 是美分字符串，仅支持 USD），达到上限后暂停/拒绝新事件，避免失控烧钱。
+
+OMA 全仓对 budget **零实现**（无字段、无 DB 列、无校验）——官方 SDK 创建带 budget 的 session 被静默忽略。
+
+## 官方契约（budgets.md + events-and-streaming.md）
+
+### 校验（400 场景）
+1. `amount` 必须是**无前导零的整数美分字符串**（如 `"125"` = $1.25），`"25.00"`/零/负数拒绝
+2. `currency` 必须是大写 `USD`
+3. 达上限时发 work-starting 事件（`user.message` 等）→ 400（错误需列出可接受的 settle 事件）
+4. 预算 ≤ 已消耗 list cost → 400
+5. 无预算的 session 加预算、或移除后重加 → 400（**本实现范围**：OMA 尚无 list cost 概念，此场景暂以「创建时设置、更新可改/移除」简化）
+6. 无定价模型 → 400（依赖模型目录，暂不实现）
+
+### 达上限行为
+- 只接受 settle 事件：`user.tool_confirmation` / `user.tool_result` / `user.custom_tool_result` / `user.interrupt`
+- work-starting 事件（`user.message` 等）→ 400
+- `user.interrupt` 在暂停时被接受但忽略
+- 改预算（高于已消耗）或移除预算（`"budget": null`）→ 恢复
+
+### 事件
+- `session.budget_reached` webhook 事件（每次设置预算最多触发一次，改预算重新武装）
+- `session.status_idle` 的 stop_reason 可为 `budget_reached`
+- 暂停顺序：`session.thread_status_idle(budget_reached)` → `session.usage` → `session.status_idle(budget_reached)`（**session.usage 依赖 #249，本实现先发 idle + budget_reached**）
+
+## 方案（最小可用实现）
+
+### 1. DB：sessions 表加 budget 列（migration）
+
+`internal/db/migrations/` 新增 migration：
+```sql
+ALTER TABLE sessions ADD COLUMN budget jsonb;
+```
+（存 `{"type":"limit","max_list_cost":{"amount":"125","currency":"USD"}}` 或 NULL）
+
+### 2. 校验（sessions/handler.go + service_helpers.go）
+
+- `sessionMutationRequest` 加 `Budget json.RawMessage`
+- 新增 `normalizeBudget(raw)`：校验 type=limit、amount 整美分字符串、currency=USD
+- create 时校验并存入；update 时允许改/移除（`"budget": null`）
+
+### 3. 达上限拒绝（sendEvents 路径）
+
+- session 带 budget 时，`user.message` 等 work-starting 事件先查「是否已达上限」（**本实现用 DB 存的 `budget_reached_at` 标记**，无真实 list cost 计算）
+- 达上限 → 400，错误列出 settle 事件清单
+- 改/移除预算清除标记
+
+### 4. 事件
+
+- `session.budget_reached` webhook 事件：注册进 `supportedEndpointEventTypes` + 默认订阅 + 映射桥（复用 #255 的模式）
+- 达上限时发 `session.status_idle`（stop_reason=budget_reached）
+
+### 明确不做（依赖后续）
+- list cost 计算（依赖 #62 用量采集）
+- `session.usage` 事件（#249）
+- 无定价模型校验（依赖模型目录）
+- 精确暂停语义（thread 级暂停）
+
+## 测试
+
+- `normalizeBudget`：合法/非法 amount、currency、type
+- create 带 budget → 存储；update 改/移除（API 级：无预算加预算 400 / 改 200 / 移除 200）
+- 达上限后 `user.message` → 400；settle 事件通过（**#271 范围**）
+- `session.budget_reached` webhook 注册 + 映射（**#271 范围**）
+
+## 验收
+
+- 官方 SDK 创建带 budget 的 session 全流程可用（字段存储 + 响应回显）
+- 达上限后 work-starting 事件 400（列出 settle 清单）
+- 改/移除预算恢复
+- `session.budget_reached` 事件可订阅
+
+## 范围更新（2026-08-16 实施后）
+
+**已实现**：
+- DB migration 00055：sessions 表加 budget jsonb 列
+- sessionRow/sessionWriteParams/sessionUpdateParams/Session 结构加 Budget
+- session_mapper.xml 的 columns/Insert/Update 支持 budget
+- `sessionMutationRequest` 加 Budget 字段 + `normalizeBudget` 校验（type=limit、美分字符串、USD）
+- create 存储 budget；update 支持改/移除（`"budget": null`）
+- session 响应回显 budget（无预算时 null）
+- 前端：
+  - **创建**：session 创建对话框新增 Budget (USD cents) 输入（`ManagedTextField`），create body 带 budget（`api.ts` `createManagedEntityBody`）
+  - **编辑回填**：`entityBudgetAmount(entity)` 从 `entity.budget.max_list_cost.amount` 回填 `budgetAmount`；`budgetInitiallySet` 记录原状态
+  - **更新三态**（`sessionBudgetUpdate`）：非空 → 发新 budget；清空且原本有 → 发 `budget: null` 移除；清空且原本无 → 不发（官方禁止给无预算 session 加预算）
+  - i18n：`managedAgents.sessions.budget` / `budgetPlaceholder`（扁平 key，en/zh 对称）
+
+**未实现（依赖后续）**：
+- 达上限拒绝 work-starting 事件（需真实 list cost，依赖 #62 用量采集）
+- `session.budget_reached` 事件（依赖达上限判定）
+- `session.status_idle` 的 stop_reason=budget_reached（依赖达上限判定）
+- 无定价模型校验（依赖模型目录）
+- `session.usage` 事件（#249）
+
+## Review 修正（2026-08-16）
+
+**已补**：
+- update 路径「给无预算 session 添加预算 → 400」（官方 budgets.md 契约，此前静默放宽）
+- `session.updated` 事件携带 budget（改/移除预算后下游可感知）
+- 补 budget 规则测试
+
+**仍依赖后续**（不变）：达上限拒绝、budget_reached 事件、list cost 计算（#62）、session.usage 真实 budget 回显（#249 需在 #244 合并后手动读取 session.Budget）。

--- a/internal/db/migrations/00055_add_session_budget.sql
+++ b/internal/db/migrations/00055_add_session_budget.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+
+-- Session-level budget (max_list_cost): hard cap in US cents on a single
+-- session. NULL means no budget. Shape:
+-- {"type":"limit","max_list_cost":{"amount":"125","currency":"USD"}}
+ALTER TABLE sessions ADD COLUMN budget jsonb;
+
+-- +goose Down
+
+ALTER TABLE sessions DROP COLUMN budget;

--- a/internal/db/session_mapper.go
+++ b/internal/db/session_mapper.go
@@ -74,6 +74,7 @@ type sessionRow struct {
 	Usage                 []byte          `db:"usage"`
 	Stats                 []byte          `db:"stats"`
 	OutcomeEvaluations    []byte          `db:"outcome_evaluations"`
+	Budget                []byte          `db:"budget"`
 	CreatedAt             time.Time       `db:"created_at"`
 	UpdatedAt             time.Time       `db:"updated_at"`
 	ArchivedAt            *time.Time      `db:"archived_at"`
@@ -101,6 +102,7 @@ type sessionWriteParams struct {
 	Usage                 []byte
 	Stats                 []byte
 	OutcomeEvaluations    []byte
+	Budget                []byte
 	CreatedAt             time.Time
 }
 
@@ -110,6 +112,7 @@ type sessionUpdateParams struct {
 	AgentSnapshot []byte
 	Title         *string
 	Metadata      []byte
+	Budget        []byte
 	UpdatedAt     time.Time
 }
 

--- a/internal/db/session_mapper.xml
+++ b/internal/db/session_mapper.xml
@@ -21,6 +21,7 @@
         usage,
         stats,
         outcome_evaluations,
+        budget,
         created_at,
         updated_at,
         archived_at,
@@ -32,7 +33,7 @@
             uuid, external_id, organization_uuid, workspace_uuid, created_by_api_key_uuid,
             environment_uuid, environment_external_id, agent_uuid, agent_external_id,
             agent_version, agent_snapshot, deployment_uuid, deployment_external_id,
-            title, metadata, vault_ids, status, usage, stats, outcome_evaluations,
+            title, metadata, vault_ids, status, usage, stats, outcome_evaluations, budget,
             created_at, updated_at
         ) VALUES (
             #{params.UUID}, #{params.ExternalID}, #{params.OrganizationUUID}, #{params.WorkspaceUUID},
@@ -42,7 +43,8 @@
             #{params.DeploymentID}, #{params.Title}, CAST(#{params.Metadata,sensitive=true} AS jsonb),
             CAST(#{params.VaultIDs,sensitive=true} AS jsonb), #{params.Status},
             CAST(#{params.Usage,sensitive=true} AS jsonb), CAST(#{params.Stats,sensitive=true} AS jsonb),
-            CAST(#{params.OutcomeEvaluations,sensitive=true} AS jsonb), #{params.CreatedAt}, #{params.CreatedAt}
+            CAST(#{params.OutcomeEvaluations,sensitive=true} AS jsonb),
+            CAST(#{params.Budget,sensitive=true} AS jsonb), #{params.CreatedAt}, #{params.CreatedAt}
         )
         RETURNING <include refid="columns"/>
     </insert>
@@ -68,6 +70,7 @@
         SET agent_snapshot = CAST(#{params.AgentSnapshot,sensitive=true} AS jsonb),
             title = #{params.Title},
             metadata = CAST(#{params.Metadata,sensitive=true} AS jsonb),
+            budget = CAST(#{params.Budget,sensitive=true} AS jsonb),
             updated_at = #{params.UpdatedAt}
         WHERE workspace_uuid = #{params.WorkspaceUUID}
         AND external_id = #{params.ExternalID}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -34,6 +34,7 @@ type Session struct {
 	Usage                 json.RawMessage
 	Stats                 json.RawMessage
 	OutcomeEvaluations    json.RawMessage
+	Budget                json.RawMessage
 	CreatedAt             time.Time
 	UpdatedAt             time.Time
 	ArchivedAt            *time.Time
@@ -250,6 +251,7 @@ func (d *DB) UpdateSession(ctx context.Context, workspaceUUID string, externalID
 		AgentSnapshot: agentJSONArg(next.AgentSnapshot),
 		Title:         next.Title,
 		Metadata:      agentJSONArg(next.Metadata),
+		Budget:        agentJSONArg(next.Budget),
 		UpdatedAt:     next.UpdatedAt,
 	})
 	return row.session(), mapNoRows(err)

--- a/internal/db/sessions_helpers.go
+++ b/internal/db/sessions_helpers.go
@@ -170,7 +170,7 @@ func sessionWriteParameters(session Session) sessionWriteParams {
 		VaultIDs: append(sessionVaultIDs{}, session.VaultIDs...), Status: session.Status,
 		Usage: agentJSONArg(session.Usage),
 		Stats: agentJSONArg(session.Stats), OutcomeEvaluations: agentJSONArg(session.OutcomeEvaluations),
-		CreatedAt: session.CreatedAt,
+		Budget: agentJSONArg(session.Budget), CreatedAt: session.CreatedAt,
 	}
 }
 
@@ -267,7 +267,8 @@ func (r sessionRow) session() Session {
 		DeploymentID: r.DeploymentID, Title: r.Title, Metadata: bytes.Clone(r.Metadata),
 		VaultIDs: append([]string{}, r.VaultIDs...), Status: r.Status,
 		Usage: bytes.Clone(r.Usage), Stats: bytes.Clone(r.Stats),
-		OutcomeEvaluations: bytes.Clone(r.OutcomeEvaluations), CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
+		OutcomeEvaluations: bytes.Clone(r.OutcomeEvaluations), Budget: bytes.Clone(r.Budget),
+		CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt,
 		ArchivedAt: r.ArchivedAt, DeletedAt: r.DeletedAt,
 	}
 }

--- a/internal/db/sessions_mapper_test.go
+++ b/internal/db/sessions_mapper_test.go
@@ -66,11 +66,11 @@ func TestSessionTableMapperWriteBuilderContracts(t *testing.T) {
 				"params.AgentUUID", "params.AgentExternalID", "params.AgentVersion", "params.AgentSnapshot",
 				"params.DeploymentUUID", "params.DeploymentID", "params.Title", "params.Metadata",
 				"params.VaultIDs", "params.Status", "params.Usage", "params.Stats",
-				"params.OutcomeEvaluations", "params.CreatedAt", "params.CreatedAt",
+				"params.OutcomeEvaluations", "params.Budget", "params.CreatedAt", "params.CreatedAt",
 			},
 			wantSensitiveArgumentNames: []string{
 				"params.AgentSnapshot", "params.Metadata", "params.VaultIDs", "params.Usage",
-				"params.Stats", "params.OutcomeEvaluations",
+				"params.Stats", "params.OutcomeEvaluations", "params.Budget",
 			},
 			wantSQLFragments: []string{"INSERT INTO sessions", "CAST($11 AS jsonb)", "RETURNING", "uuid, external_id"},
 		},

--- a/internal/sessions/budget_test.go
+++ b/internal/sessions/budget_test.go
@@ -1,0 +1,62 @@
+package sessions
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeBudgetRejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"decimal amount", `{"type":"limit","max_list_cost":{"amount":"25.00","currency":"USD"}}`},
+		{"zero amount", `{"type":"limit","max_list_cost":{"amount":"0","currency":"USD"}}`},
+		{"negative amount", `{"type":"limit","max_list_cost":{"amount":"-5","currency":"USD"}}`},
+		{"leading zero", `{"type":"limit","max_list_cost":{"amount":"0125","currency":"USD"}}`},
+		{"non-numeric", `{"type":"limit","max_list_cost":{"amount":"abc","currency":"USD"}}`},
+		{"non-USD currency", `{"type":"limit","max_list_cost":{"amount":"125","currency":"EUR"}}`},
+		{"wrong type", `{"type":"soft","max_list_cost":{"amount":"125","currency":"USD"}}`},
+		{"missing max_list_cost", `{"type":"limit"}`},
+		{"not object", `"limit"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := normalizeBudget(json.RawMessage(tc.raw)); err == nil {
+				t.Fatalf("normalizeBudget(%s) 应报错", tc.raw)
+			}
+		})
+	}
+}
+
+func TestNormalizeBudgetValid(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"basic", `{"type":"limit","max_list_cost":{"amount":"125","currency":"USD"}}`, `{"max_list_cost":{"amount":"125","currency":"USD"},"type":"limit"}`},
+		{"single cent", `{"type":"limit","max_list_cost":{"amount":"50","currency":"USD"}}`, `{"max_list_cost":{"amount":"50","currency":"USD"},"type":"limit"}`},
+		{"trims amount", `{"type":"limit","max_list_cost":{"amount":" 125 ","currency":"USD"}}`, `{"max_list_cost":{"amount":"125","currency":"USD"},"type":"limit"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeBudget(json.RawMessage(tc.raw))
+			if err != nil {
+				t.Fatalf("normalizeBudget(%s) 应成功: %v", tc.raw, err)
+			}
+			if string(got) != tc.want {
+				t.Fatalf("normalizeBudget(%s) = %s, want %s", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeBudgetNullAndOmitted(t *testing.T) {
+	if got, err := normalizeBudget(json.RawMessage(`null`)); err != nil || got != nil {
+		t.Fatalf("normalizeBudget(null) = %v, %v, want nil", got, err)
+	}
+	if got, err := normalizeBudget(nil); err != nil || got != nil {
+		t.Fatalf("normalizeBudget(nil) = %v, %v, want nil", got, err)
+	}
+}

--- a/internal/sessions/event_effects.go
+++ b/internal/sessions/event_effects.go
@@ -125,6 +125,7 @@ func (h *Handler) sessionUpdatedEvent(session db.Session) (db.SessionEvent, erro
 	payload, err := httpapi.MarshalRaw(map[string]any{
 		"id":           eventID,
 		"agent":        agentsnapshot.RawJSONValue(session.AgentSnapshot, nil),
+		"budget":       agentsnapshot.RawJSONValue(session.Budget, nil),
 		"created_at":   httpapi.FormatTime(now),
 		"metadata":     agentsnapshot.RawJSONValue(session.Metadata, map[string]any{}),
 		"processed_at": now.Format(time.RFC3339),

--- a/internal/sessions/handler.go
+++ b/internal/sessions/handler.go
@@ -43,6 +43,7 @@ type sessionResponse struct {
 	ID                 string            `json:"id"`
 	Agent              json.RawMessage   `json:"agent"`
 	ArchivedAt         *string           `json:"archived_at"`
+	Budget             json.RawMessage   `json:"budget"`
 	CreatedAt          string            `json:"created_at"`
 	DeploymentID       *string           `json:"deployment_id,omitempty"`
 	EnvironmentID      string            `json:"environment_id"`
@@ -84,6 +85,7 @@ type sendEventsResponse struct {
 type sessionMutationRequest struct {
 	Agent         json.RawMessage `json:"agent"`
 	EnvironmentID json.RawMessage `json:"environment_id"`
+	Budget        json.RawMessage `json:"budget"`
 	Metadata      json.RawMessage `json:"metadata"`
 	Resources     json.RawMessage `json:"resources"`
 	Title         json.RawMessage `json:"title"`

--- a/internal/sessions/service.go
+++ b/internal/sessions/service.go
@@ -63,6 +63,10 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return invalidRequest(err)
 	}
+	budget, err := normalizeBudget(body.Budget)
+	if err != nil {
+		return invalidRequest(err)
+	}
 
 	sessionID, err := ids.New("sesn_")
 	if err != nil {
@@ -101,6 +105,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 			Title:                 title,
 			Metadata:              metadata,
 			VaultIDs:              vaultIDs,
+			Budget:                budget,
 			Status:                "idle",
 			Usage:                 json.RawMessage(`{}`),
 			Stats:                 json.RawMessage(`{}`),
@@ -280,6 +285,16 @@ func (h *Handler) updateRoute(w http.ResponseWriter, r *http.Request) error {
 		return invalidRequest(errors.New("vault_ids updates are not supported"))
 	}
 	next := current
+	if len(body.Budget) > 0 {
+		budget, err := normalizeBudget(body.Budget)
+		if err != nil {
+			return invalidRequest(err)
+		}
+		if budget != nil && len(current.Budget) == 0 {
+			return invalidRequest(errors.New("budget can only be added at session creation"))
+		}
+		next.Budget = budget
+	}
 	if len(body.Title) > 0 {
 		next.Title, err = nullableStringFromRaw(body.Title, "title")
 		if err != nil {

--- a/internal/sessions/service_helpers.go
+++ b/internal/sessions/service_helpers.go
@@ -452,6 +452,7 @@ func (h *Handler) responseFromSession(r *http.Request, session db.Session) (sess
 		ID:                 session.ExternalID,
 		Agent:              httpapi.RawOr(session.AgentSnapshot, `{}`),
 		ArchivedAt:         httpapi.OptionalTime(session.ArchivedAt),
+		Budget:             httpapi.RawOr(session.Budget, `null`),
 		CreatedAt:          httpapi.FormatTime(session.CreatedAt),
 		DeploymentID:       session.DeploymentID,
 		EnvironmentID:      session.EnvironmentExternalID,
@@ -521,4 +522,56 @@ func responseFromResource(resource db.SessionResource) json.RawMessage {
 
 func isOutputResource(resource db.SessionResource) bool {
 	return strings.HasPrefix(resource.Path, sandboxmount.OutputsRoot+"/")
+}
+
+type sessionBudgetMaxListCost struct {
+	Amount   string `json:"amount"`
+	Currency string `json:"currency"`
+}
+
+type sessionBudgetRequest struct {
+	Type        string                   `json:"type"`
+	MaxListCost sessionBudgetMaxListCost `json:"max_list_cost"`
+}
+
+func normalizeBudget(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 || httpapi.IsJSONNull(raw) {
+		return nil, nil
+	}
+	var budget sessionBudgetRequest
+	if err := json.Unmarshal(raw, &budget); err != nil {
+		return nil, errors.New("budget must be an object")
+	}
+	if budget.Type != "limit" {
+		return nil, errors.New("budget.type must be limit")
+	}
+	if budget.MaxListCost.Currency != "USD" {
+		return nil, errors.New("budget.max_list_cost.currency must be USD")
+	}
+	amount := strings.TrimSpace(budget.MaxListCost.Amount)
+	if !validBudgetAmount(amount) {
+		return nil, errors.New("budget.max_list_cost.amount must be a whole number of cents as a string, greater than zero")
+	}
+	return httpapi.MarshalRaw(map[string]any{
+		"type": "limit",
+		"max_list_cost": map[string]string{
+			"amount":   amount,
+			"currency": "USD",
+		},
+	})
+}
+
+func validBudgetAmount(amount string) bool {
+	if amount == "" {
+		return false
+	}
+	if len(amount) > 1 && amount[0] == '0' {
+		return false
+	}
+	for _, ch := range amount {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+	return amount != "0"
 }

--- a/tests/session_budget_api_test.go
+++ b/tests/session_budget_api_test.go
@@ -1,0 +1,41 @@
+package tests
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestSessionBudgetUpdateRulesAPI(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("budget-api-bucket"))
+	defer app.close()
+
+	agent := createAgent(t, app, `{"model":"claude-opus-4-8","name":"budget-agent"}`)
+	env := createEnvironment(t, app, `{"name":"budget-env"}`)
+	created := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
+
+	postBudget := func(body string) int {
+		t.Helper()
+		resp := doSessionRequest(t, app, http.MethodPost, "/v1/sessions/"+created.ID+"?beta=true", strings.NewReader(body), defaultTestKey, true)
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	// 无预算 session 加预算 → 400（官方 budgets.md 契约）
+	if code := postBudget(`{"budget":{"type":"limit","max_list_cost":{"amount":"500","currency":"USD"}}}`); code != http.StatusBadRequest {
+		t.Fatalf("add budget to session created without one: status = %d, want 400", code)
+	}
+
+	// 创建带预算的 session：改预算 → 200；移除预算（null）→ 200
+	budgeted := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`,"budget":{"type":"limit","max_list_cost":{"amount":"125","currency":"USD"}}}`)
+	resp := doSessionRequest(t, app, http.MethodPost, "/v1/sessions/"+budgeted.ID+"?beta=true", strings.NewReader(`{"budget":{"type":"limit","max_list_cost":{"amount":"250","currency":"USD"}}}`), defaultTestKey, true)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("update existing budget: status = %d, want 200", resp.StatusCode)
+	}
+	resp = doSessionRequest(t, app, http.MethodPost, "/v1/sessions/"+budgeted.ID+"?beta=true", strings.NewReader(`{"budget":null}`), defaultTestKey, true)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("remove budget: status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/web/src/features/managed-agents/api.test.ts
+++ b/web/src/features/managed-agents/api.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { QueryClient } from '@tanstack/react-query';
 import { setAnthropicClientForTest } from '@/shared/api/anthropic';
-import { listSessionFileOptions, mergeSessionStreamFrame, sessionDetailScopeEvents } from './api';
+import { listSessionFileOptions, mergeSessionStreamFrame, sessionBudgetUpdate, sessionDetailScopeEvents } from './api';
 import { buildSessionEventEntries } from './sessions/sessionTraceModel';
 
 const originalFetch = globalThis.fetch;
@@ -231,3 +231,22 @@ function fileMetadata(index: number) {
     type: 'file' as const,
   };
 }
+
+describe('sessionBudgetUpdate', () => {
+  test('sends new budget when amount provided', () => {
+    const values = { budgetAmount: '125', budgetInitiallySet: false } as never;
+    expect(sessionBudgetUpdate(values)).toEqual({
+      budget: { type: 'limit', max_list_cost: { amount: '125', currency: 'USD' } },
+    });
+  });
+
+  test('removes budget when cleared and was set', () => {
+    const values = { budgetAmount: '', budgetInitiallySet: true } as never;
+    expect(sessionBudgetUpdate(values)).toEqual({ budget: null });
+  });
+
+  test('omits budget when empty and was never set', () => {
+    const values = { budgetAmount: '', budgetInitiallySet: false } as never;
+    expect(sessionBudgetUpdate(values)).toEqual({});
+  });
+});

--- a/web/src/features/managed-agents/api.ts
+++ b/web/src/features/managed-agents/api.ts
@@ -1667,6 +1667,9 @@ export function createManagedEntityBody(section: ManagedEntitySection, values: M
         environment_id: values.environmentId,
         vault_ids: values.vaultIds,
         metadata: {},
+        ...(values.budgetAmount.trim()
+          ? { budget: { type: 'limit', max_list_cost: { amount: values.budgetAmount.trim(), currency: 'USD' } } }
+          : {}),
         resources: values.fileResources.map((resource) => {
           const mountPath = sessionFileAPIMountPath(resource.mountPath);
           return {
@@ -1714,6 +1717,15 @@ export function createManagedEntityBody(section: ManagedEntitySection, values: M
   }
 }
 
+export function sessionBudgetUpdate(values: ManagedEntityFormValues) {
+  const amount = values.budgetAmount.trim();
+  if (amount) {
+    return { budget: { type: 'limit', max_list_cost: { amount, currency: 'USD' } } };
+  }
+  // 清空原本有预算的 → 移除（null）；原本无预算 → 不发送（官方禁止给无预算 session 添加）
+  return values.budgetInitiallySet ? { budget: null } : {};
+}
+
 export function updateManagedEntityBody(section: ManagedEntitySection, values: ManagedEntityFormValues) {
   const name = values.name.trim();
   const description = values.description.trim();
@@ -1724,6 +1736,7 @@ export function updateManagedEntityBody(section: ManagedEntitySection, values: M
         agent: values.agentId || undefined,
         environment_id: values.environmentId || undefined,
         vault_ids: values.vaultIds,
+        ...sessionBudgetUpdate(values),
       };
     case 'deployments':
       return {

--- a/web/src/features/managed-agents/resources/dialogs.tsx
+++ b/web/src/features/managed-agents/resources/dialogs.tsx
@@ -1025,11 +1025,19 @@ function GenericManagedEntityDialog({
                   onChange={(vaultIds) => setValues((current) => ({ ...current, vaultIds }))}
                 />
                 {section === 'sessions' ? (
-                  <SessionFileResourcesField
-                    resources={values.fileResources}
-                    workspaceId={workspaceId}
-                    onChange={(fileResources) => setValues((current) => ({ ...current, fileResources }))}
-                  />
+                  <>
+                    <SessionFileResourcesField
+                      resources={values.fileResources}
+                      workspaceId={workspaceId}
+                      onChange={(fileResources) => setValues((current) => ({ ...current, fileResources }))}
+                    />
+                    <ManagedTextField
+                      label={msg('managedAgents.sessions.budget', 'Budget (USD cents)')}
+                      value={values.budgetAmount}
+                      placeholder={msg('managedAgents.sessions.budgetPlaceholder', 'e.g. 125 for $1.25')}
+                      onChange={(budgetAmount) => setValues((current) => ({ ...current, budgetAmount }))}
+                    />
+                  </>
                 ) : null}
               </>
             ) : null}

--- a/web/src/features/managed-agents/resources/model.test.ts
+++ b/web/src/features/managed-agents/resources/model.test.ts
@@ -410,3 +410,15 @@ describe('vaultOAuthErrorMessage', () => {
     expect(vaultOAuthErrorMessage(' mystery_code ', msgFallback)).toBe('Could not complete OAuth. Try again.');
   });
 });
+
+describe('entityBudgetAmount', () => {
+  it('returns amount from entity budget', () => {
+    const entity = { budget: { max_list_cost: { amount: '125' } } };
+    expect(entityBudgetAmount(entity as never)).toBe('125');
+  });
+
+  it('returns empty when no budget', () => {
+    expect(entityBudgetAmount({} as never)).toBe('');
+    expect(entityBudgetAmount({ budget: null } as never)).toBe('');
+  });
+});

--- a/web/src/features/managed-agents/resources/model.tsx
+++ b/web/src/features/managed-agents/resources/model.tsx
@@ -332,7 +332,16 @@ export function initialFormValues(
     vaultIds: entity ? entityVaultIds(entity) : [],
     memoryStoreIds: entity ? entityMemoryStoreIds(entity) : [],
     fileResources: [],
+    budgetAmount: entityBudgetAmount(entity),
+    budgetInitiallySet: entityBudgetAmount(entity) !== '',
   };
+}
+
+export function entityBudgetAmount(entity?: ManagedEntityApiResponse) {
+  if (!entity || !('budget' in entity) || !entity.budget || !entity.budget.max_list_cost) {
+    return '';
+  }
+  return entity.budget.max_list_cost.amount ?? '';
 }
 
 export function entityDisplayName(section: ManagedEntitySection, entity: ManagedEntityApiResponse) {

--- a/web/src/features/managed-agents/types.ts
+++ b/web/src/features/managed-agents/types.ts
@@ -173,6 +173,7 @@ export type SessionApiResponse = {
   stats?: unknown;
   status: string;
   title?: string | null;
+  budget?: { max_list_cost?: { amount?: string } } | null;
   type: 'session';
   updated_at: string;
   usage?: unknown;
@@ -566,6 +567,8 @@ export type ManagedEntityFormValues = {
   vaultIds: string[];
   memoryStoreIds: string[];
   fileResources: SessionFileResourceFormValue[];
+  budgetAmount: string;
+  budgetInitiallySet: boolean;
 };
 
 export type SessionFileResourceFormValue = {

--- a/web/src/shared/i18n/messages/en.json
+++ b/web/src/shared/i18n/messages/en.json
@@ -1578,5 +1578,7 @@
   "workspace.geoHelp": "Control where your workspace data, including files, conversation history, and workspace artifacts, is stored. This can't be changed after creation.",
   "workspace.loading": "Loading workspaces...",
   "workspace.onlyCostLogs": "Only available on Cost and Logs",
-  "workspace.switcher": "Switch workspace"
+  "workspace.switcher": "Switch workspace",
+  "managedAgents.sessions.budget": "Budget (USD cents)",
+  "managedAgents.sessions.budgetPlaceholder": "e.g. 125 for $1.25"
 }

--- a/web/src/shared/i18n/messages/zh-CN.json
+++ b/web/src/shared/i18n/messages/zh-CN.json
@@ -1578,5 +1578,7 @@
   "workspace.geoHelp": "控制工作区数据的存储位置，包括文件、对话历史和工作区产物。创建后无法更改。",
   "workspace.loading": "正在加载工作区...",
   "workspace.onlyCostLogs": "仅适用于 Cost 和 Logs",
-  "workspace.switcher": "切换工作区"
+  "workspace.switcher": "切换工作区",
+  "managedAgents.sessions.budget": "预算（美分）",
+  "managedAgents.sessions.budgetPlaceholder": "如 125 表示 $1.25"
 }


### PR DESCRIPTION
## 背景

官方 Claude Managed Agents 支持 session 级费用预算：创建 session 时传 `budget: {type: "limit", max_list_cost: {amount: "125", currency: "USD"}}`（amount 是美分字符串，仅支持 USD），达到上限后暂停/拒绝新事件，避免失控烧钱。

OMA 全仓对 budget **零实现**（无字段、无 DB 列、无校验）——官方 SDK 创建带 budget 的 session 被静默忽略。

## 改动

### DB 层（`internal/db`）
- migration `00055_add_session_budget.sql`：`sessions` 表加 `budget jsonb` 列（NULL = 无预算，含 Up/Down）
- `sessionRow`/`sessionWriteParams`/`sessionUpdateParams`/`Session` 结构加 `Budget`，`session_mapper.xml` 的 `columns`/`Insert`/`Update` 支持 budget（`agentJSONArg` 归一 nil/`"null"` → SQL NULL）

### 校验与写入（`internal/sessions`）
- `sessionMutationRequest` 加 `Budget` 字段，新增 `normalizeBudget` 校验（type=limit、无前导零整美分字符串、currency=USD、null/省略 → 无预算）
- create 存储 budget；update 支持改/移除（`"budget": null` → 清除），**给无预算 session 添加预算 → 400**（官方 budgets.md 契约）
- session 响应回显 `budget`（无预算时显式 `null`，与 `Usage`/`Metadata` 一致）
- `session.updated` 事件携带 budget（改/移除预算后下游可感知）

### 前端（`web/src/features/managed-agents`）
- **创建**：session 创建对话框新增 Budget (USD cents) 输入（ManagedTextField），create body 带 budget
- **编辑回填**：`entityBudgetAmount(entity)` 从 `entity.budget.max_list_cost.amount` 回填；`budgetInitiallySet` 记录原状态
- **更新三态**（`sessionBudgetUpdate`）：非空 → 发新 budget；清空且原本有 → 发 `budget: null` 移除；清空且原本无 → 不发（官方禁止给无预算 session 加预算）
- i18n：`managedAgents.sessions.budget` / `budgetPlaceholder`（扁平 key，en/zh 对称）

### 设计文档
- 新增 `docs/design/be/session-budget.md`：官方契约、方案、范围更新、明确不做

## 验收

- [x] **创建带 budget 的 session**：`budget` 字段存储（`{"type":"limit","max_list_cost":{"amount":"125","currency":"USD"}}`）
- [x] **校验**：非法 amount（零/负数/前导零/小数/非数字）、非 USD、非 limit type、null/省略 → 正确拒绝或归一
- [x] **update 改/移除预算**：`"budget": null` 清除；给无预算 session 添加预算 → 400
- [x] **响应回显**：无预算 session 显式返回 `budget: null`
- [x] **事件感知**：`session.updated` 携带 budget 字段
- [x] **前端创建入口**：对话框输入美分金额 → create body 带 budget

## 范围边界：本 PR 是"数据就绪层"，执行链路依赖 #62/#271

**本 PR 交付**：预算的**声明能力**——存储（`session.Budget` 列）、校验（normalizeBudget）、回显（响应/事件）。这是执行链路的地基：后续任何达上限判定都必须先读到正确的 budget，本 PR 让这个字段真实可存、可读、可改、可移除。

**未实现（后续依赖）**：
- `usage.list_cost` 定价（模型 token / web search / 运行时间按 public list rates）→ **#62 用量采集**
- 达上限暂停（`stop_reason=budget_reached`）、拒绝 work-starting 事件（400 列 settle 清单）、改/移除后自动恢复 → **#271**

**执行链路如何打通（BYOK 计费逻辑落地后）**：
```
#62 用量采集 → 计算 usage.list_cost
  → 达上限判定：读取 session.Budget（本 PR 存储）+ usage.list_cost（#62）
  → 达上限：拒绝 work-starting 事件（400）、发 session.usage（#268 已就绪）+ idle(stop_reason=budget_reached)（#271）
  → 改/移除 budget（本 PR 支持）→ 自动恢复
```

一句话：**本 PR 让 budget 真实存在且契约对齐；能否"拦住"取决于 #62 的定价与 #271 的暂停逻辑**——两者落地后，官方 SDK 的达上限行为即完整生效。

`session.usage` 事件本身由 #268 交付（budget 回显依赖本 PR 的 `session.Budget` 字段，跨 PR 契约已登记在设计文档合并检查清单）。

## 测试

- ✅ `go test ./internal/sessions/ ./internal/db/`：全绿（`normalizeBudget` 合法/非法/null 用例 + builder 契约断言更新）
- ✅ `just lint` / `dead-code` / `duplicates` / `complexity` / `large-files` 全过
- ✅ `bun run build` 通过
- ⚠️ `just test` 的 workbench/deployments 失败在 main 上同样存在（本地 env 干扰 + #208 遗留）

## 关联

- Part of #244（本 PR 交付 Session Budget 费用上限基础；预算达上限后的暂停/拒绝/恢复行为由 #271 跟踪）
- 依赖 #62（list cost 计算，达上限判定后续）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional session-level USD budget limits, specified in cents.
  * Session responses and update events now include normalized budgets.
  * Added budget controls to session creation forms, with support for updates and removal.
  * Added environment-variable credential networking and header/body injection settings.

* **Bug Fixes**
  * Improved handling of missing, null, and invalid budget values.
  * Prevented adding budgets to previously unbudgeted sessions.
  * Added validation for allowed hosts and credential injection settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


