### PR TITLE
Fan out ephemeral code session stream events across API instances

### DIFF
--- a/docs/design/be/ccrv2/ccr-v2-epoch-design.md
+++ b/docs/design/be/ccrv2/ccr-v2-epoch-design.md
@@ -181,6 +181,10 @@ batch 中可公开的 durable output 直接以稳定 public event ID 幂等写�
 去重。internal transcript 仍按原有事务在 code session 行锁内校验 epoch 后写入
 `code_session_internal_events`。
 
+其中 ephemeral `stream_event` 会在 epoch gate 之后通过 Redis Pub/Sub 实时扇出到各
+API 实例，但仍不落 PostgreSQL；协议转换、稳定 ID 与故障语义见
+[`ccr-v2-worker-sse-fanout.md`](ccr-v2-worker-sse-fanout.md)。
+
 legacy ingress 路径如果继续使用无 epoch 的 `AppendWorkerEvent()`，必须被明确归类为兼容路径；如果要纳入 CCR v2 所有权保证，也需要改造成 register/epoch 模型。
 
 ## 7. Heartbeat 与 Lease

--- a/docs/design/be/ccrv2/ccr-v2-worker-sse-fanout.md
+++ b/docs/design/be/ccrv2/ccr-v2-worker-sse-fanout.md
@@ -1,0 +1,94 @@
+# CCR v2 Worker 事件到 Session SSE 的多实例扇出
+
+## 结论
+
+`POST /v1/code/sessions/{code_session_id}/worker/events` 与 Session SSE 可能落在不同 API 实例。服务端按 session 使用 Redis Pub/Sub 频道 `oma:s:<session_id>` 扇出实时事件，不新增 PostgreSQL 表：
+
+- 应用启动时只创建一个全局 `redis.Client`；platform session store 与事件 fanout 共享该 client 及连接池。fanout 只拥有并关闭自己的 Pub/Sub subscription，全局 client 由应用组装层关闭。
+- 每个 API 实例复用一条 Pub/Sub 连接，按本实例实际建立的 SSE session 动态增加订阅；不同 session 不再共享数据频道。
+- Redis 收到的 Worker raw batch 在每个 API 实例转换一次，session Hub 只投递转换后的事件；每条 SSE 连接只负责线程、事件类型和 preview 生命周期过滤。
+- Pub/Sub 连接初始化时订阅一个进程唯一的 `oma:i:<uuid>` 实例频道，仅用于建立连接，不承载业务事件。
+- `ephemeral: true` 的 `stream_event` 只经过 Redis，不持久化。
+- Worker ingress JWT 中已验证的 `session_id`、`public_session_id` 和 `workspace_uuid` 直接组成 stream route；生产端不为每批 preview 重新查询 code session、public session 或 primary thread。
+- 最终公开事件仍幂等写入现有 `session_events`，事务提交后再通过对应 session 频道通知已订阅实例。
+- Redis 中断时允许丢失预览；最终事件仍可通过 Sessions Events API 获取。
+- Redis 只传递事件，不保存 message、block 或 SSE 连接的关联状态。
+
+```mermaid
+sequenceDiagram
+    participant W as Worker
+    participant A as API A
+    participant R as Redis
+    participant B as API B
+    participant DB as PostgreSQL
+    participant C as SSE client
+
+    C->>B: GET session events stream
+    B->>R: SUBSCRIBE oma:s:session_id
+    R-->>B: subscribe ACK
+    B-->>C: SSE connected
+    W->>A: POST worker events
+    A->>R: PUBLISH oma:s:session_id raw stream_event batch
+    R-->>B: session fanout
+    B-->>C: event_start / event_delta
+    W->>A: final assistant event
+    A->>DB: append session_events
+    A->>R: PUBLISH oma:s:session_id persisted event
+    R-->>B: session fanout
+    B-->>C: agent.message / agent.thinking
+```
+
+## Preview 转换
+
+实际 Worker 协议中的 `content_block_delta` 已经是真正的增量片段，不是 full-so-far snapshot。后端不累计或比较文本：
+
+- `message_start.message.id` 保存为当前原始 session 的 message ID。
+- `content_block_start` 根据 block type 发送一次 `event_start`。
+- `text_delta.text` 原样映射成 `event_delta.delta.content.text`，公开 `delta.index` 固定为 `0`。
+- `thinking_delta` 不产生 `event_delta`；`agent.thinking` 只有 `event_start` 预览。
+- 缺少 message start、block start 或 Redis 重连后丢失上下文时，后续 delta 直接舍弃。
+- `parent_tool_use_id` 为空时归属主线程；非空时使用既有确定性 child thread ID。
+- Preview SSE 的 `created_at` 使用规范化 worker payload 的创建时间，缺失或无效时回退到接收时间；`processed_at` 使用接收实例的转换时间。接收实例使用 SSE 已解析出的实际订阅线程 ID 补充 `session_thread_id`，主线程 preview 不需要在生产端查询物理 thread ID。
+
+预览和最终事件共享确定性 ID：
+
+```text
+seed = "assistant-preview-v1"
+     + NUL + message.id
+     + NUL + decimal(original_content_block_index)
+     + NUL + public_event_type
+
+id = "sevt_" + first_16_bytes_hex(
+    SHA-256(code_session_id + NUL + "public" + NUL + seed)
+)
+```
+
+最终 assistant 包含完整 content 数组时，数组下标就是原始 block index。若 Worker 按单 block 输出，可显式携带顶层 `content_block_index`；该字段只用于映射，不能进入公开事件。
+
+## SSE 连接语义
+
+`event_deltas[]` 只接受 `agent.message` 和 `agent.thinking`，超过 100 个值或包含其他值返回 `400`。每个订阅者只接收自己已经见过 `event_start` 的后续 delta，避免中途连接收到孤立 delta。
+
+建立 SSE 时先注册本机 subscriber，再订阅 `oma:s:<session_id>`，并等待 Redis 返回该频道的 `subscribe` ACK；只有 ACK 成功后才向客户端发送 `: connected`。这样 ACK 之后到达的消息不会落在本机 subscriber 注册之前。多个 SSE 连接订阅同一 session 时复用同一个 Redis 频道订阅和实例级 preview converter。
+
+当前不维护 SSE 连接引用计数，也不在单个连接关闭时取消 Redis 订阅。session 频道订阅保留到 API 进程退出；基于 session terminated 信号的提前清理作为后续优化，避免在终止事件来源尚未统一前误退订。
+
+Hub subscriber 只以 `workspace_uuid + session_id` 匹配转换后的 preview 或持久事件。线程范围、`event_deltas[]` 类型和 `event_start`/`event_delta` 配对由 SSE 连接自己的状态过滤。未请求 delta 的连接不会解析 Worker raw payload，也不会维护 message/block 或去重状态。单连接缓冲区为 256 个 delivery；缓冲区满时关闭连接，而不是丢弃某个中间 delta 后继续发送，从而保证客户端只看到连续前缀。
+
+主线程 preview 在 fanout 内表示为 primary scope，不携带生产端查出的 thread ID。SSE 建立时接收实例已经确保 primary thread 存在，并在连接状态中记录 primary scope，因此可以直接匹配主线程 preview。`parent_tool_use_id` 非空时仍使用确定性 child thread ID 精确匹配，不会将主线程 preview 写入子线程 SSE。
+
+Worker HTTP 重试可能重复发布 ephemeral 事件。每个 API 实例按 `code_session_id + worker_epoch + payload.uuid` 做有界临时去重；该状态与活动 preview 状态均不进入 PostgreSQL。同一实例上的多个 SSE 共享转换结果，不复制 message/block 状态机和去重 LRU。
+
+实例级 converter 使用一个 mutex 保护 message/block 和去重状态；Worker JSON 在锁外解析，锁内只进行内存状态转换。转换完成并释放 converter 锁后，Hub 再获取自己的锁广播事件，两把锁不嵌套。Redis 接收中断时先清空实例 converter，再由 Hub 向所有连接投递 reset marker；连接按队列顺序清空 `activePreviewIDs`，之后缺少上下文的 delta 会被丢弃。
+
+## 故障与发布顺序
+
+- `/worker/events` 必须先完成整批解析和 worker epoch gate，再发布任何 preview。
+- 批量与单事件入口在分类前使用同一套 payload 规范化逻辑；已通过批量协议校验的事件会补齐缺失的 `session_id`、`created_at` 和 `timestamp`，stream fanout 发布规范化后的 payload。
+- 同一请求内保持原始事件顺序；连续 stream events 合并成一个 Redis envelope。
+- 一批已持久化事件若包含多个 session，发布前按 session 分组，每个 envelope 只进入对应的 `oma:s:<session_id>`。
+- 持久化事件的 fanout wire contract 只包含 SSE 路由与响应所需的 `external_id`、`workspace_uuid`、`session_id`、`thread_id`、`event_type`、`payload`、`processed_at` 和 `created_at`；不序列化完整数据库事件模型。
+- Preview 的 fanout 序列化或 Redis publish 失败只记录结构化元数据，不记录原始 payload，也不中断同一 worker batch 中后续的 control 或持久事件。
+- 应用关闭时先取消订阅上下文并关闭 Pub/Sub subscription，再等待接收协程退出；关闭 subscription 用于打断没有 read deadline 的阻塞读取，全局 Redis client 仍由应用组装层最后关闭。
+- 后端可以先发布：旧 Worker 的 ephemeral stream 不影响持久化合同；包含 `message.id` 的最终 assistant 会使用新的稳定 ID。
+- 不需要 migration、outbox、Redis Streams 或新的 Yourbatis Mapper。

--- a/docs/design/be/ccrv2/ccr-v2-worker-sse-fanout.md
+++ b/docs/design/be/ccrv2/ccr-v2-worker-sse-fanout.md
@@ -36,13 +36,17 @@ sequenceDiagram
     A->>R: PUBLISH oma:s:session_id persisted event
     R-->>B: session fanout
     B-->>C: agent.message / agent.thinking
+    A->>R: PUBLISH session.status_terminated
+    R-->>B: terminal session fanout
+    B-->>C: session.status_terminated
+    B->>R: UNSUBSCRIBE oma:s:session_id
 ```
 
 ## Preview 转换
 
 实际 Worker 协议中的 `content_block_delta` 已经是真正的增量片段，不是 full-so-far snapshot。后端不累计或比较文本：
 
-- `message_start.message.id` 保存为当前原始 session 的 message ID。
+- Preview 的 `message_start.message.id` 与最终 assistant payload 的 `message.id` 都在各自 Worker JSON 解码边界修剪首尾空白，再参与确定性 ID 计算。
 - `content_block_start` 根据 block type 发送一次 `event_start`。
 - `text_delta.text` 原样映射成 `event_delta.delta.content.text`，公开 `delta.index` 固定为 `0`。
 - `thinking_delta` 不产生 `event_delta`；`agent.thinking` 只有 `event_start` 预览。
@@ -51,6 +55,8 @@ sequenceDiagram
 - Preview SSE 的 `created_at` 使用规范化 worker payload 的创建时间，缺失或无效时回退到接收时间；`processed_at` 使用接收实例的转换时间。接收实例使用 SSE 已解析出的实际订阅线程 ID 补充 `session_thread_id`，主线程 preview 不需要在生产端查询物理 thread ID。
 
 预览和最终事件共享确定性 ID：
+
+最终 assistant content 数组中的兼容标量 block 也按 `agent.message` 和原始 block index 使用同一公式，确保 final event 能替换并清理对应 preview。
 
 ```text
 seed = "assistant-preview-v1"
@@ -71,7 +77,7 @@ id = "sevt_" + first_16_bytes_hex(
 
 建立 SSE 时先注册本机 subscriber，再订阅 `oma:s:<session_id>`，并等待 Redis 返回该频道的 `subscribe` ACK；只有 ACK 成功后才向客户端发送 `: connected`。这样 ACK 之后到达的消息不会落在本机 subscriber 注册之前。多个 SSE 连接订阅同一 session 时复用同一个 Redis 频道订阅和实例级 preview converter。
 
-当前不维护 SSE 连接引用计数，也不在单个连接关闭时取消 Redis 订阅。session 频道订阅保留到 API 进程退出；基于 session terminated 信号的提前清理作为后续优化，避免在终止事件来源尚未统一前误退订。
+当前不维护 SSE 连接引用计数，也不在单个连接关闭时取消 Redis 订阅。这样临时没有本地 SSE 时，实例级 preview converter 仍能连续接收 `message_start`、`content_block_start` 和 delta，后续重连不会只看到缺少上下文的孤立 delta。实例收到 `session.status_terminated` 或 `session.deleted` 后，先将终态事件加入本地 SSE 队列，再取消对应 `oma:s:<session_id>` 订阅并删除本地订阅状态；idle 和 thread terminated 不会触发整个 session 的退订。
 
 Hub subscriber 只以 `workspace_uuid + session_id` 匹配转换后的 preview 或持久事件。线程范围、`event_deltas[]` 类型和 `event_start`/`event_delta` 配对由 SSE 连接自己的状态过滤。未请求 delta 的连接不会解析 Worker raw payload，也不会维护 message/block 或去重状态。单连接缓冲区为 256 个 delivery；缓冲区满时关闭连接，而不是丢弃某个中间 delta 后继续发送，从而保证客户端只看到连续前缀。
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/platformauth"
 	"github.com/superduck-ai/open-managed-agents/internal/platformsession"
 	"github.com/superduck-ai/open-managed-agents/internal/secrets"
+	"github.com/superduck-ai/open-managed-agents/internal/sessionfanout"
 	sessionsapi "github.com/superduck-ai/open-managed-agents/internal/sessions"
 	skillsapi "github.com/superduck-ai/open-managed-agents/internal/skills"
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
@@ -81,6 +82,7 @@ type ServerDeps struct {
 	FilestoreCredentials   *filestoreapi.TokenCredentials
 	FilestoreService       *filestoreapi.Service
 	VaultSecrets           *secrets.Service
+	SessionEventBus        sessionfanout.EventBus
 }
 
 // NewServer 用显式依赖组装 HTTP API Server。
@@ -124,7 +126,7 @@ func NewServer(deps ServerDeps) *Server {
 		memory:               memoryapi.NewHandler(deps.Config, deps.DB, deps.ObjectStore, componentLogger("memory")),
 		messages:             messagesapi.NewHandler(deps.Config, componentLogger("messages")),
 		models:               modelsapi.NewHandler(deps.Config.AnthropicUpstream),
-		sessions:             sessionsapi.NewHandler(deps.Config, deps.DB, codeSessionService, webhookEnqueuer, componentLogger("sessions")),
+		sessions:             sessionsapi.NewHandler(deps.Config, deps.DB, codeSessionService, webhookEnqueuer, deps.SessionEventBus, componentLogger("sessions")),
 		skills:               skillsapi.NewHandler(deps.Config, deps.DB, deps.ObjectStore, componentLogger("skills")),
 		vaults:               vaultsapi.NewHandler(deps.Config, deps.DB, deps.VaultSecrets, webhookEnqueuer, componentLogger("vaults")),
 		webhooks:             webhooksapi.NewHandler(deps.Config.Webhook, deps.DB, webhookLogger),

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -332,13 +332,18 @@ func (h *Handler) streamCodeSessionWorkerEvents(ctx context.Context, w io.Writer
 
 func (h *Handler) handleCodeSessionWorkerEvents(w http.ResponseWriter, r *http.Request) {
 	codeSessionID := chi.URLParam(r, "code_session_id")
-	if !h.authorizeSessionIngress(w, r, codeSessionID) {
+	claims, ok := h.authorizeSessionIngressClaims(w, r, codeSessionID)
+	if !ok {
 		return
 	}
 	workerReq, err := httpapi.DecodeObjectBodyAs[codeSessionWorkerEventsBody](w, r, maxIngressBodySize)
 	if err != nil {
 		writeCodeSessionWorkerBodyReadError(w, r, err)
 		return
+	}
+	if pretty, marshalErr := json.MarshalIndent(workerReq, "", "  "); marshalErr == nil {
+		h.logger.ErrorContext(r.Context(), "code session worker events request", "code_session_id", codeSessionID)
+		println(string(pretty))
 	}
 	if workerReq.WorkerEpoch <= 0 {
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", "worker_epoch must be a positive integer"))
@@ -348,7 +353,7 @@ func (h *Handler) handleCodeSessionWorkerEvents(w http.ResponseWriter, r *http.R
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", "events must be a non-empty array"))
 		return
 	}
-	if err := h.service.AppendWorkerOutputEventsForEpoch(r.Context(), codeSessionID, int64(workerReq.WorkerEpoch), workerReq.Events); err != nil {
+	if err := h.service.AppendWorkerOutputEventsForEpoch(r.Context(), codeSessionStreamRouteFromClaims(claims), int64(workerReq.WorkerEpoch), workerReq.Events); err != nil {
 		if errors.Is(err, ErrProtocol) {
 			httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", err.Error()))
 			return
@@ -401,7 +406,8 @@ func (h *Handler) handleCodeSessionWorkerDelivery(w http.ResponseWriter, r *http
 
 func (h *Handler) handleCodeSessionWorkerDiagnostics(w http.ResponseWriter, r *http.Request) {
 	codeSessionID := chi.URLParam(r, "code_session_id")
-	if !h.authorizeSessionIngress(w, r, codeSessionID) {
+	claims, ok := h.authorizeSessionIngressClaims(w, r, codeSessionID)
+	if !ok {
 		return
 	}
 	workerReq, ok := h.requireWorkerEpochBody(w, r, codeSessionID)
@@ -413,8 +419,9 @@ func (h *Handler) handleCodeSessionWorkerDiagnostics(w http.ResponseWriter, r *h
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", err.Error()))
 		return
 	}
+	route := codeSessionStreamRouteFromClaims(claims)
 	for _, payload := range payloads {
-		if err := h.service.AppendWorkerEventForEpoch(r.Context(), codeSessionID, workerReq.epoch, payload); err != nil {
+		if err := h.service.AppendWorkerEventForEpoch(r.Context(), route, workerReq.epoch, payload); err != nil {
 			if errors.Is(err, ErrProtocol) {
 				httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", err.Error()))
 				return
@@ -535,7 +542,8 @@ func (h *Handler) handleCodeSessionWorkerOTLP(w http.ResponseWriter, r *http.Req
 
 func (h *Handler) handleSessionIngressEvents(w http.ResponseWriter, r *http.Request) {
 	codeSessionID := chi.URLParam(r, "code_session_id")
-	if !h.authorizeSessionIngress(w, r, codeSessionID) {
+	claims, ok := h.authorizeSessionIngressClaims(w, r, codeSessionID)
+	if !ok {
 		return
 	}
 	if _, err := h.requireCodeSession(r.Context(), codeSessionID); err != nil {
@@ -547,8 +555,9 @@ func (h *Handler) handleSessionIngressEvents(w http.ResponseWriter, r *http.Requ
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", err.Error()))
 		return
 	}
+	route := codeSessionStreamRouteFromClaims(claims)
 	for _, payload := range payloads {
-		if err := h.service.AppendWorkerEvent(r.Context(), codeSessionID, payload); err != nil {
+		if err := h.service.AppendWorkerEvent(r.Context(), route, payload); err != nil {
 			if errors.Is(err, ErrProtocol) {
 				httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", err.Error()))
 				return
@@ -563,7 +572,8 @@ func (h *Handler) handleSessionIngressEvents(w http.ResponseWriter, r *http.Requ
 
 func (h *Handler) handleSessionIngressDiagLogs(w http.ResponseWriter, r *http.Request) {
 	codeSessionID := chi.URLParam(r, "code_session_id")
-	if !h.authorizeSessionIngress(w, r, codeSessionID) {
+	claims, ok := h.authorizeSessionIngressClaims(w, r, codeSessionID)
+	if !ok {
 		return
 	}
 	if _, err := h.requireCodeSession(r.Context(), codeSessionID); err != nil {
@@ -575,8 +585,9 @@ func (h *Handler) handleSessionIngressDiagLogs(w http.ResponseWriter, r *http.Re
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", err.Error()))
 		return
 	}
+	route := codeSessionStreamRouteFromClaims(claims)
 	for _, payload := range payloads {
-		if err := h.service.AppendWorkerEvent(r.Context(), codeSessionID, payload); err != nil {
+		if err := h.service.AppendWorkerEvent(r.Context(), route, payload); err != nil {
 			if errors.Is(err, ErrProtocol) {
 				httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", err.Error()))
 				return
@@ -591,7 +602,8 @@ func (h *Handler) handleSessionIngressDiagLogs(w http.ResponseWriter, r *http.Re
 
 func (h *Handler) handleSessionIngressPersistence(w http.ResponseWriter, r *http.Request) {
 	codeSessionID := chi.URLParam(r, "code_session_id")
-	if !h.authorizeSessionIngress(w, r, codeSessionID) {
+	claims, ok := h.authorizeSessionIngressClaims(w, r, codeSessionID)
+	if !ok {
 		return
 	}
 	if _, err := h.requireCodeSession(r.Context(), codeSessionID); err != nil {
@@ -611,8 +623,9 @@ func (h *Handler) handleSessionIngressPersistence(w http.ResponseWriter, r *http
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", err.Error()))
 		return
 	}
+	route := codeSessionStreamRouteFromClaims(claims)
 	for _, payload := range payloads {
-		if err := h.service.AppendWorkerEvent(r.Context(), codeSessionID, payload); err != nil {
+		if err := h.service.AppendWorkerEvent(r.Context(), route, payload); err != nil {
 			h.logger.ErrorContext(r.Context(), "append code session persistence event", "code_session_id", codeSessionID, "error", err)
 			httpapi.WriteError(w, r, httpapi.NewError(http.StatusInternalServerError, "api_error", "Could not append session ingress event"))
 			return

--- a/internal/codesessions/mapper.go
+++ b/internal/codesessions/mapper.go
@@ -134,8 +134,8 @@ func publicPayloadCandidatesFromWorkerEvent(codeSessionID string, event db.CodeS
 	object := materializePublicPayload(fields)
 	switch event.EventType {
 	case "assistant":
-		var payload workerAssistantOutputPayload
-		if err := json.Unmarshal(raw, &payload); err != nil {
+		payload, err := decodeWorkerAssistantOutputPayload(raw)
+		if err != nil {
 			return nil, false, fmt.Errorf("%w: invalid assistant payload: %w", ErrProtocol, err)
 		}
 		return assistantPublicPayloadCandidates(codeSessionID, object, payload), true, nil
@@ -204,8 +204,8 @@ func publicPayloadsFromInternalSubagentEvent(codeSessionID string, event db.Code
 func publicPayloadCandidatesFromInternalSubagentEvent(codeSessionID string, raw json.RawMessage, eventType string, object map[string]any) ([]publicPayloadCandidate, error) {
 	switch eventType {
 	case "assistant":
-		var payload workerAssistantOutputPayload
-		if err := json.Unmarshal(raw, &payload); err != nil {
+		payload, err := decodeWorkerAssistantOutputPayload(raw)
+		if err != nil {
 			return nil, fmt.Errorf("%w: invalid assistant payload: %w", ErrProtocol, err)
 		}
 		return assistantPublicPayloadCandidates(codeSessionID, object, payload), nil
@@ -464,8 +464,12 @@ func assistantPublicPayloadCandidates(codeSessionID string, object map[string]an
 		contentBlockIndex := assistantContentBlockIndex(schema, index, len(blocks))
 		block, ok := value.(map[string]any)
 		if !ok {
+			payload := publicPayloadWithSingleContentBlock(object, "agent.message", value)
+			if schema.Message.ID != "" {
+				payload["id"] = maevents.StableAssistantEventID(codeSessionID, schema.Message.ID, contentBlockIndex, "agent.message")
+			}
 			candidates = append(candidates, publicPayloadCandidate{
-				payload:    publicPayloadWithSingleContentBlock(object, "agent.message", value),
+				payload:    payload,
 				seedSuffix: fmt.Sprintf("content:%d", index),
 				timeOffset: time.Duration(index) * time.Millisecond,
 			})

--- a/internal/codesessions/mapper.go
+++ b/internal/codesessions/mapper.go
@@ -1,8 +1,6 @@
 package codesessions
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -140,7 +138,7 @@ func publicPayloadCandidatesFromWorkerEvent(codeSessionID string, event db.CodeS
 		if err := json.Unmarshal(raw, &payload); err != nil {
 			return nil, false, fmt.Errorf("%w: invalid assistant payload: %w", ErrProtocol, err)
 		}
-		return assistantPublicPayloadCandidates(object, payload), true, nil
+		return assistantPublicPayloadCandidates(codeSessionID, object, payload), true, nil
 	case "user":
 		var payload workerUserOutputPayload
 		if err := json.Unmarshal(raw, &payload); err != nil {
@@ -185,7 +183,7 @@ func publicPayloadsFromInternalSubagentEvent(codeSessionID string, event db.Code
 	if err := json.Unmarshal(event.Payload, &schema); err != nil {
 		return nil, fmt.Errorf("%w: invalid internal subagent payload: %w", ErrProtocol, err)
 	}
-	candidates, err := publicPayloadCandidatesFromInternalSubagentEvent(event.Payload, schema.Type, object)
+	candidates, err := publicPayloadCandidatesFromInternalSubagentEvent(codeSessionID, event.Payload, schema.Type, object)
 	if err != nil {
 		return nil, err
 	}
@@ -203,14 +201,14 @@ func publicPayloadsFromInternalSubagentEvent(codeSessionID string, event db.Code
 	return payloads, nil
 }
 
-func publicPayloadCandidatesFromInternalSubagentEvent(raw json.RawMessage, eventType string, object map[string]any) ([]publicPayloadCandidate, error) {
+func publicPayloadCandidatesFromInternalSubagentEvent(codeSessionID string, raw json.RawMessage, eventType string, object map[string]any) ([]publicPayloadCandidate, error) {
 	switch eventType {
 	case "assistant":
 		var payload workerAssistantOutputPayload
 		if err := json.Unmarshal(raw, &payload); err != nil {
 			return nil, fmt.Errorf("%w: invalid assistant payload: %w", ErrProtocol, err)
 		}
-		return assistantPublicPayloadCandidates(object, payload), nil
+		return assistantPublicPayloadCandidates(codeSessionID, object, payload), nil
 	case "user":
 		var payload workerUserOutputPayload
 		if err := json.Unmarshal(raw, &payload); err != nil {
@@ -450,14 +448,20 @@ func resultPublicPayloadCandidates(codeSessionID string, event db.CodeSessionEve
 	return candidates
 }
 
-func assistantPublicPayloadCandidates(object map[string]any, schema workerAssistantOutputPayload) []publicPayloadCandidate {
+func assistantPublicPayloadCandidates(codeSessionID string, object map[string]any, schema workerAssistantOutputPayload) []publicPayloadCandidate {
+	delete(object, "content_block_index")
 	content := publicContentBlocks(workerOutputContent(schema.Content, schema.Message.Content))
 	blocks, ok := content.([]any)
 	if !ok || len(blocks) == 0 {
-		return []publicPayloadCandidate{{payload: publicPayloadWithType(object, "agent.message")}}
+		payload := publicPayloadWithType(object, "agent.message")
+		if schema.Message.ID != "" {
+			payload["id"] = maevents.StableAssistantEventID(codeSessionID, schema.Message.ID, assistantContentBlockIndex(schema, 0, 1), "agent.message")
+		}
+		return []publicPayloadCandidate{{payload: payload}}
 	}
 	candidates := make([]publicPayloadCandidate, 0, len(blocks))
 	for index, value := range blocks {
+		contentBlockIndex := assistantContentBlockIndex(schema, index, len(blocks))
 		block, ok := value.(map[string]any)
 		if !ok {
 			candidates = append(candidates, publicPayloadCandidate{
@@ -476,6 +480,9 @@ func assistantPublicPayloadCandidates(object map[string]any, schema workerAssist
 			eventType = "agent.tool_use"
 		}
 		payload := publicPayloadWithSingleContentBlock(object, eventType, block)
+		if schema.Message.ID != "" && (eventType == "agent.message" || eventType == "agent.thinking") {
+			payload["id"] = maevents.StableAssistantEventID(codeSessionID, schema.Message.ID, contentBlockIndex, eventType)
+		}
 		if eventType == "agent.tool_use" {
 			if toolUseID := stringField(block, "id"); toolUseID != "" {
 				payload["tool_use_id"] = toolUseID
@@ -495,6 +502,13 @@ func assistantPublicPayloadCandidates(object map[string]any, schema workerAssist
 		})
 	}
 	return candidates
+}
+
+func assistantContentBlockIndex(schema workerAssistantOutputPayload, fallback, blockCount int) int {
+	if blockCount == 1 && schema.ContentBlockIndex != nil && *schema.ContentBlockIndex >= 0 {
+		return *schema.ContentBlockIndex
+	}
+	return fallback
 }
 
 func publicPayloadWithSingleContentBlock(object map[string]any, eventType string, block any) map[string]any {
@@ -624,12 +638,7 @@ func claudeTaskThreadIDFromFields(codeSessionID, toolUseID, taskID string) strin
 }
 
 func claudeTaskThreadIDFromKey(codeSessionID string, key string) string {
-	key = strings.TrimSpace(key)
-	if key == "" {
-		return ""
-	}
-	sum := sha256.Sum256([]byte(strings.TrimSpace(codeSessionID) + "\x00claude-task\x00" + key))
-	return "sthr_" + hex.EncodeToString(sum[:16])
+	return maevents.ClaudeTaskThreadID(codeSessionID, key)
 }
 
 func claudeToolResultContent(block map[string]any) []any {

--- a/internal/codesessions/mapper_test.go
+++ b/internal/codesessions/mapper_test.go
@@ -195,6 +195,37 @@ func TestPublicPayloadsFromWorkerEventMapsClaudeAssistantBlocks(t *testing.T) {
 	}
 }
 
+func TestPublicPayloadsFromWorkerEventMapsScalarAssistantBlockToPreviewID(t *testing.T) {
+	payloads, ok, err := publicPayloadsFromWorkerEvent("csev_test", db.CodeSessionEvent{
+		ExternalID:     "csev_scalar_assistant_block",
+		EventType:      "assistant",
+		IdempotencyKey: "scalar_assistant_block",
+		CreatedAt:      time.Date(2026, 6, 16, 1, 10, 0, 0, time.UTC),
+	}, mustRawJSON(t, map[string]any{
+		"type": "assistant",
+		"uuid": "scalar-assistant-block",
+		"message": map[string]any{
+			"id":      " msg_scalar_block ",
+			"role":    "assistant",
+			"content": []any{"hello"},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("publicPayloadsFromWorkerEvent returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("publicPayloadsFromWorkerEvent ok = false, want true")
+	}
+	objects := decodePublicPayloads(t, payloads)
+	if len(objects) != 1 || objects[0]["type"] != "agent.message" {
+		t.Fatalf("scalar assistant payloads = %#v, want one agent.message", objects)
+	}
+	wantID := maevents.StableAssistantEventID("csev_test", "msg_scalar_block", 0, "agent.message")
+	if got := objects[0]["id"]; got != wantID {
+		t.Fatalf("scalar assistant id = %q, want preview id %q", got, wantID)
+	}
+}
+
 func TestPublicPayloadsFromInternalSubagentEventMarksOwnerThread(t *testing.T) {
 	payloads, err := publicPayloadsFromInternalSubagentEvent("csev_test", db.CodeSessionInternalEvent{
 		ExternalID:     "csie_subagent_assistant",

--- a/internal/codesessions/mapper_test.go
+++ b/internal/codesessions/mapper_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
+	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 )
 
 func TestPublicPayloadsFromWorkerEventRejectsTypeSpecificSchemaMismatch(t *testing.T) {
@@ -145,6 +146,7 @@ func TestPublicPayloadsFromWorkerEventMapsClaudeAssistantBlocks(t *testing.T) {
 		"type": "assistant",
 		"uuid": "assistant-blocks",
 		"message": map[string]any{
+			"id":   "msg_assistant_blocks",
 			"role": "assistant",
 			"content": []any{
 				map[string]any{"type": "thinking", "thinking": "plan"},
@@ -176,6 +178,12 @@ func TestPublicPayloadsFromWorkerEventMapsClaudeAssistantBlocks(t *testing.T) {
 		if objects[index]["id"] == "" || objects[index]["processed_at"] == "" {
 			t.Fatalf("payload[%d] missing normalized fields: %#v", index, objects[index])
 		}
+	}
+	if got, want := objects[0]["id"], maevents.StableAssistantEventID("csev_test", "msg_assistant_blocks", 0, "agent.thinking"); got != want {
+		t.Fatalf("thinking id = %q, want %q", got, want)
+	}
+	if got, want := objects[1]["id"], maevents.StableAssistantEventID("csev_test", "msg_assistant_blocks", 1, "agent.message"); got != want {
+		t.Fatalf("message id = %q, want %q", got, want)
 	}
 	toolPayload := objects[2]
 	if toolPayload["tool_use_id"] != "tool_translate" || toolPayload["name"] != "Agent" || toolPayload["tool_name"] != "Agent" {

--- a/internal/codesessions/public_event_sink.go
+++ b/internal/codesessions/public_event_sink.go
@@ -7,10 +7,19 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 )
 
+// CodeSessionStreamRoute carries immutable routing fields from the verified
+// worker credential to the ephemeral session fanout path.
+type CodeSessionStreamRoute struct {
+	CodeSessionID     string
+	WorkspaceUUID     string
+	SessionExternalID string
+}
+
 // PublicEventSink 隔离 code-session 领域逻辑与公开 session 事件投递实现。
 // 接口保留在 codesessions 包内，避免 Service 反向依赖具体 API/传输层。
 type PublicEventSink interface {
 	PublishCodeSessionEvents(ctx context.Context, codeSession db.CodeSession, payloads []json.RawMessage) error
+	PublishCodeSessionStreamEvents(ctx context.Context, route CodeSessionStreamRoute, workerEpoch int64, payloads []json.RawMessage) error
 }
 
 // SetPublicEventSink 在服务组装阶段注入事件接收端。

--- a/internal/codesessions/runtime_auth.go
+++ b/internal/codesessions/runtime_auth.go
@@ -23,24 +23,44 @@ func (h *Handler) authenticateRuntimeSession(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *Handler) authorizeSessionIngress(w http.ResponseWriter, r *http.Request, codeSessionID string) bool {
-	if err := h.authorizeSessionIngressRequest(r, codeSessionID); err != nil {
+	_, ok := h.authorizeSessionIngressClaims(w, r, codeSessionID)
+	return ok
+}
+
+func (h *Handler) authorizeSessionIngressClaims(w http.ResponseWriter, r *http.Request, codeSessionID string) (SessionCredentialClaims, bool) {
+	claims, err := h.sessionIngressClaims(r, codeSessionID)
+	if err != nil {
 		h.errorAdapter.Write(w, r, err)
-		return false
+		return SessionCredentialClaims{}, false
 	}
-	return true
+	return claims, true
 }
 
 func (h *Handler) authorizeSessionIngressRequest(r *http.Request, codeSessionID string) error {
+	_, err := h.sessionIngressClaims(r, codeSessionID)
+	return err
+}
+
+func (h *Handler) sessionIngressClaims(r *http.Request, codeSessionID string) (SessionCredentialClaims, error) {
 	// 校验 URL 中的 codeSessionID，为空时返回 404，避免处理没有明确 session 归属的请求。
 	if strings.TrimSpace(codeSessionID) == "" {
-		return codeSessionRouteNotFound()
+		return SessionCredentialClaims{}, codeSessionRouteNotFound()
 	}
 	token := auth.ExtractAPIKey(r)
 	if token == "" {
-		return sessionIngressTokenRequired()
+		return SessionCredentialClaims{}, sessionIngressTokenRequired()
 	}
-	if _, err := h.service.AuthenticateSessionIngress(token, codeSessionID); err != nil {
-		return sessionIngressTokenInvalid(err)
+	claims, err := h.service.AuthenticateSessionIngress(token, codeSessionID)
+	if err != nil {
+		return SessionCredentialClaims{}, sessionIngressTokenInvalid(err)
 	}
-	return nil
+	return claims, nil
+}
+
+func codeSessionStreamRouteFromClaims(claims SessionCredentialClaims) CodeSessionStreamRoute {
+	return CodeSessionStreamRoute{
+		CodeSessionID:     claims.SessionID,
+		WorkspaceUUID:     claims.WorkspaceUUID,
+		SessionExternalID: claims.PublicSessionID,
+	}
 }

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -115,41 +115,41 @@ func (s *Service) QueueRawCodeSessionEvents(ctx context.Context, codeSession db.
 	return nil
 }
 
-func (s *Service) AppendWorkerEvent(ctx context.Context, codeSessionID string, raw json.RawMessage) error {
+func (s *Service) AppendWorkerEvent(ctx context.Context, route CodeSessionStreamRoute, raw json.RawMessage) error {
 	if s == nil {
 		return nil
 	}
-	prepared, err := prepareSingleWorkerEvent(codeSessionID, raw, time.Now().UTC())
+	codeSessionID := route.CodeSessionID
+	prepared, err := prepareWorkerOutputEvent(codeSessionID, workerOutputEvent{Payload: raw}, time.Now().UTC())
 	if err != nil {
 		return err
 	}
-	if prepared.eventType == "keep_alive" {
+	if _, keepAlive := prepared.(preparedKeepAliveAction); keepAlive {
 		return s.db.TouchCodeSessionWorkerActivity(ctx, codeSessionID)
 	}
-	return s.applyWorkerOutputEvent(ctx, codeSessionID, &prepared)
+	return s.applyWorkerOutputEvents(ctx, route, 0, []preparedWorkerOutputEvent{prepared})
 }
 
-func (s *Service) AppendWorkerEventForEpoch(ctx context.Context, codeSessionID string, workerEpoch int64, raw json.RawMessage) error {
+func (s *Service) AppendWorkerEventForEpoch(ctx context.Context, route CodeSessionStreamRoute, workerEpoch int64, raw json.RawMessage) error {
 	if s == nil {
 		return nil
 	}
-	prepared, err := prepareSingleWorkerEvent(codeSessionID, raw, time.Now().UTC())
+	codeSessionID := route.CodeSessionID
+	prepared, err := prepareWorkerOutputEvent(codeSessionID, workerOutputEvent{Payload: raw}, time.Now().UTC())
 	if err != nil {
 		return err
 	}
 	if err := s.db.TouchCodeSessionWorkerActivityForEpoch(ctx, codeSessionID, workerEpoch); err != nil {
 		return err
 	}
-	if prepared.eventType == "keep_alive" {
-		return nil
-	}
-	return s.applyWorkerOutputEvent(ctx, codeSessionID, &prepared)
+	return s.applyWorkerOutputEvents(ctx, route, workerEpoch, []preparedWorkerOutputEvent{prepared})
 }
 
-func (s *Service) AppendWorkerOutputEventsForEpoch(ctx context.Context, codeSessionID string, workerEpoch int64, events []workerOutputEvent) error {
+func (s *Service) AppendWorkerOutputEventsForEpoch(ctx context.Context, route CodeSessionStreamRoute, workerEpoch int64, events []workerOutputEvent) error {
 	if s == nil || len(events) == 0 {
 		return nil
 	}
+	codeSessionID := route.CodeSessionID
 	if codeSessionID == "" {
 		return ErrProtocol
 	}
@@ -166,49 +166,37 @@ func (s *Service) AppendWorkerOutputEventsForEpoch(ctx context.Context, codeSess
 	if err := s.db.TouchCodeSessionWorkerActivityForEpoch(ctx, codeSessionID, workerEpoch); err != nil {
 		return err
 	}
-	return s.applyWorkerOutputEvents(ctx, codeSessionID, prepared)
+	return s.applyWorkerOutputEvents(ctx, route, workerEpoch, prepared)
 }
 
-type preparedWorkerOutputEvent struct {
-	eventType      string
-	metadata       EventMetadata
-	controlRequest *workerControlRequestPayload
-	publicPayloads []json.RawMessage
+// preparedWorkerOutputEvent is implemented by each prepared worker output
+// variant to keep the apply path type-safe.
+type preparedWorkerOutputEvent interface {
+	implPreparedWorkerOutputEvent()
 }
 
-func prepareSingleWorkerEvent(codeSessionID string, raw json.RawMessage, now time.Time) (preparedWorkerOutputEvent, error) {
-	if codeSessionID == "" {
-		return preparedWorkerOutputEvent{}, ErrProtocol
-	}
-	payload, err := normalizeWorkerOutboundPayload(codeSessionID, raw, now)
-	if err != nil {
-		return preparedWorkerOutputEvent{}, err
-	}
-	meta, err := BuildEventMetadata(codeSessionID, "outbound", payload)
-	if err != nil {
-		return preparedWorkerOutputEvent{}, err
-	}
-	prepared := preparedWorkerOutputEvent{eventType: meta.EventType}
-	if meta.EventType == "keep_alive" || isHiddenWorkerEvent(meta.EventType) {
-		if meta.EventType == "control_request" && meta.EventSubtype == "can_use_tool" {
-			controlRequest, err := prepareWorkerControlRequest(payload, meta)
-			if err != nil {
-				return preparedWorkerOutputEvent{}, fmt.Errorf("%w: invalid control_request payload", ErrProtocol)
-			}
-			controlRequest.eventType = meta.EventType
-			return controlRequest, nil
-		}
-		return prepared, nil
-	}
-	publicPayloads, ok, err := publicPayloadsFromWorkerEvent(codeSessionID, transientWorkerEvent(meta, now), payload)
-	if err != nil {
-		return preparedWorkerOutputEvent{}, err
-	}
-	if ok {
-		prepared.publicPayloads = publicPayloads
-	}
-	return prepared, nil
+type preparedNoopAction struct{}
+
+type preparedKeepAliveAction struct{}
+
+type preparedStreamAction struct {
+	payload json.RawMessage
 }
+
+type preparedControlAction struct {
+	request  workerControlRequestPayload
+	metadata EventMetadata
+}
+
+type preparedPublicAction struct {
+	payloads []json.RawMessage
+}
+
+func (preparedNoopAction) implPreparedWorkerOutputEvent()      {}
+func (preparedKeepAliveAction) implPreparedWorkerOutputEvent() {}
+func (preparedStreamAction) implPreparedWorkerOutputEvent()    {}
+func (preparedControlAction) implPreparedWorkerOutputEvent()   {}
+func (preparedPublicAction) implPreparedWorkerOutputEvent()    {}
 
 func prepareWorkerOutputEvents(codeSessionID string, events []workerOutputEvent, now time.Time) ([]preparedWorkerOutputEvent, error) {
 	prepared := make([]preparedWorkerOutputEvent, 0, len(events))
@@ -223,64 +211,114 @@ func prepareWorkerOutputEvents(codeSessionID string, events []workerOutputEvent,
 }
 
 func prepareWorkerOutputEvent(codeSessionID string, input workerOutputEvent, now time.Time) (preparedWorkerOutputEvent, error) {
+	if codeSessionID == "" {
+		return nil, ErrProtocol
+	}
 	header, err := decodeWorkerPayloadHeader(input.Payload)
 	if err != nil {
-		return preparedWorkerOutputEvent{}, err
+		return nil, err
 	}
 	if header.Type == "keep_alive" {
-		return preparedWorkerOutputEvent{}, nil
+		return preparedKeepAliveAction{}, nil
 	}
-	meta, err := BuildEventMetadata(codeSessionID, "outbound", input.Payload)
+	payload, err := normalizeWorkerOutboundPayload(codeSessionID, input.Payload, now)
 	if err != nil {
-		return preparedWorkerOutputEvent{}, err
+		return nil, err
+	}
+	meta, err := BuildEventMetadata(codeSessionID, "outbound", payload)
+	if err != nil {
+		return nil, err
 	}
 	if header.Type == "control_request" {
-		return prepareWorkerControlRequest(input.Payload, meta)
+		prepared, err := prepareWorkerControlAction(payload, meta)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid control_request payload", ErrProtocol)
+		}
+		return prepared, nil
 	}
-	if input.Ephemeral || !isPublicWorkerOutputEvent(meta.EventType) {
-		return preparedWorkerOutputEvent{}, nil
+	if input.Ephemeral {
+		if meta.EventType == "stream_event" {
+			return preparedStreamAction{payload: payload}, nil
+		}
+		return preparedNoopAction{}, nil
 	}
-	publicPayloads, ok, err := publicPayloadsFromWorkerEvent(codeSessionID, transientWorkerEvent(meta, now), input.Payload)
+	if !isPublicWorkerOutputEvent(meta.EventType) {
+		return preparedNoopAction{}, nil
+	}
+	publicPayloads, ok, err := publicPayloadsFromWorkerEvent(codeSessionID, transientWorkerEvent(meta, now), payload)
 	if err != nil {
-		return preparedWorkerOutputEvent{}, err
+		return nil, err
 	}
 	if !ok {
-		return preparedWorkerOutputEvent{}, nil
+		return preparedNoopAction{}, nil
 	}
-	return preparedWorkerOutputEvent{publicPayloads: publicPayloads}, nil
+	return preparedPublicAction{payloads: publicPayloads}, nil
 }
 
-func prepareWorkerControlRequest(payload json.RawMessage, meta EventMetadata) (preparedWorkerOutputEvent, error) {
+func prepareWorkerControlAction(payload json.RawMessage, meta EventMetadata) (preparedWorkerOutputEvent, error) {
 	controlRequest, err := decodeWorkerControlRequestPayload(payload)
 	if err != nil {
-		return preparedWorkerOutputEvent{}, errors.New("payload is an invalid control_request")
+		return nil, errors.New("payload is an invalid control_request")
 	}
 	if controlRequest.Request.Subtype != "can_use_tool" {
-		return preparedWorkerOutputEvent{}, nil
+		return preparedNoopAction{}, nil
 	}
-	return preparedWorkerOutputEvent{
-		metadata:       meta,
-		controlRequest: &controlRequest,
+	return preparedControlAction{
+		request:  controlRequest,
+		metadata: meta,
 	}, nil
 }
 
-func (s *Service) applyWorkerOutputEvents(ctx context.Context, codeSessionID string, events []preparedWorkerOutputEvent) error {
-	for i := range events {
-		if err := s.applyWorkerOutputEvent(ctx, codeSessionID, &events[i]); err != nil {
+func (s *Service) applyWorkerOutputEvents(ctx context.Context, route CodeSessionStreamRoute, workerEpoch int64, workerOutputEvents []preparedWorkerOutputEvent) error {
+	for index := 0; index < len(workerOutputEvents); {
+		if _, ok := workerOutputEvents[index].(preparedStreamAction); ok {
+			payloads := leadingWorkerStreamPayloads(workerOutputEvents[index:])
+			s.publishWorkerStreamPayloads(ctx, route, workerEpoch, payloads)
+			index += len(payloads)
+			continue
+		}
+		if err := s.applyNonStreamWorkerOutputEvent(ctx, route.CodeSessionID, workerOutputEvents[index]); err != nil {
 			return err
 		}
+		index++
 	}
 	return nil
 }
 
-func (s *Service) applyWorkerOutputEvent(ctx context.Context, codeSessionID string, event *preparedWorkerOutputEvent) error {
-	if event.controlRequest != nil {
-		return s.handleToolPermissionRequest(ctx, codeSessionID, event.controlRequest, event.metadata)
+func leadingWorkerStreamPayloads(workerOutputEvents []preparedWorkerOutputEvent) []json.RawMessage {
+	payloads := make([]json.RawMessage, 0, len(workerOutputEvents))
+	for _, workerOutputEvent := range workerOutputEvents {
+		stream, ok := workerOutputEvent.(preparedStreamAction)
+		if !ok {
+			break
+		}
+		payloads = append(payloads, stream.payload)
 	}
-	if len(event.publicPayloads) == 0 {
+	return payloads
+}
+
+func (s *Service) applyNonStreamWorkerOutputEvent(ctx context.Context, codeSessionID string, workerOutputEvent preparedWorkerOutputEvent) error {
+	switch prepared := workerOutputEvent.(type) {
+	case preparedNoopAction:
 		return nil
+	case preparedKeepAliveAction:
+		return nil
+	case preparedControlAction:
+		return s.handleToolPermissionRequest(ctx, codeSessionID, &prepared.request, prepared.metadata)
+	case preparedPublicAction:
+		return s.publishWorkerPublicPayloads(ctx, codeSessionID, prepared.payloads)
+	default:
+		return fmt.Errorf("unsupported non-stream worker output event %T", workerOutputEvent)
 	}
-	return s.publishWorkerPublicPayloads(ctx, codeSessionID, event.publicPayloads)
+}
+
+func (s *Service) publishWorkerStreamPayloads(ctx context.Context, route CodeSessionStreamRoute, workerEpoch int64, payloads []json.RawMessage) {
+	if len(payloads) == 0 || s.sink == nil {
+		return
+	}
+	if err := s.sink.PublishCodeSessionStreamEvents(ctx, route, workerEpoch, payloads); err != nil {
+		s.logger.WarnContext(ctx, "publish worker stream preview", "code_session_id", route.CodeSessionID, "worker_epoch", workerEpoch, "event_count", len(payloads), "error", err)
+	}
 }
 
 func transientWorkerEvent(meta EventMetadata, createdAt time.Time) db.CodeSessionEvent {
@@ -475,15 +513,6 @@ func (s *Service) subagentThreadMappings(ctx context.Context, codeSession db.Cod
 func shouldForwardPublicEventToWorker(eventType string) bool {
 	switch eventType {
 	case "user.message", "user.interrupt", "user.tool_confirmation", "user.tool_result", "user.custom_tool_result":
-		return true
-	default:
-		return false
-	}
-}
-
-func isHiddenWorkerEvent(eventType string) bool {
-	switch eventType {
-	case "control_request", "control_response", "control_cancel_request":
 		return true
 	default:
 		return false

--- a/internal/codesessions/worker_output_prepare_test.go
+++ b/internal/codesessions/worker_output_prepare_test.go
@@ -8,34 +8,49 @@ import (
 	"time"
 )
 
-func TestPrepareSingleWorkerEventRejectsInvalidControlRequest(t *testing.T) {
-	prepared, err := prepareSingleWorkerEvent(
+func TestPrepareWorkerOutputEventRejectsInvalidControlRequest(t *testing.T) {
+	prepared, err := prepareWorkerOutputEvent(
 		"cse_test",
-		json.RawMessage(`{"type":"control_request","uuid":"control-uuid","request_id":"request-id","request":42}`),
+		workerOutputEvent{Payload: json.RawMessage(`{"type":"control_request","uuid":"control-uuid","request_id":"request-id","request":42}`)},
 		time.Unix(1, 0).UTC(),
 	)
 	if !errors.Is(err, ErrProtocol) {
-		t.Fatalf("prepareSingleWorkerEvent() error = %v, want ErrProtocol", err)
+		t.Fatalf("prepareWorkerOutputEvent() error = %v, want ErrProtocol", err)
 	}
-	if prepared.eventType != "" || prepared.controlRequest != nil || len(prepared.publicPayloads) != 0 {
-		t.Fatalf("prepared event = %#v, want zero value", prepared)
+	if prepared != nil {
+		t.Fatalf("prepared action = %#v, want nil", prepared)
 	}
 }
 
-func TestPrepareSingleWorkerEventBuildsKeepAliveAction(t *testing.T) {
-	prepared, err := prepareSingleWorkerEvent(
+func TestPrepareWorkerOutputEventBuildsKeepAliveAction(t *testing.T) {
+	prepared, err := prepareWorkerOutputEvent(
 		"cse_test",
-		json.RawMessage(`{"type":"keep_alive"}`),
+		workerOutputEvent{Payload: json.RawMessage(`{"type":"keep_alive"}`)},
 		time.Unix(1, 0).UTC(),
 	)
 	if err != nil {
-		t.Fatalf("prepareSingleWorkerEvent() error = %v", err)
+		t.Fatalf("prepareWorkerOutputEvent() error = %v", err)
 	}
-	if prepared.eventType != "keep_alive" {
-		t.Fatalf("event type = %q, want keep_alive", prepared.eventType)
+	if _, ok := prepared.(preparedKeepAliveAction); !ok {
+		t.Fatalf("prepared action = %T, want preparedKeepAliveAction", prepared)
 	}
-	if prepared.controlRequest != nil || len(prepared.publicPayloads) != 0 {
-		t.Fatalf("keep-alive action = %#v, want no event application", prepared)
+}
+
+func TestPrepareWorkerOutputEventIgnoresNonEphemeralStream(t *testing.T) {
+	prepared, err := prepareWorkerOutputEvent(
+		"cse_test",
+		workerOutputEvent{Payload: json.RawMessage(`{
+			"type":"stream_event",
+			"uuid":"stream-uuid",
+			"event":{"type":"message_start","message":{"id":"msg_test"}}
+		}`)},
+		time.Unix(1, 0).UTC(),
+	)
+	if err != nil {
+		t.Fatalf("prepareWorkerOutputEvent() error = %v", err)
+	}
+	if _, ok := prepared.(preparedNoopAction); !ok {
+		t.Fatalf("prepared action = %T, want preparedNoopAction", prepared)
 	}
 }
 
@@ -68,6 +83,11 @@ func TestPrepareWorkerOutputEventsRejectsBatchBeforeApply(t *testing.T) {
 func TestPrepareWorkerOutputEventsBuildsActions(t *testing.T) {
 	events := []workerOutputEvent{
 		{Payload: json.RawMessage(`{"type":"keep_alive"}`)},
+		{Ephemeral: true, Payload: json.RawMessage(`{
+			"type":"stream_event",
+			"uuid":"stream-uuid",
+			"event":{"type":"message_start","message":{"id":"msg_test"}}
+		}`)},
 		{Payload: json.RawMessage(`{
 			"type":"control_request",
 			"uuid":"control-uuid",
@@ -88,13 +108,43 @@ func TestPrepareWorkerOutputEventsBuildsActions(t *testing.T) {
 	if len(prepared) != len(events) {
 		t.Fatalf("prepared event count = %d, want %d", len(prepared), len(events))
 	}
-	if prepared[0].controlRequest != nil || len(prepared[0].publicPayloads) != 0 {
-		t.Fatalf("keep-alive action = %#v, want empty", prepared[0])
+	if _, ok := prepared[0].(preparedKeepAliveAction); !ok {
+		t.Fatalf("prepared[0] = %T, want preparedKeepAliveAction", prepared[0])
 	}
-	if prepared[1].controlRequest == nil || prepared[1].metadata.EventType != "control_request" {
-		t.Fatalf("control action = %#v", prepared[1])
+	stream, ok := prepared[1].(preparedStreamAction)
+	if !ok || len(stream.payload) == 0 {
+		t.Fatalf("prepared[1] = %#v, want preparedStreamAction", prepared[1])
 	}
-	if len(prepared[2].publicPayloads) == 0 {
-		t.Fatalf("public action = %#v, want payloads", prepared[2])
+	var streamPayload workerOutputCommonPayload
+	if err := json.Unmarshal(stream.payload, &streamPayload); err != nil {
+		t.Fatalf("decode stream payload: %v", err)
+	}
+	if streamPayload.UUID != "stream-uuid" || streamPayload.SessionID != "cse_test" {
+		t.Fatalf("normalized stream identity = %#v, want original uuid and code session id", streamPayload)
+	}
+	if streamPayload.CreatedAt == "" || streamPayload.Timestamp != streamPayload.CreatedAt {
+		t.Fatalf("normalized stream timestamps = %#v, want matching created_at and timestamp", streamPayload)
+	}
+	control, ok := prepared[2].(preparedControlAction)
+	if !ok || control.metadata.EventType != "control_request" {
+		t.Fatalf("prepared[2] = %#v, want preparedControlAction", prepared[2])
+	}
+	public, ok := prepared[3].(preparedPublicAction)
+	if !ok || len(public.payloads) == 0 {
+		t.Fatalf("prepared[3] = %#v, want preparedPublicAction", prepared[3])
+	}
+}
+
+func TestLeadingWorkerStreamPayloadsStopsAtNonStreamEvent(t *testing.T) {
+	actions := []preparedWorkerOutputEvent{
+		preparedStreamAction{payload: json.RawMessage(`{"sequence":1}`)},
+		preparedStreamAction{payload: json.RawMessage(`{"sequence":2}`)},
+		preparedPublicAction{payloads: []json.RawMessage{json.RawMessage(`{"type":"agent.message"}`)}},
+		preparedStreamAction{payload: json.RawMessage(`{"sequence":3}`)},
+	}
+
+	payloads := leadingWorkerStreamPayloads(actions)
+	if len(payloads) != 2 || string(payloads[0]) != `{"sequence":1}` || string(payloads[1]) != `{"sequence":2}` {
+		t.Fatalf("leadingWorkerStreamPayloads() = %q, want first two stream payloads", payloads)
 	}
 }

--- a/internal/codesessions/worker_output_schema.go
+++ b/internal/codesessions/worker_output_schema.go
@@ -36,6 +36,7 @@ type workerPayloadHeader struct {
 // records. The mapper decodes those fields only in the event-type branch that
 // interprets them.
 type workerOutputMessage struct {
+	ID      string          `json:"id"`
 	Content json.RawMessage `json:"content"`
 }
 
@@ -53,9 +54,10 @@ type workerOutputCommonPayload struct {
 }
 
 type workerAssistantOutputPayload struct {
-	Type    string              `json:"type"`
-	Content json.RawMessage     `json:"content"`
-	Message workerOutputMessage `json:"message"`
+	Type              string              `json:"type"`
+	Content           json.RawMessage     `json:"content"`
+	ContentBlockIndex *int                `json:"content_block_index"`
+	Message           workerOutputMessage `json:"message"`
 }
 
 type workerUserOutputPayload struct {

--- a/internal/codesessions/worker_output_schema.go
+++ b/internal/codesessions/worker_output_schema.go
@@ -3,6 +3,7 @@ package codesessions
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 )
 
 // Worker output protocol sources in superduck-code:
@@ -58,6 +59,15 @@ type workerAssistantOutputPayload struct {
 	Content           json.RawMessage     `json:"content"`
 	ContentBlockIndex *int                `json:"content_block_index"`
 	Message           workerOutputMessage `json:"message"`
+}
+
+func decodeWorkerAssistantOutputPayload(raw json.RawMessage) (workerAssistantOutputPayload, error) {
+	var payload workerAssistantOutputPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return workerAssistantOutputPayload{}, err
+	}
+	payload.Message.ID = strings.TrimSpace(payload.Message.ID)
+	return payload, nil
 }
 
 type workerUserOutputPayload struct {

--- a/internal/codesessions/worker_stream_route_test.go
+++ b/internal/codesessions/worker_stream_route_test.go
@@ -1,0 +1,46 @@
+package codesessions
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+)
+
+func TestPublishWorkerStreamPayloadsUsesProvidedRouteWithoutDatabase(t *testing.T) {
+	service := newTestService(t, nil)
+	sink := &recordingWorkerStreamSink{}
+	service.SetPublicEventSink(sink)
+	route := CodeSessionStreamRoute{
+		CodeSessionID:     "cse-test",
+		WorkspaceUUID:     "workspace-test",
+		SessionExternalID: "session-test",
+	}
+	payloads := []json.RawMessage{json.RawMessage(`{"type":"stream_event"}`)}
+
+	service.publishWorkerStreamPayloads(context.Background(), route, 7, payloads)
+
+	if !sink.called || sink.route != route || sink.workerEpoch != 7 || len(sink.payloads) != 1 {
+		t.Fatalf("stream publication = %#v, want supplied route and payload", sink)
+	}
+}
+
+type recordingWorkerStreamSink struct {
+	called      bool
+	route       CodeSessionStreamRoute
+	workerEpoch int64
+	payloads    []json.RawMessage
+}
+
+func (s *recordingWorkerStreamSink) PublishCodeSessionEvents(context.Context, db.CodeSession, []json.RawMessage) error {
+	return nil
+}
+
+func (s *recordingWorkerStreamSink) PublishCodeSessionStreamEvents(_ context.Context, route CodeSessionStreamRoute, workerEpoch int64, payloads []json.RawMessage) error {
+	s.called = true
+	s.route = route
+	s.workerEpoch = workerEpoch
+	s.payloads = payloads
+	return nil
+}

--- a/internal/managedagentsevents/identity.go
+++ b/internal/managedagentsevents/identity.go
@@ -8,8 +8,8 @@ import (
 )
 
 func StableAssistantEventID(codeSessionID, messageID string, contentBlockIndex int, eventType string) string {
-	seed := "assistant-preview-v1\x00" + strings.TrimSpace(messageID) + "\x00" + strconv.Itoa(contentBlockIndex) + "\x00" + strings.TrimSpace(eventType)
-	sum := sha256.Sum256([]byte(strings.TrimSpace(codeSessionID) + "\x00public\x00" + seed))
+	seed := "assistant-preview-v1\x00" + messageID + "\x00" + strconv.Itoa(contentBlockIndex) + "\x00" + eventType
+	sum := sha256.Sum256([]byte(codeSessionID + "\x00public\x00" + seed))
 	return "sevt_" + hex.EncodeToString(sum[:16])
 }
 

--- a/internal/managedagentsevents/identity.go
+++ b/internal/managedagentsevents/identity.go
@@ -1,0 +1,23 @@
+package managedagentsevents
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+)
+
+func StableAssistantEventID(codeSessionID, messageID string, contentBlockIndex int, eventType string) string {
+	seed := "assistant-preview-v1\x00" + strings.TrimSpace(messageID) + "\x00" + strconv.Itoa(contentBlockIndex) + "\x00" + strings.TrimSpace(eventType)
+	sum := sha256.Sum256([]byte(strings.TrimSpace(codeSessionID) + "\x00public\x00" + seed))
+	return "sevt_" + hex.EncodeToString(sum[:16])
+}
+
+func ClaudeTaskThreadID(codeSessionID, key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(strings.TrimSpace(codeSessionID) + "\x00claude-task\x00" + key))
+	return "sthr_" + hex.EncodeToString(sum[:16])
+}

--- a/internal/managedagentsevents/identity_test.go
+++ b/internal/managedagentsevents/identity_test.go
@@ -1,0 +1,16 @@
+package managedagentsevents
+
+import "testing"
+
+func TestStableAssistantEventIDDoesNotNormalizeInputs(t *testing.T) {
+	canonical := StableAssistantEventID("cse_test", "msg_test", 0, "agent.message")
+	for name, eventID := range map[string]string{
+		"code session id": StableAssistantEventID(" cse_test ", "msg_test", 0, "agent.message"),
+		"message id":      StableAssistantEventID("cse_test", " msg_test ", 0, "agent.message"),
+		"event type":      StableAssistantEventID("cse_test", "msg_test", 0, " agent.message "),
+	} {
+		if eventID == canonical {
+			t.Fatalf("%s was normalized inside StableAssistantEventID", name)
+		}
+	}
+}

--- a/internal/platformsession/redis.go
+++ b/internal/platformsession/redis.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 
@@ -15,20 +14,11 @@ type RedisStore struct {
 	client *redis.Client
 }
 
-func NewRedisStore(ctx context.Context, redisURL string) (*RedisStore, error) {
-	if strings.TrimSpace(redisURL) == "" {
-		return nil, errors.New("redis.url is required")
+func NewRedisStore(client *redis.Client) *RedisStore {
+	if client == nil {
+		panic("platformsession: redis client is required")
 	}
-	options, err := redis.ParseURL(redisURL)
-	if err != nil {
-		return nil, fmt.Errorf("parse redis.url: %w", err)
-	}
-	client := redis.NewClient(options)
-	if err := client.Ping(ctx).Err(); err != nil {
-		_ = client.Close()
-		return nil, fmt.Errorf("connect redis: %w", err)
-	}
-	return &RedisStore{client: client}, nil
+	return &RedisStore{client: client}
 }
 
 func (s *RedisStore) Save(ctx context.Context, sessionKey string, session Session) error {
@@ -78,11 +68,4 @@ func (s *RedisStore) Delete(ctx context.Context, sessionKey string) error {
 		return nil
 	}
 	return s.client.Del(ctx, storeKey(sessionKey)).Err()
-}
-
-func (s *RedisStore) Close() error {
-	if s == nil || s.client == nil {
-		return nil
-	}
-	return s.client.Close()
 }

--- a/internal/redisclient/client.go
+++ b/internal/redisclient/client.go
@@ -1,0 +1,26 @@
+package redisclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func Open(ctx context.Context, redisURL string) (*redis.Client, error) {
+	if strings.TrimSpace(redisURL) == "" {
+		return nil, errors.New("redis.url is required")
+	}
+	options, err := redis.ParseURL(redisURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse redis.url: %w", err)
+	}
+	client := redis.NewClient(options)
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("connect redis: %w", err)
+	}
+	return client, nil
+}

--- a/internal/sessionfanout/bus.go
+++ b/internal/sessionfanout/bus.go
@@ -1,0 +1,328 @@
+package sessionfanout
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/superduck-ai/open-managed-agents/internal/logging"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	instanceChannelPrefix = "oma:i:"
+	sessionChannelPrefix  = "oma:s:"
+)
+
+type Kind string
+
+const (
+	KindSessionEvents     Kind = "session_events"
+	KindCodeSessionStream Kind = "code_session_stream"
+)
+
+type Envelope struct {
+	Kind    Kind            `json:"kind"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+type Handler func(context.Context, Envelope)
+
+type EventBus interface {
+	Publish(context.Context, string, Envelope) error
+	Subscribe(context.Context, string) error
+	Register(Handler, func())
+	Close() error
+}
+
+type LocalBus struct {
+	mu       sync.RWMutex
+	handlers []Handler
+}
+
+func NewLocal() *LocalBus {
+	return &LocalBus{}
+}
+
+func (b *LocalBus) Publish(ctx context.Context, sessionID string, envelope Envelope) error {
+	if _, err := sessionChannel(sessionID); err != nil {
+		return err
+	}
+	if err := validateEnvelope(envelope); err != nil {
+		return err
+	}
+	b.mu.RLock()
+	handlers := append([]Handler(nil), b.handlers...)
+	b.mu.RUnlock()
+	for _, handler := range handlers {
+		handler(ctx, envelope)
+	}
+	return nil
+}
+
+func (b *LocalBus) Subscribe(_ context.Context, sessionID string) error {
+	_, err := sessionChannel(sessionID)
+	return err
+}
+
+func (b *LocalBus) Register(handler Handler, _ func()) {
+	if handler == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.handlers = append(b.handlers, handler)
+}
+
+func (b *LocalBus) Close() error {
+	return nil
+}
+
+type RedisBus struct {
+	client        *redis.Client
+	pubsub        redisSubscription
+	logger        *slog.Logger
+	mu            sync.RWMutex
+	handlers      []Handler
+	resetters     []func()
+	subscriptions map[string]*sessionSubscription
+	cancel        context.CancelFunc
+	done          chan struct{}
+	closeOnce     sync.Once
+	closeErr      error
+}
+
+type redisSubscription interface {
+	Receive(context.Context) (any, error)
+	Subscribe(context.Context, ...string) error
+	Close() error
+}
+
+type sessionSubscription struct {
+	done      chan struct{}
+	err       error
+	completed bool
+}
+
+func NewRedis(ctx context.Context, client *redis.Client, logger *slog.Logger) (*RedisBus, error) {
+	if client == nil {
+		return nil, errors.New("redis client is required")
+	}
+	listenCtx, cancel := context.WithCancel(ctx)
+	instanceChannel := instanceChannelPrefix + uuid.NewString()
+	pubsub := client.Subscribe(listenCtx, instanceChannel)
+	if _, err := pubsub.Receive(listenCtx); err != nil {
+		cancel()
+		_ = pubsub.Close()
+		return nil, fmt.Errorf("subscribe redis instance channel: %w", err)
+	}
+	bus := &RedisBus{
+		client:        client,
+		pubsub:        pubsub,
+		logger:        logging.LoggerOrDefault(logger),
+		subscriptions: make(map[string]*sessionSubscription),
+		cancel:        cancel,
+		done:          make(chan struct{}),
+	}
+	go bus.receive(listenCtx)
+	return bus, nil
+}
+
+func (b *RedisBus) Publish(ctx context.Context, sessionID string, envelope Envelope) error {
+	channel, err := sessionChannel(sessionID)
+	if err != nil {
+		return err
+	}
+	if err := validateEnvelope(envelope); err != nil {
+		return err
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("marshal session fanout envelope: %w", err)
+	}
+	if err := b.client.Publish(ctx, channel, body).Err(); err != nil {
+		return fmt.Errorf("publish redis channel %s: %w", channel, err)
+	}
+	return nil
+}
+
+func (b *RedisBus) Subscribe(ctx context.Context, sessionID string) error {
+	channel, err := sessionChannel(sessionID)
+	if err != nil {
+		return err
+	}
+	subscription, created := b.sessionSubscription(channel)
+	if created {
+		if err := b.pubsub.Subscribe(ctx, channel); err != nil {
+			b.completeSubscription(channel, subscription, fmt.Errorf("subscribe redis channel %s: %w", channel, err), true)
+		}
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-subscription.done:
+		return subscription.err
+	}
+}
+
+func (b *RedisBus) Register(handler Handler, reset func()) {
+	if handler == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.handlers = append(b.handlers, handler)
+	if reset != nil {
+		b.resetters = append(b.resetters, reset)
+	}
+}
+
+func (b *RedisBus) Close() error {
+	if b == nil {
+		return nil
+	}
+	b.closeOnce.Do(func() {
+		b.failPendingSubscriptions(errors.New("session fanout is closed"))
+		b.cancel()
+		b.closeErr = b.pubsub.Close()
+		<-b.done
+	})
+	return b.closeErr
+}
+
+func (b *RedisBus) receive(ctx context.Context) {
+	defer close(b.done)
+	for {
+		item, err := b.pubsub.Receive(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			b.logger.WarnContext(ctx, "session event fanout interrupted", "channel_prefix", sessionChannelPrefix, "error", err)
+			b.reset()
+			timer := time.NewTimer(time.Second)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+			continue
+		}
+		b.receiveItem(ctx, item)
+	}
+}
+
+func (b *RedisBus) receiveItem(ctx context.Context, item any) {
+	switch item := item.(type) {
+	case *redis.Message:
+		b.receiveMessage(ctx, item)
+	case *redis.Subscription:
+		if item.Kind == "subscribe" {
+			b.completeSubscription(item.Channel, nil, nil, false)
+		}
+	}
+}
+
+func (b *RedisBus) receiveMessage(ctx context.Context, message *redis.Message) {
+	var envelope Envelope
+	if err := json.Unmarshal([]byte(message.Payload), &envelope); err != nil {
+		b.logger.WarnContext(ctx, "discard malformed session event fanout", "channel", message.Channel, "error", err)
+		return
+	}
+	if err := validateEnvelope(envelope); err != nil {
+		b.logger.WarnContext(ctx, "discard invalid session event fanout", "channel", message.Channel, "error", err)
+		return
+	}
+	b.dispatch(ctx, envelope)
+}
+
+func (b *RedisBus) sessionSubscription(channel string) (*sessionSubscription, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if subscription, exists := b.subscriptions[channel]; exists {
+		return subscription, false
+	}
+	subscription := &sessionSubscription{done: make(chan struct{})}
+	b.subscriptions[channel] = subscription
+	return subscription, true
+}
+
+func (b *RedisBus) completeSubscription(channel string, expected *sessionSubscription, err error, remove bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	subscription, exists := b.subscriptions[channel]
+	if !exists || subscription.completed || (expected != nil && subscription != expected) {
+		return
+	}
+	subscription.err = err
+	subscription.completed = true
+	close(subscription.done)
+	if remove {
+		delete(b.subscriptions, channel)
+	}
+}
+
+func (b *RedisBus) failPendingSubscriptions(err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for channel, subscription := range b.subscriptions {
+		if subscription.completed {
+			continue
+		}
+		subscription.err = err
+		subscription.completed = true
+		close(subscription.done)
+		delete(b.subscriptions, channel)
+	}
+}
+
+func (b *RedisBus) dispatch(ctx context.Context, envelope Envelope) {
+	b.mu.RLock()
+	handlers := append([]Handler(nil), b.handlers...)
+	b.mu.RUnlock()
+	for _, handler := range handlers {
+		handler(ctx, envelope)
+	}
+}
+
+func (b *RedisBus) reset() {
+	b.mu.RLock()
+	resetters := append([]func(){}, b.resetters...)
+	b.mu.RUnlock()
+	for _, reset := range resetters {
+		reset()
+	}
+}
+
+func validateEnvelope(envelope Envelope) error {
+	if !envelope.Kind.valid() {
+		return fmt.Errorf("unsupported session fanout kind %q", envelope.Kind)
+	}
+	if len(envelope.Payload) == 0 {
+		return errors.New("session fanout payload is required")
+	}
+	return nil
+}
+
+func (kind Kind) valid() bool {
+	switch kind {
+	case KindSessionEvents, KindCodeSessionStream:
+		return true
+	default:
+		return false
+	}
+}
+
+func sessionChannel(sessionID string) (string, error) {
+	if sessionID == "" {
+		return "", errors.New("session fanout session ID is required")
+	}
+	return sessionChannelPrefix + sessionID, nil
+}

--- a/internal/sessionfanout/bus.go
+++ b/internal/sessionfanout/bus.go
@@ -37,6 +37,7 @@ type Handler func(context.Context, Envelope)
 type EventBus interface {
 	Publish(context.Context, string, Envelope) error
 	Subscribe(context.Context, string) error
+	Unsubscribe(context.Context, string) error
 	Register(Handler, func())
 	Close() error
 }
@@ -71,6 +72,11 @@ func (b *LocalBus) Subscribe(_ context.Context, sessionID string) error {
 	return err
 }
 
+func (b *LocalBus) Unsubscribe(_ context.Context, sessionID string) error {
+	_, err := sessionChannel(sessionID)
+	return err
+}
+
 func (b *LocalBus) Register(handler Handler, _ func()) {
 	if handler == nil {
 		return
@@ -101,6 +107,7 @@ type RedisBus struct {
 type redisSubscription interface {
 	Receive(context.Context) (any, error)
 	Subscribe(context.Context, ...string) error
+	Unsubscribe(context.Context, ...string) error
 	Close() error
 }
 
@@ -169,6 +176,23 @@ func (b *RedisBus) Subscribe(ctx context.Context, sessionID string) error {
 	case <-subscription.done:
 		return subscription.err
 	}
+}
+
+func (b *RedisBus) Unsubscribe(ctx context.Context, sessionID string) error {
+	channel, err := sessionChannel(sessionID)
+	if err != nil {
+		return err
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, exists := b.subscriptions[channel]; !exists {
+		return nil
+	}
+	delete(b.subscriptions, channel)
+	if err := b.pubsub.Unsubscribe(ctx, channel); err != nil {
+		return fmt.Errorf("unsubscribe redis channel %s: %w", channel, err)
+	}
+	return nil
 }
 
 func (b *RedisBus) Register(handler Handler, reset func()) {

--- a/internal/sessionfanout/bus_test.go
+++ b/internal/sessionfanout/bus_test.go
@@ -1,0 +1,209 @@
+package sessionfanout
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestRedisBusCloseUnblocksDeadlineLessReceive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	subscription := newBlockingRedisSubscription()
+	bus := &RedisBus{
+		pubsub: subscription,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	go bus.receive(ctx)
+
+	select {
+	case <-subscription.receiveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Redis receive loop did not start")
+	}
+
+	closed := make(chan error, 1)
+	go func() {
+		closed <- bus.Close()
+	}()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		_ = subscription.Close()
+		<-closed
+		t.Fatal("Close() blocked on deadline-less Redis receive")
+	}
+
+	if err := bus.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+func TestRedisBusSubscribesToSessionChannelAndWaitsForAcknowledgement(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	subscription := newAcknowledgingRedisSubscription()
+	bus := &RedisBus{
+		pubsub:        subscription,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		subscriptions: make(map[string]*sessionSubscription),
+		cancel:        cancel,
+		done:          make(chan struct{}),
+	}
+	go bus.receive(ctx)
+
+	subscribed := make(chan error, 1)
+	go func() {
+		subscribed <- bus.Subscribe(ctx, "session-test")
+	}()
+	select {
+	case <-subscription.subscribeCalled:
+	case <-time.After(time.Second):
+		t.Fatal("Redis Subscribe() was not called")
+	}
+	select {
+	case err := <-subscribed:
+		t.Fatalf("Subscribe() returned before acknowledgement: %v", err)
+	default:
+	}
+	if got, want := subscription.lastChannel(), "oma:s:session-test"; got != want {
+		t.Fatalf("subscribed channel = %q, want %q", got, want)
+	}
+	subscription.acknowledge("oma:s:session-test")
+	select {
+	case err := <-subscribed:
+		if err != nil {
+			t.Fatalf("Subscribe() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe() did not return after acknowledgement")
+	}
+	if err := bus.Subscribe(ctx, "session-test"); err != nil {
+		t.Fatalf("second Subscribe() error = %v", err)
+	}
+	if got := subscription.subscribeCount(); got != 1 {
+		t.Fatalf("Redis subscribe count = %d, want 1", got)
+	}
+	if err := bus.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestValidateEnvelopeKind(t *testing.T) {
+	for _, kind := range []Kind{KindSessionEvents, KindCodeSessionStream} {
+		envelope := Envelope{Kind: kind, Payload: json.RawMessage(`{}`)}
+		if err := validateEnvelope(envelope); err != nil {
+			t.Fatalf("validateEnvelope(%q) returned error: %v", kind, err)
+		}
+	}
+
+	envelope := Envelope{Kind: Kind("unknown"), Payload: json.RawMessage(`{}`)}
+	if err := validateEnvelope(envelope); err == nil {
+		t.Fatal("validateEnvelope(unknown) error = nil, want unsupported kind error")
+	}
+}
+
+type blockingRedisSubscription struct {
+	receiveStarted chan struct{}
+	closed         chan struct{}
+	receiveOnce    sync.Once
+	closeOnce      sync.Once
+}
+
+func newBlockingRedisSubscription() *blockingRedisSubscription {
+	return &blockingRedisSubscription{
+		receiveStarted: make(chan struct{}),
+		closed:         make(chan struct{}),
+	}
+}
+
+func (s *blockingRedisSubscription) Receive(context.Context) (any, error) {
+	s.receiveOnce.Do(func() {
+		close(s.receiveStarted)
+	})
+	<-s.closed
+	return nil, errors.New("subscription closed")
+}
+
+func (s *blockingRedisSubscription) Subscribe(context.Context, ...string) error {
+	return nil
+}
+
+func (s *blockingRedisSubscription) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.closed)
+	})
+	return nil
+}
+
+type acknowledgingRedisSubscription struct {
+	mu              sync.Mutex
+	channels        []string
+	items           chan any
+	closed          chan struct{}
+	subscribeCalled chan struct{}
+	closeOnce       sync.Once
+}
+
+func newAcknowledgingRedisSubscription() *acknowledgingRedisSubscription {
+	return &acknowledgingRedisSubscription{
+		items:           make(chan any, 1),
+		closed:          make(chan struct{}),
+		subscribeCalled: make(chan struct{}, 1),
+	}
+}
+
+func (s *acknowledgingRedisSubscription) Receive(ctx context.Context) (any, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.closed:
+		return nil, errors.New("subscription closed")
+	case item := <-s.items:
+		return item, nil
+	}
+}
+
+func (s *acknowledgingRedisSubscription) Subscribe(_ context.Context, channels ...string) error {
+	s.mu.Lock()
+	s.channels = append(s.channels, channels...)
+	s.mu.Unlock()
+	s.subscribeCalled <- struct{}{}
+	return nil
+}
+
+func (s *acknowledgingRedisSubscription) acknowledge(channel string) {
+	s.items <- &redis.Subscription{Kind: "subscribe", Channel: channel}
+}
+
+func (s *acknowledgingRedisSubscription) Close() error {
+	s.closeOnce.Do(func() {
+		close(s.closed)
+	})
+	return nil
+}
+
+func (s *acknowledgingRedisSubscription) lastChannel() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.channels) == 0 {
+		return ""
+	}
+	return s.channels[len(s.channels)-1]
+}
+
+func (s *acknowledgingRedisSubscription) subscribeCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.channels)
+}

--- a/internal/sessionfanout/bus_test.go
+++ b/internal/sessionfanout/bus_test.go
@@ -99,6 +99,70 @@ func TestRedisBusSubscribesToSessionChannelAndWaitsForAcknowledgement(t *testing
 	}
 }
 
+func TestRedisBusUnsubscribesSessionChannelAndAllowsResubscribe(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	subscription := newAcknowledgingRedisSubscription()
+	bus := &RedisBus{
+		pubsub:        subscription,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		subscriptions: make(map[string]*sessionSubscription),
+		cancel:        cancel,
+		done:          make(chan struct{}),
+	}
+	go bus.receive(ctx)
+
+	first := make(chan error, 1)
+	go func() {
+		first <- bus.Subscribe(ctx, "session-test")
+	}()
+	select {
+	case <-subscription.subscribeCalled:
+	case <-time.After(time.Second):
+		t.Fatal("initial Redis Subscribe() was not called")
+	}
+	subscription.acknowledge("oma:s:session-test")
+	select {
+	case err := <-first:
+		if err != nil {
+			t.Fatalf("initial Subscribe() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("initial Subscribe() did not return after acknowledgement")
+	}
+
+	if err := bus.Unsubscribe(ctx, "session-test"); err != nil {
+		t.Fatalf("Unsubscribe() error = %v", err)
+	}
+	if got, want := subscription.lastUnsubscribedChannel(), "oma:s:session-test"; got != want {
+		t.Fatalf("unsubscribed channel = %q, want %q", got, want)
+	}
+
+	second := make(chan error, 1)
+	go func() {
+		second <- bus.Subscribe(ctx, "session-test")
+	}()
+	select {
+	case <-subscription.subscribeCalled:
+	case <-time.After(time.Second):
+		t.Fatal("second Redis Subscribe() was not called")
+	}
+	subscription.acknowledge("oma:s:session-test")
+	select {
+	case err := <-second:
+		if err != nil {
+			t.Fatalf("second Subscribe() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second Subscribe() did not return after acknowledgement")
+	}
+	if got := subscription.subscribeCount(); got != 2 {
+		t.Fatalf("Redis subscribe count = %d, want 2", got)
+	}
+	if err := bus.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
 func TestValidateEnvelopeKind(t *testing.T) {
 	for _, kind := range []Kind{KindSessionEvents, KindCodeSessionStream} {
 		envelope := Envelope{Kind: kind, Payload: json.RawMessage(`{}`)}
@@ -139,6 +203,10 @@ func (s *blockingRedisSubscription) Subscribe(context.Context, ...string) error 
 	return nil
 }
 
+func (s *blockingRedisSubscription) Unsubscribe(context.Context, ...string) error {
+	return nil
+}
+
 func (s *blockingRedisSubscription) Close() error {
 	s.closeOnce.Do(func() {
 		close(s.closed)
@@ -149,6 +217,7 @@ func (s *blockingRedisSubscription) Close() error {
 type acknowledgingRedisSubscription struct {
 	mu              sync.Mutex
 	channels        []string
+	unsubscribed    []string
 	items           chan any
 	closed          chan struct{}
 	subscribeCalled chan struct{}
@@ -182,6 +251,13 @@ func (s *acknowledgingRedisSubscription) Subscribe(_ context.Context, channels .
 	return nil
 }
 
+func (s *acknowledgingRedisSubscription) Unsubscribe(_ context.Context, channels ...string) error {
+	s.mu.Lock()
+	s.unsubscribed = append(s.unsubscribed, channels...)
+	s.mu.Unlock()
+	return nil
+}
+
 func (s *acknowledgingRedisSubscription) acknowledge(channel string) {
 	s.items <- &redis.Subscription{Kind: "subscribe", Channel: channel}
 }
@@ -206,4 +282,13 @@ func (s *acknowledgingRedisSubscription) subscribeCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.channels)
+}
+
+func (s *acknowledgingRedisSubscription) lastUnsubscribedChannel() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.unsubscribed) == 0 {
+		return ""
+	}
+	return s.unsubscribed[len(s.unsubscribed)-1]
 }

--- a/internal/sessions/code_event_bridge.go
+++ b/internal/sessions/code_event_bridge.go
@@ -18,9 +18,7 @@ func (h *Handler) appendAndBroadcastInternal(r *http.Request, sessionID string, 
 		h.logger.ErrorContext(r.Context(), "append internal session events", "session_id", sessionID, "error", err)
 		return
 	}
-	for _, event := range created {
-		h.broadcast(event)
-	}
+	h.publishSessionEvents(r.Context(), created)
 }
 
 func (h *Handler) PublishCodeSessionEvents(ctx context.Context, codeSession db.CodeSession, payloads []json.RawMessage) error {
@@ -34,6 +32,7 @@ func (h *Handler) PublishCodeSessionEvents(ctx context.Context, codeSession db.C
 	if !found {
 		return db.ErrNotFound
 	}
+	var streamEvents []db.SessionEvent
 	var events []db.SessionEvent
 	now := time.Now().UTC()
 	for _, raw := range payloads {
@@ -43,7 +42,7 @@ func (h *Handler) PublishCodeSessionEvents(ctx context.Context, codeSession db.C
 				h.logger.WarnContext(ctx, "skip code session stream delta", "session_id", session.ExternalID, "code_session_id", codeSession.ExternalID, "error", err)
 				continue
 			}
-			h.broadcastStreamDelta(event)
+			streamEvents = append(streamEvents, event)
 			continue
 		}
 		batch, err := h.sessionEventsFromCodeSessionPayload(ctx, session, codeSession.ExternalID, raw, now)
@@ -53,6 +52,7 @@ func (h *Handler) PublishCodeSessionEvents(ctx context.Context, codeSession db.C
 		}
 		events = append(events, batch...)
 	}
+	h.publishSessionEvents(ctx, streamEvents)
 	if len(events) == 0 {
 		return nil
 	}
@@ -76,7 +76,7 @@ func (h *Handler) PublishCodeSessionEvents(ctx context.Context, codeSession db.C
 	for _, event := range created {
 		persisted[event.ExternalID] = event
 	}
-	// Idempotent retries reapply stored state projections; only newly inserted events leave the process.
+	// Idempotent retries reapply stored state projections; only newly inserted convertEvents leave the process.
 	var projectionErr error
 	for _, event := range events {
 		stored, ok := persisted[event.ExternalID]
@@ -89,9 +89,7 @@ func (h *Handler) PublishCodeSessionEvents(ctx context.Context, codeSession db.C
 		}
 		projectionErr = errors.Join(projectionErr, eventErr)
 	}
-	for _, event := range created {
-		h.broadcast(event)
-	}
+	h.publishSessionEvents(ctx, created)
 	h.enqueueWebhooksForSessionEvents(ctx, session.WorkspaceUUID, session.ExternalID, created)
 	return projectionErr
 }

--- a/internal/sessions/code_event_bridge.go
+++ b/internal/sessions/code_event_bridge.go
@@ -76,7 +76,8 @@ func (h *Handler) PublishCodeSessionEvents(ctx context.Context, codeSession db.C
 	for _, event := range created {
 		persisted[event.ExternalID] = event
 	}
-	// Idempotent retries reapply stored state projections; only newly inserted convertEvents leave the process.
+	// Idempotent retries reapply stored state projections. Only newly inserted
+	// events are broadcast and have webhooks enqueued.
 	var projectionErr error
 	for _, event := range events {
 		stored, ok := persisted[event.ExternalID]

--- a/internal/sessions/event_payload.go
+++ b/internal/sessions/event_payload.go
@@ -215,22 +215,26 @@ func isToolResultOrConfirmationEvent(eventType string) bool {
 }
 
 func sessionEventPayloadForResponse(event db.SessionEvent, threadID string) json.RawMessage {
+	return eventPayloadForResponse(event.Payload, event.CreatedAt, event.ProcessedAt, threadID)
+}
+
+func eventPayloadForResponse(payloadRaw json.RawMessage, createdAt, processedAt time.Time, threadID string) json.RawMessage {
 	var payload map[string]any
-	if err := json.Unmarshal(event.Payload, &payload); err != nil {
-		return event.Payload
+	if err := json.Unmarshal(payloadRaw, &payload); err != nil {
+		return payloadRaw
 	}
-	changed := ensureSessionEventTimeField(payload, "created_at", event.CreatedAt)
-	changed = ensureSessionEventTimeField(payload, "processed_at", event.ProcessedAt) || changed
+	changed := ensureSessionEventTimeField(payload, "created_at", createdAt)
+	changed = ensureSessionEventTimeField(payload, "processed_at", processedAt) || changed
 	if strings.TrimSpace(threadID) != "" && !hasSessionThreadOwnerField(payload) {
 		payload["session_thread_id"] = strings.TrimSpace(threadID)
 		changed = true
 	}
 	if !changed {
-		return event.Payload
+		return payloadRaw
 	}
 	raw, err := httpapi.MarshalRaw(payload)
 	if err != nil {
-		return event.Payload
+		return payloadRaw
 	}
 	return raw
 }

--- a/internal/sessions/fanout.go
+++ b/internal/sessions/fanout.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
+	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 	"github.com/superduck-ai/open-managed-agents/internal/sessionfanout"
 )
 
@@ -93,9 +94,7 @@ func (h *Handler) receiveFanout(ctx context.Context, envelope sessionfanout.Enve
 			h.logger.WarnContext(ctx, "discard session events fanout", "error", err)
 			return
 		}
-		for _, event := range payload.Events {
-			h.streams.broadcastEvent(event)
-		}
+		h.receiveSessionEventsFanout(ctx, payload.Events)
 	case sessionfanout.KindCodeSessionStream:
 		var payload codeSessionStreamFanout
 		if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
@@ -105,6 +104,22 @@ func (h *Handler) receiveFanout(ctx context.Context, envelope sessionfanout.Enve
 		for _, event := range h.previews.convert(payload) {
 			h.streams.broadcastEvent(event)
 		}
+	}
+}
+
+func (h *Handler) receiveSessionEventsFanout(ctx context.Context, events []sessionStreamEvent) {
+	terminalSessionID := ""
+	for _, event := range events {
+		h.streams.broadcastEvent(event)
+		if status, ok := maevents.SessionStatus(event.EventType); ok && status == "terminated" {
+			terminalSessionID = event.SessionExternalID
+		}
+	}
+	if terminalSessionID == "" {
+		return
+	}
+	if err := h.eventBus.Unsubscribe(ctx, terminalSessionID); err != nil {
+		h.logger.WarnContext(ctx, "unsubscribe terminated session fanout", "session_id", terminalSessionID, "error", err)
 	}
 }
 

--- a/internal/sessions/fanout.go
+++ b/internal/sessions/fanout.go
@@ -1,0 +1,127 @@
+package sessions
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/sessionfanout"
+)
+
+type sessionEventsFanout struct {
+	Events []sessionStreamEvent `json:"events"`
+}
+
+type sessionStreamEvent struct {
+	ExternalID        string          `json:"external_id"`
+	WorkspaceUUID     string          `json:"workspace_uuid"`
+	SessionExternalID string          `json:"session_id"`
+	ThreadExternalID  *string         `json:"thread_id,omitempty"`
+	PrimaryThread     bool            `json:"primary_thread,omitempty"`
+	EventType         string          `json:"event_type"`
+	Payload           json.RawMessage `json:"payload"`
+	ProcessedAt       time.Time       `json:"processed_at,omitempty"`
+	CreatedAt         time.Time       `json:"created_at,omitempty"`
+}
+
+type codeSessionStreamFanout struct {
+	WorkspaceUUID     string            `json:"workspace_uuid"`
+	SessionExternalID string            `json:"session_id"`
+	CodeSessionID     string            `json:"code_session_id"`
+	WorkerEpoch       int64             `json:"worker_epoch"`
+	Payloads          []json.RawMessage `json:"payloads"`
+}
+
+func (h *Handler) publishSessionEvents(ctx context.Context, events []db.SessionEvent) {
+	if len(events) == 0 {
+		return
+	}
+	payloads := make(map[string]*sessionEventsFanout)
+	sessionIDs := make([]string, 0, 1)
+	for _, event := range events {
+		payload, exists := payloads[event.SessionExternalID]
+		if !exists {
+			payload = &sessionEventsFanout{}
+			payloads[event.SessionExternalID] = payload
+			sessionIDs = append(sessionIDs, event.SessionExternalID)
+		}
+		payload.Events = append(payload.Events, sessionStreamEventFrom(event))
+	}
+	for _, sessionID := range sessionIDs {
+		payload := payloads[sessionID]
+		if err := h.publishFanout(ctx, sessionID, sessionfanout.KindSessionEvents, payload); err != nil {
+			h.logger.WarnContext(ctx, "publish session events fanout", "session_id", sessionID, "event_count", len(payload.Events), "error", err)
+		}
+	}
+}
+
+func (h *Handler) PublishCodeSessionStreamEvents(ctx context.Context, route codesessions.CodeSessionStreamRoute, workerEpoch int64, payloads []json.RawMessage) error {
+	if len(payloads) == 0 {
+		return nil
+	}
+	payload := codeSessionStreamFanout{
+		WorkspaceUUID:     route.WorkspaceUUID,
+		SessionExternalID: route.SessionExternalID,
+		CodeSessionID:     route.CodeSessionID,
+		WorkerEpoch:       workerEpoch,
+		Payloads:          payloads,
+	}
+	if err := h.publishFanout(ctx, route.SessionExternalID, sessionfanout.KindCodeSessionStream, payload); err != nil {
+		h.logger.WarnContext(ctx, "publish code session stream fanout", "code_session_id", route.CodeSessionID, "worker_epoch", workerEpoch, "event_count", len(payloads), "error", err)
+	}
+	return nil
+}
+
+func (h *Handler) publishFanout(ctx context.Context, sessionID string, kind sessionfanout.Kind, payload any) error {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	return h.eventBus.Publish(ctx, sessionID, sessionfanout.Envelope{
+		Kind:    kind,
+		Payload: raw,
+	})
+}
+
+func (h *Handler) receiveFanout(ctx context.Context, envelope sessionfanout.Envelope) {
+	switch envelope.Kind {
+	case sessionfanout.KindSessionEvents:
+		var payload sessionEventsFanout
+		if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+			h.logger.WarnContext(ctx, "discard session events fanout", "error", err)
+			return
+		}
+		for _, event := range payload.Events {
+			h.streams.broadcastEvent(event)
+		}
+	case sessionfanout.KindCodeSessionStream:
+		var payload codeSessionStreamFanout
+		if err := json.Unmarshal(envelope.Payload, &payload); err != nil {
+			h.logger.WarnContext(ctx, "discard code session stream fanout", "error", err)
+			return
+		}
+		for _, event := range h.previews.convert(payload) {
+			h.streams.broadcastEvent(event)
+		}
+	}
+}
+
+func (h *Handler) resetFanout() {
+	h.previews.reset()
+	h.streams.reset()
+}
+
+func sessionStreamEventFrom(event db.SessionEvent) sessionStreamEvent {
+	return sessionStreamEvent{
+		ExternalID:        event.ExternalID,
+		WorkspaceUUID:     event.WorkspaceUUID,
+		SessionExternalID: event.SessionExternalID,
+		ThreadExternalID:  event.ThreadExternalID,
+		EventType:         event.EventType,
+		Payload:           event.Payload,
+		ProcessedAt:       event.ProcessedAt,
+		CreatedAt:         event.CreatedAt,
+	}
+}

--- a/internal/sessions/fanout_test.go
+++ b/internal/sessions/fanout_test.go
@@ -130,13 +130,55 @@ func TestPublishCodeSessionStreamEventsUsesProvidedRouteWithoutDatabase(t *testi
 	}
 }
 
+func TestReceiveSessionEventsFanoutKeepsNonTerminalSubscription(t *testing.T) {
+	bus := &recordingEventBus{}
+	handler := &Handler{
+		eventBus: bus,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		streams:  newStreamHub(),
+	}
+	handler.receiveSessionEventsFanout(context.Background(), []sessionStreamEvent{{
+		WorkspaceUUID:     "workspace-test",
+		SessionExternalID: "session-test",
+		EventType:         "session.status_idle",
+	}})
+	if len(bus.unsubscribedSessionIDs) != 0 {
+		t.Fatalf("unsubscribed sessions = %v, want none", bus.unsubscribedSessionIDs)
+	}
+}
+
+func TestReceiveSessionEventsFanoutDeliversTerminalEventBeforeUnsubscribe(t *testing.T) {
+	bus := &recordingEventBus{}
+	handler := &Handler{
+		eventBus: bus,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		streams:  newStreamHub(),
+	}
+	_, ch := handler.streams.subscribe("workspace-test", "session-test")
+	handler.receiveSessionEventsFanout(context.Background(), []sessionStreamEvent{{
+		WorkspaceUUID:     "workspace-test",
+		SessionExternalID: "session-test",
+		EventType:         "session.status_terminated",
+	}})
+
+	delivery := <-ch
+	eventDelivery, ok := delivery.(sessionEventDelivery)
+	if !ok || eventDelivery.event.EventType != "session.status_terminated" {
+		t.Fatalf("terminal delivery = %#v, want session.status_terminated", delivery)
+	}
+	if len(bus.unsubscribedSessionIDs) != 1 || bus.unsubscribedSessionIDs[0] != "session-test" {
+		t.Fatalf("unsubscribed sessions = %v, want session-test", bus.unsubscribedSessionIDs)
+	}
+}
+
 type recordedPublication struct {
 	sessionID string
 	envelope  sessionfanout.Envelope
 }
 
 type recordingEventBus struct {
-	publications []recordedPublication
+	publications           []recordedPublication
+	unsubscribedSessionIDs []string
 }
 
 func (b *recordingEventBus) Publish(_ context.Context, sessionID string, envelope sessionfanout.Envelope) error {
@@ -145,6 +187,11 @@ func (b *recordingEventBus) Publish(_ context.Context, sessionID string, envelop
 }
 
 func (b *recordingEventBus) Subscribe(context.Context, string) error {
+	return nil
+}
+
+func (b *recordingEventBus) Unsubscribe(_ context.Context, sessionID string) error {
+	b.unsubscribedSessionIDs = append(b.unsubscribedSessionIDs, sessionID)
 	return nil
 }
 

--- a/internal/sessions/fanout_test.go
+++ b/internal/sessions/fanout_test.go
@@ -1,0 +1,180 @@
+package sessions
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/sessionfanout"
+)
+
+func TestPublishSessionEventsGroupsEnvelopesBySession(t *testing.T) {
+	bus := &recordingEventBus{}
+	handler := &Handler{
+		eventBus: bus,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	handler.publishSessionEvents(context.Background(), []db.SessionEvent{
+		{SessionExternalID: "session-a", ExternalID: "event-a1"},
+		{SessionExternalID: "session-b", ExternalID: "event-b1"},
+		{SessionExternalID: "session-a", ExternalID: "event-a2"},
+	})
+
+	if got := len(bus.publications); got != 2 {
+		t.Fatalf("publication count = %d, want 2", got)
+	}
+	assertSessionPublication(t, bus.publications[0], "session-a", []string{"event-a1", "event-a2"})
+	assertSessionPublication(t, bus.publications[1], "session-b", []string{"event-b1"})
+}
+
+func TestSessionEventsFanoutUsesMinimalSSEContract(t *testing.T) {
+	bus := &recordingEventBus{}
+	handler := &Handler{
+		eventBus: bus,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	threadID := "thread-test"
+	threadUUID := "thread-uuid-test"
+	deletedAt := time.Date(2026, time.August, 20, 1, 2, 3, 0, time.UTC)
+	createdAt := deletedAt.Add(-time.Minute)
+	processedAt := deletedAt.Add(-30 * time.Second)
+
+	handler.publishSessionEvents(context.Background(), []db.SessionEvent{{
+		UUID:              "event-uuid-test",
+		ExternalID:        "event-test",
+		OrganizationUUID:  "organization-test",
+		WorkspaceUUID:     "workspace-test",
+		SessionUUID:       "session-uuid-test",
+		SessionExternalID: "session-test",
+		ThreadUUID:        &threadUUID,
+		ThreadExternalID:  &threadID,
+		EventType:         "agent.message",
+		Payload:           json.RawMessage(`{"type":"agent.message"}`),
+		ProcessedAt:       processedAt,
+		CreatedAt:         createdAt,
+		DeletedAt:         &deletedAt,
+	}})
+
+	if len(bus.publications) != 1 {
+		t.Fatalf("publication count = %d, want 1", len(bus.publications))
+	}
+	var rawPayload struct {
+		Events []map[string]json.RawMessage `json:"events"`
+	}
+	if err := json.Unmarshal(bus.publications[0].envelope.Payload, &rawPayload); err != nil {
+		t.Fatalf("decode publication payload: %v", err)
+	}
+	if len(rawPayload.Events) != 1 {
+		t.Fatalf("publication event count = %d, want 1", len(rawPayload.Events))
+	}
+	wantFields := map[string]struct{}{
+		"external_id": {}, "workspace_uuid": {}, "session_id": {}, "thread_id": {},
+		"event_type": {}, "payload": {}, "processed_at": {}, "created_at": {},
+	}
+	if len(rawPayload.Events[0]) != len(wantFields) {
+		t.Fatalf("fanout fields = %v, want exactly %v", rawPayload.Events[0], wantFields)
+	}
+	for field := range rawPayload.Events[0] {
+		if _, ok := wantFields[field]; !ok {
+			t.Fatalf("unexpected fanout field %q", field)
+		}
+	}
+
+	var payload sessionEventsFanout
+	if err := json.Unmarshal(bus.publications[0].envelope.Payload, &payload); err != nil {
+		t.Fatalf("decode typed publication payload: %v", err)
+	}
+	event := payload.Events[0]
+	if event.ExternalID != "event-test" || event.WorkspaceUUID != "workspace-test" || event.SessionExternalID != "session-test" {
+		t.Fatalf("fanout event routing = %+v", event)
+	}
+	if event.ThreadExternalID == nil || *event.ThreadExternalID != threadID || event.EventType != "agent.message" {
+		t.Fatalf("fanout event delivery fields = %+v", event)
+	}
+	if !event.CreatedAt.Equal(createdAt) || !event.ProcessedAt.Equal(processedAt) {
+		t.Fatalf("fanout event times = created:%v processed:%v", event.CreatedAt, event.ProcessedAt)
+	}
+}
+
+func TestPublishCodeSessionStreamEventsUsesProvidedRouteWithoutDatabase(t *testing.T) {
+	bus := &recordingEventBus{}
+	handler := &Handler{
+		eventBus: bus,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	route := codesessions.CodeSessionStreamRoute{
+		CodeSessionID:     "cse-test",
+		WorkspaceUUID:     "workspace-test",
+		SessionExternalID: "session-test",
+	}
+	payloads := []json.RawMessage{json.RawMessage(`{"type":"stream_event"}`)}
+
+	if err := handler.PublishCodeSessionStreamEvents(context.Background(), route, 7, payloads); err != nil {
+		t.Fatalf("PublishCodeSessionStreamEvents() error = %v", err)
+	}
+	if len(bus.publications) != 1 || bus.publications[0].sessionID != route.SessionExternalID {
+		t.Fatalf("publications = %#v, want one publication for %q", bus.publications, route.SessionExternalID)
+	}
+	var fanout codeSessionStreamFanout
+	if err := json.Unmarshal(bus.publications[0].envelope.Payload, &fanout); err != nil {
+		t.Fatalf("decode stream fanout: %v", err)
+	}
+	if fanout.CodeSessionID != route.CodeSessionID || fanout.WorkspaceUUID != route.WorkspaceUUID || fanout.SessionExternalID != route.SessionExternalID || fanout.WorkerEpoch != 7 || len(fanout.Payloads) != 1 {
+		t.Fatalf("stream fanout = %#v, want supplied immutable route", fanout)
+	}
+}
+
+type recordedPublication struct {
+	sessionID string
+	envelope  sessionfanout.Envelope
+}
+
+type recordingEventBus struct {
+	publications []recordedPublication
+}
+
+func (b *recordingEventBus) Publish(_ context.Context, sessionID string, envelope sessionfanout.Envelope) error {
+	b.publications = append(b.publications, recordedPublication{sessionID: sessionID, envelope: envelope})
+	return nil
+}
+
+func (b *recordingEventBus) Subscribe(context.Context, string) error {
+	return nil
+}
+
+func (b *recordingEventBus) Register(sessionfanout.Handler, func()) {}
+
+func (b *recordingEventBus) Close() error {
+	return nil
+}
+
+func assertSessionPublication(t *testing.T, publication recordedPublication, sessionID string, eventIDs []string) {
+	t.Helper()
+	if publication.sessionID != sessionID {
+		t.Fatalf("publication session ID = %q, want %q", publication.sessionID, sessionID)
+	}
+	if publication.envelope.Kind != sessionfanout.KindSessionEvents {
+		t.Fatalf("publication kind = %q, want %q", publication.envelope.Kind, sessionfanout.KindSessionEvents)
+	}
+	var payload sessionEventsFanout
+	if err := json.Unmarshal(publication.envelope.Payload, &payload); err != nil {
+		t.Fatalf("decode publication payload: %v", err)
+	}
+	if len(payload.Events) != len(eventIDs) {
+		t.Fatalf("publication event count = %d, want %d", len(payload.Events), len(eventIDs))
+	}
+	for i, eventID := range eventIDs {
+		if payload.Events[i].ExternalID != eventID {
+			t.Fatalf("publication event %d ID = %q, want %q", i, payload.Events[i].ExternalID, eventID)
+		}
+		if payload.Events[i].SessionExternalID != sessionID {
+			t.Fatalf("publication event %d session ID = %q, want %q", i, payload.Events[i].SessionExternalID, sessionID)
+		}
+	}
+}

--- a/internal/sessions/handler.go
+++ b/internal/sessions/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
+	"github.com/superduck-ai/open-managed-agents/internal/sessionfanout"
 	"github.com/superduck-ai/open-managed-agents/internal/webhooks"
 
 	"github.com/go-chi/chi/v5"
@@ -25,6 +26,8 @@ type Handler struct {
 	errorAdapter *httpapi.ErrorAdapter
 	router       chi.Router
 	streams      *streamHub
+	eventBus     sessionfanout.EventBus
+	previews     *workerPreviewConverter
 }
 
 type webhookEnqueuer interface {

--- a/internal/sessions/service.go
+++ b/internal/sessions/service.go
@@ -376,7 +376,7 @@ func (h *Handler) deleteRoute(w http.ResponseWriter, r *http.Request) error {
 			h.appendAndBroadcastInternal(r, sessionID, []db.SessionEvent{deletedEvent})
 		} else {
 			deletedEvent.SessionExternalID = sessionID
-			h.broadcast(deletedEvent)
+			h.publishSessionEvents(r.Context(), []db.SessionEvent{deletedEvent})
 		}
 	}
 	deleted, err := h.db.DeleteSession(r.Context(), principal.WorkspaceUUID, sessionID)
@@ -565,9 +565,7 @@ func (h *Handler) sendEventsRoute(w http.ResponseWriter, r *http.Request) error 
 		}
 		return mapSessionLoadError(err, sessionID)
 	}
-	for _, event := range created {
-		h.broadcast(event)
-	}
+	h.publishSessionEvents(r.Context(), created)
 	if h.codeSessions != nil {
 		if err := h.codeSessions.QueuePublicSessionEvents(r.Context(), session, created); err != nil {
 			h.logger.ErrorContext(r.Context(), "queue session events for code session", "session_id", session.ExternalID, "error", err)

--- a/internal/sessions/stream_hub.go
+++ b/internal/sessions/stream_hub.go
@@ -1,12 +1,14 @@
 package sessions
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
-	"github.com/superduck-ai/open-managed-agents/internal/db"
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 
 	"github.com/go-chi/chi/v5"
@@ -15,119 +17,202 @@ import (
 type streamHub struct {
 	mu          sync.Mutex
 	nextSubID   int64
-	subscribers map[int64]subscriber
+	subscribers map[int64]*subscriber
 }
 
 type subscriber struct {
-	sessionID           string
-	threadID            string
-	includeStreamDeltas bool
-	ch                  chan db.SessionEvent
+	workspaceUUID string
+	sessionID     string
+	ch            chan streamDelivery
+}
+
+// streamDelivery is implemented by each delivery variant consumed by an SSE
+// connection.
+type streamDelivery interface {
+	implStreamDelivery()
+}
+
+type sessionEventDelivery struct {
+	event sessionStreamEvent
+}
+
+type streamResetDelivery struct{}
+
+func (sessionEventDelivery) implStreamDelivery() {}
+func (streamResetDelivery) implStreamDelivery()  {}
+
+type streamConnection struct {
+	threadID         string
+	primaryThread    bool
+	streamDeltaTypes map[string]struct{}
+	activePreviewIDs map[string]struct{}
 }
 
 func newStreamHub() *streamHub {
-	return &streamHub{subscribers: map[int64]subscriber{}}
+	return &streamHub{subscribers: map[int64]*subscriber{}}
 }
 
-func (h *Handler) subscribe(sessionID, threadID string, includeStreamDeltas bool) (int64, <-chan db.SessionEvent) {
-	return h.streams.subscribe(sessionID, threadID, includeStreamDeltas)
-}
-
-func (h *Handler) unsubscribe(id int64) {
-	h.streams.unsubscribe(id)
-}
-
-func (h *Handler) broadcast(event db.SessionEvent) {
-	h.streams.broadcast(event)
-}
-
-func (h *Handler) broadcastStreamDelta(event db.SessionEvent) {
-	h.streams.broadcastStreamDelta(event)
-}
-
-func (h *streamHub) subscribe(sessionID, threadID string, includeStreamDeltas bool) (int64, <-chan db.SessionEvent) {
+func (h *streamHub) subscribe(workspaceUUID, sessionID string) (int64, <-chan streamDelivery) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.nextSubID++
 	id := h.nextSubID
-	ch := make(chan db.SessionEvent, 32)
-	h.subscribers[id] = subscriber{sessionID: sessionID, threadID: threadID, includeStreamDeltas: includeStreamDeltas, ch: ch}
+	ch := make(chan streamDelivery, 256)
+	h.subscribers[id] = &subscriber{
+		workspaceUUID: workspaceUUID,
+		sessionID:     sessionID,
+		ch:            ch,
+	}
 	return id, ch
 }
 
 func (h *streamHub) unsubscribe(id int64) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	delete(h.subscribers, id)
+	if sub, ok := h.subscribers[id]; ok {
+		delete(h.subscribers, id)
+		close(sub.ch)
+	}
 }
 
-func (h *streamHub) broadcast(event db.SessionEvent) {
-	if !maevents.IsPublicSessionHistoryEvent(event.EventType) {
+func (h *streamHub) broadcastEvent(event sessionStreamEvent) {
+	if !maevents.IsPublicSessionHistoryEvent(event.EventType) && !maevents.IsStreamDelta(event.EventType) {
 		return
 	}
-	h.broadcastToSubscribers(event, false)
+	h.broadcastToSession(event.WorkspaceUUID, event.SessionExternalID, sessionEventDelivery{event: event})
 }
 
-func (h *streamHub) broadcastStreamDelta(event db.SessionEvent) {
-	if !maevents.IsStreamDelta(event.EventType) {
-		return
-	}
-	h.broadcastToSubscribers(event, true)
-}
-
-func (h *streamHub) broadcastToSubscribers(event db.SessionEvent, streamDelta bool) {
+func (h *streamHub) broadcastToSession(workspaceUUID, sessionID string, delivery streamDelivery) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	for _, sub := range h.subscribers {
-		if streamDelta && !sub.includeStreamDeltas {
+	for id, sub := range h.subscribers {
+		if sub.workspaceUUID != workspaceUUID || sub.sessionID != sessionID {
 			continue
 		}
-		if sub.sessionID != event.SessionExternalID {
-			continue
-		}
-		if sub.threadID == "" && event.ThreadExternalID != nil {
-			continue
-		}
-		if sub.threadID != "" && (event.ThreadExternalID == nil || *event.ThreadExternalID != sub.threadID) {
-			continue
-		}
-		select {
-		case sub.ch <- event:
-		default:
-		}
+		h.enqueue(id, sub, delivery)
 	}
+}
+
+func (h *streamHub) reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for id, sub := range h.subscribers {
+		h.enqueue(id, sub, streamResetDelivery{})
+	}
+}
+
+func (h *streamHub) enqueue(id int64, sub *subscriber, delivery streamDelivery) {
+	select {
+	case sub.ch <- delivery:
+	default:
+		delete(h.subscribers, id)
+		close(sub.ch)
+	}
+}
+
+func newStreamConnection(threadID string, primaryThread bool, streamDeltaTypes map[string]struct{}) *streamConnection {
+	return &streamConnection{
+		threadID:         threadID,
+		primaryThread:    primaryThread,
+		streamDeltaTypes: streamDeltaTypes,
+		activePreviewIDs: make(map[string]struct{}),
+	}
+}
+
+func (c *streamConnection) event(delivery streamDelivery) (sessionStreamEvent, bool) {
+	switch delivery := delivery.(type) {
+	case streamResetDelivery:
+		clear(c.activePreviewIDs)
+		return sessionStreamEvent{}, false
+	case sessionEventDelivery:
+		return delivery.event, c.accepts(delivery.event)
+	}
+	return sessionStreamEvent{}, false
+}
+
+func (c *streamConnection) accepts(event sessionStreamEvent) bool {
+	if !c.matches(event) {
+		return false
+	}
+	if maevents.IsPublicSessionHistoryEvent(event.EventType) {
+		delete(c.activePreviewIDs, event.ExternalID)
+		return true
+	}
+	if !maevents.IsStreamDelta(event.EventType) {
+		return false
+	}
+	if len(c.streamDeltaTypes) == 0 {
+		return false
+	}
+	previewType, previewID := streamPreviewTarget(event)
+	if event.EventType == previewEventDelta && previewID == "" {
+		// Legacy event_delta payloads predate preview lifecycle IDs. They cannot
+		// be correlated with an event_start, so retain their previous opt-in
+		// delivery behavior for clients requesting stream deltas.
+		return true
+	}
+	if event.EventType == previewEventStart {
+		if !c.acceptsPreviewType(previewType) {
+			return false
+		}
+		if _, active := c.activePreviewIDs[previewID]; active {
+			return false
+		}
+		c.activePreviewIDs[previewID] = struct{}{}
+		return true
+	}
+	_, active := c.activePreviewIDs[previewID]
+	return active
+}
+
+func (c *streamConnection) matches(event sessionStreamEvent) bool {
+	if event.PrimaryThread {
+		return c.primaryThread
+	}
+	return event.ThreadExternalID != nil && *event.ThreadExternalID == c.threadID
+}
+
+func (c *streamConnection) acceptsPreviewType(eventType string) bool {
+	_, ok := c.streamDeltaTypes[eventType]
+	return ok
 }
 
 func (h *Handler) streamEventsRoute(w http.ResponseWriter, r *http.Request) {
-	h.streamEvents(w, r, chi.URLParam(r, "session_id"), "")
+	h.streamEvents(w, r, chi.URLParam(r, "session_id"), "", true)
 }
 
 func (h *Handler) StreamEvents(w http.ResponseWriter, r *http.Request, sessionID string) {
-	h.streamEvents(w, r, sessionID, "")
+	h.streamEvents(w, r, sessionID, "", true)
 }
 
 func (h *Handler) streamThreadEventsRoute(w http.ResponseWriter, r *http.Request) {
 	sessionID := chi.URLParam(r, "session_id")
 	threadID := chi.URLParam(r, "thread_id")
 	if h.isFixtureThread(r, sessionID, threadID) {
-		h.streamEvents(w, r, sessionID, threadID)
+		h.streamEvents(w, r, sessionID, threadID, false)
 		return
 	}
 	if _, err := h.authorizeSession(r, sessionID, sessionAccessEventsRead); err != nil {
 		h.errorAdapter.Write(w, r, err)
 		return
 	}
-	if _, err := h.db.GetSessionThread(r.Context(), workspaceUUIDFromRequest(r), sessionID, threadID); err != nil {
+	thread, err := h.db.GetSessionThread(r.Context(), workspaceUUIDFromRequest(r), sessionID, threadID)
+	if err != nil {
 		h.errorAdapter.Write(w, r, mapThreadLoadError(err, threadID))
 		return
 	}
-	h.streamEvents(w, r, sessionID, threadID)
+	h.streamEvents(w, r, sessionID, threadID, thread.ParentThreadUUID == nil)
 }
 
-func (h *Handler) streamEvents(w http.ResponseWriter, r *http.Request, sessionID, threadID string) {
+func (h *Handler) streamEvents(w http.ResponseWriter, r *http.Request, sessionID, threadID string, primaryThread bool) {
 	session, err := h.authorizeSession(r, sessionID, sessionAccessEventsRead)
 	if err != nil {
 		h.errorAdapter.Write(w, r, err)
+		return
+	}
+	streamDeltaTypes, err := requestedStreamDeltaTypes(r)
+	if err != nil {
+		h.errorAdapter.Write(w, r, invalidRequest(err))
 		return
 	}
 	subscribeThreadID := threadID
@@ -138,17 +223,24 @@ func (h *Handler) streamEvents(w http.ResponseWriter, r *http.Request, sessionID
 			return
 		}
 		subscribeThreadID = primary.ExternalID
+		primaryThread = true
 	}
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		h.errorAdapter.Write(w, r, streamingUnsupported())
 		return
 	}
+	subID, ch := h.streams.subscribe(session.WorkspaceUUID, sessionID)
+	if err := h.eventBus.Subscribe(r.Context(), session.ExternalID); err != nil {
+		h.streams.unsubscribe(subID)
+		h.errorAdapter.Write(w, r, internalError("Could not subscribe to session event stream", err))
+		return
+	}
+	defer h.streams.unsubscribe(subID)
+	connection := newStreamConnection(subscribeThreadID, primaryThread, streamDeltaTypes)
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	subID, ch := h.subscribe(sessionID, subscribeThreadID, acceptsStreamDeltas(r))
-	defer h.unsubscribe(subID)
 	fmt.Fprint(w, ": connected\n\n")
 	flusher.Flush()
 	ticker := time.NewTicker(15 * time.Second)
@@ -160,18 +252,54 @@ func (h *Handler) streamEvents(w http.ResponseWriter, r *http.Request, sessionID
 		case <-ticker.C:
 			fmt.Fprint(w, ": keepalive\n\n")
 			flusher.Flush()
-		case event := <-ch:
-			writeSSE(w, event, threadID)
-			flusher.Flush()
+		case delivery, ok := <-ch:
+			if !ok {
+				return
+			}
+			event, accepted := connection.event(delivery)
+			if accepted {
+				writeSSE(w, event, subscribeThreadID)
+				flusher.Flush()
+			}
 		}
 	}
 }
 
-func acceptsStreamDeltas(r *http.Request) bool {
-	return len(parseRepeatedQuery(r, "event_deltas[]", "event_deltas")) > 0
+func requestedStreamDeltaTypes(r *http.Request) (map[string]struct{}, error) {
+	values := parseRepeatedQuery(r, "event_deltas[]", "event_deltas")
+	if len(values) > 100 {
+		return nil, errors.New("event_deltas may contain at most 100 values")
+	}
+	types := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		switch value {
+		case "agent.message", "agent.thinking":
+			types[value] = struct{}{}
+		default:
+			return nil, errors.New("event_deltas must contain agent.message or agent.thinking")
+		}
+	}
+	return types, nil
 }
 
-func writeSSE(w http.ResponseWriter, event db.SessionEvent, threadID string) {
+func writeSSE(w http.ResponseWriter, event sessionStreamEvent, threadID string) {
 	fmt.Fprintf(w, "event: %s\n", event.EventType)
-	fmt.Fprintf(w, "data: %s\n\n", sessionEventPayloadForResponse(event, threadID))
+	fmt.Fprintf(w, "data: %s\n\n", eventPayloadForResponse(event.Payload, event.CreatedAt, event.ProcessedAt, threadID))
+}
+
+func streamPreviewTarget(event sessionStreamEvent) (string, string) {
+	var payload struct {
+		Event struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"event"`
+		EventID string `json:"event_id"`
+	}
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return "", ""
+	}
+	if event.EventType == "event_start" {
+		return strings.TrimSpace(payload.Event.Type), strings.TrimSpace(payload.Event.ID)
+	}
+	return "", strings.TrimSpace(payload.EventID)
 }

--- a/internal/sessions/transport.go
+++ b/internal/sessions/transport.go
@@ -9,17 +9,21 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
 	"github.com/superduck-ai/open-managed-agents/internal/logging"
+	"github.com/superduck-ai/open-managed-agents/internal/sessionfanout"
 
 	"github.com/go-chi/chi/v5"
 )
 
 // NewHandler 要求显式注入与 environment runner 和 code-session HTTP Handler 共用的 Service，
 // 并把自身注册为公开事件 sink；这样 worker 输出会进入同一 session stream，而不会落到另一份 Service 状态。
-func NewHandler(cfg config.Config, database *db.DB, codeSessionService *codesessions.Service, webhookEvents webhookEnqueuer, logger *slog.Logger) *Handler {
+func NewHandler(cfg config.Config, database *db.DB, codeSessionService *codesessions.Service, webhookEvents webhookEnqueuer, eventBus sessionfanout.EventBus, logger *slog.Logger) *Handler {
 	if codeSessionService == nil {
 		panic("sessions: code-session service is required")
 	}
 	logger = logging.LoggerOrDefault(logger)
+	if eventBus == nil {
+		eventBus = sessionfanout.NewLocal()
+	}
 	h := &Handler{
 		cfg:          cfg,
 		db:           database,
@@ -28,7 +32,10 @@ func NewHandler(cfg config.Config, database *db.DB, codeSessionService *codesess
 		logger:       logger,
 		errorAdapter: httpapi.NewErrorAdapter(logger),
 		streams:      newStreamHub(),
+		eventBus:     eventBus,
+		previews:     newWorkerPreviewConverter(),
 	}
+	eventBus.Register(h.receiveFanout, h.resetFanout)
 	codeSessionService.SetPublicEventSink(h)
 	wrap := h.errorAdapter.Wrap
 	router := chi.NewRouter()

--- a/internal/sessions/worker_stream_preview.go
+++ b/internal/sessions/worker_stream_preview.go
@@ -1,0 +1,375 @@
+package sessions
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
+)
+
+const (
+	previewCacheTTL                    = 30 * time.Minute
+	maxPreviewMessages                 = 10_000
+	maxSeenStreamEvents                = 100_000
+	previewEventStart                  = "event_start"
+	previewEventDelta                  = "event_delta"
+	workerStreamPayloadTypeStreamEvent = "stream_event"
+	workerStreamContentBlockThinking   = "thinking"
+	workerStreamContentBlockText       = "text"
+	workerStreamDeltaText              = "text_delta"
+)
+
+type workerPreviewConverter struct {
+	mu     sync.Mutex
+	states *simplelru.LRU[previewScope, *previewState]
+	seen   *simplelru.LRU[seenStreamEventKey, time.Time]
+}
+
+type previewScope struct {
+	codeSessionID   string
+	workerEpoch     int64
+	rawSessionID    string
+	parentToolUseID string
+}
+
+type seenStreamEventKey struct {
+	codeSessionID string
+	workerEpoch   int64
+	eventUUID     string
+}
+
+type previewBlock struct {
+	eventID   string
+	eventType string
+	updatedAt time.Time
+}
+
+type previewState struct {
+	messageID string
+	blocks    map[int]previewBlock
+	updatedAt time.Time
+}
+
+type workerStreamPayload struct {
+	Type            string            `json:"type"`
+	Event           workerStreamEvent `json:"event"`
+	SessionID       string            `json:"session_id"`
+	ParentToolUseID *string           `json:"parent_tool_use_id"`
+	UUID            string            `json:"uuid"`
+	CreatedAt       string            `json:"created_at"`
+	Timestamp       string            `json:"timestamp"`
+}
+
+type workerStreamEventType string
+
+const (
+	workerStreamEventTypeMessageStart      workerStreamEventType = "message_start"
+	workerStreamEventTypeContentBlockStart workerStreamEventType = "content_block_start"
+	workerStreamEventTypeContentBlockDelta workerStreamEventType = "content_block_delta"
+	workerStreamEventTypeContentBlockStop  workerStreamEventType = "content_block_stop"
+	workerStreamEventTypeMessageStop       workerStreamEventType = "message_stop"
+)
+
+type workerStreamEvent struct {
+	Type         workerStreamEventType    `json:"type"`
+	Index        *int                     `json:"index"`
+	Message      workerStreamMessage      `json:"message"`
+	ContentBlock workerStreamContentBlock `json:"content_block"`
+	Delta        workerStreamDelta        `json:"delta"`
+}
+
+type workerStreamMessage struct {
+	ID string `json:"id"`
+}
+
+type workerStreamContentBlock struct {
+	Type string `json:"type"`
+}
+
+type workerStreamDelta struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func newWorkerPreviewConverter() *workerPreviewConverter {
+	return &workerPreviewConverter{
+		states: newWorkerPreviewLRU[previewScope, *previewState](maxPreviewMessages),
+		seen:   newWorkerPreviewLRU[seenStreamEventKey, time.Time](maxSeenStreamEvents),
+	}
+}
+
+func newWorkerPreviewLRU[K comparable, V any](size int) *simplelru.LRU[K, V] {
+	cache, err := simplelru.NewLRU[K, V](size, nil)
+	if err != nil {
+		panic(fmt.Sprintf("create worker preview cache: %v", err))
+	}
+	return cache
+}
+
+func (c *workerPreviewConverter) convert(batch codeSessionStreamFanout) []sessionStreamEvent {
+	payloads := decodeWorkerStreamPayloads(batch.Payloads)
+	if len(payloads) == 0 {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now().UTC()
+	events := make([]sessionStreamEvent, 0, len(payloads))
+	for _, payload := range payloads {
+		if c.isDuplicate(batch, payload, now) {
+			continue
+		}
+		if event, emit := c.applyStreamEvent(batch, payload, now); emit {
+			events = append(events, event)
+		}
+	}
+	return events
+}
+
+func decodeWorkerStreamPayloads(rawPayloads []json.RawMessage) []workerStreamPayload {
+	payloads := make([]workerStreamPayload, 0, len(rawPayloads))
+	for _, raw := range rawPayloads {
+		payload, ok := decodeWorkerStreamPayload(raw)
+		if ok && payload.Event.affectsPreview() {
+			payloads = append(payloads, payload)
+		}
+	}
+	return payloads
+}
+
+func decodeWorkerStreamPayload(raw json.RawMessage) (workerStreamPayload, bool) {
+	var payload workerStreamPayload
+	if err := json.Unmarshal(raw, &payload); err != nil || payload.Type != workerStreamPayloadTypeStreamEvent {
+		return workerStreamPayload{}, false
+	}
+	payload.SessionID = strings.TrimSpace(payload.SessionID)
+	payload.CreatedAt = strings.TrimSpace(payload.CreatedAt)
+	payload.Timestamp = strings.TrimSpace(payload.Timestamp)
+	if payload.ParentToolUseID != nil {
+		*payload.ParentToolUseID = strings.TrimSpace(*payload.ParentToolUseID)
+	}
+	payload.Event.Message.ID = strings.TrimSpace(payload.Event.Message.ID)
+	payload.Event.ContentBlock.Type = strings.TrimSpace(payload.Event.ContentBlock.Type)
+	return payload, true
+}
+
+func (event workerStreamEvent) affectsPreview() bool {
+	switch event.Type {
+	case workerStreamEventTypeMessageStart:
+		return event.Message.ID != ""
+	case workerStreamEventTypeContentBlockStart:
+		return event.Index != nil && publicPreviewEventType(event.ContentBlock.Type) != ""
+	case workerStreamEventTypeContentBlockDelta:
+		return event.Index != nil && event.Delta.Type == workerStreamDeltaText && event.Delta.Text != ""
+	case workerStreamEventTypeContentBlockStop:
+		return event.Index != nil
+	case workerStreamEventTypeMessageStop:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *workerPreviewConverter) isDuplicate(batch codeSessionStreamFanout, payload workerStreamPayload, now time.Time) bool {
+	if payload.UUID == "" {
+		return false
+	}
+	key := seenStreamEventKey{
+		codeSessionID: batch.CodeSessionID,
+		workerEpoch:   batch.WorkerEpoch,
+		eventUUID:     payload.UUID,
+	}
+	expiresAt, seen := c.seen.Get(key)
+	if seen && !expiresAt.Before(now) {
+		return true
+	}
+	c.seen.Add(key, now.Add(previewCacheTTL))
+	return false
+}
+
+func (c *workerPreviewConverter) applyStreamEvent(batch codeSessionStreamFanout, payload workerStreamPayload, now time.Time) (sessionStreamEvent, bool) {
+	scope := previewScope{
+		codeSessionID:   batch.CodeSessionID,
+		workerEpoch:     batch.WorkerEpoch,
+		rawSessionID:    payload.SessionID,
+		parentToolUseID: optionalString(payload.ParentToolUseID),
+	}
+	switch payload.Event.Type {
+	case workerStreamEventTypeMessageStart:
+		c.startPreviewMessage(scope, payload.Event.Message.ID, now)
+	case workerStreamEventTypeContentBlockStart:
+		return c.startPreviewBlock(batch, payload, scope, now)
+	case workerStreamEventTypeContentBlockDelta:
+		return c.appendPreviewBlockDelta(batch, payload, scope, now)
+	case workerStreamEventTypeContentBlockStop:
+		c.stopPreviewBlock(scope, *payload.Event.Index, now)
+	case workerStreamEventTypeMessageStop:
+		c.deletePreviewState(scope)
+	}
+	return sessionStreamEvent{}, false
+}
+
+func (c *workerPreviewConverter) startPreviewMessage(scope previewScope, messageID string, now time.Time) {
+	c.deletePreviewState(scope)
+	c.states.Add(scope, &previewState{
+		messageID: messageID,
+		blocks:    make(map[int]previewBlock),
+		updatedAt: now,
+	})
+}
+
+func (c *workerPreviewConverter) startPreviewBlock(batch codeSessionStreamFanout, payload workerStreamPayload, scope previewScope, now time.Time) (sessionStreamEvent, bool) {
+	state, found := c.activePreviewState(scope, now)
+	eventType := publicPreviewEventType(payload.Event.ContentBlock.Type)
+	if !found {
+		return sessionStreamEvent{}, false
+	}
+	index := *payload.Event.Index
+	if _, exists := state.blocks[index]; exists {
+		return sessionStreamEvent{}, false
+	}
+	block := previewBlock{
+		eventID:   managedagentsevents.StableAssistantEventID(batch.CodeSessionID, state.messageID, index, eventType),
+		eventType: eventType,
+		updatedAt: now,
+	}
+	state.blocks[index] = block
+	state.updatedAt = now
+	return previewSessionEvent(batch, payload, now, block.eventID, previewEventStart, eventStartPayload(block)), true
+}
+
+func (c *workerPreviewConverter) appendPreviewBlockDelta(batch codeSessionStreamFanout, payload workerStreamPayload, scope previewScope, now time.Time) (sessionStreamEvent, bool) {
+	state, found := c.activePreviewState(scope, now)
+	if !found {
+		return sessionStreamEvent{}, false
+	}
+	index := *payload.Event.Index
+	block, found := state.blocks[index]
+	if !found || block.eventType != "agent.message" {
+		return sessionStreamEvent{}, false
+	}
+	block.updatedAt = now
+	state.blocks[index] = block
+	state.updatedAt = now
+	payloadJSON := eventDeltaPayload(block.eventID, payload.Event.Delta.Text)
+	return previewSessionEvent(batch, payload, now, block.eventID, previewEventDelta, payloadJSON), true
+}
+
+func (c *workerPreviewConverter) activePreviewState(scope previewScope, now time.Time) (*previewState, bool) {
+	state, found := c.states.Get(scope)
+	if !found {
+		return nil, false
+	}
+	cutoff := now.Add(-previewCacheTTL)
+	if state.updatedAt.Before(cutoff) {
+		c.deletePreviewState(scope)
+		return nil, false
+	}
+	for index, block := range state.blocks {
+		if block.updatedAt.Before(cutoff) {
+			delete(state.blocks, index)
+		}
+	}
+	return state, true
+}
+
+func (c *workerPreviewConverter) stopPreviewBlock(scope previewScope, index int, now time.Time) {
+	if state, found := c.activePreviewState(scope, now); found {
+		if _, exists := state.blocks[index]; !exists {
+			return
+		}
+		delete(state.blocks, index)
+	}
+}
+
+func (c *workerPreviewConverter) deletePreviewState(scope previewScope) {
+	c.states.Remove(scope)
+}
+
+func (c *workerPreviewConverter) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.states.Purge()
+	c.seen.Purge()
+}
+
+func previewSessionEvent(batch codeSessionStreamFanout, source workerStreamPayload, processedAt time.Time, externalID, eventType string, payload json.RawMessage) sessionStreamEvent {
+	event := sessionStreamEvent{
+		ExternalID:        externalID,
+		WorkspaceUUID:     batch.WorkspaceUUID,
+		SessionExternalID: batch.SessionExternalID,
+		PrimaryThread:     true,
+		EventType:         eventType,
+		Payload:           payload,
+		ProcessedAt:       processedAt,
+		CreatedAt:         source.previewCreatedAt(processedAt),
+	}
+	if parentToolUseID := optionalString(source.ParentToolUseID); parentToolUseID != "" {
+		threadID := managedagentsevents.ClaudeTaskThreadID(batch.CodeSessionID, parentToolUseID)
+		event.PrimaryThread = false
+		event.ThreadExternalID = &threadID
+	}
+	return event
+}
+
+func (payload workerStreamPayload) previewCreatedAt(fallback time.Time) time.Time {
+	for _, value := range []string{payload.CreatedAt, payload.Timestamp} {
+		if value == "" {
+			continue
+		}
+		parsed, err := time.Parse(time.RFC3339Nano, value)
+		if err == nil {
+			return parsed.UTC()
+		}
+	}
+	return fallback
+}
+
+func eventStartPayload(block previewBlock) json.RawMessage {
+	payload, _ := json.Marshal(map[string]any{
+		"type": "event_start",
+		"event": map[string]string{
+			"type": block.eventType,
+			"id":   block.eventID,
+		},
+	})
+	return payload
+}
+
+func eventDeltaPayload(eventID, text string) json.RawMessage {
+	payload, _ := json.Marshal(map[string]any{
+		"type":     "event_delta",
+		"event_id": eventID,
+		"delta": map[string]any{
+			"type":  "content_delta",
+			"index": 0,
+			"content": map[string]string{
+				"type": "text",
+				"text": text,
+			},
+		},
+	})
+	return payload
+}
+
+func publicPreviewEventType(blockType string) string {
+	switch blockType {
+	case workerStreamContentBlockThinking:
+		return "agent.thinking"
+	case workerStreamContentBlockText:
+		return "agent.message"
+	default:
+		return ""
+	}
+}
+
+func optionalString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/sessions/worker_stream_preview_test.go
+++ b/internal/sessions/worker_stream_preview_test.go
@@ -1,0 +1,457 @@
+package sessions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
+	"github.com/superduck-ai/open-managed-agents/internal/sessionfanout"
+)
+
+func TestWorkerPreviewConverterHandlesConcurrentBatches(t *testing.T) {
+	const batchCount = 32
+	converter := newWorkerPreviewConverter()
+	errs := make(chan error, batchCount)
+	var workers sync.WaitGroup
+	workers.Add(batchCount)
+	for index := range batchCount {
+		go func() {
+			defer workers.Done()
+			batch := previewTestBatch([]json.RawMessage{
+				json.RawMessage(`{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg_test"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"raw-start"}`),
+				json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"text-start"}`),
+			})
+			batch.CodeSessionID = fmt.Sprintf("cse-%d", index)
+			if events := converter.convert(batch); len(events) != 1 {
+				errs <- fmt.Errorf("batch %d produced %d preview events, want 1", index, len(events))
+			}
+		}()
+	}
+	workers.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func TestWorkerPreviewConverterMessageStopClearsAllBlocks(t *testing.T) {
+	converter := newWorkerPreviewConverter()
+	batch := previewTestBatch([]json.RawMessage{
+		json.RawMessage(`{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg_test"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"raw-start"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"text-start"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"thinking","thinking":""}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"thinking-start"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"message_stop"},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"message-stop"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"orphan"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"text-delta"}`),
+	})
+
+	events := converter.convert(batch)
+	if len(events) != 2 {
+		t.Fatalf("preview event count = %d, want two block starts: %#v", len(events), events)
+	}
+	if converter.states.Len() != 0 {
+		t.Fatalf("state after message stop = %d, want zero", converter.states.Len())
+	}
+}
+
+func TestWorkerPreviewConverterExpiresBlockLazilyWithoutDroppingActiveMessage(t *testing.T) {
+	converter := newWorkerPreviewConverter()
+	now := time.Now().UTC()
+	scope := previewScope{codeSessionID: "cse_test", workerEpoch: 1, rawSessionID: "raw-session"}
+	converter.states.Add(scope, &previewState{
+		messageID: "msg_test",
+		updatedAt: now,
+		blocks: map[int]previewBlock{
+			0: {eventID: "expired", eventType: "agent.message", updatedAt: now.Add(-previewCacheTTL - time.Second)},
+			1: {eventID: "active", eventType: "agent.message", updatedAt: now},
+		},
+	})
+
+	state, exists := converter.activePreviewState(scope, now)
+	if !exists {
+		t.Fatal("active message state expired with an expired sibling block")
+	}
+	if _, exists := state.blocks[0]; exists {
+		t.Fatal("expired block was not removed on access")
+	}
+	if _, exists := state.blocks[1]; !exists || len(state.blocks) != 1 {
+		t.Fatalf("active block state = exists:%t total:%d, want true and 1", exists, len(state.blocks))
+	}
+}
+
+func TestWorkerPreviewConverterExpiresDedupEntryLazily(t *testing.T) {
+	converter := newWorkerPreviewConverter()
+	batch := previewTestBatch(nil)
+	payload := workerStreamPayload{UUID: "event-test"}
+	now := time.Now().UTC()
+
+	if converter.isDuplicate(batch, payload, now) {
+		t.Fatal("first event was treated as duplicate")
+	}
+	if !converter.isDuplicate(batch, payload, now.Add(previewCacheTTL)) {
+		t.Fatal("event at dedup expiry boundary was not treated as duplicate")
+	}
+	if converter.isDuplicate(batch, payload, now.Add(previewCacheTTL+time.Nanosecond)) {
+		t.Fatal("expired dedup entry was treated as duplicate")
+	}
+}
+
+func TestWorkerPreviewConverterEvictsOldestMessageAtCapacity(t *testing.T) {
+	converter := newWorkerPreviewConverter()
+	now := time.Now().UTC()
+	oldestScope := previewScope{codeSessionID: "cse_test", workerEpoch: 1, rawSessionID: "oldest"}
+	converter.startPreviewMessage(oldestScope, "msg_oldest", now)
+	for workerEpoch := int64(2); workerEpoch <= maxPreviewMessages; workerEpoch++ {
+		converter.startPreviewMessage(previewScope{codeSessionID: "cse_test", workerEpoch: workerEpoch}, "msg_test", now)
+	}
+	converter.startPreviewMessage(previewScope{codeSessionID: "cse_test", workerEpoch: maxPreviewMessages + 1}, "msg_newest", now)
+
+	if converter.states.Contains(oldestScope) {
+		t.Fatal("oldest message state was retained beyond LRU capacity")
+	}
+	if converter.states.Len() != maxPreviewMessages {
+		t.Fatalf("message state count = %d, want %d", converter.states.Len(), maxPreviewMessages)
+	}
+}
+
+func TestWorkerPreviewConverterFiltersNonPreviewStreamVariantsBeforeDedup(t *testing.T) {
+	converter := newWorkerPreviewConverter()
+	first := previewTestBatch([]json.RawMessage{
+		json.RawMessage(`{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg_test","content":[]}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"message-start","ttft_ms":5821}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"thinking-start"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"The"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"thinking-delta"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"signature"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"signature-delta"}`),
+	})
+	firstEvents := converter.convert(first)
+	if len(firstEvents) != 1 {
+		t.Fatalf("first preview event count = %d, want thinking start: %#v", len(firstEvents), firstEvents)
+	}
+
+	second := previewTestBatch([]json.RawMessage{
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"thinking-stop"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool_test","name":"Bash","input":{}}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"tool-start"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\":"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"input-json-delta"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_stop","index":1},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"tool-stop"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_start","index":2,"content_block":{"type":"text","text":"","citations":null}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"text-start"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_delta","index":2,"delta":{"type":"citations_delta","citation":{"type":"page_location","cited_text":"source"}}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"citation-delta"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"Hi"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"text-delta"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"future_event","future_field":true},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"future-event"}`),
+	})
+	secondEvents := converter.convert(second)
+	if len(secondEvents) != 2 {
+		t.Fatalf("second preview event count = %d, want text start and delta: %#v", len(secondEvents), secondEvents)
+	}
+	wantTextID := managedagentsevents.StableAssistantEventID(second.CodeSessionID, "msg_test", 2, "agent.message")
+	assertPreviewStart(t, secondEvents[0].Payload, "agent.message", wantTextID)
+	assertPreviewDelta(t, secondEvents[1].Payload, wantTextID, "Hi")
+
+	last := previewTestBatch([]json.RawMessage{
+		json.RawMessage(`{"type":"stream_event","event":{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"message-delta"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"message_stop"},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"message-stop"}`),
+	})
+	if events := converter.convert(last); len(events) != 0 {
+		t.Fatalf("terminal preview events = %#v, want none", events)
+	}
+	if converter.states.Len() != 0 {
+		t.Fatalf("state count after message stop = %d, want zero", converter.states.Len())
+	}
+
+	for _, eventUUID := range []string{
+		"thinking-delta",
+		"signature-delta",
+		"tool-start",
+		"input-json-delta",
+		"citation-delta",
+		"future-event",
+		"message-delta",
+	} {
+		key := seenStreamEventKey{codeSessionID: first.CodeSessionID, workerEpoch: first.WorkerEpoch, eventUUID: eventUUID}
+		if seen := converter.seen.Contains(key); seen {
+			t.Errorf("non-preview stream event %q entered dedup state", eventUUID)
+		}
+	}
+}
+
+func TestWorkerPreviewConverterEmitsThinkingStartWithoutDeltas(t *testing.T) {
+	converter := newWorkerPreviewConverter()
+	batch := previewTestBatch([]json.RawMessage{
+		json.RawMessage(`{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg_test"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"raw-start"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"thinking-start"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"The"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"thinking-one"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":" user"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"thinking-two"}`),
+	})
+
+	events := converter.convert(batch)
+	if len(events) != 1 {
+		t.Fatalf("preview event count = %d, want 1: %#v", len(events), events)
+	}
+	wantID := managedagentsevents.StableAssistantEventID(batch.CodeSessionID, "msg_test", 0, "agent.thinking")
+	assertPreviewStart(t, events[0].Payload, "agent.thinking", wantID)
+}
+
+func TestWorkerPreviewConverterForwardsTextFragmentsAcrossBatches(t *testing.T) {
+	converter := newWorkerPreviewConverter()
+	first := previewTestBatch([]json.RawMessage{
+		json.RawMessage(`{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg_test"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"raw-start"}`),
+	})
+	if events := converter.convert(first); len(events) != 0 {
+		t.Fatalf("message_start events = %#v, want none", events)
+	}
+	second := previewTestBatch([]json.RawMessage{
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"text-start"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hello"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"text-one"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" world"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"text-two"}`),
+	})
+
+	events := converter.convert(second)
+	if len(events) != 3 {
+		t.Fatalf("preview event count = %d, want 3: %#v", len(events), events)
+	}
+	wantID := managedagentsevents.StableAssistantEventID(second.CodeSessionID, "msg_test", 1, "agent.message")
+	assertPreviewStart(t, events[0].Payload, "agent.message", wantID)
+	assertPreviewDelta(t, events[1].Payload, wantID, "Hello")
+	assertPreviewDelta(t, events[2].Payload, wantID, " world")
+	for index, event := range events {
+		if event.CreatedAt.IsZero() || event.ProcessedAt.IsZero() {
+			t.Fatalf("preview event %d times = created:%v processed:%v, want non-zero", index, event.CreatedAt, event.ProcessedAt)
+		}
+	}
+
+	if duplicates := converter.convert(second); len(duplicates) != 0 {
+		t.Fatalf("duplicate worker events produced previews: %#v", duplicates)
+	}
+}
+
+func TestPreviewSessionEventDistinguishesPrimaryAndChildScopes(t *testing.T) {
+	batch := previewTestBatch(nil)
+	processedAt := time.Date(2026, time.August, 20, 1, 2, 3, 0, time.UTC)
+	primary := previewSessionEvent(batch, workerStreamPayload{}, processedAt, "primary-event", "event_start", json.RawMessage(`{}`))
+	if !primary.PrimaryThread || primary.ThreadExternalID != nil {
+		t.Fatalf("primary preview routing = %#v, want primary scope without physical thread id", primary)
+	}
+
+	parentToolUseID := "tool-parent"
+	child := previewSessionEvent(batch, workerStreamPayload{ParentToolUseID: &parentToolUseID}, processedAt, "child-event", "event_start", json.RawMessage(`{}`))
+	wantThreadID := managedagentsevents.ClaudeTaskThreadID(batch.CodeSessionID, parentToolUseID)
+	if child.PrimaryThread || child.ThreadExternalID == nil || *child.ThreadExternalID != wantThreadID {
+		t.Fatalf("child preview routing = %#v, want child thread %q", child, wantThreadID)
+	}
+}
+
+func TestPreviewSSEIncludesTimesAndResolvedPrimaryThread(t *testing.T) {
+	createdAt := time.Date(2026, time.August, 20, 1, 2, 3, 0, time.UTC)
+	processedAt := createdAt.Add(2 * time.Second)
+	event := previewSessionEvent(
+		previewTestBatch(nil),
+		workerStreamPayload{CreatedAt: createdAt.Format(time.RFC3339Nano)},
+		processedAt,
+		"preview-event",
+		previewEventStart,
+		json.RawMessage(`{"type":"event_start"}`),
+	)
+	recorder := httptest.NewRecorder()
+
+	writeSSE(recorder, event, "primary-thread")
+
+	data := strings.TrimSpace(strings.TrimPrefix(strings.Split(recorder.Body.String(), "\n")[1], "data: "))
+	var payload struct {
+		CreatedAt       string `json:"created_at"`
+		ProcessedAt     string `json:"processed_at"`
+		SessionThreadID string `json:"session_thread_id"`
+	}
+	if err := json.Unmarshal([]byte(data), &payload); err != nil {
+		t.Fatalf("decode preview SSE data: %v", err)
+	}
+	if payload.CreatedAt != createdAt.Format(time.RFC3339Nano) {
+		t.Fatalf("created_at = %q, want %q", payload.CreatedAt, createdAt.Format(time.RFC3339Nano))
+	}
+	if payload.ProcessedAt != processedAt.Format(time.RFC3339Nano) {
+		t.Fatalf("processed_at = %q, want %q", payload.ProcessedAt, processedAt.Format(time.RFC3339Nano))
+	}
+	if payload.SessionThreadID != "primary-thread" {
+		t.Fatalf("session_thread_id = %q, want primary-thread", payload.SessionThreadID)
+	}
+}
+
+func TestSessionFanoutConvertsWorkerStreamOncePerInstance(t *testing.T) {
+	bus := sessionfanout.NewLocal()
+	publisher := newFanoutTestHandler(bus)
+	receiver := newFanoutTestHandler(bus)
+	_, firstCh := receiver.streams.subscribe("workspace-test", "session-test")
+	_, secondCh := receiver.streams.subscribe("workspace-test", "session-test")
+	_, childCh := receiver.streams.subscribe("workspace-test", "session-test")
+	first := newStreamConnection("thread-test", true, map[string]struct{}{"agent.message": {}})
+	second := newStreamConnection("thread-test", true, map[string]struct{}{"agent.message": {}})
+	child := newStreamConnection("child-thread-test", false, map[string]struct{}{"agent.message": {}})
+	primaryStreams := []struct {
+		connection *streamConnection
+		ch         <-chan streamDelivery
+	}{
+		{connection: first, ch: firstCh},
+		{connection: second, ch: secondCh},
+	}
+
+	batch := previewTestBatch([]json.RawMessage{
+		json.RawMessage(`{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg_test"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"raw-start"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"text-start"}`),
+		json.RawMessage(`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}},"session_id":"raw-session","parent_tool_use_id":null,"uuid":"text-delta"}`),
+	})
+	if err := publisher.publishFanout(context.Background(), batch.SessionExternalID, sessionfanout.KindCodeSessionStream, batch); err != nil {
+		t.Fatalf("publish fanout: %v", err)
+	}
+
+	for index, stream := range primaryStreams {
+		events := collectConnectionEvents(t, stream.connection, stream.ch, 2)
+		if len(events) != 2 || events[0].EventType != previewEventStart || events[1].EventType != previewEventDelta {
+			t.Fatalf("connection %d preview events = %#v, want start and delta", index, events)
+		}
+	}
+	if events := collectConnectionEvents(t, child, childCh, 2); len(events) != 0 {
+		t.Fatalf("primary preview leaked to child connection: %#v", events)
+	}
+	if seen := receiver.previews.seen.Len(); seen != 3 {
+		t.Fatalf("instance preview dedup state = %d, want one three-event batch", seen)
+	}
+}
+
+func TestStreamConnectionResetDropsOrphanDelta(t *testing.T) {
+	connection := newStreamConnection("thread-test", true, map[string]struct{}{"agent.message": {}})
+	block := previewBlock{eventID: "event-test", eventType: "agent.message"}
+	start := sessionStreamEvent{
+		ExternalID:    block.eventID,
+		PrimaryThread: true,
+		EventType:     previewEventStart,
+		Payload:       eventStartPayload(block),
+	}
+	if _, accepted := connection.event(sessionEventDelivery{event: start}); !accepted {
+		t.Fatal("preview start was not accepted")
+	}
+	connection.event(streamResetDelivery{})
+	delta := sessionStreamEvent{
+		ExternalID:    block.eventID,
+		PrimaryThread: true,
+		EventType:     previewEventDelta,
+		Payload:       eventDeltaPayload(block.eventID, "orphan"),
+	}
+	if _, accepted := connection.event(sessionEventDelivery{event: delta}); accepted {
+		t.Fatal("orphan delta was accepted after reset")
+	}
+}
+
+func TestStreamConnectionAcceptsLegacyDeltaWithoutPreviewID(t *testing.T) {
+	connection := newStreamConnection("thread-test", true, map[string]struct{}{"agent.message": {}})
+	event := sessionStreamEvent{
+		ExternalID:    "legacy-event-test",
+		PrimaryThread: true,
+		EventType:     previewEventDelta,
+		Payload:       json.RawMessage(`{"type":"event_delta","delta":{"text":"legacy"}}`),
+	}
+	if _, accepted := connection.event(sessionEventDelivery{event: event}); !accepted {
+		t.Fatal("legacy stream delta without preview ID was not accepted")
+	}
+}
+
+func TestRequestedStreamDeltaTypesValidatesValues(t *testing.T) {
+	req := httptest.NewRequest("GET", "/events/stream?event_deltas%5B%5D=agent.message&event_deltas%5B%5D=other", nil)
+	if _, err := requestedStreamDeltaTypes(req); err == nil {
+		t.Fatal("requestedStreamDeltaTypes() error = nil, want invalid type error")
+	}
+
+	values := ""
+	for i := 0; i < 101; i++ {
+		values += "&event_deltas%5B%5D=agent.message"
+	}
+	req = httptest.NewRequest("GET", "/events/stream?"+values[1:], nil)
+	if _, err := requestedStreamDeltaTypes(req); err == nil {
+		t.Fatal("requestedStreamDeltaTypes() error = nil, want value limit error")
+	}
+}
+
+func previewTestBatch(payloads []json.RawMessage) codeSessionStreamFanout {
+	return codeSessionStreamFanout{
+		WorkspaceUUID:     "workspace-test",
+		SessionExternalID: "session-test",
+		CodeSessionID:     "cse_test",
+		WorkerEpoch:       1,
+		Payloads:          payloads,
+	}
+}
+
+func newFanoutTestHandler(bus sessionfanout.EventBus) *Handler {
+	handler := &Handler{
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		streams:  newStreamHub(),
+		eventBus: bus,
+		previews: newWorkerPreviewConverter(),
+	}
+	bus.Register(handler.receiveFanout, handler.resetFanout)
+	return handler
+}
+
+func collectConnectionEvents(t *testing.T, connection *streamConnection, ch <-chan streamDelivery, deliveryCount int) []sessionStreamEvent {
+	t.Helper()
+	events := make([]sessionStreamEvent, 0, deliveryCount)
+	for range deliveryCount {
+		if event, accepted := connection.event(awaitStreamDelivery(t, ch)); accepted {
+			events = append(events, event)
+		}
+	}
+	return events
+}
+
+func awaitStreamDelivery(t *testing.T, ch <-chan streamDelivery) streamDelivery {
+	t.Helper()
+	select {
+	case delivery := <-ch:
+		return delivery
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stream delivery")
+		return nil
+	}
+}
+
+func assertPreviewStart(t *testing.T, raw json.RawMessage, eventType, eventID string) {
+	t.Helper()
+	var payload struct {
+		Type  string `json:"type"`
+		Event struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"event"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decode event_start: %v", err)
+	}
+	if payload.Type != "event_start" || payload.Event.Type != eventType || payload.Event.ID != eventID {
+		t.Fatalf("event_start = %#v, want type=%q id=%q", payload, eventType, eventID)
+	}
+}
+
+func assertPreviewDelta(t *testing.T, raw json.RawMessage, eventID, text string) {
+	t.Helper()
+	var payload struct {
+		Type    string `json:"type"`
+		EventID string `json:"event_id"`
+		Delta   struct {
+			Type    string `json:"type"`
+			Index   int    `json:"index"`
+			Content struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"delta"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("decode event_delta: %v", err)
+	}
+	if payload.Type != "event_delta" || payload.EventID != eventID || payload.Delta.Type != "content_delta" || payload.Delta.Index != 0 || payload.Delta.Content.Type != "text" || payload.Delta.Content.Text != text {
+		t.Fatalf("event_delta = %#v, want id=%q text=%q", payload, eventID, text)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -21,8 +21,10 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/filestore"
 	"github.com/superduck-ai/open-managed-agents/internal/logging"
 	"github.com/superduck-ai/open-managed-agents/internal/platformsession"
+	"github.com/superduck-ai/open-managed-agents/internal/redisclient"
 	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
 	"github.com/superduck-ai/open-managed-agents/internal/secrets"
+	"github.com/superduck-ai/open-managed-agents/internal/sessionfanout"
 	skillsapi "github.com/superduck-ai/open-managed-agents/internal/skills"
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
 	"github.com/superduck-ai/open-managed-agents/internal/webhooks"
@@ -63,11 +65,17 @@ func run(logger *slog.Logger) error {
 	if err := database.Seed(ctx, cfg.Bootstrap.SeedAPIKeys); err != nil {
 		return fmt.Errorf("seed database: %w", err)
 	}
-	platformSessions, err := platformsession.NewRedisStore(ctx, cfg.Redis.URL)
+	redisClient, err := redisclient.Open(ctx, cfg.Redis.URL)
 	if err != nil {
-		return fmt.Errorf("open platform session store: %w", err)
+		return fmt.Errorf("open redis client: %w", err)
 	}
-	defer platformSessions.Close()
+	defer redisClient.Close()
+	platformSessions := platformsession.NewRedisStore(redisClient)
+	sessionEventBus, err := sessionfanout.NewRedis(ctx, redisClient, logger.With("component", "session_event_bus"))
+	if err != nil {
+		return fmt.Errorf("open session event fanout: %w", err)
+	}
+	defer sessionEventBus.Close()
 
 	storageClient, err := storage.New(cfg.Storage)
 	if err != nil {
@@ -136,6 +144,7 @@ func run(logger *slog.Logger) error {
 			FilestoreCredentials:   filestoreCredentials,
 			FilestoreService:       filestoreService,
 			VaultSecrets:           vaultSecrets,
+			SessionEventBus:        sessionEventBus,
 		}),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       10 * time.Minute,

--- a/tests/sessions_api_test.go
+++ b/tests/sessions_api_test.go
@@ -1373,7 +1373,7 @@ func TestCodeSessionWorkerEndpointsPublishEvents(t *testing.T) {
 		t.Fatalf("make session projection stale: %v", err)
 	}
 	retryService := codesessions.NewServiceWithCredentials(app.db, app.credentials, nil)
-	retrySink := sessionsapi.NewHandler(app.cfg, app.db, retryService, nil, nil)
+	retrySink := sessionsapi.NewHandler(app.cfg, app.db, retryService, nil, nil, nil)
 	if err := retrySink.PublishCodeSessionEvents(context.Background(), codeSession, runningEvents.Data); err != nil {
 		t.Fatalf("retry existing running event projection: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Route verified worker ingress events using session claims and workspace metadata
- Fan out ephemeral `stream_event` payloads through the session event bus without persisting them to PostgreSQL
- Generate stable assistant event IDs and preserve stream identity metadata
- Share the application Redis client with the platform session store

## Testing

- Added and updated worker output preparation and payload mapping tests
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time session event delivery across multiple API instances.
  * Added live worker stream previews for message and thinking updates.
  * Added filtering for thread, delta type, and preview lifecycle events.
  * Added automatic event deduplication, reconnection handling, and stream resets.
* **Bug Fixes**
  * Improved session routing and authorization to prevent events from being associated with an incorrect session.
  * Added stable identifiers for assistant messages and streamed content.
* **Documentation**
  * Documented event fanout, delivery behavior, persistence, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->