### PR TITLE
fix(managed-agents): 优化 Agent 表单交互样式

### DIFF
--- a/web/src/features/analytics/AnalyticsPages.test.tsx
+++ b/web/src/features/analytics/AnalyticsPages.test.tsx
@@ -214,6 +214,7 @@ describe('Analytics pages', () => {
     renderWithWorkspace(<LogsPage />);
 
     expect(screen.getByRole('heading', { name: 'Logs' })).toBeTruthy();
+    expect(screen.getByRole('searchbox', { name: 'Search logs' }).getAttribute('type')).toBe('search');
     expect(screen.getByText('June 18, 2026 at 11:34 PM GMT+8')).toBeTruthy();
     for (const heading of ['Time', 'ID', 'Model', 'Input Tokens', 'Output Tokens', 'Type', 'Service Tier', 'Request']) {
       expect(screen.getAllByText(heading).length).toBeGreaterThan(0);

--- a/web/src/features/analytics/AnalyticsPages.tsx
+++ b/web/src/features/analytics/AnalyticsPages.tsx
@@ -535,6 +535,7 @@ export function LogsPage() {
           <div className="flex items-center gap-2">
             <Search className="size-4 text-muted-foreground/70" aria-hidden />
             <Input
+              type="search"
               aria-label={msg('analytics.logs.searchAria', 'Search logs')}
               placeholder={msg('analytics.logs.searchPlaceholder', 'Search request IDs')}
               className="h-8 flex-1 border-0 bg-transparent px-0 text-sm shadow-none focus-visible:border-transparent focus-visible:ring-0"

--- a/web/src/features/analytics/AnalyticsPages.tsx
+++ b/web/src/features/analytics/AnalyticsPages.tsx
@@ -538,7 +538,7 @@ export function LogsPage() {
               type="search"
               aria-label={msg('analytics.logs.searchAria', 'Search logs')}
               placeholder={msg('analytics.logs.searchPlaceholder', 'Search request IDs')}
-              className="h-8 flex-1 border-0 bg-transparent px-0 text-sm shadow-none focus-visible:border-transparent focus-visible:ring-0"
+              className="h-8 flex-1 border-0 bg-transparent px-0 text-sm shadow-none focus-visible:border-transparent"
             />
             <LogsFiltersMenu
               requestTypeOptions={requestTypeOptions}

--- a/web/src/features/dashboard/feature-pages.tsx
+++ b/web/src/features/dashboard/feature-pages.tsx
@@ -83,7 +83,7 @@ export function WorkbenchPage() {
           <CardContent className="p-0">
             <Textarea
               aria-label="Prompt"
-              className="mt-4 min-h-[360px] resize-none border-0 bg-transparent px-0 py-0 text-sm leading-6 shadow-none placeholder:text-muted-foreground/70 focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent"
+              className="mt-4 min-h-[360px] resize-none border-0 bg-transparent px-0 py-0 text-sm leading-6 shadow-none placeholder:text-muted-foreground/70 focus-visible:border-transparent dark:bg-transparent"
               placeholder="Write a prompt..."
             />
           </CardContent>

--- a/web/src/features/managed-agents/ManagedAgentsPage.agents.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.agents.suite.tsx
@@ -82,6 +82,7 @@ export function registerManagedAgentsAgentsTests() {
     expect(within(dialog).getByRole('tab', { name: 'Rendered' }).getAttribute('aria-selected')).toBe('true');
     expect(within(dialog).getByText('General')).toBeTruthy();
     expect(within(dialog).getByDisplayValue('Untitled agent')).toBeTruthy();
+    expect(within(dialog).getByText('Description (optional)').closest('label')?.className).toContain('grid gap-2');
     fireEvent.click(within(dialog).getByRole('tab', { name: 'Raw' }));
     expect(dialog.textContent).toContain('name: Untitled agent');
     expect(dialog.textContent).toContain('mcp_servers: []');
@@ -382,7 +383,17 @@ export function registerManagedAgentsAgentsTests() {
     const githubCard = within(dialog).getByText('GitHub').closest('[data-slot="card"]') as HTMLElement;
     expect(githubCard).toBeTruthy();
     fireEvent.click(within(githubCard).getByRole('button', { name: 'Tool permissions' }));
-    fireEvent.click(screen.getByRole('menuitemradio', { name: 'Always allow' }));
+    const alwaysAllowItem = screen.getByRole('menuitemradio', { name: 'Always allow' });
+    expect(alwaysAllowItem.className).toContain('whitespace-nowrap');
+    for (const label of ['Always allow', 'Always ask', 'Always deny']) {
+      expect(
+        screen.getByRole('menuitemradio', { name: label }).querySelector('[data-slot="permission-option-icon"]'),
+      ).toBeTruthy();
+    }
+    const permissionMenu = alwaysAllowItem.closest('[data-slot="dropdown-menu-content"]');
+    expect(permissionMenu?.className).toContain('w-max');
+    expect(permissionMenu?.className).toContain('min-w-40');
+    fireEvent.click(alwaysAllowItem);
 
     const addMcpButton = within(dialog).getByRole('combobox', { name: 'Add MCP server' });
     const addCustomToolButton = within(dialog).getByRole('button', { name: 'Add custom tool' });
@@ -1368,7 +1379,7 @@ export function registerManagedAgentsAgentsTests() {
     expect(within(dialog).getByText('General')).toBeTruthy();
     expect(within(dialog).getByDisplayValue('Editable agent')).toBeTruthy();
     expect(within(dialog).getByRole('button', { name: 'Close' })).toBeTruthy();
-    expect(within(dialog).getByRole('button', { name: 'Save new version' }).hasAttribute('disabled')).toBe(true);
+    expect(within(dialog).getByRole('button', { name: 'Save' }).hasAttribute('disabled')).toBe(true);
 
     fireEvent.click(within(dialog).getByRole('tab', { name: 'Raw' }));
 
@@ -1413,7 +1424,10 @@ export function registerManagedAgentsAgentsTests() {
     const nameInput = within(dialog).getByDisplayValue('Historical config');
     expect(within(dialog).getByDisplayValue('Historical description')).toBeTruthy();
     fireEvent.change(nameInput, { target: { value: 'Historical config revised' } });
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Save new version' }));
+    const saveButton = within(dialog).getByRole('button', { name: 'Save' });
+    expect(saveButton.className).toContain('hover:bg-foreground/90');
+    expect(saveButton.className).not.toContain('hover:bg-muted');
+    fireEvent.click(saveButton);
 
     await waitFor(() =>
       expect(
@@ -1476,7 +1490,7 @@ export function registerManagedAgentsAgentsTests() {
 
     fireEvent.click(within(dialog).getByRole('tab', { name: 'Raw' }));
     expect(within(dialog).getByText(/Name is required/i)).toBeTruthy();
-    expect(within(dialog).getByRole('button', { name: 'Save new version' }).hasAttribute('disabled')).toBe(true);
+    expect(within(dialog).getByRole('button', { name: 'Save' }).hasAttribute('disabled')).toBe(true);
   });
 
   test('validates JSON edit config and saves a canonicalized new version body', async () => {
@@ -1506,7 +1520,7 @@ export function registerManagedAgentsAgentsTests() {
     setAgentConfigEditorValue(dialog, '{', 'Agent config JSON');
 
     expect(within(dialog).getByText(/JSON is not valid/i)).toBeTruthy();
-    expect(within(dialog).getByRole('button', { name: 'Save new version' }).hasAttribute('disabled')).toBe(true);
+    expect(within(dialog).getByRole('button', { name: 'Save' }).hasAttribute('disabled')).toBe(true);
 
     setAgentConfigEditorValue(
       dialog,
@@ -1529,7 +1543,7 @@ export function registerManagedAgentsAgentsTests() {
     );
     expect(within(dialog).queryByText(/JSON is not valid/i)).toBeNull();
 
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Save new version' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
 
     await waitFor(() =>
       expect(
@@ -1582,7 +1596,7 @@ export function registerManagedAgentsAgentsTests() {
       fireEvent.change(within(dialog).getByDisplayValue(`Editable agent ${status}`), {
         target: { value: `Updated agent ${status}` },
       });
-      fireEvent.click(within(dialog).getByRole('button', { name: 'Save new version' }));
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
 
       expect(await within(dialog).findByText(message)).toBeTruthy();
       expect(within(dialog).getByDisplayValue(`Updated agent ${status}`)).toBeTruthy();
@@ -1656,7 +1670,7 @@ export function registerManagedAgentsAgentsTests() {
     expect(await within(dialog).findByText('Worker')).toBeTruthy();
 
     fireEvent.change(within(dialog).getByDisplayValue('Coordinator'), { target: { value: 'Coordinator updated' } });
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Save new version' }));
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
 
     await waitFor(() =>
       expect(

--- a/web/src/features/managed-agents/agents/create-dialog-rendered.tsx
+++ b/web/src/features/managed-agents/agents/create-dialog-rendered.tsx
@@ -105,7 +105,7 @@ export function AgentConfigRenderedEditor({
         )}
       >
         <div className="space-y-4">
-          <label className="block space-y-1.5 text-sm font-medium">
+          <label className="grid gap-2 text-sm font-medium">
             <span>{msg('managedAgents.common.name', 'Name')}</span>
             <Input
               className="h-10"
@@ -114,7 +114,7 @@ export function AgentConfigRenderedEditor({
               onChange={(event) => onChange({ ...draft, name: event.target.value })}
             />
           </label>
-          <label className="block space-y-1.5 text-sm font-medium">
+          <label className="grid gap-2 text-sm font-medium">
             <span>{msg('managedAgents.common.model', 'Model')}</span>
             <ModelPicker
               options={modelOptions}
@@ -122,7 +122,7 @@ export function AgentConfigRenderedEditor({
               onChange={(id) => onChange({ ...draft, model: updateDraftModelID(draft.model, id) })}
             />
           </label>
-          <label className="block space-y-1.5 text-sm font-medium">
+          <label className="grid gap-2 text-sm font-medium">
             <span>{msg('managedAgents.agents.createDialog.optionalDescription', 'Description (optional)')}</span>
             <Textarea
               className="min-h-20 resize-y"
@@ -130,7 +130,7 @@ export function AgentConfigRenderedEditor({
               onChange={(event) => onChange({ ...draft, description: event.target.value || null })}
             />
           </label>
-          <label className="block space-y-1.5 text-sm font-medium">
+          <label className="grid gap-2 text-sm font-medium">
             <span>{msg('managedAgents.agents.createDialog.optionalSystemPrompt', 'System prompt (optional)')}</span>
             <Textarea
               className="min-h-28 resize-y"

--- a/web/src/features/managed-agents/agents/create-dialog-tools-editor.tsx
+++ b/web/src/features/managed-agents/agents/create-dialog-tools-editor.tsx
@@ -39,7 +39,11 @@ import {
 } from './tools/model';
 import { RemoteServerIcon } from './tools/RemoteServerIcon';
 
-const permissionValues: EditablePermission[] = ['always_allow', 'always_ask', 'always_deny'];
+const permissionOptions = [
+  { value: 'always_allow' as const, icon: CheckCircle2 },
+  { value: 'always_ask' as const, icon: Hand },
+  { value: 'always_deny' as const, icon: Ban },
+];
 
 export function CreateDialogToolsEditor({
   draft,
@@ -296,10 +300,11 @@ function PermissionMenu({
         {permissionLabel(value, msg)}
         <ChevronDown className="size-3.5" aria-hidden />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" className="w-max min-w-40">
         <DropdownMenuRadioGroup value={value} onValueChange={(next) => onChange(next as EditablePermission)}>
-          {permissionValues.map((permission) => (
-            <DropdownMenuRadioItem key={permission} value={permission}>
+          {permissionOptions.map(({ value: permission, icon: PermissionIcon }) => (
+            <DropdownMenuRadioItem key={permission} value={permission} className="whitespace-nowrap">
+              <PermissionIcon data-slot="permission-option-icon" className="size-4 text-muted-foreground" aria-hidden />
               {permissionLabel(permission, msg)}
             </DropdownMenuRadioItem>
           ))}
@@ -317,42 +322,25 @@ function PermissionButtons({
   onChange: (permission: EditablePermission) => void;
 }) {
   const { msg } = useI18n();
-  const buttons = [
-    {
-      value: 'always_allow' as const,
-      label: msg('managedAgents.agents.detail.alwaysAllow', 'Always allow'),
-      icon: CheckCircle2,
-    },
-    {
-      value: 'always_ask' as const,
-      label: msg('managedAgents.agents.detail.alwaysAsk', 'Always ask'),
-      icon: Hand,
-    },
-    {
-      value: 'always_deny' as const,
-      label: msg('managedAgents.agents.detail.alwaysDeny', 'Always deny'),
-      icon: Ban,
-    },
-  ];
   return (
     <div className="flex rounded-lg bg-muted p-0.5">
-      {buttons.map((button) => {
-        const Icon = button.icon;
+      {permissionOptions.map(({ value: permission, icon: PermissionIcon }) => {
+        const label = permissionLabel(permission, msg);
         return (
           <Button
-            key={button.value}
+            key={permission}
             type="button"
             variant="ghost"
             size="icon-sm"
-            aria-label={button.label}
-            title={button.label}
+            aria-label={label}
+            title={label}
             className={cn(
               'size-7 text-muted-foreground',
-              value === button.value && 'bg-background text-foreground shadow-sm',
+              value === permission && 'bg-background text-foreground shadow-sm',
             )}
-            onClick={() => onChange(button.value)}
+            onClick={() => onChange(permission)}
           >
-            <Icon className="size-4" aria-hidden />
+            <PermissionIcon className="size-4" aria-hidden />
           </Button>
         );
       })}

--- a/web/src/features/managed-agents/agents/detail.tsx
+++ b/web/src/features/managed-agents/agents/detail.tsx
@@ -1887,13 +1887,11 @@ export function AgentEditDialog({
                 'px-3 text-[14px] font-semibold leading-5',
                 saveDisabled
                   ? 'cursor-not-allowed bg-accent text-muted-foreground/70'
-                  : 'bg-foreground text-background hover:bg-muted',
+                  : 'bg-foreground text-background hover:bg-foreground/90',
               )}
               onClick={() => void submit()}
             >
-              {submitting
-                ? msg('common.saving', 'Saving...')
-                : msg('managedAgents.agents.editDialog.saveNewVersion', 'Save new version')}
+              {submitting ? msg('common.saving', 'Saving...') : msg('common.save', 'Save')}
             </Button>
           </div>
         </div>

--- a/web/src/features/managed-agents/components/common.tsx
+++ b/web/src/features/managed-agents/components/common.tsx
@@ -108,6 +108,7 @@ export function ManagedSearchField({
       <Input
         ref={inputRef}
         type="search"
+        data-custom-clear
         id={id}
         value={value}
         placeholder={placeholder}

--- a/web/src/features/managed-agents/components/common.tsx
+++ b/web/src/features/managed-agents/components/common.tsx
@@ -112,7 +112,7 @@ export function ManagedSearchField({
         value={value}
         placeholder={placeholder}
         className={clsx(
-          'h-9 border-border bg-secondary text-sm text-foreground placeholder:text-muted-foreground focus-visible:border-border focus-visible:ring-0',
+          'h-9 border-border bg-secondary text-sm text-foreground placeholder:text-muted-foreground focus-visible:border-border',
           prefix ? 'pl-[64px]' : 'pl-9',
           value ? 'pr-9' : 'pr-3',
         )}

--- a/web/src/features/managed-agents/components/common.tsx
+++ b/web/src/features/managed-agents/components/common.tsx
@@ -107,6 +107,7 @@ export function ManagedSearchField({
       ) : null}
       <Input
         ref={inputRef}
+        type="search"
         id={id}
         value={value}
         placeholder={placeholder}

--- a/web/src/features/managed-agents/quickstart/components.tsx
+++ b/web/src/features/managed-agents/quickstart/components.tsx
@@ -1744,6 +1744,7 @@ export function BrowseTemplatesPanel({
           />
           <Input
             ref={searchRef}
+            type="search"
             id="agent-template-search"
             value={query}
             placeholder={msg('managedAgents.quickstart.searchTemplates', 'Search templates')}

--- a/web/src/features/managed-agents/sessions/SessionTracePanel.tsx
+++ b/web/src/features/managed-agents/sessions/SessionTracePanel.tsx
@@ -388,7 +388,7 @@ export function SessionTraceSearch({ value, onChange }: { value: string; onChang
       tabIndex={expanded ? undefined : 0}
       aria-label={expanded ? undefined : msg('managedAgents.sessions.trace.openSearchFilter', 'Open search filter')}
       className={clsx(
-        'relative flex h-7 shrink-0 items-center overflow-hidden rounded-md transition-[width,background-color,box-shadow]',
+        'relative flex h-7 shrink-0 items-center overflow-hidden rounded-md transition-[width,background-color,box-shadow] focus-within:ring-2 focus-within:ring-ring/50',
         expanded
           ? 'w-56 bg-secondary ring-1 ring-border'
           : 'w-7 cursor-pointer text-muted-foreground hover:bg-accent hover:text-foreground',

--- a/web/src/features/managed-agents/sessions/SessionTracePanel.tsx
+++ b/web/src/features/managed-agents/sessions/SessionTracePanel.tsx
@@ -406,6 +406,7 @@ export function SessionTraceSearch({ value, onChange }: { value: string; onChang
       </span>
       <Input
         ref={inputRef}
+        type="search"
         aria-label={msg('managedAgents.sessions.trace.filterEvents', 'Filter events')}
         value={value}
         placeholder={msg('managedAgents.sessions.trace.filterEvents', 'Filter events')}

--- a/web/src/features/managed-agents/sessions/SessionTracePanel.tsx
+++ b/web/src/features/managed-agents/sessions/SessionTracePanel.tsx
@@ -407,6 +407,7 @@ export function SessionTraceSearch({ value, onChange }: { value: string; onChang
       <Input
         ref={inputRef}
         type="search"
+        data-custom-clear
         aria-label={msg('managedAgents.sessions.trace.filterEvents', 'Filter events')}
         value={value}
         placeholder={msg('managedAgents.sessions.trace.filterEvents', 'Filter events')}

--- a/web/src/shared/i18n/messages/en.json
+++ b/web/src/shared/i18n/messages/en.json
@@ -473,7 +473,6 @@
   "managedAgents.agents.editDialog.description": "Saving creates the next version for this agent.",
   "managedAgents.agents.editDialog.modelsError": "Could not load available models.",
   "managedAgents.agents.editDialog.renderedUnavailable": "This configuration contains fields that cannot be edited safely in Rendered mode. Continue in Raw.",
-  "managedAgents.agents.editDialog.saveNewVersion": "Save new version",
   "managedAgents.agents.editDialog.title": "Edit agent",
   "managedAgents.agents.emptyAction": "Get started with agents",
   "managedAgents.agents.emptyTitle": "No agents yet",

--- a/web/src/shared/i18n/messages/zh-CN.json
+++ b/web/src/shared/i18n/messages/zh-CN.json
@@ -473,7 +473,6 @@
   "managedAgents.agents.editDialog.description": "保存会为此 Agent 创建下一个版本。",
   "managedAgents.agents.editDialog.modelsError": "无法加载可用模型。",
   "managedAgents.agents.editDialog.renderedUnavailable": "此配置包含无法在“表单”模式下安全编辑的字段，请继续使用“原始配置”。",
-  "managedAgents.agents.editDialog.saveNewVersion": "保存新版本",
   "managedAgents.agents.editDialog.title": "编辑 Agent",
   "managedAgents.agents.emptyAction": "开始使用 Agents",
   "managedAgents.agents.emptyTitle": "暂无 Agent",

--- a/web/src/shared/ui/command.test.tsx
+++ b/web/src/shared/ui/command.test.tsx
@@ -22,11 +22,12 @@ describe('CommandInput', () => {
     expect(wrapper?.className).toContain('has-[[data-slot=command-input]:focus-visible]:ring-2');
   });
 
-  test('keeps command focus on its wrapper and hides the native search cancel button', async () => {
+  test('keeps command focus on its wrapper and scopes native search cancel suppression', async () => {
     const stylesheet = await Bun.file(new URL('../../styles/foundation.css', import.meta.url)).text();
 
     expect(stylesheet).toContain(":where([data-slot='input'], [data-slot='textarea'], [data-slot='command-input'])");
-    expect(stylesheet).toContain("input[type='search']::-webkit-search-cancel-button");
+    expect(stylesheet).toContain("input[type='search'][data-custom-clear]::-webkit-search-cancel-button");
+    expect(stylesheet).not.toContain("input[type='search']::-webkit-search-cancel-button");
     expect(stylesheet).toContain('-webkit-appearance: none');
   });
 });

--- a/web/src/shared/ui/command.test.tsx
+++ b/web/src/shared/ui/command.test.tsx
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import '../../test/setup';
+import { Command, CommandInput } from './command';
+
+const { cleanup, render, screen } = await import('@testing-library/react');
+
+afterEach(cleanup);
+
+describe('CommandInput', () => {
+  test('marks the nested input for the command-specific focus style', () => {
+    render(
+      <Command>
+        <CommandInput aria-label="搜索" />
+      </Command>,
+    );
+
+    expect(screen.getByRole('combobox').dataset.slot).toBe('command-input');
+  });
+
+  test('removes the global focus ring from command and search inputs', async () => {
+    const stylesheet = await Bun.file(new URL('../../styles/foundation.css', import.meta.url)).text();
+
+    expect(stylesheet).toContain(":focus-visible:not(\n    :where([data-slot='input'], [data-slot='textarea'])\n  )");
+    expect(stylesheet).toContain(
+      ":where([data-slot='command-input'], input[type='search']):focus-visible {\n  box-shadow: none;\n}",
+    );
+  });
+});

--- a/web/src/shared/ui/command.test.tsx
+++ b/web/src/shared/ui/command.test.tsx
@@ -7,22 +7,26 @@ const { cleanup, render, screen } = await import('@testing-library/react');
 afterEach(cleanup);
 
 describe('CommandInput', () => {
-  test('marks the nested input for the command-specific focus style', () => {
+  test('marks the nested input and wrapper for the command-specific focus style', () => {
     render(
       <Command>
         <CommandInput aria-label="搜索" />
       </Command>,
     );
 
-    expect(screen.getByRole('combobox').dataset.slot).toBe('command-input');
+    const input = screen.getByRole('combobox');
+    const wrapper = input.parentElement;
+
+    expect(input.dataset.slot).toBe('command-input');
+    expect(wrapper?.dataset.slot).toBe('command-input-wrapper');
+    expect(wrapper?.className).toContain('has-[[data-slot=command-input]:focus-visible]:ring-2');
   });
 
-  test('removes the global focus ring from command and search inputs', async () => {
+  test('keeps command focus on its wrapper and hides the native search cancel button', async () => {
     const stylesheet = await Bun.file(new URL('../../styles/foundation.css', import.meta.url)).text();
 
-    expect(stylesheet).toContain(":focus-visible:not(\n    :where([data-slot='input'], [data-slot='textarea'])\n  )");
-    expect(stylesheet).toContain(
-      ":where([data-slot='command-input'], input[type='search']):focus-visible {\n  box-shadow: none;\n}",
-    );
+    expect(stylesheet).toContain(":where([data-slot='input'], [data-slot='textarea'], [data-slot='command-input'])");
+    expect(stylesheet).toContain("input[type='search']::-webkit-search-cancel-button");
+    expect(stylesheet).toContain('-webkit-appearance: none');
   });
 });

--- a/web/src/shared/ui/command.tsx
+++ b/web/src/shared/ui/command.tsx
@@ -51,7 +51,10 @@ function CommandDialog({
 
 function CommandInput({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
-    <div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b border-border px-3">
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b border-border px-3 has-[[data-slot=command-input]:focus-visible]:ring-2 has-[[data-slot=command-input]:focus-visible]:ring-ring/50"
+    >
       <SearchIcon className="size-4 shrink-0 opacity-50" />
       <CommandPrimitive.Input
         data-slot="command-input"

--- a/web/src/styles/foundation.css
+++ b/web/src/styles/foundation.css
@@ -410,14 +410,15 @@ select {
 }
 
 :where(a, button, input, textarea, select, [role='button'], [role='combobox'], [tabindex]):focus-visible:not(
-    :where([data-slot='input'], [data-slot='textarea'])
+    :where([data-slot='input'], [data-slot='textarea'], [data-slot='command-input'])
   ) {
   outline: none;
   box-shadow: var(--focus-ring);
 }
 
-:where([data-slot='command-input'], input[type='search']):focus-visible {
-  box-shadow: none;
+input[type='search']::-webkit-search-cancel-button {
+  appearance: none;
+  -webkit-appearance: none;
 }
 
 :where([data-slot='input-group-control']):focus-visible {

--- a/web/src/styles/foundation.css
+++ b/web/src/styles/foundation.css
@@ -416,7 +416,7 @@ select {
   box-shadow: var(--focus-ring);
 }
 
-input[type='search']::-webkit-search-cancel-button {
+input[type='search'][data-custom-clear]::-webkit-search-cancel-button {
   appearance: none;
   -webkit-appearance: none;
 }

--- a/web/src/styles/foundation.css
+++ b/web/src/styles/foundation.css
@@ -409,9 +409,15 @@ select {
   -webkit-tap-highlight-color: transparent;
 }
 
-:where(a, button, input, textarea, select, [role='button'], [role='combobox'], [tabindex]):focus-visible {
+:where(a, button, input, textarea, select, [role='button'], [role='combobox'], [tabindex]):focus-visible:not(
+    :where([data-slot='input'], [data-slot='textarea'])
+  ) {
   outline: none;
   box-shadow: var(--focus-ring);
+}
+
+:where([data-slot='command-input'], input[type='search']):focus-visible {
+  box-shadow: none;
 }
 
 :where([data-slot='input-group-control']):focus-visible {


### PR DESCRIPTION
## 变更概览

- 修复 Command 搜索框与普通搜索框继承全局焦点环后产生的错位，并为搜索输入补充明确的 `search` 语义
- 修复 Agent 表单标题与 Input / Textarea 焦点环重叠，统一字段间距
- 优化 Tool permissions 菜单：选项单行显示、按内容扩展宽度，并在左侧展示允许 / 询问 / 拒绝图标
- 将编辑 Agent 的按钮文案从 `Save new version` 简化为 `Save` / `保存`，并修复暗色主题下 hover 对比度过低

## 背景

Agent 创建与编辑表单中的部分控件同时受到共享组件样式和全局焦点样式影响，导致搜索框焦点态错位、字段标题与焦点环过近，以及权限菜单文案换行。编辑按钮的文案和 hover 配色也与当前表单语义不够一致。

本 PR 统一这些表单交互细节，不改变 Agent 配置、权限策略或版本保存语义。

## 影响

- Agent 搜索、日志搜索、Session 事件搜索和模板搜索使用一致的焦点样式
- Agent Rendered 表单的 Name、Model、Description、System prompt 字段保持稳定的 8px 标题间距
- 权限菜单中的 `Always allow`、`Always ask`、`Always deny` 始终单行显示，并与快捷按钮使用同一组图标
- `Save` 仍调用原有更新接口并创建 Agent 新版本；API 请求和数据模型不变
- 无后端、数据库、路由或公开 API 变更

## 验证

- `bun test src/shared/i18n/I18nProvider.test.tsx src/shared/ui/command.test.tsx src/features/managed-agents/ManagedAgentsPage.test.tsx` — 161 项通过
- `bun run format:check`
- `bun run build`
- 托管 pre-commit hooks 全部通过
- TypeScript 命名、复杂度与前后端重复代码门禁通过
- 大文件检查通过
- 浏览器验证 Command / 普通搜索框焦点态无溢出，Agent 表单标题间距为 8px、焦点环为 3px

## 文档

本次仅调整前端视觉与交互细节，不改变公开行为、API、数据模型或架构边界，设计文档无需更新。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search fields across logs, managed agents, templates, and session traces now use native search behavior.
  * Managed-agent permission options display consistent labels and icons.
  * Managed-agent editing now uses a simplified “Save” action.

* **UI Improvements**
  * Refined form spacing, permission menus, and focus indicators for command and search inputs.
  * Improved search-field presentation by hiding native cancel controls.

* **Tests**
  * Added coverage for search behavior, permission controls, updated save flows, and focus styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->