### PR TITLE
Improve managed agent session lifecycle and sandbox recovery

### DIFF
--- a/.grok/review-scratch/grok-review-cd4bce49.md
+++ b/.grok/review-scratch/grok-review-cd4bce49.md
@@ -1,0 +1,51 @@
+# 严格代码质量审查
+
+## Summary
+
+本改动实现了 E2B Sandbox 的 pause/resume 与“Provider 已删除后替换 Sandbox 并复用 Code Session”恢复链路：事件入队后 `SetTimeout` 唤醒，`ErrSandboxNotFound` 时原子失败旧 Sandbox 并重排队 Work，Runner 走 `RecoverManagedAgentCodeSession` 轮换凭证并注入递增 worker epoch。方向正确，测试也覆盖了临时失败重试与替换启动。
+
+**不能批准。** 恢复路径被塞进原先只服务“新建 Code Session”的 Runner 失败清理流，导致恢复中途失败会 `Terminate` 本应保留的 durable Code Session——这是正确性 blocker。另外，`codesessions` 依赖 `e2bruntime` sentinel、用 Work metadata 开关控制 create/recover，以及把更多用例堆进已经 4900+ 行的 `sessions_api_test.go`，都是明显的结构债；存在可删除整类分支的 code-judo 空间。
+
+## Issues
+
+### Issue 1 -- Severity: bug
+- File: internal/environments/runner.go:554
+- Description: `createManagedAgentRuntimeLaunch` 在 recovery 分支调用 `RecoverManagedAgentCodeSession` 成功后，若 `buildEnvironmentManagerV0Payload` 失败，仍会执行 `TerminateManagedAgentCodeSession`。该清理逻辑原本假设“刚创建、可丢弃的 CSE”；恢复场景下 CSE 已承载持久化入站队列与会话身份。Terminate 会把本应复用的 Code Session 标为 terminated，入站事件随之失效。更糟的是后续 `failManagedAgentRuntime`（manager 启动失败 / publish metadata 失败，约 410–430 行）对 recovery 同样无条件 Terminate。恢复失败后 Work/Sandbox 也会被 fail/stop，自动恢复标记可能无法再次触发，会话会卡死。
+- Suggestion: 把 launch 结果显式建模为 `created | recovered`（或 `PreserveCodeSession bool`）。仅 create 路径在失败时 Terminate；recover 路径失败时保留 CSE，并把 Work 重新标回 `queued` 且保留 `sandbox_recovery_code_session_id`（或等价恢复状态），以便 Runner 重试。补回归测试：Recover 成功后强制 payload/manager/publish 失败，断言 CSE 仍为 `active` 且队列消息仍在。
+- Status: open
+
+### Issue 2 -- Severity: bug
+- File: internal/environments/runner.go:521
+- Description: Create 与 Recover 共用同一套失败编排，是 Issue 1 的结构根因。Recovery 不是 Create 的特殊参数，而是另一种生命周期：身份保留、凭证轮换、失败可重试。现在用 `if RecoveryCodeSessionID != ""` 插入既有忙碌函数，再复用 `failManagedAgentRuntime`，属于往共享路径打补丁的 spaghetti 增长；行为上必然把“新建可销毁”与“恢复必须保留”混在一起。
+- Suggestion: 拆出独立的 `recoverManagedAgentRuntimeLaunch`（或让 `CodeSessionRuntime` 暴露带明确失败语义的 API），Runner 主流程按模式分派；失败策略与 create 完全分离。目标是让 Terminate-on-failure 从恢复路径上消失，而不是再加一个 `if recovering` 分支。
+- Status: open
+
+### Issue 3 -- Severity: suggestion
+- File: internal/codesessions/service.go:18
+- Description: `codesessions.Service` 直接 import `internal/runtime/e2bruntime` 只为识别 `ErrSandboxNotFound`。这是资源编排层向具体 Provider 包的边界泄漏：换 Provider 或把 E2B 细节关在 runtime 后，codesessions 仍被钉死。也让 `resumeSandboxForCodeSession` 的错误语义依赖实现细节而非 `SandboxTimeoutExtender` 合同。
+- Suggestion: 在 `codesessions`（或共享 provider 合同包）定义 `var ErrSandboxNotFound = errors.New(...)`，由 `e2bruntime.classifySandboxError` wrap 该 sentinel；或让 extender 返回可识别的领域错误类型。Service 不应依赖 `e2bruntime`。
+- Status: open
+
+### Issue 4 -- Severity: suggestion
+- File: internal/environments/runner.go:849
+- Description: 用 Work metadata 字段 `sandbox_recovery_code_session_id` 作为 create/recover 控制平面，再在 `publishManagedAgentRuntime` 里用 `nil` patch“清除”。这是临时旗标式设计：解析 helper、SQL jsonb_build_object、publish 时写 null、Go 侧依赖 null→空字符串，概念分散在 DB SQL、Runner preparation、publish 三处。PostgreSQL `||` 合并 null 只会把键写成 JSON null 而非删除，留下脏 metadata。
+- Suggestion: code-judo——把恢复意图做成显式状态，而不是 metadata 副作用。例如 Work `data`/`state` 旁路字段、或 `environment_work` 上的 typed recovery marker，最好与 `ScheduleRecoveryForCodeSession` 同事务写入并在成功绑定 runtime 时清除。Runner 读强类型字段而不是 JSON 侦察。清除用 SQL `metadata - 'key'` 或专用 update，不要依赖 null merge。
+- Status: open
+
+### Issue 5 -- Severity: suggestion
+- File: internal/codesessions/managed_agent_code_session.go:137
+- Description: `RecoverManagedAgentCodeSession` 与 Create 尾部重复：发 OAuth token、读 credential context、签 ingress JWT、拼 `ManagedAgentCreateResult`（含 `CurrentWorkerEpoch + 1`）。Recover 还多一次 `GetCodeSession` round-trip。Rotate 未 bump epoch，只清 lease；在 Register 完成前，旧 epoch 仍能通过 `ValidateCodeSessionWorkerEpoch`，旧 session-ingress JWT 仍有效，存在恢复窗口内的 fencing 空隙（heartbeat 因 lease=null 会被拒，但事件写入路径主要看 epoch）。
+- Suggestion: 抽取 `issueSandboxCredentials(ctx, org, ws, codeSessionID) (token, ingress, epochHint, error)` 供 Create/Recover 共用。认真考虑在 `RotateCredentials` 时立即 bump/作废旧 epoch（并相应调整 Register 与 env 注入合同），让恢复一开始就 fence 旧 worker，而不是等 Register。
+- Status: open
+
+### Issue 6 -- Severity: suggestion
+- File: tests/sessions_api_test.go:769
+- Description: 该文件已约 4904 行，本改动再加约 168 行。审查标准明确反对无必要地继续膨胀超大文件。新增的 resume/recovery E2E 有价值，但不该继续堆进巨型 suite。
+- Suggestion: 抽到聚焦文件，例如 `tests/sessions_sandbox_recovery_test.go`（或 `tests/sandbox_lifecycle_api_test.go`），共享 `newTestApp` fixture。同步为 recover 失败不 Terminate 补测试（见 Issue 1）。
+- Status: open
+
+### Issue 7 -- Severity: nit
+- File: internal/environments/runner.go:585
+- Description: `patchJSONMetadata(..., {"sandbox_recovery_code_session_id": nil})` 依赖 JSON null 语义清除控制旗标，可读性差，且留下 null 键。
+- Suggestion: 若短期仍用 metadata，提供 `deleteJSONMetadataKeys` 或 DB 侧 `metadata - 'sandbox_recovery_code_session_id'`；与 Issue 4 的显式状态方案一并处理更佳。
+- Status: open

--- a/.grok/review-scratch/grok-review-summary-cd4bce49.md
+++ b/.grok/review-scratch/grok-review-summary-cd4bce49.md
@@ -1,0 +1,17 @@
+# Review Summary
+
+- **Mode**: local
+- **Target**: 本地未提交改动（相对 HEAD）
+- **Files reviewed**: 24（api/server、codesessions、db、environments、e2bruntime、config、docs、tests 等）
+- **Diff stats**: 24 files changed, 690 insertions(+), 58 deletions(-)
+- **Issue counts**: 2 bugs, 4 suggestions, 1 nit
+
+## Top issues
+
+- [bug] internal/environments/runner.go:554 -- 恢复失败会 Terminate 本应保留的 durable Code Session
+- [bug] internal/environments/runner.go:521 -- Create/Recover 共用失败清理流，是结构根因
+- [suggestion] internal/codesessions/service.go:18 -- codesessions 依赖 e2bruntime sentinel，边界泄漏
+- [suggestion] internal/environments/runner.go:849 -- 用 metadata 旗标做 create/recover 控制平面
+- [suggestion] managed_agent_code_session.go:137 -- Recover 重复凭证签发；epoch fencing 窗口
+
+See the full review at: /Users/arthur/.codex/worktrees/1ec9/open-managed-agents/.grok/review-scratch/grok-review-cd4bce49.md

--- a/docs/configuration-reference.yaml
+++ b/docs/configuration-reference.yaml
@@ -58,7 +58,7 @@ e2b:
   debug: false
   template: managed-agent-sandbox
   request_timeout: 60s
-  sandbox_timeout: 5m
+  sandbox_timeout: 30s
 
 environment_runner:
   enabled: true

--- a/docs/design/be/ccrv2/ccr-v2-epoch-design.md
+++ b/docs/design/be/ccrv2/ccr-v2-epoch-design.md
@@ -213,23 +213,25 @@ returning worker_lease_expires_at;
 
 lease 过期本身不修改 epoch。UI 或观测状态用 `worker_lease_expires_at <= now()` 判断 stale。后台 sweep 在 v1 中不是正确性的必要条件。
 
+同一个 Provider Sandbox 因 idle timeout 被 pause 时，worker ownership 没有变化，因此 resume 也不 bump epoch。用户事件触发显式 `Connect`/`SetTimeout` 并确认同一个活动 Sandbox 恢复成功后，服务端可以把当前已注册 lease 重新设为 `now + leaseTTL`。该写入必须同时匹配租户、Code Session、活动 Work 和精确的 Provider Sandbox ID，并拒绝 lease 已被 credential rotation 清空的记录；Provider 恢复失败时不得续租。replacement 创建新 Sandbox 时仍必须 bump epoch 并清空旧 lease。
+
 ## 8. 读路径兼容
 
 读路径不 bump epoch：
 
 - `GET /worker` 可以可选支持 `worker_epoch` query/header；传了且不匹配返回 `409`，没传则返回当前 worker state。
-- `GET /worker/events/stream` 只做 auth 和 session 存在校验；如果请求带 epoch，可以校验并在 mismatch 时返回 `409`，否则保持兼容。
+- `GET /worker/events/stream` 优先使用 query/header 中的 epoch；没有显式参数时使用已认证 JWT 的正 `worker_epoch`。显式值不匹配返回 `409`；只有旧 JWT 也没有 epoch 时才保持 legacy 兼容。
 - SSE/HTTP poll 读取 queued inbound events 不改变 epoch。
 
 当前实现约束：
 
 - 无 `worker_epoch` 的 `GET /worker` 只读当前 state，不刷新 `connection_status` 或 activity 时间。
 - 带 `worker_epoch` 的 `GET /worker` 可以刷新连接状态，但必须使用 `current_worker_epoch = $epoch` 条件更新。
-- `GET /worker/events/stream` 只有在请求携带当前 epoch 时才写入 connected/disconnected 状态；无 epoch stream 不做状态写入。
+- `GET /worker/events/stream` 在请求参数或 JWT claim 提供当前 epoch 时写入 connected/disconnected 状态；只有两者都无 epoch 时才不做状态写入。
 - 带 `worker_epoch` 的 stream 会先解析 `from_sequence_num` / `Last-Event-ID`；cursor 非法时返回 `400`，不会先把 worker 标记为 connected。
 - 带 `worker_epoch` 的 stream 使用 `ListCodeSessionInboundEventsForWorkerStream(ctx, sessionID, epoch, afterSequence)`，读取 `sequence_num > afterSequence` 且 `delivery_status <> 'processed'` 的 inbound events，并继续约束 `current_worker_epoch = $epoch`。
 - epoch-scoped stream 写出事件后使用 `MarkCodeSessionInboundEventSentForEpoch()` 标记 `sent`、`delivery_worker_epoch` 和 delivery attempt；新 register bump 后，旧 stream 应停止，不能读取或标记新 epoch 的事件。
-- 无 `worker_epoch` 的 legacy stream 仍使用 queued-only 兼容路径，不提供 epoch takeover/replay 语义。
+- 请求参数和 JWT claim 都无 `worker_epoch` 的 legacy stream 仍使用 queued-only 兼容路径，不提供 epoch takeover/replay 语义。managed-agent JWT 带 epoch，因此它即使使用不带 query 的 stream URL，也必须进入 epoch-scoped 路径并在 pause/resume 重连时重放未 processed 的事件。
 - stream 断开时旧 epoch 的 disconnected 更新会被条件 update 拒绝，不能覆盖新 worker 的 connected 状态。
 
 ## 9. 并发与竞态防护

--- a/docs/design/be/ccrv2/ccr-v2-epoch-design.md
+++ b/docs/design/be/ccrv2/ccr-v2-epoch-design.md
@@ -7,7 +7,7 @@
 CCR v2 下，一个 Claude Code worker 可能因为容器重启、transport 重建或 lease 过期后的重新调度而被替换。服务端需要提供一个强一致的所有权边界：
 
 - epoch 是 code session 级别的单调小整数 counter。
-- 每次 worker register 都递增该 code session 的 epoch。
+- legacy worker register 递增该 code session 的 epoch；managed-agent 凭证在签发时绑定一个已预留 epoch，register 对该 epoch 幂等。
 - worker 写请求必须携带 `worker_epoch`。
 - 请求 epoch 不等于当前 epoch 时返回 `409 conflict_error`，让旧 worker 退出。
 - PostgreSQL 是唯一强一致来源，不使用内存 counter。
@@ -48,7 +48,7 @@ create index if not exists code_sessions_worker_lease_expiry_v1_idx
 | # | 不变量 | 服务端要求 |
 |---|---|---|
 | 1 | epoch 是 per-code-session 的 | 不同 `cse_*` 独立计数，互不影响 |
-| 2 | register 递增 epoch | 每次合法 register 都在事务内 `current_worker_epoch + 1` |
+| 2 | register 获得唯一 epoch | legacy register 在事务内执行 `current_worker_epoch + 1`；managed register 只能提交 JWT 中已预留的 epoch |
 | 3 | epoch 单调递增 | 不回退，不使用 timestamp、UUID 或随机数 |
 | 4 | 只有当前 epoch 可以写 | 不匹配返回 `409 conflict_error` |
 | 5 | lease 过期不自动 bump | 只有下一次 register 才 bump |
@@ -59,7 +59,7 @@ create index if not exists code_sessions_worker_lease_expiry_v1_idx
 
 - `POST /v1/code/sessions/{code_session_id}/worker/register`
 
-`RegisterCodeSessionWorker(ctx, codeSessionID, binding, leaseTTL)` 是唯一 epoch 变更入口。它必须在单个 DB 事务中：
+legacy 客户端使用 `RegisterCodeSessionWorker(ctx, codeSessionID, binding, leaseTTL)`，在单个 DB 事务中递增 epoch：
 
 ```go
 tx := begin()
@@ -93,6 +93,8 @@ return nextEpoch
 - 不同 code session 可以并发 register。
 - 不等待 lease 过期；任何合法新 register 都可以抢占并 bump epoch。
 - 返回 `worker_epoch` 建议用 JSON string，实际值保持在 JS safe integer 范围内。
+
+managed-agent session-ingress JWT 额外携带 `worker_epoch`。首次创建时直接把现有 `current_worker_epoch` 初始化为 `1` 并签发 epoch `1`；Sandbox 恢复时，凭证轮换 SQL 在同一更新中替换 OAuth hash、把 `current_worker_epoch` 加一并清空旧 lease，再把新的 current epoch 写入 JWT。带该 claim 的 register 使用 `RegisterCodeSessionWorkerAtEpoch()`：持有行锁时再次要求数据库 current epoch 等于 JWT claim，然后把 lease/binding 写到该确切 epoch。相同 JWT 重试 register 只刷新同一 epoch，不再次 bump；旧 managed-agent JWT 通常在入口鉴权返回 `401`，即使其请求恰好在轮换前通过入口校验，事务内 worker epoch 复核也会阻止它抢回所有权。旧版不含 `worker_epoch` 的 JWT 可继续使用 legacy register，但凭证轮换预留 epoch 并清空 lease 后，legacy register 不得继续递增越过该 fence。
 
 ## 5. Worker 写请求校验
 
@@ -283,7 +285,8 @@ CCR v2 worker 使用持久化 inbound event 队列和带 epoch 的
 
 需要覆盖：
 
-- 新 code session 第一次 register 返回 `1`，第二次返回 `2`。
+- legacy code session 第一次 register 返回 `1`，第二次返回 `2`。
+- managed-agent 新 JWT 重复 register 返回相同的预留 epoch；恢复轮换后旧 JWT 返回 `401`，新 JWT 返回下一 epoch。
 - 同一 code session 两个并发 register 返回连续不同 epoch。
 - 不同 code session 都从 `1` 开始，互不影响。
 - 旧 epoch 调 worker 写 endpoints 返回 `409`。

--- a/docs/design/be/ccrv2/ccr-v2-worker-events-delivery-backend-design.md
+++ b/docs/design/be/ccrv2/ccr-v2-worker-events-delivery-backend-design.md
@@ -341,14 +341,14 @@ data: {
 
 1. ingress token 鉴权。
 2. 确认 code session 存在。
-3. 可选解析并校验 `worker_epoch` query/header。
+3. 可选解析并校验 `worker_epoch` query/header；请求未显式携带时，使用已认证 session-ingress JWT 中的正 `worker_epoch`。
 4. 解析 `from_sequence_num` 或 `Last-Event-ID`。
 5. cursor 非法时直接返回 `400`，不会把 worker 标记为 connected。
-6. 如果带当前 epoch，调用 `MarkCodeSessionWorkerConnectedForEpoch`。
+6. 如果显式参数或 JWT claim 解析出当前 epoch，调用 `MarkCodeSessionWorkerConnectedForEpoch`。
 7. 写 SSE headers，进入 polling loop。
 8. stream 退出时用 epoch 条件调用 `MarkCodeSessionWorkerDisconnectedForEpoch`。
 
-无 epoch 的 stream 保持兼容，只读 queued events，不刷新连接状态。
+只有旧版 JWT 本身也没有 `worker_epoch` 时，stream 才保持 legacy 兼容：只读 queued events，不刷新连接状态。managed-agent 实际建立 SSE 时可以不在 URL 重复传 epoch；其 JWT claim 会让该连接进入 epoch-scoped delivery/replay 路径。
 
 ### 8.3 写出后的状态
 
@@ -424,6 +424,8 @@ and processed_at is null
 ```
 
 这能避免升级后把旧实现中已 `sent`、但没有 epoch/ACK 字段的历史事件重新当作新 prompt 发送。代价是：如果新代码路径产生同形态数据，也会被排除。因此新的 epoch-scoped stream 必须在写出后使用 `MarkCodeSessionInboundEventSentForEpoch` 写入 `delivery_worker_epoch`，不能继续走 legacy mark sent。
+
+这条约束也适用于 pause/resume：旧 SSE 连接可能在 Sandbox 真正冻结前抢先写出刚入队的消息。如果连接使用 managed-agent JWT，即使 URL 没有 `worker_epoch`，服务端也必须从 claim 取得 epoch 并记录 `delivery_worker_epoch`；resume 后的新连接才能把未 ACK 的 `sent` 事件重放，而不会把它误认成历史 legacy 事件永久跳过。
 
 ---
 

--- a/docs/design/be/ccrv2/otlp-metrics-api.md
+++ b/docs/design/be/ccrv2/otlp-metrics-api.md
@@ -70,7 +70,7 @@ POST /v1/code/sessions/{code_session_id}/worker/otlp/logs
 
 | Header | 必需 | 描述 |
 |--------|------|------|
-| `Authorization: Bearer sk-ant-si-<JWT>` | 是 | session-ingress JWT，必须通过签名和标准 claims 校验，且 `session_id` 必须与 path 一致 |
+| `Authorization: Bearer sk-ant-si-<JWT>` | 是 | session-ingress JWT，必须通过签名和标准 claims 校验，`session_id` 必须与 path 一致；managed-agent JWT 的 worker epoch 必须仍匹配 active Code Session |
 | `X-Worker-Epoch: {epoch}` | 否 | 当前 worker epoch；携带时用于拒绝旧 worker 写入并检查 lease，不携带时按 session-scoped telemetry 接收 |
 | `Content-Type` | 是 | `application/x-protobuf` 或 `application/json` |
 | `Accept` | 否 | 如果包含 `application/json`，即使请求是 protobuf，成功响应也会返回 JSON |
@@ -241,7 +241,7 @@ function getOTLPExporterConfig() {
 ```bash
 CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2=1
 CLAUDE_CODE_USE_CCR_V2=1
-CLAUDE_CODE_WORKER_EPOCH=1
+CLAUDE_CODE_WORKER_EPOCH={next_worker_epoch}
 CLAUDE_CODE_INCLUDE_PARTIAL_MESSAGES=true
 ```
 
@@ -251,8 +251,10 @@ CLAUDE_CODE_INCLUDE_PARTIAL_MESSAGES=true
 OTEL_METRICS_EXPORTER=otlp
 OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf
 OTEL_EXPORTER_OTLP_METRICS_ENDPOINT={api_base_url}/v1/code/sessions/{code_session_id}/worker/otlp/metrics
-OTEL_EXPORTER_OTLP_METRICS_HEADERS=Authorization=Bearer {session_ingress_token},x-worker-epoch=1
+OTEL_EXPORTER_OTLP_METRICS_HEADERS=Authorization=Bearer {session_ingress_token},x-worker-epoch={next_worker_epoch}
 ```
+
+首次启动时 `{next_worker_epoch}` 为 `1`。Sandbox 丢失后的替换启动复用原 Code Session，并注入 `current_worker_epoch + 1`；environment-manager 注册成功后使用同一递增 epoch，避免恢复 worker 被旧 epoch fencing。
 
 如果没有显式配置 `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` 或 `OTEL_EXPORTER_OTLP_ENDPOINT`，并且 `OTEL_LOGS_EXPORTER` 未设置或包含 `otlp`，后端会默认注入：
 

--- a/docs/design/be/ccrv2/upstream-proxy-and-model-runtime.md
+++ b/docs/design/be/ccrv2/upstream-proxy-and-model-runtime.md
@@ -64,9 +64,11 @@ CLAUDE_CODE_REMOTE=true
 CCR_UPSTREAM_PROXY_ENABLED=1
 CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2=1
 CLAUDE_CODE_USE_CCR_V2=1
-CLAUDE_CODE_WORKER_EPOCH=1
+CLAUDE_CODE_WORKER_EPOCH={next_worker_epoch}
 CLAUDE_CODE_INCLUDE_PARTIAL_MESSAGES=true
 ```
+
+首次启动的 `{next_worker_epoch}` 是 `1`；替换 Sandbox 复用 Code Session 时，它是数据库当前 epoch 加一，并与 environment-manager 随后的 `/worker/register` 返回值一致。
 
 `startup_context.api_base_url` 是 sandbox 可访问的 Open Managed Agents API 地址。payload 不再注入上游 `ANTHROPIC_BASE_URL` 或 `ANTHROPIC_API_KEY`；environment-manager 使用 `api_base_url` 作为 Claude 的 `ANTHROPIC_BASE_URL` fallback。
 
@@ -181,7 +183,7 @@ Runner 不再把 Managed Agent MCP URL 改写到该接口。MCP config 保留 Ag
 
 代理执行以下边界：
 
-1. 从 `Authorization: Bearer` 或 `X-Api-Key` 读取 session-ingress JWT，并将签名 claims 中的 `session_id` 绑定到路径参数。
+1. 从 `Authorization: Bearer` 或 `X-Api-Key` 读取 session-ingress JWT，将签名 claims 中的 `session_id` 绑定到路径参数；managed-agent JWT 还会按租户回查 active Code Session 的 `current_worker_epoch`，Sandbox 恢复递增 epoch 后旧 JWT 立即失效。
 2. `mcp_url` 必须是唯一、长度不超过 2048 字节、不含 userinfo/fragment 的绝对 HTTP(S) URL，并精确匹配当前 Session Agent Snapshot 的一个远程 MCP URL。
 3. 每次请求新鲜读取 Code Session → Environment / Session 租户关系，并在加载边界通过 `ParseMCPProxyPolicy` 一次性把 Agent Snapshot 编译为精确 URL 集合、MCP host 集合以及 Environment host/port matcher。handler 只把未改写的 `mcp_url` 交给 `AuthorizeMCPURL`；策略同时完成精确 URL 与真实 scheme/host/有效端口授权，不使用伪造的 `host:443`，也不在 handler 中重新解析 snapshot。随后解析目标地址并应用与 upstream proxy 相同的公网 IP / DNS rebinding 防护。受控本地排障可复用 `upstream_proxy_disable_ssrf_protection`，生产默认不得关闭。
 4. 删除 OMA 的 `Authorization`、`X-Api-Key`、`Proxy-Authorization` 和 `Proxy-Connection`，保留 MCP 协议与 content negotiation header。真实 MCP 凭证只允许在服务端 header injector 边界按已验签 session claims 和目标 URL 注入；默认实现不注入。

--- a/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
+++ b/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
@@ -12,7 +12,8 @@
 - 只有通过当前 epoch 与 lease 校验、且 `worker_status=running` 的 heartbeat 才能续期对应的 E2B Sandbox。
 - E2B 续期时长复用 `e2b.sandbox_timeout`，不维护另一套 Sandbox TTL 配置。
 - `idle` 和 `requires_action` heartbeat 仍续 worker lease，但不续 E2B Sandbox，避免常驻 CCRv2 heartbeat 让空闲 Sandbox 永不过期。
-- 使用 OMA 签发的 Ed25519 session-ingress JWT，并将签名 `session_id` 与请求路径绑定；session 与 lease 状态由 heartbeat 数据库状态机判断。
+- E2B Sandbox 超时后进入 `pause` 而不是 `kill`；新的可转发 Session 用户事件持久化后会显式连接 Sandbox、恢复执行并重置 TTL。
+- 使用 OMA 签发的 Ed25519 session-ingress JWT，并将签名 `session_id` 与请求路径绑定；managed-agent JWT 携带的 `worker_epoch` 还会与 active Code Session 的现有 `current_worker_epoch` 比对，session lease 由各 handler 的数据库状态机判断。
 
 相关实现文件：
 
@@ -102,7 +103,7 @@ worker 心跳状态直接使用 `code_sessions` 现有列：
 - `connection_status`
 - `updated_at`
 
-不新增 migration。Code Session 通过受信任的 Session Work 数据关联 `environment_work`，再通过 `work_id` 定位 `environment_sandboxes` 中最新的 `running` Sandbox；查询同时约束 organization、workspace 和 environment，且要求 Code Session 的 `worker_status=running`、`provider_sandbox_id` 非空。未关联活动 Sandbox 的独立 Code Session，以及 `idle`/`requires_action` Code Session，只续 worker lease，不调用 Provider。worker 是否已注册由以下条件判断：
+本流程不增加数据库列或 migration。Code Session 通过受信任的 Session Work 数据关联 `environment_work`，再通过 `work_id` 定位 `environment_sandboxes` 中最新的 `running` Sandbox；查询同时约束 organization、workspace 和 environment，并要求 `provider_sandbox_id` 非空。heartbeat 调用只查询 `worker_status=running`；Session 用户事件唤醒路径允许 `idle`、`running` 和 `requires_action`，从而既不让空闲 heartbeat 无限续期，又能在新工作到达时恢复 Sandbox。未关联活动 Sandbox 的独立 Code Session 只更新自身队列或 worker lease，不调用 Provider。worker 是否已注册由以下条件判断：
 
 - `current_worker_epoch > 0`
 - `worker_lease_expires_at is not null`
@@ -207,7 +208,13 @@ heartbeat 使用 `SELECT ... FOR UPDATE` 锁定目标 `code_sessions` 行，因�
 
 E2B 网络调用不在 PostgreSQL 事务中执行，避免远端延迟占用 `code_sessions` 行锁。worker lease 先提交，再按提交后的 worker 状态解析可续期 Sandbox，因此 running worker 遇到 Provider 临时失败时接口返回 `503`，但已经观测到的 worker heartbeat 仍保留；客户端下一次 heartbeat 会重新尝试 `SetTimeout`。`SetTimeout` 是幂等的相对 TTL 更新，并发成功调用以 E2B 最后处理的请求为准。
 
-E2B SDK 的 `Connect` 也会携带 timeout。Provider 所有 connect 操作显式使用 `e2b.sandbox_timeout`，避免 SDK 默认值覆盖项目配置；running heartbeat 随后显式调用 `SetTimeout`，把 Sandbox 生命周期从本次请求重新延长相同配置时长。worker 切换到 `idle` 或 `requires_action` 后，后续 heartbeat 不再连接 Provider；如果没有其他 Provider 操作，Sandbox 会在最后一次 running 续期后的 `e2b.sandbox_timeout` 内自然过期。`last_worker_activity_at` 会被 heartbeat 自身刷新，不能作为 Sandbox idle 计时来源。
+E2B SDK 的 `Connect` 也会携带 timeout。Provider 所有 connect 操作显式使用 `e2b.sandbox_timeout`，避免 SDK 默认值覆盖项目配置；running heartbeat 随后显式调用 `SetTimeout`，把 Sandbox 生命周期从本次请求重新延长相同配置时长。创建 Sandbox 时显式设置 `onTimeout=pause`，但不启用请求或流量触发的 `autoResume`；恢复统一由 Provider 的显式 `Connect` 完成，因此超时资源可恢复，而不是被销毁。
+
+该配置默认是 `30s`，因此运行态 worker 的 heartbeat 周期必须显著短于 30 秒，并为网络抖动和 Provider 延迟留出余量。worker 切换到 `idle` 或 `requires_action` 后，后续 heartbeat 不再连接 Provider；如果没有其他 Provider 操作，Sandbox 会在最后一次 running 续期后的 `e2b.sandbox_timeout` 内 pause。之后收到 `user.message`、`user.interrupt`、`user.tool_confirmation`、`user.tool_result` 或 `user.custom_tool_result` 时，服务端先将事件写入持久化 Code Session 入站队列，再对关联 Sandbox 调用 `SetTimeout`。E2B Provider 在 `SetTimeout` 前先执行 `Connect`，因此 paused Sandbox 会被恢复，TTL 也从该次事件重新计算。Provider 临时失败不回滚已经持久化的消息；下一条可转发用户事件会再次尝试恢复。`last_worker_activity_at` 会被 heartbeat 自身刷新，不能作为 Sandbox idle 计时来源。
+
+如果 Provider 明确返回 sandbox not found，服务端原子地把旧 `environment_sandboxes` 记录标为 `failed`，并把同一 Work 重新排为 `queued`。Runner 根据 Work 对应的 organization、workspace、environment 和 public Session 查询 active Code Session：没有 active 记录时执行 create，恰好一条时执行 recover，多于一条则按无效状态失败，从而不使用 metadata 旗标或新增恢复列。恢复会创建新的 Provider Sandbox，但复用原 `cse_*` 及其持久化事件和 transcript。
+
+首次创建 managed-agent Code Session 时直接把现有 `current_worker_epoch` 初始化为 `1`。恢复启动在一条数据库更新中替换 OAuth token hash、递增 `current_worker_epoch` 并清空旧 lease。新 session-ingress JWT 携带该预留 epoch；每次 managed-agent ingress 鉴权都会按租户回查 active Code Session，因此携带旧 epoch 的 JWT 立即失效。environment-manager 使用同一 epoch 作为 `CLAUDE_CODE_WORKER_EPOCH` 和 OTLP header，`/worker/register` 对该 epoch 幂等，不会因为重复注册再次递增。旧版不含 `worker_epoch` 的 JWT 维持兼容鉴权，但凭证轮换后不能越过“正 epoch 且 lease 为空”的注册 fence。Provider 创建、manager 启动或 metadata 发布失败时，若仍能从 Work 推导出唯一 active Code Session，则只清理本次 replacement Sandbox 并延迟重新排队，不终止 durable Code Session。
 
 ## 日志
 
@@ -234,7 +241,7 @@ epoch mismatch 和 lease expired 会记录结构化文本日志，字段包括�
 
 ## 测试覆盖
 
-主要覆盖在 `tests/sessions_api_test.go`：
+基础 heartbeat 覆盖在 `tests/sessions_api_test.go`，Sandbox 恢复覆盖在 `tests/session_sandbox_recovery_test.go`：
 
 - invalid auth 返回 `401 authentication_error`。
 - malformed JSON、非 object body、缺失或不匹配 `session_id` 返回 `400 invalid_request_error`。
@@ -246,6 +253,10 @@ epoch mismatch 和 lease expired 会记录结构化文本日志，字段包括�
 - running heartbeat 使用对应 `provider_sandbox_id` 和 `e2b.sandbox_timeout` 调用 Sandbox 续期。
 - idle 和 requires-action heartbeat 续 worker lease，但不调用 Sandbox 续期。
 - running heartbeat 的 E2B Sandbox 续期失败返回 `503`。
+- idle Sandbox 收到可转发用户事件后调用 Provider 恢复，并使用 `e2b.sandbox_timeout` 重置 TTL；Provider 临时失败后下一条事件会重试。
+- Provider Sandbox 已不存在时，旧记录转为 failed、原 Work 重新排队并创建替换 Sandbox；同一 Code Session 以递增 worker epoch 继续运行。
+- replacement 启动失败时原 Code Session 仍为 active、Work 延迟重试，只有失败的 replacement Sandbox 被清理。
+- managed-agent 凭证轮换后携带旧 worker epoch 的 session-ingress JWT 返回 `401`；新 JWT 重复注册都返回预留 worker epoch。
 - 旧 epoch、未来 epoch 和超过 grace 的 heartbeat 不调用 Sandbox 续期。
 - 刚过期但在 `10s` grace 内 heartbeat 返回 `200`。
 - 超过 grace 返回 `410 session_expired`，并断言状态不更新。

--- a/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
+++ b/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
@@ -210,7 +210,9 @@ E2B 网络调用不在 PostgreSQL 事务中执行，避免远端延迟占用 `co
 
 E2B SDK 的 `Connect` 也会携带 timeout。Provider 所有 connect 操作显式使用 `e2b.sandbox_timeout`，避免 SDK 默认值覆盖项目配置；running heartbeat 随后显式调用 `SetTimeout`，把 Sandbox 生命周期从本次请求重新延长相同配置时长。创建 Sandbox 时显式设置 `onTimeout=pause`，但不启用请求或流量触发的 `autoResume`；恢复统一由 Provider 的显式 `Connect` 完成，因此超时资源可恢复，而不是被销毁。
 
-该配置默认是 `30s`，因此运行态 worker 的 heartbeat 周期必须显著短于 30 秒，并为网络抖动和 Provider 延迟留出余量。worker 切换到 `idle` 或 `requires_action` 后，后续 heartbeat 不再连接 Provider；如果没有其他 Provider 操作，Sandbox 会在最后一次 running 续期后的 `e2b.sandbox_timeout` 内 pause。之后收到 `user.message`、`user.interrupt`、`user.tool_confirmation`、`user.tool_result` 或 `user.custom_tool_result` 时，服务端先将事件写入持久化 Code Session 入站队列，再对关联 Sandbox 调用 `SetTimeout`。E2B Provider 在 `SetTimeout` 前先执行 `Connect`，因此 paused Sandbox 会被恢复，TTL 也从该次事件重新计算。Provider 临时失败不回滚已经持久化的消息；下一条可转发用户事件会再次尝试恢复。`last_worker_activity_at` 会被 heartbeat 自身刷新，不能作为 Sandbox idle 计时来源。
+该配置默认是 `30s`，因此运行态 worker 的 heartbeat 周期必须显著短于 30 秒，并为网络抖动和 Provider 延迟留出余量。worker 切换到 `idle` 或 `requires_action` 后，后续 heartbeat 不再连接 Provider；如果没有其他 Provider 操作，Sandbox 会在最后一次 running 续期后的 `e2b.sandbox_timeout` 内 pause。之后收到 `user.message`、`user.interrupt`、`user.tool_confirmation`、`user.tool_result` 或 `user.custom_tool_result` 时，服务端先将事件写入持久化 Code Session 入站队列，再对关联 Sandbox 调用 `SetTimeout`。E2B Provider 在 `SetTimeout` 前先执行 `Connect`，因此 paused Sandbox 会被恢复，TTL 也从该次事件重新计算。
+
+pause 期间进程不会发送 heartbeat，但数据库 lease 仍按墙钟推进，因而长时间 pause 后 lease 可能已经超过 grace。Provider 成功恢复同一个活动 Sandbox 后，服务端会把已注册的当前 worker lease 重新设为 `now + 60s`，但不修改 `current_worker_epoch`、`worker_last_heartbeat_at` 或 `last_worker_activity_at`。该条件更新同时校验 organization、workspace、Code Session、活动 Work 和精确的 `provider_sandbox_id`；已被 replacement 标记为 failed 的旧 Sandbox 或凭证轮换后 lease 已清空的 worker 都不能借此复活。Provider 临时失败不续租，也不回滚已经持久化的消息；下一条可转发用户事件会再次尝试恢复。
 
 如果 Provider 明确返回 sandbox not found，服务端原子地把旧 `environment_sandboxes` 记录标为 `failed`，并把同一 Work 重新排为 `queued`。Runner 根据 Work 对应的 organization、workspace、environment 和 public Session 查询 active Code Session：没有 active 记录时执行 create，恰好一条时执行 recover，多于一条则按无效状态失败，从而不使用 metadata 旗标或新增恢复列。恢复会创建新的 Provider Sandbox，但复用原 `cse_*` 及其持久化事件和 transcript。
 

--- a/docs/design/be/filestore.md
+++ b/docs/design/be/filestore.md
@@ -207,7 +207,7 @@ Input attach 不创建新的 `files` 行，不复制 File 元数据或 S3 对象
 
 Environment Manager 不再接收 `type=file` resource。它只在 rclone ready 后看到已经完成的 `/uploads` 文件系统视图；File 的下载、路径投影或内容刷新均不属于 Environment Manager 职责。
 
-Provider Sandbox 创建前的失败会停止 Environment Work，且不会创建 Sandbox 或 Code Session；创建后的身份解析、rclone 启动、ready、heartbeat 或 Environment Manager 启动失败会把 Sandbox 标记为 `failed`、停止 Environment Work 并 Kill provider Sandbox。Code Session 只在 rclone ready、Sandbox running 和首次 heartbeat 成功之后创建；Environment Manager 启动或运行时 metadata 原子发布失败时，Runner 将 Code Session 标记为 `terminated`、清除 OAuth hash 与 worker lease，再 Kill Sandbox。ready 失败路径会 best-effort 删除 Token 配置；ready 后的配置删除按上面的有限重试与告警处理，不使已就绪 Sandbox 失败。对外错误保留稳定阶段 sentinel，服务日志只记录阶段和错误类型，不包含 Token 或完整配置。
+Provider Sandbox 创建前的普通启动失败会停止 Environment Work，且不会创建 Sandbox 或 Code Session；创建后的身份解析、rclone 启动、ready、heartbeat 或 Environment Manager 启动失败会把 Sandbox 标记为 `failed`、停止 Environment Work 并 Kill provider Sandbox。Code Session 只在 rclone ready、Sandbox running 和首次 heartbeat 成功之后创建；首次创建时 Environment Manager 启动或运行时 metadata 原子发布失败会将新 Code Session 标记为 `terminated`、清除 OAuth hash 与 worker lease，再 Kill Sandbox。若 Work 仍能关联到唯一 active durable Code Session，则按丢失 Sandbox 的恢复启动处理：保留该 Code Session、延迟重新排队 Work，只清理本次 replacement Sandbox。ready 失败路径会 best-effort 删除 Token 配置；ready 后的配置删除按上面的有限重试与告警处理，不使已就绪 Sandbox 失败。对外错误保留稳定阶段 sentinel，服务日志只记录阶段和错误类型，不包含 Token 或完整配置。
 
 ## 数据模型
 

--- a/docs/design/be/messages-proxy.md
+++ b/docs/design/be/messages-proxy.md
@@ -42,7 +42,7 @@ code-session token 只有在以下条件全部满足时才通过鉴权：
 - CCR v2 `worker_lease_expires_at > now()`；
 - 请求方法和路径严格对应 `POST /v1/messages`。
 
-environment-manager 在启动 Claude Code 前调用 `/worker/register`，建立首个 60 秒 lease；Claude 之后每 20 秒调用 `/worker/heartbeat` 续租。Claude 异常退出时不再续租，OAuth-compatible Messages 凭证最多在最后一个 lease TTL 内继续有效。session-ingress JWT 统一只校验签名、固定 claims 和请求路径绑定；register、heartbeat 及其他 ingress 请求不在 JWT 鉴权阶段回查 session 或 lease。worker epoch、heartbeat grace 和 OTLP lease 仍由各自 handler 的状态机判断。
+environment-manager 在启动 Claude Code 前调用 `/worker/register`，建立首个 60 秒 lease；Claude 之后每 20 秒调用 `/worker/heartbeat` 续租。Claude 异常退出时不再续租，OAuth-compatible Messages 凭证最多在最后一个 lease TTL 内继续有效。session-ingress JWT 校验签名、固定 claims 和请求路径绑定；managed-agent JWT 还携带 `worker_epoch`，入口会按租户回查 active Code Session 的 `current_worker_epoch`。heartbeat grace 和 OTLP lease 仍由各自 handler 的状态机判断。
 
 code-session 请求来自受信任的沙箱调用方，handler 不解析或校验 `model`。请求体由上游按照 Anthropic Messages 合同校验；本服务只负责入口鉴权、请求大小限制、header 清洗和流式代理。因此代理不需要为了读取 JSON 字段而将整个 body 放入内存。
 
@@ -53,7 +53,7 @@ code-session 请求来自受信任的沙箱调用方，handler 不解析或校�
 - `oauth_access_token_hash text`；
 - 未删除记录的非空 hash 具有唯一索引。
 
-OAuth-compatible token 没有 11 分钟或 8 小时墙钟上限，但每次 `/v1/messages` 鉴权仍复核 active code session、未 terminated 的 public session 和 worker lease。managed-agent 启动时签发的 session-ingress JWT 也不写入独立 `exp`，当前仅验证密码学身份与请求路径，不因 session 终止或 lease 到期而自动撤销；后续如需撤销语义，应单独引入明确的 token version、denylist 或状态复核策略。
+OAuth-compatible token 没有 11 分钟或 8 小时墙钟上限，但每次 `/v1/messages` 鉴权仍复核 active code session、未 terminated 的 public session 和 worker lease。managed-agent 启动时签发的 session-ingress JWT 也不写入独立 `exp`；它复用现有 worker epoch 支持 fencing：Code Session 终止或 Sandbox 恢复递增 epoch 后，携带旧 epoch 的 JWT 在下一次请求时失效。worker lease 是否有效仍由具体 ingress handler 判断，不在 JWT 鉴权阶段统一要求。
 
 进程启动时只创建一份 `SessionCredentials`。启动组合根把它注入 API server，并用它构造 environment runner 所需的 code-session service；Runner 通过 `RunnerDependencies` 接收这个最终 service，不自行读取密钥或生成临时签名器。密钥配置错误和 Runner 缺少依赖都会在 worker 启动前返回错误，保证签发端与验签端使用同一套密钥。
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -97,7 +97,8 @@ func NewServer(deps ServerDeps) *Server {
 		platformStore = platformsession.NewMemoryStore()
 	}
 	codeSessionLogger := componentLogger("codesessions")
-	codeSessionService := codesessions.NewServiceWithCredentials(deps.DB, deps.CodeSessionCredentials, codeSessionLogger)
+	codeSessionService := codesessions.NewServiceWithCredentials(deps.DB, deps.CodeSessionCredentials, codeSessionLogger).
+		WithSandboxTimeoutExtender(deps.SandboxTimeoutExtender, deps.Config.E2B.SandboxTimeout)
 	webhookLogger := componentLogger("webhooks")
 	webhookEnqueuer := webhooksapi.NewEnqueuer(deps.DB, deps.Config.Webhook, webhookLogger)
 	workbenchLogger := componentLogger("workbench")

--- a/internal/codesessions/handler.go
+++ b/internal/codesessions/handler.go
@@ -34,8 +34,8 @@ type Handler struct {
 	otlpLogMu                 sync.Mutex
 }
 
-// SandboxTimeoutExtender renews the provider-side lifetime of a managed-agent
-// sandbox after its current worker proves liveness.
+// SandboxTimeoutExtender resumes or renews the provider-side lifetime of a
+// managed-agent sandbox after worker liveness or new queued work is observed.
 type SandboxTimeoutExtender interface {
 	SetTimeout(ctx context.Context, sandboxID string, timeout time.Duration) error
 }

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -252,19 +252,31 @@ func (h *Handler) handleCodeSessionWorkerEventsStream(w http.ResponseWriter, r *
 
 func (h *Handler) handleCodeSessionWorkerRegister(w http.ResponseWriter, r *http.Request) {
 	codeSessionID := chi.URLParam(r, "code_session_id")
-	if !h.authorizeSessionIngress(w, r, codeSessionID) {
+	claims, ok := h.authorizeSessionIngressClaims(w, r, codeSessionID)
+	if !ok {
 		return
 	}
 	if err := validateCodeSessionWorkerRegisterBody(w, r, codeSessionID); err != nil {
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusBadRequest, "invalid_request_error", err.Error()))
 		return
 	}
-	epoch, _, err := h.db.RegisterCodeSessionWorker(r.Context(), codeSessionID, db.CodeSessionWorkerBinding{
+	binding := db.CodeSessionWorkerBinding{
 		TokenSessionID: codeSessionID,
 		AuthMode:       "session_ingress_token",
 		Subject:        codeSessionID,
 		Issuer:         "claude-api-server",
-	}, codeSessionWorkerLeaseTTL)
+	}
+	var epoch int64
+	var err error
+	if claims.WorkerEpoch > 0 {
+		epoch, _, err = h.db.RegisterCodeSessionWorkerAtEpoch(
+			r.Context(), codeSessionID, claims.WorkerEpoch, binding, codeSessionWorkerLeaseTTL,
+		)
+	} else {
+		// Legacy credentials issued before worker epochs were bound to JWT claims
+		// retain the original monotonic register behavior until their next rotation.
+		epoch, _, err = h.db.RegisterCodeSessionWorker(r.Context(), codeSessionID, binding, codeSessionWorkerLeaseTTL)
+	}
 	if err != nil {
 		h.writeWorkerEpochDBError(w, r, codeSessionID, err, "Could not register code session worker")
 		return

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -207,7 +207,8 @@ func (h *Handler) handleCodeSessionWorkerInternalEvents(w http.ResponseWriter, r
 
 func (h *Handler) handleCodeSessionWorkerEventsStream(w http.ResponseWriter, r *http.Request) {
 	codeSessionID := chi.URLParam(r, "code_session_id")
-	if !h.authorizeSessionIngress(w, r, codeSessionID) {
+	claims, authorized := h.authorizeSessionIngressClaims(w, r, codeSessionID)
+	if !authorized {
 		return
 	}
 	if _, err := h.requireCodeSession(r.Context(), codeSessionID); err != nil {
@@ -217,6 +218,10 @@ func (h *Handler) handleCodeSessionWorkerEventsStream(w http.ResponseWriter, r *
 	epoch, hasEpoch, ok := h.validateOptionalWorkerEpochRequest(w, r, codeSessionID)
 	if !ok {
 		return
+	}
+	if !hasEpoch && claims.WorkerEpoch > 0 {
+		epoch = claims.WorkerEpoch
+		hasEpoch = true
 	}
 	fromSequence, err := parseCodeSessionWorkerStreamFromSequence(r)
 	if err != nil {

--- a/internal/codesessions/managed_agent_code_session.go
+++ b/internal/codesessions/managed_agent_code_session.go
@@ -31,8 +31,14 @@ type ManagedAgentCreateResult struct {
 	CodeSessionID       string
 	PublicSessionID     string
 	SDKURLPath          string
+	WorkerEpoch         int64
 	OAuthAccessToken    string
 	SessionIngressToken string
+}
+
+type ManagedAgentRecoverInput struct {
+	Session       db.Session
+	CodeSessionID string
 }
 
 // CreateManagedAgentCodeSession 原子地建立 code-session 身份上下文，并为 sandbox
@@ -69,6 +75,7 @@ func (s *Service) CreateManagedAgentCodeSession(ctx context.Context, input Manag
 		Metadata:              metadata,
 		// OAuth-compatible token 只落 SHA-256 hash；明文仅存在于当前返回值中。
 		OAuthAccessTokenHash: auth.HashAPIKey(oauthAccessToken),
+		InitialWorkerEpoch:   1,
 		CreatedAt:            now,
 	})
 	if err != nil {
@@ -101,25 +108,75 @@ func (s *Service) CreateManagedAgentCodeSession(ctx context.Context, input Manag
 	if err := s.ActivateManagedAgentCodeSession(ctx, record); err != nil {
 		return ManagedAgentCreateResult{}, err
 	}
-	credentialContext, err := s.db.GetCodeSessionCredentialContextForIssue(
+	result, err := s.managedAgentCreateResult(
 		ctx,
-		input.Session.OrganizationUUID,
-		input.Session.WorkspaceUUID,
+		input.Session,
 		record.ExternalID,
+		oauthAccessToken,
+		record.CurrentWorkerEpoch,
 	)
 	if err != nil {
 		return ManagedAgentCreateResult{}, err
 	}
-	// 重新从数据库读取签发上下文，保证 JWT claims 与实际持久化的租户和 agent 一致。
-	sessionIngressToken, err := s.issueSessionIngressToken(credentialContext)
+	needsCleanup = false
+	return result, nil
+}
+
+// RecoverManagedAgentCodeSession rotates both sandbox credentials while
+// preserving the Code Session identity and its durable inbound queue.
+func (s *Service) RecoverManagedAgentCodeSession(
+	ctx context.Context,
+	input ManagedAgentRecoverInput,
+) (ManagedAgentCreateResult, error) {
+	oauthAccessToken, err := newOAuthCompatibleToken()
 	if err != nil {
 		return ManagedAgentCreateResult{}, err
 	}
-	needsCleanup = false
+	workerEpoch, err := s.db.RotateManagedAgentCodeSessionCredentials(
+		ctx,
+		input.Session,
+		input.CodeSessionID,
+		auth.HashAPIKey(oauthAccessToken),
+	)
+	if err != nil {
+		return ManagedAgentCreateResult{}, err
+	}
+	return s.managedAgentCreateResult(
+		ctx,
+		input.Session,
+		input.CodeSessionID,
+		oauthAccessToken,
+		workerEpoch,
+	)
+}
+
+func (s *Service) managedAgentCreateResult(
+	ctx context.Context,
+	session db.Session,
+	codeSessionID string,
+	oauthAccessToken string,
+	workerEpoch int64,
+) (ManagedAgentCreateResult, error) {
+	credentialContext, err := s.db.GetCodeSessionCredentialContextForIssue(
+		ctx,
+		session.OrganizationUUID,
+		session.WorkspaceUUID,
+		codeSessionID,
+	)
+	if err != nil {
+		return ManagedAgentCreateResult{}, err
+	}
+	// 重新从数据库读取签发上下文，保证 JWT claims 与实际持久化的租户、agent
+	// 和已预留 worker epoch 一致。
+	sessionIngressToken, err := s.issueSessionIngressToken(credentialContext, workerEpoch)
+	if err != nil {
+		return ManagedAgentCreateResult{}, err
+	}
 	return ManagedAgentCreateResult{
-		CodeSessionID:       record.ExternalID,
-		PublicSessionID:     record.SessionExternalID,
-		SDKURLPath:          "/v1/code/sessions/" + record.ExternalID,
+		CodeSessionID:       credentialContext.CodeSessionExternalID,
+		PublicSessionID:     credentialContext.PublicSessionExternalID,
+		SDKURLPath:          "/v1/code/sessions/" + credentialContext.CodeSessionExternalID,
+		WorkerEpoch:         workerEpoch,
 		OAuthAccessToken:    oauthAccessToken,
 		SessionIngressToken: sessionIngressToken,
 	}, nil

--- a/internal/codesessions/runtime_auth.go
+++ b/internal/codesessions/runtime_auth.go
@@ -14,7 +14,7 @@ func (h *Handler) authenticateRuntimeSession(w http.ResponseWriter, r *http.Requ
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusUnauthorized, "authentication_error", "Missing code session token"))
 		return SessionCredentialClaims{}, "", false
 	}
-	claims, err := h.service.AuthenticateSessionIngress(token, "")
+	claims, err := h.service.AuthenticateSessionIngress(r.Context(), token, "")
 	if err != nil {
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusUnauthorized, "authentication_error", "Invalid code session token"))
 		return SessionCredentialClaims{}, "", false
@@ -50,7 +50,7 @@ func (h *Handler) sessionIngressClaims(r *http.Request, codeSessionID string) (S
 	if token == "" {
 		return SessionCredentialClaims{}, sessionIngressTokenRequired()
 	}
-	claims, err := h.service.AuthenticateSessionIngress(token, codeSessionID)
+	claims, err := h.service.AuthenticateSessionIngress(r.Context(), token, codeSessionID)
 	if err != nil {
 		return SessionCredentialClaims{}, sessionIngressTokenInvalid(err)
 	}

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -92,14 +92,14 @@ func (s *Service) QueuePublicSessionEvents(ctx context.Context, session db.Sessi
 	if err := s.QueueRawPublicSessionEvents(ctx, codeSession, payloads); err != nil {
 		return err
 	}
-	return s.resumeSandboxForCodeSession(ctx, codeSession.ExternalID)
+	return s.resumeSandboxForCodeSession(ctx, codeSession)
 }
 
-func (s *Service) resumeSandboxForCodeSession(ctx context.Context, codeSessionExternalID string) error {
+func (s *Service) resumeSandboxForCodeSession(ctx context.Context, codeSession db.CodeSession) error {
 	if s.sandboxTimeoutExtender == nil {
 		return nil
 	}
-	sandbox, err := s.db.GetResumableEnvironmentSandboxForCodeSession(ctx, codeSessionExternalID)
+	sandbox, err := s.db.GetResumableEnvironmentSandboxForCodeSession(ctx, codeSession.ExternalID)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			return nil
@@ -111,12 +111,23 @@ func (s *Service) resumeSandboxForCodeSession(ctx context.Context, codeSessionEx
 	}
 	providerSandboxID := *sandbox.ProviderSandboxID
 	err = s.sandboxTimeoutExtender.SetTimeout(ctx, providerSandboxID, s.sandboxTimeout)
+	if err == nil {
+		_, err = s.db.ResumeCodeSessionWorkerLeaseForSandbox(
+			ctx,
+			codeSession.OrganizationUUID,
+			codeSession.WorkspaceUUID,
+			codeSession.ExternalID,
+			providerSandboxID,
+			codeSessionWorkerLeaseTTL,
+		)
+		return err
+	}
 	if !errors.Is(err, sandboxruntime.ErrSandboxNotFound) {
 		return err
 	}
 	scheduled, scheduleErr := s.db.ScheduleEnvironmentSandboxRecoveryForCodeSession(
 		ctx,
-		codeSessionExternalID,
+		codeSession.ExternalID,
 		providerSandboxID,
 		err,
 	)
@@ -127,7 +138,7 @@ func (s *Service) resumeSandboxForCodeSession(ctx context.Context, codeSessionEx
 		s.logger.InfoContext(
 			ctx,
 			"managed agent sandbox recovery scheduled",
-			"code_session_id", codeSessionExternalID,
+			"code_session_id", codeSession.ExternalID,
 			"provider_sandbox_id", providerSandboxID,
 		)
 	}

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
 	"github.com/superduck-ai/open-managed-agents/internal/logging"
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
+	"github.com/superduck-ai/open-managed-agents/internal/runtime/sandboxruntime"
 
 	"github.com/google/uuid"
 )
@@ -22,10 +23,12 @@ import (
 // Service 封装会被 sessions、environment runner 与 code-session HTTP handler 共同复用的业务能力。
 // 它不持有 HTTP 鉴权、代理连接或日志状态，因而可以安全地注入非 HTTP 调用方。
 type Service struct {
-	db          *db.DB
-	credentials *SessionCredentials
-	logger      *slog.Logger
-	sink        PublicEventSink
+	db                     *db.DB
+	credentials            *SessionCredentials
+	logger                 *slog.Logger
+	sink                   PublicEventSink
+	sandboxTimeoutExtender SandboxTimeoutExtender
+	sandboxTimeout         time.Duration
 }
 
 func NewServiceWithCredentials(database *db.DB, credentials *SessionCredentials, logger *slog.Logger) *Service {
@@ -35,6 +38,17 @@ func NewServiceWithCredentials(database *db.DB, credentials *SessionCredentials,
 	}
 	logger = logging.LoggerOrDefault(logger)
 	return &Service{db: database, credentials: credentials, logger: logger}
+}
+
+// WithSandboxTimeoutExtender wires the provider lifecycle operation used to
+// resume a paused sandbox when new public Session events are queued.
+func (s *Service) WithSandboxTimeoutExtender(extender SandboxTimeoutExtender, timeout time.Duration) *Service {
+	if s == nil {
+		return s
+	}
+	s.sandboxTimeoutExtender = extender
+	s.sandboxTimeout = timeout
+	return s
 }
 
 func (s *Service) QueuePublicSessionEvents(ctx context.Context, session db.Session, events []db.SessionEvent) error {
@@ -72,7 +86,52 @@ func (s *Service) QueuePublicSessionEvents(ctx context.Context, session db.Sessi
 		}
 		payloads = append(payloads, payload)
 	}
-	return s.QueueRawPublicSessionEvents(ctx, codeSession, payloads)
+	if len(payloads) == 0 {
+		return nil
+	}
+	if err := s.QueueRawPublicSessionEvents(ctx, codeSession, payloads); err != nil {
+		return err
+	}
+	return s.resumeSandboxForCodeSession(ctx, codeSession.ExternalID)
+}
+
+func (s *Service) resumeSandboxForCodeSession(ctx context.Context, codeSessionExternalID string) error {
+	if s.sandboxTimeoutExtender == nil {
+		return nil
+	}
+	sandbox, err := s.db.GetResumableEnvironmentSandboxForCodeSession(ctx, codeSessionExternalID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	if sandbox.ProviderSandboxID == nil || *sandbox.ProviderSandboxID == "" {
+		return nil
+	}
+	providerSandboxID := *sandbox.ProviderSandboxID
+	err = s.sandboxTimeoutExtender.SetTimeout(ctx, providerSandboxID, s.sandboxTimeout)
+	if !errors.Is(err, sandboxruntime.ErrSandboxNotFound) {
+		return err
+	}
+	scheduled, scheduleErr := s.db.ScheduleEnvironmentSandboxRecoveryForCodeSession(
+		ctx,
+		codeSessionExternalID,
+		providerSandboxID,
+		err,
+	)
+	if scheduleErr != nil {
+		return fmt.Errorf("schedule replacement sandbox: %w", scheduleErr)
+	}
+	if scheduled {
+		s.logger.InfoContext(
+			ctx,
+			"managed agent sandbox recovery scheduled",
+			"code_session_id", codeSessionExternalID,
+			"provider_sandbox_id", providerSandboxID,
+		)
+	}
+	return nil
 }
 
 func (s *Service) QueueRawPublicSessionEvents(ctx context.Context, codeSession db.CodeSession, payloads []json.RawMessage) error {

--- a/internal/codesessions/session_credential_service.go
+++ b/internal/codesessions/session_credential_service.go
@@ -1,15 +1,19 @@
 package codesessions
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 )
 
-// AuthenticateSessionIngress 验证 JWT 的密码学身份并将 session_id 绑定到请求路径。
-// 当前不回查 session 状态或 worker lease；worker epoch/lease 由对应 handler 的状态机处理。
-func (s *Service) AuthenticateSessionIngress(rawToken, expectedCodeSessionID string) (SessionCredentialClaims, error) {
+// AuthenticateSessionIngress verifies the signed identity, binds session_id to
+// the request path, and checks a claimed worker epoch against the active Code
+// Session. Legacy credentials without worker_epoch remain signature-only and
+// are fenced during worker registration after a credential rotation.
+func (s *Service) AuthenticateSessionIngress(ctx context.Context, rawToken, expectedCodeSessionID string) (SessionCredentialClaims, error) {
 	claims, err := s.credentials.Verify(strings.TrimSpace(rawToken))
 	if err != nil {
 		return SessionCredentialClaims{}, err
@@ -17,10 +21,21 @@ func (s *Service) AuthenticateSessionIngress(rawToken, expectedCodeSessionID str
 	if strings.TrimSpace(expectedCodeSessionID) != "" && claims.SessionID != strings.TrimSpace(expectedCodeSessionID) {
 		return SessionCredentialClaims{}, errors.New("session ingress token does not match request path")
 	}
+	if s.db != nil && claims.WorkerEpoch > 0 {
+		if err := s.db.ValidateCodeSessionIngressWorkerEpoch(
+			ctx,
+			claims.OrganizationUUID,
+			claims.WorkspaceUUID,
+			claims.SessionID,
+			claims.WorkerEpoch,
+		); err != nil {
+			return SessionCredentialClaims{}, fmt.Errorf("session ingress worker epoch is no longer active: %w", err)
+		}
+	}
 	return claims, nil
 }
 
-func (s *Service) issueSessionIngressToken(credentialContext db.CodeSessionCredentialContext) (string, error) {
+func (s *Service) issueSessionIngressToken(credentialContext db.CodeSessionCredentialContext, workerEpoch int64) (string, error) {
 	return s.credentials.Issue(SessionCredentialIdentity{
 		SessionID:        credentialContext.CodeSessionExternalID,
 		PublicSessionID:  credentialContext.PublicSessionExternalID,
@@ -29,5 +44,6 @@ func (s *Service) issueSessionIngressToken(credentialContext db.CodeSessionCrede
 		OrganizationUUID: credentialContext.OrganizationUUID,
 		WorkspaceUUID:    credentialContext.WorkspaceUUID,
 		AccountEmail:     credentialContext.AccountEmail,
+		WorkerEpoch:      workerEpoch,
 	})
 }

--- a/internal/codesessions/session_credentials.go
+++ b/internal/codesessions/session_credentials.go
@@ -41,6 +41,7 @@ type SessionCredentialClaims struct {
 	Application      string `json:"application"`
 	Role             string `json:"role"`
 	AccountEmail     string `json:"account_email,omitempty"`
+	WorkerEpoch      int64  `json:"worker_epoch,omitempty"`
 }
 
 // SessionCredentialIdentity 是签发输入；调用方必须从 active code session 数据库记录构造。
@@ -52,6 +53,7 @@ type SessionCredentialIdentity struct {
 	OrganizationUUID string
 	WorkspaceUUID    string
 	AccountEmail     string
+	WorkerEpoch      int64
 }
 
 // SessionCredentials 持有同一进程使用的 Ed25519 签发与验证密钥。
@@ -126,8 +128,8 @@ func readSessionCredentialPrivateKey(path string) (ed25519.PrivateKey, error) {
 	return privateKey, nil
 }
 
-// Issue 签发带 sk-ant-si- 前缀的 Ed25519 JWT。JWT 不设置独立 expiry；当前只通过
-// 签名、固定 claims 和请求路径绑定完成鉴权，不回查 session 或 worker lease。
+// Issue 签发带 sk-ant-si- 前缀的 Ed25519 JWT。JWT 不设置独立 expiry；携带
+// worker_epoch 的 managed-agent 凭证会在 HTTP 鉴权和 worker 注册时回查当前 epoch。
 func (c *SessionCredentials) Issue(identity SessionCredentialIdentity) (string, error) {
 	if c == nil || len(c.privateKey) == 0 {
 		return "", errors.New("code-session credential signer is not configured")
@@ -157,6 +159,7 @@ func (c *SessionCredentials) Issue(identity SessionCredentialIdentity) (string, 
 		Application:      "ccr",
 		Role:             "worker",
 		AccountEmail:     strings.TrimSpace(identity.AccountEmail),
+		WorkerEpoch:      identity.WorkerEpoch,
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
 	// golang-jwt 默认设置 typ=JWT；这里额外写入可验证的公钥标识。
@@ -226,6 +229,9 @@ func validateSessionCredentialIdentity(identity SessionCredentialIdentity) error
 	if identity.AgentVersion <= 0 {
 		return errors.New("code-session credential agent version is invalid")
 	}
+	if identity.WorkerEpoch < 0 {
+		return errors.New("code-session credential epoch is invalid")
+	}
 	return nil
 }
 
@@ -237,6 +243,7 @@ func validateSessionCredentialClaims(claims SessionCredentialClaims) error {
 		AgentVersion:     claims.AgentVersion,
 		OrganizationUUID: claims.OrganizationUUID,
 		WorkspaceUUID:    claims.WorkspaceUUID,
+		WorkerEpoch:      claims.WorkerEpoch,
 	}
 	if err := validateSessionCredentialIdentity(identity); err != nil {
 		return err

--- a/internal/codesessions/session_credentials_test.go
+++ b/internal/codesessions/session_credentials_test.go
@@ -1,6 +1,7 @@
 package codesessions
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/x509"
@@ -124,14 +125,14 @@ func TestAuthenticateSessionIngressUsesSignedIdentityWithoutDatabaseLifecycle(t 
 		t.Fatalf("Issue() error = %v", err)
 	}
 	service := NewServiceWithCredentials(nil, credentials, nil)
-	claims, err := service.AuthenticateSessionIngress(token, "cse_test")
+	claims, err := service.AuthenticateSessionIngress(context.Background(), token, "cse_test")
 	if err != nil {
 		t.Fatalf("AuthenticateSessionIngress() error = %v", err)
 	}
 	if claims.SessionID != "cse_test" {
 		t.Fatalf("session_id = %q, want cse_test", claims.SessionID)
 	}
-	if _, err := service.AuthenticateSessionIngress(token, "cse_other"); err == nil {
+	if _, err := service.AuthenticateSessionIngress(context.Background(), token, "cse_other"); err == nil {
 		t.Fatal("AuthenticateSessionIngress() accepted token for another request path")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -507,6 +507,17 @@ func TestLoadStorageS3ForcePathStyleDefault(t *testing.T) {
 	}
 }
 
+func TestLoadE2BSandboxTimeoutDefault(t *testing.T) {
+	prepareLoadTest(t)
+	cfg, err := loadConfigTestYAML(t, "")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.E2B.SandboxTimeout != 30*time.Second {
+		t.Fatalf("E2B.SandboxTimeout = %s, want 30s", cfg.E2B.SandboxTimeout)
+	}
+}
+
 func TestLoadDatabaseAutoMigrateDefaultDevelopment(t *testing.T) {
 	prepareLoadTest(t)
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -30,7 +30,7 @@ func defaultConfig() Config {
 		E2B: E2BConfig{
 			Template:       DefaultE2BTemplate,
 			RequestTimeout: 60 * time.Second,
-			SandboxTimeout: 5 * time.Minute,
+			SandboxTimeout: 30 * time.Second,
 		},
 		EnvironmentRunner: EnvironmentRunnerConfig{
 			Enabled:                 true,

--- a/internal/db/code_session_mapper.go
+++ b/internal/db/code_session_mapper.go
@@ -138,6 +138,15 @@ type codeSessionWorkerExpiryRow struct {
 	WorkerLeaseExpiresAt time.Time `db:"worker_lease_expires_at"`
 }
 
+type resumeCodeSessionWorkerLeaseParams struct {
+	OrganizationUUID      string
+	WorkspaceUUID         string
+	CodeSessionExternalID string
+	ProviderSandboxID     string
+	ExpiresAt             time.Time
+	Now                   time.Time
+}
+
 // CodeSessionMapper contains queries whose primary table is code_sessions.
 type CodeSessionMapper interface {
 	Insert(ctx context.Context, params createCodeSessionParams) (codeSessionRow, error)
@@ -155,6 +164,7 @@ type CodeSessionMapper interface {
 	RegisterWorker(ctx context.Context, params registerCodeSessionWorkerParams) (int64, error)
 	HeartbeatWorkerByExternalID(ctx context.Context, params heartbeatCodeSessionWorkerParams) (codeSessionWorkerExpiryRow, error)
 	HeartbeatWorkerByUUID(ctx context.Context, params heartbeatCodeSessionWorkerParams) (codeSessionWorkerExpiryRow, error)
+	ResumeWorkerLeaseForSandbox(ctx context.Context, params resumeCodeSessionWorkerLeaseParams) (int64, error)
 	UpdateWorkerState(ctx context.Context, params updateCodeSessionWorkerStateParams) (codeSessionRow, error)
 	UpdateCodeSessionInboundSequence(ctx context.Context, codeSessionUUID string, sequenceNum int64, now time.Time) (int64, error)
 	UpdateCodeSessionInternalSequence(ctx context.Context, codeSessionUUID string, sequenceNum int64, now time.Time) error

--- a/internal/db/code_session_mapper.go
+++ b/internal/db/code_session_mapper.go
@@ -57,6 +57,7 @@ type createCodeSessionParams struct {
 	Status                string
 	Metadata              []byte
 	OAuthAccessTokenHash  *string
+	InitialWorkerEpoch    int64
 	CreatedAt             time.Time
 }
 
@@ -91,6 +92,14 @@ type updateCodeSessionConnectionParams struct {
 	Connected     bool
 	RequiredEpoch *int64
 	Now           time.Time
+}
+
+type rotateCodeSessionCredentialsParams struct {
+	OrganizationUUID      string
+	WorkspaceUUID         string
+	SessionExternalID     string
+	CodeSessionExternalID string
+	OAuthAccessTokenHash  string
 }
 
 type codeSessionCredentialContextRow struct {
@@ -137,6 +146,7 @@ type CodeSessionMapper interface {
 	FindNetworkPolicyContext(ctx context.Context, organizationUUID, workspaceUUID, codeSessionExternalID string) (codeSessionNetworkPolicyContextRow, error)
 	FindVaultIDs(ctx context.Context, organizationUUID, workspaceUUID, codeSessionExternalID string) (codeSessionVaultIDsRow, bool, error)
 	FindByExternalID(ctx context.Context, codeSessionExternalID string) (codeSessionRow, bool, error)
+	FindActiveForEnvironmentWork(ctx context.Context, organizationUUID, workspaceUUID, environmentUUID, sessionUUID string) ([]codeSessionRow, error)
 	FindLatestBySessionExternalID(ctx context.Context, workspaceUUID, sessionExternalID string) (codeSessionRow, error)
 	LockCodeSessionByExternalID(ctx context.Context, codeSessionExternalID string) (codeSessionRow, bool, error)
 	LockInitializingCodeSession(ctx context.Context, workspaceUUID, codeSessionUUID string) (codeSessionRow, bool, error)
@@ -153,6 +163,8 @@ type CodeSessionMapper interface {
 	TouchWorkerActivityForActiveLease(ctx context.Context, codeSessionExternalID string, epoch int64, now time.Time) (int64, error)
 	TouchWorkerActivity(ctx context.Context, codeSessionExternalID string, requiredEpoch *int64, now time.Time) (int64, error)
 	UpdateConnection(ctx context.Context, params updateCodeSessionConnectionParams) (int64, error)
+	CountActiveIngressWorkerEpoch(ctx context.Context, organizationUUID, workspaceUUID, codeSessionExternalID string, workerEpoch int64) (int64, error)
+	RotateCredentials(ctx context.Context, params rotateCodeSessionCredentialsParams) (int64, error)
 	TerminateByExternalID(ctx context.Context, organizationUUID, workspaceUUID, codeSessionExternalID string) (int64, error)
 }
 

--- a/internal/db/code_session_mapper.xml
+++ b/internal/db/code_session_mapper.xml
@@ -281,6 +281,39 @@
         RETURNING worker_lease_expires_at
     </update>
 
+    <update id="ResumeWorkerLeaseForSandbox" result="rows">
+        UPDATE code_sessions code_session
+        SET worker_lease_expires_at = #{params.ExpiresAt},
+            updated_at = #{params.Now}
+        WHERE code_session.organization_uuid = #{params.OrganizationUUID}
+          AND code_session.workspace_uuid = #{params.WorkspaceUUID}
+          AND code_session.external_id = #{params.CodeSessionExternalID}
+          AND code_session.status = 'active'
+          AND code_session.current_worker_epoch &gt; 0
+          AND code_session.worker_lease_expires_at IS NOT NULL
+          AND code_session.worker_status IN ('idle', 'running', 'requires_action')
+          AND code_session.deleted_at IS NULL
+          AND EXISTS (
+              SELECT 1
+              FROM environment_work work
+              JOIN environment_sandboxes sandbox
+                ON sandbox.organization_uuid = work.organization_uuid
+               AND sandbox.workspace_uuid = work.workspace_uuid
+               AND sandbox.environment_uuid = work.environment_uuid
+               AND sandbox.work_uuid = work.uuid
+               AND sandbox.provider_sandbox_id = #{params.ProviderSandboxID}
+               AND sandbox.state = 'running'
+              WHERE work.organization_uuid = code_session.organization_uuid
+                AND work.workspace_uuid = code_session.workspace_uuid
+                AND work.environment_uuid = code_session.environment_uuid
+                AND work.environment_external_id = code_session.environment_external_id
+                AND work.data-&gt;&gt;'type' = 'session'
+                AND work.data-&gt;&gt;'id' = code_session.session_external_id
+                AND work.state = 'active'
+                AND work.deleted_at IS NULL
+          )
+    </update>
+
     <update id="UpdateWorkerState" result="returning" resultType="codeSessionRow">
         UPDATE code_sessions
         SET worker_status = #{params.WorkerStatus},

--- a/internal/db/code_session_mapper.xml
+++ b/internal/db/code_session_mapper.xml
@@ -81,6 +81,7 @@
             status,
             metadata,
             oauth_access_token_hash,
+            current_worker_epoch,
             created_at,
             updated_at
         ) VALUES (
@@ -97,6 +98,7 @@
             #{params.Status},
             CAST(#{params.Metadata,sensitive=true} AS jsonb),
             #{params.OAuthAccessTokenHash,sensitive=true},
+            #{params.InitialWorkerEpoch},
             #{params.CreatedAt},
             #{params.CreatedAt}
         )
@@ -177,6 +179,20 @@
         FROM code_sessions
         WHERE external_id = #{codeSessionExternalID}
           AND deleted_at IS NULL
+    </select>
+
+    <select id="FindActiveForEnvironmentWork" resultType="codeSessionRow">
+        SELECT
+        <include refid="columns"/>
+        FROM code_sessions
+        WHERE organization_uuid = #{organizationUUID}
+          AND workspace_uuid = #{workspaceUUID}
+          AND environment_uuid = #{environmentUUID}
+          AND session_uuid = #{sessionUUID}
+          AND status = 'active'
+          AND deleted_at IS NULL
+        ORDER BY created_at DESC, uuid DESC
+        LIMIT 2
     </select>
 
     <select id="FindLatestBySessionExternalID" resultType="codeSessionRow">
@@ -344,6 +360,33 @@
               AND current_worker_epoch = #{params.RequiredEpoch}
           </if>
           AND deleted_at IS NULL
+    </update>
+
+    <select id="CountActiveIngressWorkerEpoch" result="scalar" resultType="int64">
+        SELECT COUNT(*)
+        FROM code_sessions
+        WHERE organization_uuid = #{organizationUUID}
+          AND workspace_uuid = #{workspaceUUID}
+          AND external_id = #{codeSessionExternalID}
+          AND current_worker_epoch = #{workerEpoch}
+          AND status = 'active'
+          AND deleted_at IS NULL
+    </select>
+
+    <update id="RotateCredentials" result="returning" resultType="int64">
+        UPDATE code_sessions
+        SET oauth_access_token_hash = #{params.OAuthAccessTokenHash,sensitive=true},
+            current_worker_epoch = current_worker_epoch + 1,
+            worker_lease_expires_at = NULL,
+            connection_status = 'disconnected',
+            updated_at = NOW()
+        WHERE organization_uuid = #{params.OrganizationUUID}
+          AND workspace_uuid = #{params.WorkspaceUUID}
+          AND session_external_id = #{params.SessionExternalID}
+          AND external_id = #{params.CodeSessionExternalID}
+          AND status = 'active'
+          AND deleted_at IS NULL
+        RETURNING current_worker_epoch
     </update>
 
     <update id="TerminateByExternalID" result="rows">

--- a/internal/db/code_session_mapper_test.go
+++ b/internal/db/code_session_mapper_test.go
@@ -54,7 +54,7 @@ func TestCodeSessionMapperBuilderContracts(t *testing.T) {
 		SessionUUID: "session-uuid", SessionExternalID: "session_test", EnvironmentUUID: "environment-uuid",
 		EnvironmentExternalID: "env_test", WorkDir: "/workspace", PermissionMode: "default",
 		Model: "model", Status: "active", Metadata: []byte(`{"source":"test"}`),
-		OAuthAccessTokenHash: &tokenHash, CreatedAt: now,
+		OAuthAccessTokenHash: &tokenHash, InitialWorkerEpoch: 1, CreatedAt: now,
 	}
 	tests := []struct {
 		name     string
@@ -68,7 +68,8 @@ func TestCodeSessionMapperBuilderContracts(t *testing.T) {
 				"params.ExternalID", "params.OrganizationUUID", "params.WorkspaceUUID", "params.SessionUUID",
 				"params.SessionExternalID", "params.EnvironmentUUID", "params.EnvironmentExternalID", "params.WorkDir",
 				"params.PermissionMode", "params.Model", "params.Status", "params.Metadata",
-				"params.OAuthAccessTokenHash", "params.CreatedAt", "params.CreatedAt",
+				"params.OAuthAccessTokenHash", "params.InitialWorkerEpoch",
+				"params.CreatedAt", "params.CreatedAt",
 			},
 			wantSensitiveArgumentNames: []string{"params.Metadata", "params.OAuthAccessTokenHash"},
 			wantSQLFragments:           []string{"INSERT INTO code_sessions", "CAST($12 AS jsonb)", "RETURNING uuid"},
@@ -82,6 +83,28 @@ func TestCodeSessionMapperBuilderContracts(t *testing.T) {
 			wantArgumentNames:          []string{"tokenHash"},
 			wantSensitiveArgumentNames: []string{"tokenHash"},
 			wantSQLFragments:           []string{"JOIN sessions", "oauth_access_token_hash = $1", "worker_lease_expires_at > NOW()"},
+		}},
+		{"find active for environment work", mapperBuilderContract{
+			statement: codeSessionMapperFindActiveForEnvironmentWorkStatement,
+			bound: buildCodeSessionMapperFindActiveForEnvironmentWork(
+				yourbatis.DialectPostgres, "org-uuid", "workspace-uuid", "environment-uuid", "session-uuid",
+			),
+			wantID: "CodeSessionMapper.FindActiveForEnvironmentWork", wantKind: yourbatis.StatementSelect,
+			wantArgumentNames: []string{"organizationUUID", "workspaceUUID", "environmentUUID", "sessionUUID"},
+			wantSQLFragments:  []string{"FROM code_sessions", "environment_uuid = $3", "session_uuid = $4", "LIMIT 2"},
+		}},
+		{"active ingress worker epoch", mapperBuilderContract{
+			statement: codeSessionMapperCountActiveIngressWorkerEpochStatement,
+			bound: buildCodeSessionMapperCountActiveIngressWorkerEpoch(
+				yourbatis.DialectPostgres, "org-uuid", "workspace-uuid", "codeses_test", 1,
+			),
+			wantID: "CodeSessionMapper.CountActiveIngressWorkerEpoch", wantKind: yourbatis.StatementSelect,
+			wantArgumentNames: []string{
+				"organizationUUID", "workspaceUUID", "codeSessionExternalID", "workerEpoch",
+			},
+			wantSQLFragments: []string{
+				"SELECT COUNT(*)", "current_worker_epoch = $4", "status = 'active'",
+			},
 		}},
 		{"network policy context", mapperBuilderContract{
 			statement: codeSessionMapperFindNetworkPolicyContextStatement,

--- a/internal/db/code_session_mapper_test.go
+++ b/internal/db/code_session_mapper_test.go
@@ -129,6 +129,22 @@ func TestCodeSessionMapperBuilderContracts(t *testing.T) {
 			wantSensitiveArgumentNames: []string{"params.WorkerTokenSessionID", "params.WorkerBinding"},
 			wantSQLFragments:           []string{"UPDATE code_sessions", "CAST($5 AS jsonb)", "RETURNING current_worker_epoch"},
 		}},
+		{"resume worker lease for sandbox", mapperBuilderContract{
+			statement: codeSessionMapperResumeWorkerLeaseForSandboxStatement,
+			bound: buildCodeSessionMapperResumeWorkerLeaseForSandbox(yourbatis.DialectPostgres, resumeCodeSessionWorkerLeaseParams{
+				OrganizationUUID: "org-uuid", WorkspaceUUID: "workspace-uuid", CodeSessionExternalID: "codeses_test",
+				ProviderSandboxID: "sandbox_test", ExpiresAt: expiresAt, Now: now,
+			}),
+			wantID: "CodeSessionMapper.ResumeWorkerLeaseForSandbox", wantKind: yourbatis.StatementUpdate,
+			wantArgumentNames: []string{
+				"params.ExpiresAt", "params.Now", "params.OrganizationUUID", "params.WorkspaceUUID",
+				"params.CodeSessionExternalID", "params.ProviderSandboxID",
+			},
+			wantSQLFragments: []string{
+				"UPDATE code_sessions", "current_worker_epoch > 0", "worker_lease_expires_at IS NOT NULL",
+				"JOIN environment_sandboxes", "provider_sandbox_id = $6", "work.state = 'active'",
+			},
+		}},
 		{"update worker state", mapperBuilderContract{
 			statement: codeSessionMapperUpdateWorkerStateStatement,
 			bound: buildCodeSessionMapperUpdateWorkerState(yourbatis.DialectPostgres, updateCodeSessionWorkerStateParams{

--- a/internal/db/code_sessions.go
+++ b/internal/db/code_sessions.go
@@ -62,6 +62,7 @@ type CreateCodeSessionInput struct {
 	Status                string
 	Metadata              json.RawMessage
 	OAuthAccessTokenHash  string
+	InitialWorkerEpoch    int64
 	CreatedAt             time.Time
 }
 
@@ -260,6 +261,7 @@ func (d *DB) CreateCodeSession(ctx context.Context, input CreateCodeSessionInput
 		Status:                status,
 		Metadata:              input.Metadata,
 		OAuthAccessTokenHash:  oauthAccessTokenHash,
+		InitialWorkerEpoch:    input.InitialWorkerEpoch,
 		CreatedAt:             now,
 	})
 	if err != nil {
@@ -469,6 +471,30 @@ func (d *DB) GetCodeSessionCredentialContextForIssue(ctx context.Context, organi
 	return row.context(), nil
 }
 
+func (d *DB) ValidateCodeSessionIngressWorkerEpoch(
+	ctx context.Context,
+	organizationUUID string,
+	workspaceUUID string,
+	codeSessionExternalID string,
+	workerEpoch int64,
+) error {
+	mapper := NewCodeSessionMapper(d.mapperDB)
+	count, err := mapper.CountActiveIngressWorkerEpoch(
+		ctx,
+		organizationUUID,
+		workspaceUUID,
+		codeSessionExternalID,
+		workerEpoch,
+	)
+	if err != nil {
+		return err
+	}
+	if count != 1 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // GetCodeSessionNetworkPolicyContext 从已验签的租户身份出发，一次性加载并校验
 // Code Session、Environment 与 Session 的策略关系。项目不使用数据库外键，因此
 // 每个 join 都显式约束 organization/workspace 与稳定 UUID；任一关系缺失都 fail closed。
@@ -561,7 +587,57 @@ func (d *DB) GetCodeSessionBySessionExternalID(ctx context.Context, workspaceUUI
 	return row.session(), nil
 }
 
+func (d *DB) GetActiveCodeSessionForEnvironmentWork(ctx context.Context, work EnvironmentWork, sessionUUID string) (CodeSession, error) {
+	mapper := NewCodeSessionMapper(d.mapperDB)
+	rows, err := mapper.FindActiveForEnvironmentWork(
+		ctx,
+		work.OrganizationUUID,
+		work.WorkspaceUUID,
+		work.EnvironmentUUID,
+		sessionUUID,
+	)
+	if err != nil {
+		return CodeSession{}, err
+	}
+	if len(rows) == 0 {
+		return CodeSession{}, ErrNotFound
+	}
+	if len(rows) != 1 {
+		return CodeSession{}, ErrInvalidState
+	}
+	return rows[0].session(), nil
+}
+
 func (d *DB) RegisterCodeSessionWorker(ctx context.Context, codeSessionExternalID string, binding CodeSessionWorkerBinding, leaseTTL time.Duration) (int64, time.Time, error) {
+	return d.registerCodeSessionWorker(ctx, codeSessionExternalID, binding, leaseTTL, nil)
+}
+
+func (d *DB) RegisterCodeSessionWorkerAtEpoch(
+	ctx context.Context,
+	codeSessionExternalID string,
+	workerEpoch int64,
+	binding CodeSessionWorkerBinding,
+	leaseTTL time.Duration,
+) (int64, time.Time, error) {
+	if workerEpoch <= 0 {
+		return 0, time.Time{}, ErrWorkerEpochMismatch
+	}
+	return d.registerCodeSessionWorker(
+		ctx,
+		codeSessionExternalID,
+		binding,
+		leaseTTL,
+		&workerEpoch,
+	)
+}
+
+func (d *DB) registerCodeSessionWorker(
+	ctx context.Context,
+	codeSessionExternalID string,
+	binding CodeSessionWorkerBinding,
+	leaseTTL time.Duration,
+	expectedEpoch *int64,
+) (int64, time.Time, error) {
 	if leaseTTL <= 0 {
 		leaseTTL = time.Minute
 	}
@@ -581,9 +657,21 @@ func (d *DB) RegisterCodeSessionWorker(ctx context.Context, codeSessionExternalI
 		if !found {
 			return ErrNotFound
 		}
+		// Credential rotation reserves a positive epoch and clears the lease. A
+		// legacy JWT without worker_epoch must not advance past that fence.
+		if expectedEpoch == nil && row.CurrentWorkerEpoch > 0 && row.WorkerLeaseExpiresAt == nil {
+			return ErrWorkerEpochMismatch
+		}
+		nextEpoch := row.CurrentWorkerEpoch + 1
+		if expectedEpoch != nil {
+			if row.CurrentWorkerEpoch != *expectedEpoch {
+				return ErrWorkerEpochMismatch
+			}
+			nextEpoch = *expectedEpoch
+		}
 		epoch, err = mapper.RegisterWorker(ctx, registerCodeSessionWorkerParams{
 			UUID:                 row.UUID,
-			Epoch:                row.CurrentWorkerEpoch + 1,
+			Epoch:                nextEpoch,
 			ExpiresAt:            expiresAt,
 			Now:                  now,
 			WorkerTokenSessionID: optionalCodeSessionString(binding.TokenSessionID),

--- a/internal/db/code_sessions.go
+++ b/internal/db/code_sessions.go
@@ -805,6 +805,37 @@ func (d *DB) RecordCodeSessionWorkerHeartbeat(ctx context.Context, codeSessionEx
 	return expiresAt, err
 }
 
+// ResumeCodeSessionWorkerLeaseForSandbox re-arms the existing worker lease
+// after the provider has successfully resumed the same sandbox. It preserves
+// the current epoch and only updates a registered worker still associated with
+// the exact active sandbox, so a retired sandbox cannot revive a fenced worker.
+func (d *DB) ResumeCodeSessionWorkerLeaseForSandbox(
+	ctx context.Context,
+	organizationUUID string,
+	workspaceUUID string,
+	codeSessionExternalID string,
+	providerSandboxID string,
+	leaseTTL time.Duration,
+) (bool, error) {
+	if leaseTTL <= 0 {
+		leaseTTL = time.Minute
+	}
+	now := time.Now().UTC()
+	mapper := NewCodeSessionMapper(d.mapperDB)
+	rowsAffected, err := mapper.ResumeWorkerLeaseForSandbox(ctx, resumeCodeSessionWorkerLeaseParams{
+		OrganizationUUID:      organizationUUID,
+		WorkspaceUUID:         workspaceUUID,
+		CodeSessionExternalID: codeSessionExternalID,
+		ProviderSandboxID:     providerSandboxID,
+		ExpiresAt:             now.Add(leaseTTL),
+		Now:                   now,
+	})
+	if err != nil {
+		return false, err
+	}
+	return rowsAffected == 1, nil
+}
+
 func (d *DB) UpdateCodeSessionWorkerState(ctx context.Context, codeSessionExternalID string, input UpdateCodeSessionWorkerStateInput) (CodeSession, error) {
 	if input.WorkerEpoch <= 0 {
 		return CodeSession{}, ErrWorkerEpochMismatch

--- a/internal/db/environment_mapper_test.go
+++ b/internal/db/environment_mapper_test.go
@@ -141,6 +141,10 @@ func TestEnvironmentWorkMapperBuilderContracts(t *testing.T) {
 		WorkspaceUUID: params.WorkspaceUUID, EnvironmentExternalID: params.EnvironmentExternalID,
 		WorkUUID: params.UUID, State: "active", TTLSeconds: 60,
 	}
+	recoveryParams := environmentWorkRecoveryRetryParams{
+		OrganizationUUID: params.OrganizationUUID, WorkspaceUUID: params.WorkspaceUUID,
+		EnvironmentUUID: params.EnvironmentUUID, WorkUUID: params.UUID, RetryAt: now,
+	}
 	stopParams := environmentWorkStopParams{
 		WorkspaceUUID: params.WorkspaceUUID, EnvironmentExternalID: params.EnvironmentExternalID,
 		WorkExternalID: params.ExternalID, State: "stopped",
@@ -227,6 +231,19 @@ func TestEnvironmentWorkMapperBuilderContracts(t *testing.T) {
 			},
 			wantSensitiveArgumentNames: []string{"params.Metadata"}, wantSQLFragments: []string{"CAST($1 AS jsonb)", "RETURNING"},
 		}},
+		{"requeue recoverable work", mapperBuilderContract{
+			statement: environmentWorkMapperRequeueIfRecoverableStatement,
+			bound:     buildEnvironmentWorkMapperRequeueIfRecoverable(yourbatis.DialectPostgres, recoveryParams),
+			wantID:    "EnvironmentWorkMapper.RequeueIfRecoverable", wantKind: yourbatis.StatementUpdate,
+			wantArgumentNames: []string{
+				"params.RetryAt", "params.OrganizationUUID", "params.WorkspaceUUID",
+				"params.EnvironmentUUID", "params.WorkUUID",
+			},
+			wantSQLFragments: []string{
+				"state = 'queued'", "claim_expires_at = $1", "state IN ('starting', 'active')",
+				"EXISTS", "code_session.session_external_id = environment_work.data->>'id'",
+			},
+		}},
 		{"heartbeat", mapperBuilderContract{
 			statement: environmentWorkMapperHeartbeatStatement,
 			bound:     buildEnvironmentWorkMapperHeartbeat(yourbatis.DialectPostgres, heartbeatParams),
@@ -271,6 +288,11 @@ func TestEnvironmentSandboxMapperBuilderContracts(t *testing.T) {
 		WorkspaceUUID: params.WorkspaceUUID, ExternalID: params.ExternalID, State: "running",
 		ProviderSandboxID: params.ProviderSandboxID, LastError: params.LastError, StoppedAt: &now,
 	}
+	recoveryParams := environmentSandboxRecoveryParams{
+		CodeSessionExternalID: "codesession_test",
+		ProviderSandboxID:     "sandbox_test",
+		LastError:             "sandbox not found",
+	}
 	tests := []struct {
 		name     string
 		contract mapperBuilderContract
@@ -304,12 +326,35 @@ func TestEnvironmentSandboxMapperBuilderContracts(t *testing.T) {
 			wantArgumentNames: []string{"workspaceUUID", "environmentExternalID", "workExternalID"},
 			wantSQLFragments:  []string{"FROM environment_sandboxes", "provider_sandbox_id IS NOT NULL", "LIMIT 1"},
 		}},
-		{"find renewable", mapperBuilderContract{
-			statement: environmentSandboxMapperFindRenewableByCodeSessionExternalIDStatement,
-			bound:     buildEnvironmentSandboxMapperFindRenewableByCodeSessionExternalID(yourbatis.DialectPostgres, "codesession_test"),
-			wantID:    "EnvironmentSandboxMapper.FindRenewableByCodeSessionExternalID", wantKind: yourbatis.StatementSelect,
-			wantArgumentNames: []string{"codeSessionExternalID"},
-			wantSQLFragments:  []string{"JOIN environment_work", "JOIN environment_sandboxes", "worker_status = 'running'"},
+		{"find active for code session worker statuses", mapperBuilderContract{
+			statement: environmentSandboxMapperFindActiveByCodeSessionExternalIDAndWorkerStatusesStatement,
+			bound: buildEnvironmentSandboxMapperFindActiveByCodeSessionExternalIDAndWorkerStatuses(
+				yourbatis.DialectPostgres,
+				"codesession_test",
+				[]string{"idle", "running", "requires_action"},
+			),
+			wantID: "EnvironmentSandboxMapper.FindActiveByCodeSessionExternalIDAndWorkerStatuses", wantKind: yourbatis.StatementSelect,
+			wantArgumentNames: []string{"codeSessionExternalID", "workerStatus", "workerStatus", "workerStatus"},
+			wantSQLFragments: []string{
+				"JOIN environment_work", "JOIN environment_sandboxes", "worker_status IN ( $2 , $3 , $4 )",
+			},
+		}},
+		{"schedule recovery for code session", mapperBuilderContract{
+			statement: environmentSandboxMapperScheduleRecoveryForCodeSessionStatement,
+			bound: buildEnvironmentSandboxMapperScheduleRecoveryForCodeSession(
+				yourbatis.DialectPostgres,
+				recoveryParams,
+			),
+			wantID:   "EnvironmentSandboxMapper.ScheduleRecoveryForCodeSession",
+			wantKind: yourbatis.StatementUpdate,
+			wantArgumentNames: []string{
+				"params.ProviderSandboxID", "params.CodeSessionExternalID", "params.LastError",
+			},
+			wantSensitiveArgumentNames: []string{"params.LastError"},
+			wantSQLFragments: []string{
+				"WITH recovery_target AS", "FOR UPDATE OF code_session, work, sandbox",
+				"state = 'failed'", "state = 'queued'",
+			},
 		}},
 	}
 	for _, test := range tests {

--- a/internal/db/environment_sandbox_mapper.go
+++ b/internal/db/environment_sandbox_mapper.go
@@ -54,9 +54,16 @@ type environmentSandboxStateParams struct {
 	StoppedAt         *time.Time
 }
 
+type environmentSandboxRecoveryParams struct {
+	CodeSessionExternalID string
+	ProviderSandboxID     string
+	LastError             string
+}
+
 type EnvironmentSandboxMapper interface {
 	Insert(ctx context.Context, params environmentSandboxWriteParams) (environmentSandboxMapperRow, error)
 	UpdateState(ctx context.Context, params environmentSandboxStateParams) error
 	FindActiveForWork(ctx context.Context, workspaceUUID, environmentExternalID, workExternalID string) (environmentSandboxMapperRow, error)
-	FindRenewableByCodeSessionExternalID(ctx context.Context, codeSessionExternalID string) (environmentSandboxMapperRow, error)
+	FindActiveByCodeSessionExternalIDAndWorkerStatuses(ctx context.Context, codeSessionExternalID string, workerStatuses []string) (environmentSandboxMapperRow, error)
+	ScheduleRecoveryForCodeSession(ctx context.Context, params environmentSandboxRecoveryParams) (int64, error)
 }

--- a/internal/db/environment_sandbox_mapper.xml
+++ b/internal/db/environment_sandbox_mapper.xml
@@ -84,7 +84,7 @@
         LIMIT 1
     </select>
 
-    <select id="FindRenewableByCodeSessionExternalID" resultType="environmentSandboxMapperRow">
+    <select id="FindActiveByCodeSessionExternalIDAndWorkerStatuses" resultType="environmentSandboxMapperRow">
         SELECT
         <include refid="columns"/>
         FROM environment_sandboxes
@@ -108,10 +108,60 @@
             AND sandbox.state = 'running'
             WHERE code_session.external_id = #{codeSessionExternalID}
             AND code_session.status = 'active'
-            AND code_session.worker_status = 'running'
+            AND code_session.worker_status IN
+            <foreach collection="workerStatuses" item="workerStatus" open="(" separator="," close=")">
+                #{workerStatus}
+            </foreach>
             AND code_session.deleted_at IS NULL
             ORDER BY sandbox.created_at DESC, sandbox.uuid DESC
             LIMIT 1
         )
     </select>
+
+    <update id="ScheduleRecoveryForCodeSession" result="rows">
+        WITH recovery_target AS (
+            SELECT sandbox.uuid AS sandbox_uuid, work.uuid AS work_uuid
+            FROM code_sessions code_session
+            JOIN environment_work work
+            ON work.organization_uuid = code_session.organization_uuid
+            AND work.workspace_uuid = code_session.workspace_uuid
+            AND work.environment_uuid = code_session.environment_uuid
+            AND work.environment_external_id = code_session.environment_external_id
+            AND work.data-&gt;&gt;'type' = 'session'
+            AND work.data-&gt;&gt;'id' = code_session.session_external_id
+            AND work.state = 'active'
+            AND work.deleted_at IS NULL
+            JOIN environment_sandboxes sandbox
+            ON sandbox.organization_uuid = code_session.organization_uuid
+            AND sandbox.workspace_uuid = code_session.workspace_uuid
+            AND sandbox.environment_uuid = code_session.environment_uuid
+            AND sandbox.work_uuid = work.uuid
+            AND sandbox.provider_sandbox_id = #{params.ProviderSandboxID}
+            AND sandbox.state = 'running'
+            WHERE code_session.external_id = #{params.CodeSessionExternalID}
+            AND code_session.status = 'active'
+            AND code_session.worker_status IN ('idle', 'running', 'requires_action')
+            AND code_session.deleted_at IS NULL
+            FOR UPDATE OF code_session, work, sandbox
+        ), failed_sandbox AS (
+            UPDATE environment_sandboxes sandbox
+            SET state = 'failed',
+                last_error = #{params.LastError,sensitive=true},
+                stopped_at = COALESCE(stopped_at, NOW()),
+                updated_at = NOW()
+            FROM recovery_target target
+            WHERE sandbox.uuid = target.sandbox_uuid
+            RETURNING sandbox.uuid
+        )
+        UPDATE environment_work work
+        SET state = 'queued',
+            claimed_by_worker_id = NULL,
+            claim_expires_at = NULL,
+            latest_heartbeat_at = NULL,
+            heartbeat_ttl_seconds = NULL,
+            updated_at = NOW()
+        FROM recovery_target target
+        WHERE work.uuid = target.work_uuid
+        AND EXISTS (SELECT 1 FROM failed_sandbox)
+    </update>
 </mapper>

--- a/internal/db/environment_work_mapper.go
+++ b/internal/db/environment_work_mapper.go
@@ -76,6 +76,14 @@ type environmentWorkHeartbeatParams struct {
 	TTLSeconds            int
 }
 
+type environmentWorkRecoveryRetryParams struct {
+	OrganizationUUID string
+	WorkspaceUUID    string
+	EnvironmentUUID  string
+	WorkUUID         string
+	RetryAt          time.Time
+}
+
 type environmentWorkStopParams struct {
 	WorkspaceUUID         string
 	EnvironmentExternalID string
@@ -102,6 +110,7 @@ type EnvironmentWorkMapper interface {
 	AckByExternalID(ctx context.Context, workspaceUUID, environmentExternalID, workExternalID string) (environmentWorkMapperRow, error)
 	UpdateMetadata(ctx context.Context, params environmentWorkMetadataParams) (environmentWorkMapperRow, error)
 	MergeMetadata(ctx context.Context, params environmentWorkMetadataPatchParams) (int64, error)
+	RequeueIfRecoverable(ctx context.Context, params environmentWorkRecoveryRetryParams) (int64, error)
 	Heartbeat(ctx context.Context, params environmentWorkHeartbeatParams) (environmentWorkMapperRow, error)
 	Stop(ctx context.Context, params environmentWorkStopParams) (environmentWorkMapperRow, error)
 	StopForDeletedSession(ctx context.Context, workspaceUUID, environmentExternalID, sessionExternalID string) (int64, error)

--- a/internal/db/environment_work_mapper.xml
+++ b/internal/db/environment_work_mapper.xml
@@ -199,6 +199,33 @@
         AND deleted_at IS NULL
     </update>
 
+    <update id="RequeueIfRecoverable" result="rows">
+        UPDATE environment_work
+        SET state = 'queued',
+            claimed_by_worker_id = NULL,
+            claim_expires_at = #{params.RetryAt},
+            latest_heartbeat_at = NULL,
+            heartbeat_ttl_seconds = NULL,
+            updated_at = NOW()
+        WHERE organization_uuid = #{params.OrganizationUUID}
+          AND workspace_uuid = #{params.WorkspaceUUID}
+          AND environment_uuid = #{params.EnvironmentUUID}
+          AND uuid = #{params.WorkUUID}
+          AND state IN ('starting', 'active')
+          AND deleted_at IS NULL
+          AND data-&gt;&gt;'type' = 'session'
+          AND EXISTS (
+              SELECT 1
+              FROM code_sessions code_session
+              WHERE code_session.organization_uuid = environment_work.organization_uuid
+                AND code_session.workspace_uuid = environment_work.workspace_uuid
+                AND code_session.environment_uuid = environment_work.environment_uuid
+                AND code_session.session_external_id = environment_work.data-&gt;&gt;'id'
+                AND code_session.status = 'active'
+                AND code_session.deleted_at IS NULL
+          )
+    </update>
+
     <update id="Heartbeat" result="returning" resultType="environmentWorkMapperRow">
         UPDATE environment_work
         SET state = #{params.State},

--- a/internal/db/environments.go
+++ b/internal/db/environments.go
@@ -411,6 +411,58 @@ func (d *DB) StopEnvironmentWork(ctx context.Context, workspaceUUID string, envi
 	return row.work(), nil
 }
 
+func (d *DB) RequeueEnvironmentWorkIfRecoverable(ctx context.Context, work EnvironmentWork, retryAt time.Time) (bool, error) {
+	mapper := NewEnvironmentWorkMapper(d.mapperDB)
+	rowsAffected, err := mapper.RequeueIfRecoverable(ctx, environmentWorkRecoveryRetryParams{
+		OrganizationUUID: work.OrganizationUUID,
+		WorkspaceUUID:    work.WorkspaceUUID,
+		EnvironmentUUID:  work.EnvironmentUUID,
+		WorkUUID:         work.UUID,
+		RetryAt:          retryAt,
+	})
+	return rowsAffected == 1, err
+}
+
+func (d *DB) FailEnvironmentSandboxAndRequeueRecovery(
+	ctx context.Context,
+	sandbox EnvironmentSandbox,
+	work EnvironmentWork,
+	providerSandboxID string,
+	cause error,
+	retryAt time.Time,
+) (bool, error) {
+	requeued := false
+	err := d.mapperDB.Transaction(ctx, func(executor yourbatis.Executor) error {
+		sandboxMapper := NewEnvironmentSandboxMapper(executor)
+		workMapper := NewEnvironmentWorkMapper(executor)
+		now := time.Now().UTC()
+		message := cause.Error()
+		if err := sandboxMapper.UpdateState(ctx, environmentSandboxStateParams{
+			WorkspaceUUID:     sandbox.WorkspaceUUID,
+			ExternalID:        sandbox.ExternalID,
+			State:             "failed",
+			ProviderSandboxID: optionalEnvironmentString(providerSandboxID),
+			LastError:         &message,
+			StoppedAt:         &now,
+		}); err != nil {
+			return err
+		}
+		rowsAffected, err := workMapper.RequeueIfRecoverable(ctx, environmentWorkRecoveryRetryParams{
+			OrganizationUUID: work.OrganizationUUID,
+			WorkspaceUUID:    work.WorkspaceUUID,
+			EnvironmentUUID:  work.EnvironmentUUID,
+			WorkUUID:         work.UUID,
+			RetryAt:          retryAt,
+		})
+		if err != nil {
+			return err
+		}
+		requeued = rowsAffected == 1
+		return nil
+	})
+	return requeued, err
+}
+
 func (d *DB) EnvironmentWorkStats(ctx context.Context, workspaceUUID string, environmentExternalID string) (EnvironmentWorkStats, error) {
 	mapper := NewEnvironmentWorkMapper(d.mapperDB)
 	row, err := mapper.Stats(ctx, workspaceUUID, environmentExternalID)
@@ -455,12 +507,49 @@ func (d *DB) GetActiveEnvironmentSandboxForWork(ctx context.Context, workspaceUU
 // workers intentionally return ErrNotFound so their heartbeats cannot keep the
 // sandbox alive indefinitely.
 func (d *DB) GetRenewableEnvironmentSandboxForCodeSession(ctx context.Context, codeSessionExternalID string) (EnvironmentSandbox, error) {
+	return d.getActiveEnvironmentSandboxForCodeSession(ctx, codeSessionExternalID, []string{"running"})
+}
+
+// GetResumableEnvironmentSandboxForCodeSession resolves the provider sandbox
+// owned by an active managed-agent Code Session. All valid worker states are
+// eligible because a queued user event must wake idle and requires-action
+// workers, while a running worker may also need recovery after a missed lease.
+func (d *DB) GetResumableEnvironmentSandboxForCodeSession(ctx context.Context, codeSessionExternalID string) (EnvironmentSandbox, error) {
+	return d.getActiveEnvironmentSandboxForCodeSession(ctx, codeSessionExternalID, []string{"idle", "running", "requires_action"})
+}
+
+func (d *DB) getActiveEnvironmentSandboxForCodeSession(ctx context.Context, codeSessionExternalID string, workerStatuses []string) (EnvironmentSandbox, error) {
 	mapper := NewEnvironmentSandboxMapper(d.mapperDB)
-	row, err := mapper.FindRenewableByCodeSessionExternalID(ctx, codeSessionExternalID)
+	row, err := mapper.FindActiveByCodeSessionExternalIDAndWorkerStatuses(ctx, codeSessionExternalID, workerStatuses)
 	if err != nil {
 		return EnvironmentSandbox{}, mapNoRows(err)
 	}
 	return row.sandbox(), nil
+}
+
+// ScheduleEnvironmentSandboxRecoveryForCodeSession atomically retires the
+// missing provider sandbox and requeues its active managed-agent work. The
+// provider ID comparison makes repeated or concurrent recovery requests safe.
+func (d *DB) ScheduleEnvironmentSandboxRecoveryForCodeSession(
+	ctx context.Context,
+	codeSessionExternalID string,
+	providerSandboxID string,
+	cause error,
+) (bool, error) {
+	lastError := "provider sandbox not found"
+	if cause != nil {
+		lastError = cause.Error()
+	}
+	mapper := NewEnvironmentSandboxMapper(d.mapperDB)
+	rowsAffected, err := mapper.ScheduleRecoveryForCodeSession(ctx, environmentSandboxRecoveryParams{
+		CodeSessionExternalID: codeSessionExternalID,
+		ProviderSandboxID:     providerSandboxID,
+		LastError:             lastError,
+	})
+	if err != nil {
+		return false, err
+	}
+	return rowsAffected > 0, nil
 }
 
 func normalizedHeartbeatTTL(ttlSeconds int) int {
@@ -603,4 +692,11 @@ func nullableWorkerID(workerID string) *string {
 		return nil
 	}
 	return &workerID
+}
+
+func optionalEnvironmentString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
 }

--- a/internal/db/managed_agent_runtime.go
+++ b/internal/db/managed_agent_runtime.go
@@ -2,10 +2,37 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 
 	"github.com/superduck-ai/yourbatis"
 )
+
+// RotateManagedAgentCodeSessionCredentials replaces the one-way OAuth token
+// hash before a replacement sandbox starts and revokes the dead worker lease.
+func (d *DB) RotateManagedAgentCodeSessionCredentials(
+	ctx context.Context,
+	session Session,
+	codeSessionExternalID string,
+	oauthAccessTokenHash string,
+) (int64, error) {
+	mapper := NewCodeSessionMapper(d.mapperDB)
+	workerEpoch, err := mapper.RotateCredentials(ctx, rotateCodeSessionCredentialsParams{
+		OrganizationUUID:      session.OrganizationUUID,
+		WorkspaceUUID:         session.WorkspaceUUID,
+		SessionExternalID:     session.ExternalID,
+		CodeSessionExternalID: codeSessionExternalID,
+		OAuthAccessTokenHash:  oauthAccessTokenHash,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, ErrNotFound
+	}
+	if err != nil {
+		return 0, err
+	}
+	return workerEpoch, nil
+}
 
 // BindManagedAgentRuntimeMetadata 将已启动的 Managed Agent runtime 信息同时发布到
 // public Session 和调用方指定的 Environment Work。

--- a/internal/db/managed_agent_runtime_mapper_test.go
+++ b/internal/db/managed_agent_runtime_mapper_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql/driver"
 	"errors"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 
 func TestManagedAgentRuntimeMapperBuilderContracts(t *testing.T) {
 	sessionParams, workParams := managedAgentRuntimeMapperTestParams()
+	rotateParams := managedAgentRuntimeRotateParams(sessionParams)
 	tests := []struct {
 		name     string
 		contract mapperBuilderContract
@@ -24,7 +26,7 @@ func TestManagedAgentRuntimeMapperBuilderContracts(t *testing.T) {
 			wantSensitiveArgumentNames: []string{"params.MetadataPatch"},
 			wantSQLFragments:           []string{"UPDATE sessions", "CAST($1 AS jsonb)", "organization_uuid = $2"},
 		}},
-		{"merge work metadata", mapperBuilderContract{
+		{"merge work runtime metadata", mapperBuilderContract{
 			statement: environmentWorkMapperMergeMetadataStatement,
 			bound:     buildEnvironmentWorkMapperMergeMetadata(yourbatis.DialectPostgres, workParams),
 			wantID:    "EnvironmentWorkMapper.MergeMetadata", wantKind: yourbatis.StatementUpdate,
@@ -46,6 +48,20 @@ func TestManagedAgentRuntimeMapperBuilderContracts(t *testing.T) {
 			wantID: "CodeSessionMapper.TerminateByExternalID", wantKind: yourbatis.StatementUpdate,
 			wantArgumentNames: []string{"organizationUUID", "workspaceUUID", "codeSessionExternalID"},
 			wantSQLFragments:  []string{"UPDATE code_sessions", "oauth_access_token_hash = NULL", "external_id = $3"},
+		}},
+		{"rotate code session credentials", mapperBuilderContract{
+			statement: codeSessionMapperRotateCredentialsStatement,
+			bound:     buildCodeSessionMapperRotateCredentials(yourbatis.DialectPostgres, rotateParams),
+			wantID:    "CodeSessionMapper.RotateCredentials", wantKind: yourbatis.StatementUpdate,
+			wantArgumentNames: []string{
+				"params.OAuthAccessTokenHash", "params.OrganizationUUID", "params.WorkspaceUUID",
+				"params.SessionExternalID", "params.CodeSessionExternalID",
+			},
+			wantSensitiveArgumentNames: []string{"params.OAuthAccessTokenHash"},
+			wantSQLFragments: []string{
+				"UPDATE code_sessions", "current_worker_epoch = current_worker_epoch + 1",
+				"worker_lease_expires_at = NULL", "status = 'active'", "RETURNING",
+			},
 		}},
 	}
 	for _, test := range tests {
@@ -111,6 +127,31 @@ func TestManagedAgentRuntimeMapperRowsAffected(t *testing.T) {
 	}
 }
 
+func TestManagedAgentRuntimeMapperRotateCredentials(t *testing.T) {
+	ctx := context.Background()
+	sessionParams, _ := managedAgentRuntimeMapperTestParams()
+	rotateParams := managedAgentRuntimeRotateParams(sessionParams)
+	executor := newMapperTestExecutor(t, mapperTestResponse{
+		columns: []string{"current_worker_epoch"},
+		rows:    [][]driver.Value{{int64(2)}},
+	})
+
+	got, err := NewCodeSessionMapper(executor).RotateCredentials(ctx, rotateParams)
+	if err != nil || got != 2 {
+		t.Fatalf("RotateCredentials() = (%d, %v), want epoch 2", got, err)
+	}
+	assertMapperTestExecution(
+		t,
+		executor,
+		"CodeSessionMapper.RotateCredentials",
+		yourbatis.StatementUpdate,
+		[]any{
+			rotateParams.OAuthAccessTokenHash, rotateParams.OrganizationUUID, rotateParams.WorkspaceUUID,
+			rotateParams.SessionExternalID, rotateParams.CodeSessionExternalID,
+		},
+	)
+}
+
 func TestManagedAgentRuntimeMapperExecutionErrors(t *testing.T) {
 	sessionParams, workParams := managedAgentRuntimeMapperTestParams()
 	tests := []struct {
@@ -148,6 +189,18 @@ func TestManagedAgentRuntimeMapperExecutionErrors(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("rotate credentials", func(t *testing.T) {
+		executionErr := errors.New("execution failed")
+		executor := newMapperTestExecutor(t, mapperTestResponse{queryErr: executionErr})
+		_, err := NewCodeSessionMapper(executor).RotateCredentials(
+			context.Background(),
+			managedAgentRuntimeRotateParams(sessionParams),
+		)
+		if !errors.Is(err, executionErr) {
+			t.Fatalf("mapper error = %v, want %v", err, executionErr)
+		}
+	})
 }
 
 func managedAgentRuntimeMapperTestParams() (sessionMetadataPatchParams, environmentWorkMetadataPatchParams) {
@@ -162,5 +215,15 @@ func managedAgentRuntimeMapperTestParams() (sessionMetadataPatchParams, environm
 		EnvironmentUUID:       "00000000-0000-4000-8000-000000000003",
 		EnvironmentExternalID: "env_test", WorkExternalID: "envwork_test",
 		MetadataPatch: metadataPatch,
+	}
+}
+
+func managedAgentRuntimeRotateParams(sessionParams sessionMetadataPatchParams) rotateCodeSessionCredentialsParams {
+	return rotateCodeSessionCredentialsParams{
+		OrganizationUUID:      sessionParams.OrganizationUUID,
+		WorkspaceUUID:         sessionParams.WorkspaceUUID,
+		SessionExternalID:     sessionParams.SessionExternalID,
+		CodeSessionExternalID: "codeses_test",
+		OAuthAccessTokenHash:  "oauth-hash",
 	}
 }

--- a/internal/environments/environment_manager.go
+++ b/internal/environments/environment_manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	urlpkg "net/url"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -242,7 +243,7 @@ func modelIDFromAgentSnapshot(raw json.RawMessage) string {
 }
 
 // buildEnvironmentManagerV0Payload 把 code session 映射为 environment-manager v0 合同；relay、runtime API 与 ingress 绑定同一 external ID，真实上游凭证不进入 sandbox。
-func buildEnvironmentManagerV0Payload(codeSessionID string, sessionIngressToken string, oauthAccessToken string, workDir string, sessionConfig json.RawMessage, cfg config.Config) ([]byte, error) {
+func buildEnvironmentManagerV0Payload(codeSessionID string, sessionIngressToken string, oauthAccessToken string, workerEpoch int64, workDir string, sessionConfig json.RawMessage, cfg config.Config) ([]byte, error) {
 	startupContext := map[string]any{}
 	if len(sessionConfig) > 0 && string(sessionConfig) != "null" {
 		if err := json.Unmarshal(sessionConfig, &startupContext); err != nil {
@@ -261,13 +262,14 @@ func buildEnvironmentManagerV0Payload(codeSessionID string, sessionIngressToken 
 	environmentVariables["CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2"] = "1"
 	delete(environmentVariables, "CLAUDE_CODE_SESSION_ACCESS_TOKEN") // 避免遮蔽 environment-manager 注入的 WebSocket auth FD。
 	environmentVariables["CLAUDE_CODE_USE_CCR_V2"] = "1"
-	environmentVariables["CLAUDE_CODE_WORKER_EPOCH"] = "1"
+	workerEpochText := strconv.FormatInt(workerEpoch, 10)
+	environmentVariables["CLAUDE_CODE_WORKER_EPOCH"] = workerEpochText
 	environmentVariables["CLAUDE_CODE_INCLUDE_PARTIAL_MESSAGES"] = "true" // 让 worker 输出包含 streaming 中间消息。
 	environmentVariables["CCR_UPSTREAM_PROXY_ENABLED"] = "1"              // 还需 REMOTE_SESSION_ID 和 /run/ccr/session_token 才会注入 HTTPS_PROXY。
 	for key, value := range claudeRuntimeModelEnvironment(stringFromMap(startupContext, "model")) {
 		environmentVariables[key] = value
 	}
-	applyCodeSessionOTLPEnvironment(environmentVariables, stringFromMap(startupContext, "api_base_url"), codeSessionID, sessionIngressToken, "1")
+	applyCodeSessionOTLPEnvironment(environmentVariables, stringFromMap(startupContext, "api_base_url"), codeSessionID, sessionIngressToken, workerEpochText)
 	startupContext["environment_variables"] = environmentVariables
 	if _, ok := startupContext["sources"]; !ok {
 		startupContext["sources"] = []any{}

--- a/internal/environments/environment_manager_test.go
+++ b/internal/environments/environment_manager_test.go
@@ -244,7 +244,7 @@ func TestBuildEnvironmentManagerPayloadAndCommand(t *testing.T) {
 	sessionConfig := json.RawMessage(`{"model":"claude-opus-4-8","sources":[{"type":"git_repository","url":"https://github.com/acme/widgets"}]}`)
 	const sessionIngressToken = "sk-ant-si-test-token"
 	const oauthAccessToken = "sk-ant-oat01-test-token"
-	payload, err := buildEnvironmentManagerV0Payload("cse_test", sessionIngressToken, oauthAccessToken, "/workspace/widgets", sessionConfig, cfg)
+	payload, err := buildEnvironmentManagerV0Payload("cse_test", sessionIngressToken, oauthAccessToken, 1, "/workspace/widgets", sessionConfig, cfg)
 	if err != nil {
 		t.Fatalf("build payload: %v", err)
 	}
@@ -371,7 +371,7 @@ func TestBuildEnvironmentManagerPayloadPreservesMCPConfig(t *testing.T) {
 		"mcp_config_file":{"path":"/tmp/stale.json","content":"stale","mode":384},
 		"claude_code_args":{"mcp-config":"/tmp/managed-agent-mcp-config.json"}
 	}`)
-	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", "", sessionConfig, cfg)
+	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", 1, "", sessionConfig, cfg)
 	if err != nil {
 		t.Fatalf("build payload: %v", err)
 	}
@@ -420,7 +420,7 @@ func TestBuildEnvironmentManagerPayloadPreservesCustomOTLPMetricsEnvironment(t *
 		"OTEL_METRICS_EXPORTER":"console",
 		"OTEL_EXPORTER_OTLP_HEADERS":"x-custom=value"
 	}}`)
-	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", "", sessionConfig, cfg)
+	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", 1, "", sessionConfig, cfg)
 	if err != nil {
 		t.Fatalf("build payload: %v", err)
 	}
@@ -461,7 +461,7 @@ func TestBuildEnvironmentManagerPayloadPreservesCustomOTLPLogsEnvironment(t *tes
 		"OTEL_LOGS_EXPORTER":"console",
 		"OTEL_EXPORTER_OTLP_HEADERS":"x-custom=value"
 	}}`)
-	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", "", sessionConfig, cfg)
+	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", 1, "", sessionConfig, cfg)
 	if err != nil {
 		t.Fatalf("build payload: %v", err)
 	}
@@ -497,7 +497,7 @@ func TestBuildEnvironmentManagerPayloadPreservesCustomGenericOTLPEndpoint(t *tes
 	sessionConfig := json.RawMessage(`{"environment_variables":{
 		"OTEL_EXPORTER_OTLP_ENDPOINT":"https://collector.example.com"
 	}}`)
-	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", "", sessionConfig, cfg)
+	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", 1, "", sessionConfig, cfg)
 	if err != nil {
 		t.Fatalf("build payload: %v", err)
 	}
@@ -528,7 +528,7 @@ func TestBuildEnvironmentManagerPayloadDoesNotLeakHeadersToCustomMetricsEndpoint
 	sessionConfig := json.RawMessage(`{"environment_variables":{
 		"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT":"https://collector.example.com/v1/metrics"
 	}}`)
-	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", "", sessionConfig, cfg)
+	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", 1, "", sessionConfig, cfg)
 	if err != nil {
 		t.Fatalf("build payload: %v", err)
 	}
@@ -557,7 +557,7 @@ func TestBuildEnvironmentManagerPayloadDoesNotLeakHeadersToCustomLogsEndpoint(t 
 	sessionConfig := json.RawMessage(`{"environment_variables":{
 		"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT":"https://collector.example.com/v1/logs"
 	}}`)
-	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", "", sessionConfig, cfg)
+	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", 1, "", sessionConfig, cfg)
 	if err != nil {
 		t.Fatalf("build payload: %v", err)
 	}

--- a/internal/environments/runner.go
+++ b/internal/environments/runner.go
@@ -36,6 +36,7 @@ var (
 // by Runner without coupling it to the concrete service implementation.
 type CodeSessionRuntime interface {
 	CreateManagedAgentCodeSession(context.Context, codesessions.ManagedAgentCreateInput) (codesessions.ManagedAgentCreateResult, error)
+	RecoverManagedAgentCodeSession(context.Context, codesessions.ManagedAgentRecoverInput) (codesessions.ManagedAgentCreateResult, error)
 	TerminateManagedAgentCodeSession(context.Context, db.Session, string) error
 }
 
@@ -76,10 +77,11 @@ type Runner struct {
 }
 
 type managedAgentLaunchPreparation struct {
-	Session       db.Session
-	SessionConfig json.RawMessage
-	WorkDir       string
-	Title         string
+	Session               db.Session
+	SessionConfig         json.RawMessage
+	WorkDir               string
+	Title                 string
+	RecoveryCodeSessionID string
 }
 
 type managedAgentRuntimeLaunch struct {
@@ -87,7 +89,10 @@ type managedAgentRuntimeLaunch struct {
 	PublicSessionID string
 	SDKURLPath      string
 	Manager         environmentManagerCommand
+	Recovered       bool
 }
+
+const managedAgentRecoveryRetryDelay = 5 * time.Second
 
 // NewRunner constructs a fully usable environment Runner from final runtime
 // collaborators. It rejects incomplete dependency sets before workers start.
@@ -196,24 +201,24 @@ func (r *Runner) RunOnce(ctx context.Context, workerID string) (bool, error) {
 	// 此时实际的 E2B Sandbox 尚未创建；失败只需停止 Work，不存在远端资源需要清理。
 	env, err := r.db.GetEnvironmentByUUID(ctx, work.WorkspaceUUID, work.EnvironmentUUID)
 	if err != nil {
-		_, _ = r.db.StopEnvironmentWork(ctx, work.WorkspaceUUID, work.EnvironmentExternalID, work.ExternalID, true)
+		r.failWorkBeforeSandbox(ctx, *work)
 		return true, err
 	}
 	sandboxID, err := ids.New("envsbx_")
 	if err != nil {
-		_, _ = r.db.StopEnvironmentWork(ctx, work.WorkspaceUUID, work.EnvironmentExternalID, work.ExternalID, true)
+		r.failWorkBeforeSandbox(ctx, *work)
 		return true, err
 	}
 
 	// 在 Provider 解析之前固化 Managed Agent 的网络 metadata。这样 Resolve 和
 	// 后续 Create 使用的是同一份 MCP allowlist，避免创建时网络策略发生漂移。
 	if err := r.prepareManagedAgentNetworkMetadata(ctx, env, work); err != nil {
-		_, _ = r.db.StopEnvironmentWork(ctx, work.WorkspaceUUID, work.EnvironmentExternalID, work.ExternalID, true)
+		r.failWorkBeforeSandbox(ctx, *work)
 		return true, err
 	}
 	resolution, err := r.provider.Resolve(env, work)
 	if err != nil {
-		_, _ = r.db.StopEnvironmentWork(ctx, work.WorkspaceUUID, work.EnvironmentExternalID, work.ExternalID, true)
+		r.failWorkBeforeSandbox(ctx, *work)
 		return true, err
 	}
 
@@ -222,7 +227,7 @@ func (r *Runner) RunOnce(ctx context.Context, workerID string) (bool, error) {
 	// 后续只创建 Sandbox，不进入 Managed Agent 专属分支。
 	preparation, err := r.prepareManagedAgentLaunch(ctx, env, work)
 	if err != nil {
-		_, _ = r.db.StopEnvironmentWork(ctx, work.WorkspaceUUID, work.EnvironmentExternalID, work.ExternalID, true)
+		r.failWorkBeforeSandbox(ctx, *work)
 		return true, err
 	}
 
@@ -244,7 +249,7 @@ func (r *Runner) RunOnce(ctx context.Context, workerID string) (bool, error) {
 		CreatedAt:             time.Now().UTC(),
 	})
 	if err != nil {
-		_, _ = r.db.StopEnvironmentWork(ctx, work.WorkspaceUUID, work.EnvironmentExternalID, work.ExternalID, true)
+		r.failWorkBeforeSandbox(ctx, *work)
 		return true, err
 	}
 
@@ -252,10 +257,7 @@ func (r *Runner) RunOnce(ctx context.Context, workerID string) (bool, error) {
 	// 分属远端 Provider 和本服务两个命名空间。
 	sandbox, err := r.provider.Create(ctx, env, work, resolution)
 	if err != nil {
-		now := time.Now().UTC()
-		message := err.Error()
-		_ = r.db.UpdateEnvironmentSandboxState(ctx, record.WorkspaceUUID, record.ExternalID, "failed", nil, &message, &now)
-		_, _ = r.db.StopEnvironmentWork(ctx, work.WorkspaceUUID, work.EnvironmentExternalID, work.ExternalID, true)
+		r.failCreatedSandbox(ctx, record, work, "", err)
 		return true, err
 	}
 	providerSandboxID := sandbox.ID
@@ -341,14 +343,15 @@ func (r *Runner) RunOnce(ctx context.Context, workerID string) (bool, error) {
 				errEnvironmentManagerStart,
 				err,
 			)
-			r.failManagedAgentRuntime(ctx, record, work, providerSandboxID, preparation.Session, launch.CodeSessionID, publicError)
+			r.failManagedAgentRuntime(ctx, record, work, providerSandboxID, preparation.Session, launch, publicError)
 			return true, publicError
 		}
 
 		// 只有 Manager 后台命令成功提交后才发布 runtime metadata，避免把启动失败的
-		// Code Session 暴露为可用。发布失败时同样终止 Code Session 并清理 Sandbox。
+		// Code Session 暴露为可用。新建失败会终止 Code Session；恢复失败则保留其
+		// durable queue 并重新排队，只清理本次 replacement Sandbox。
 		if err := r.publishManagedAgentRuntime(ctx, preparation.Session, *work, launch); err != nil {
-			r.failManagedAgentRuntime(ctx, record, work, providerSandboxID, preparation.Session, launch.CodeSessionID, err)
+			r.failManagedAgentRuntime(ctx, record, work, providerSandboxID, preparation.Session, launch, err)
 			return true, fmt.Errorf("publish managed-agent runtime metadata: %w", err)
 		}
 	}
@@ -411,21 +414,64 @@ func (r *Runner) failManagedAgentRuntime(
 	work *db.EnvironmentWork,
 	providerSandboxID string,
 	session db.Session,
-	codeSessionID string,
+	launch managedAgentRuntimeLaunch,
 	cause error,
 ) {
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if err := r.codeSessions.TerminateManagedAgentCodeSession(cleanupCtx, session, codeSessionID); err != nil {
+	if !launch.Recovered {
+		if err := r.codeSessions.TerminateManagedAgentCodeSession(cleanupCtx, session, launch.CodeSessionID); err != nil {
+			r.logger.ErrorContext(
+				cleanupCtx,
+				"terminate failed managed agent runtime",
+				"code_session_id", launch.CodeSessionID,
+				"stage_error_type", fmt.Sprintf("%T", cause),
+				"error", err,
+			)
+		}
+	}
+	r.failCreatedSandbox(ctx, record, work, providerSandboxID, cause)
+}
+
+func (r *Runner) failWorkBeforeSandbox(ctx context.Context, work db.EnvironmentWork) {
+	requeued, err := r.db.RequeueEnvironmentWorkIfRecoverable(
+		ctx,
+		work,
+		time.Now().UTC().Add(managedAgentRecoveryRetryDelay),
+	)
+	if err == nil && requeued {
+		return
+	}
+	if err != nil {
+		r.logger.ErrorContext(ctx, "requeue managed agent sandbox recovery", "work_id", work.ExternalID, "error", err)
+	}
+	_, _ = r.db.StopEnvironmentWork(ctx, work.WorkspaceUUID, work.EnvironmentExternalID, work.ExternalID, true)
+}
+
+func (r *Runner) requeueFailedRecoverySandbox(
+	ctx context.Context,
+	record db.EnvironmentSandbox,
+	work db.EnvironmentWork,
+	providerSandboxID string,
+	cause error,
+) bool {
+	requeued, err := r.db.FailEnvironmentSandboxAndRequeueRecovery(
+		ctx,
+		record,
+		work,
+		providerSandboxID,
+		cause,
+		time.Now().UTC().Add(managedAgentRecoveryRetryDelay),
+	)
+	if err != nil {
 		r.logger.ErrorContext(
-			cleanupCtx,
-			"terminate failed managed agent runtime",
-			"code_session_id", codeSessionID,
-			"stage_error_type", fmt.Sprintf("%T", cause),
+			ctx,
+			"requeue failed managed agent sandbox recovery",
+			"work_id", work.ExternalID,
 			"error", err,
 		)
 	}
-	r.failCreatedSandbox(ctx, record, work, providerSandboxID, cause)
+	return err == nil && requeued
 }
 
 // failCreatedSandbox returns true when a concurrent user stop already won and
@@ -436,6 +482,17 @@ func (r *Runner) failCreatedSandbox(ctx context.Context, record db.EnvironmentSa
 		*work = currentWork
 		r.stopCreatedSandbox(ctx, record, work, providerSandboxID)
 		return true
+	}
+	if err == nil {
+		*work = currentWork
+	}
+	if r.requeueFailedRecoverySandbox(ctx, record, *work, providerSandboxID, cause) {
+		if strings.TrimSpace(providerSandboxID) != "" {
+			killCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+			_ = r.provider.Kill(killCtx, providerSandboxID)
+		}
+		return false
 	}
 	now := time.Now().UTC()
 	message := cause.Error()
@@ -499,11 +556,19 @@ func (r *Runner) prepareManagedAgentLaunch(
 	if session.Title != nil {
 		title = *session.Title
 	}
+	recoveryCodeSessionID := ""
+	codeSession, err := r.db.GetActiveCodeSessionForEnvironmentWork(ctx, *work, session.UUID)
+	if err == nil {
+		recoveryCodeSessionID = codeSession.ExternalID
+	} else if !errors.Is(err, db.ErrNotFound) {
+		return nil, fmt.Errorf("load managed agent recovery Code Session: %w", err)
+	}
 	return &managedAgentLaunchPreparation{
-		Session:       session,
-		SessionConfig: sessionConfig,
-		WorkDir:       workDir,
-		Title:         title,
+		Session:               session,
+		SessionConfig:         sessionConfig,
+		WorkDir:               workDir,
+		Title:                 title,
+		RecoveryCodeSessionID: recoveryCodeSessionID,
 	}, nil
 }
 
@@ -513,17 +578,26 @@ func (r *Runner) createManagedAgentRuntimeLaunch(
 	work db.EnvironmentWork,
 	preparation managedAgentLaunchPreparation,
 ) (managedAgentRuntimeLaunch, error) {
-	local, err := r.codeSessions.CreateManagedAgentCodeSession(ctx, codesessions.ManagedAgentCreateInput{
-		Session:                    preparation.Session,
-		Environment:                env,
-		EnvironmentWork:            work,
-		Model:                      modelIDFromAgentSnapshot(preparation.Session.AgentSnapshot),
-		Title:                      preparation.Title,
-		WorkDir:                    preparation.WorkDir,
-		PermissionMode:             "bypassPermissions",
-		DangerouslySkipPermissions: true,
-		Config:                     preparation.SessionConfig,
-	})
+	var local codesessions.ManagedAgentCreateResult
+	var err error
+	if preparation.RecoveryCodeSessionID != "" {
+		local, err = r.codeSessions.RecoverManagedAgentCodeSession(ctx, codesessions.ManagedAgentRecoverInput{
+			Session:       preparation.Session,
+			CodeSessionID: preparation.RecoveryCodeSessionID,
+		})
+	} else {
+		local, err = r.codeSessions.CreateManagedAgentCodeSession(ctx, codesessions.ManagedAgentCreateInput{
+			Session:                    preparation.Session,
+			Environment:                env,
+			EnvironmentWork:            work,
+			Model:                      modelIDFromAgentSnapshot(preparation.Session.AgentSnapshot),
+			Title:                      preparation.Title,
+			WorkDir:                    preparation.WorkDir,
+			PermissionMode:             "bypassPermissions",
+			DangerouslySkipPermissions: true,
+			Config:                     preparation.SessionConfig,
+		})
+	}
 	if err != nil {
 		return managedAgentRuntimeLaunch{}, err
 	}
@@ -531,18 +605,21 @@ func (r *Runner) createManagedAgentRuntimeLaunch(
 		local.CodeSessionID,
 		local.SessionIngressToken,
 		local.OAuthAccessToken,
+		local.WorkerEpoch,
 		preparation.WorkDir,
 		preparation.SessionConfig,
 		r.cfg,
 	)
 	if err != nil {
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		_ = r.codeSessions.TerminateManagedAgentCodeSession(
-			cleanupCtx,
-			preparation.Session,
-			local.CodeSessionID,
-		)
+		if preparation.RecoveryCodeSessionID == "" {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			_ = r.codeSessions.TerminateManagedAgentCodeSession(
+				cleanupCtx,
+				preparation.Session,
+				local.CodeSessionID,
+			)
+		}
 		return managedAgentRuntimeLaunch{}, err
 	}
 	return managedAgentRuntimeLaunch{
@@ -550,6 +627,7 @@ func (r *Runner) createManagedAgentRuntimeLaunch(
 		PublicSessionID: local.PublicSessionID,
 		SDKURLPath:      local.SDKURLPath,
 		Manager:         buildEnvironmentManagerCommand(local.CodeSessionID, r.cfg, payload),
+		Recovered:       preparation.RecoveryCodeSessionID != "",
 	}, nil
 }
 

--- a/internal/runtime/e2bruntime/runtime.go
+++ b/internal/runtime/e2bruntime/runtime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/networkpolicy"
+	"github.com/superduck-ai/open-managed-agents/internal/runtime/sandboxruntime"
 
 	e2b "github.com/superduck-ai/e2b-go-sdk"
 )
@@ -62,7 +63,7 @@ type E2BProvider struct {
 	cfg config.E2BConfig
 }
 
-const defaultSandboxTimeout = 5 * time.Minute
+const defaultSandboxTimeout = 30 * time.Second
 
 func NewProvider(cfg config.E2BConfig) *E2BProvider {
 	return &E2BProvider{cfg: cfg}
@@ -134,6 +135,9 @@ func (p *E2BProvider) Create(ctx context.Context, env db.Environment, work *db.E
 		TimeoutMs:           &timeoutMs,
 		AllowInternetAccess: &allowInternet,
 		Network:             resolved.Network,
+		Lifecycle: &e2b.SandboxLifecycle{
+			OnTimeout: "pause",
+		},
 	}
 	if volumeMounts := p.sandboxVolumeMounts(work); len(volumeMounts) > 0 {
 		opts.VolumeMounts = volumeMounts
@@ -168,9 +172,20 @@ func (p *E2BProvider) SetTimeout(ctx context.Context, sandboxID string, timeout 
 	}
 	sandbox, err := p.connect(ctx, sandboxID)
 	if err != nil {
-		return err
+		return classifySandboxError(err)
 	}
-	return sandbox.SetTimeout(ctx, int(timeout/time.Millisecond), nil)
+	return classifySandboxError(sandbox.SetTimeout(ctx, int(timeout/time.Millisecond), nil))
+}
+
+func classifySandboxError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var notFound *e2b.SandboxNotFoundError
+	if errors.As(err, &notFound) {
+		return fmt.Errorf("%w: %v", sandboxruntime.ErrSandboxNotFound, err)
+	}
+	return err
 }
 
 func (p *E2BProvider) WriteFile(ctx context.Context, sandboxID string, filePath string, data []byte) error {

--- a/internal/runtime/e2bruntime/runtime_test.go
+++ b/internal/runtime/e2bruntime/runtime_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/runtime/sandboxruntime"
 )
 
 func TestConnectionOptsFromConfigMapsAllFields(t *testing.T) {
@@ -38,6 +39,57 @@ func TestConnectionOptsFromConfigMapsAllFields(t *testing.T) {
 	wantTimeoutMs := int(cfg.RequestTimeout / time.Millisecond)
 	if got.RequestTimeoutMs == nil || *got.RequestTimeoutMs != wantTimeoutMs {
 		t.Fatalf("ConnectionOptsFromConfig().RequestTimeoutMs = %v, want %d", got.RequestTimeoutMs, wantTimeoutMs)
+	}
+}
+
+func TestSandboxTimeoutDefaultsToThirtySeconds(t *testing.T) {
+	provider := NewProvider(config.E2BConfig{})
+	if got := provider.sandboxTimeout(); got != 30*time.Second {
+		t.Fatalf("sandboxTimeout() = %s, want 30s", got)
+	}
+}
+
+func TestCreateConfiguresExplicitConnectPauseLifecycle(t *testing.T) {
+	var body struct {
+		AutoPause  bool `json:"autoPause"`
+		AutoResume struct {
+			Enabled bool `json:"enabled"`
+		} `json:"autoResume"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/sandboxes" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode create request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"sandboxID":"sbx_lifecycle","templateID":"base","envdVersion":"0.1.0","envdURL":"http://127.0.0.1:1"}`)
+	}))
+	defer server.Close()
+
+	provider := NewProvider(config.E2BConfig{
+		APIKey:         "e2b_0000000000000000000000000000000000000000",
+		APIURL:         server.URL,
+		SandboxURL:     server.URL,
+		RequestTimeout: time.Second,
+	})
+	sandbox, err := provider.Create(context.Background(), db.Environment{}, nil, Resolution{
+		Template:            "base",
+		Timeout:             30 * time.Second,
+		AllowInternetAccess: true,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if sandbox.ID != "sbx_lifecycle" {
+		t.Fatalf("Create().ID = %q, want sbx_lifecycle", sandbox.ID)
+	}
+	if !body.AutoPause || body.AutoResume.Enabled {
+		t.Fatalf("create lifecycle = autoPause:%t autoResume:%t, want pause with explicit connect", body.AutoPause, body.AutoResume.Enabled)
 	}
 }
 
@@ -84,6 +136,24 @@ func TestSetTimeoutUsesConfiguredConnectTimeoutAndRequestedRenewal(t *testing.T)
 	}
 	if want := []int{420, 180}; !reflect.DeepEqual(timeouts, want) {
 		t.Fatalf("request timeouts = %#v, want %#v", timeouts, want)
+	}
+}
+
+func TestSetTimeoutClassifiesMissingSandbox(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"message":"sandbox not found"}`, http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	provider := NewProvider(config.E2BConfig{
+		APIKey:         "e2b_0000000000000000000000000000000000000000",
+		APIURL:         server.URL,
+		SandboxURL:     server.URL,
+		RequestTimeout: time.Second,
+	})
+	err := provider.SetTimeout(context.Background(), "sbx_missing", 30*time.Second)
+	if !errors.Is(err, sandboxruntime.ErrSandboxNotFound) {
+		t.Fatalf("SetTimeout() error = %v, want sandbox not found", err)
 	}
 }
 

--- a/internal/runtime/sandboxruntime/errors.go
+++ b/internal/runtime/sandboxruntime/errors.go
@@ -1,0 +1,7 @@
+// Package sandboxruntime defines provider-independent sandbox lifecycle errors.
+package sandboxruntime
+
+import "errors"
+
+// ErrSandboxNotFound means the provider has permanently removed a sandbox.
+var ErrSandboxNotFound = errors.New("sandbox not found")

--- a/tests/ccrv2_upstream_proxy_test.go
+++ b/tests/ccrv2_upstream_proxy_test.go
@@ -344,10 +344,7 @@ func TestCCRV2UpstreamProxyPolicyChainFailures(t *testing.T) {
 			"",
 			"00000000-0000-0000-0000-000000000099",
 		)
-		status := connectViaCCRV2Proxy(t, app, codeSessionID, mismatchedToken, "10.0.0.1:443")
-		if !strings.HasPrefix(status, "HTTP/1.1 403 Forbidden") {
-			t.Fatalf("mismatched-workspace CONNECT status = %q, want 403", status)
-		}
+		assertCCRV2UpstreamProxyAuthRejected(t, app, mismatchedToken)
 	})
 
 	t.Run("failure signed token with mismatched organization scope fails closed", func(t *testing.T) {
@@ -358,10 +355,7 @@ func TestCCRV2UpstreamProxyPolicyChainFailures(t *testing.T) {
 			"00000000-0000-0000-0000-000000000098",
 			"",
 		)
-		status := connectViaCCRV2Proxy(t, app, codeSessionID, mismatchedToken, "10.0.0.1:443")
-		if !strings.HasPrefix(status, "HTTP/1.1 403 Forbidden") {
-			t.Fatalf("mismatched-organization CONNECT status = %q, want 403", status)
-		}
+		assertCCRV2UpstreamProxyAuthRejected(t, app, mismatchedToken)
 	})
 
 	t.Run("failure malformed persisted allowlist fails closed as a whole", func(t *testing.T) {
@@ -455,10 +449,7 @@ func TestCCRV2UpstreamProxyPolicyChainFailures(t *testing.T) {
 				t.Errorf("restore code session status: %v", err)
 			}
 		})
-		status := connect(t, "10.0.0.1:443")
-		if !strings.HasPrefix(status, "HTTP/1.1 403 Forbidden") {
-			t.Fatalf("inactive-code-session CONNECT status = %q, want 403", status)
-		}
+		assertCCRV2UpstreamProxyAuthRejected(t, app, ingressToken)
 	})
 
 	t.Run("failure terminated session fails closed", func(t *testing.T) {
@@ -569,6 +560,7 @@ func codeSessionIngressTokenWithScope(
 		OrganizationUUID: organizationUUID,
 		WorkspaceUUID:    workspaceUUID,
 		AccountEmail:     credentialContext.AccountEmail,
+		WorkerEpoch:      record.CurrentWorkerEpoch,
 	})
 	if err != nil {
 		t.Fatalf("issue mismatched-scope token: %v", err)
@@ -636,6 +628,25 @@ func dialCCRV2UpstreamProxy(t *testing.T, app *testApp, sessionIngressToken stri
 		t.Fatalf("dial upstream proxy websocket: %v", err)
 	}
 	return connection
+}
+
+func assertCCRV2UpstreamProxyAuthRejected(t *testing.T, app *testApp, sessionIngressToken string) {
+	t.Helper()
+	request, err := http.NewRequest(http.MethodGet, app.baseURL+"/v1/code/upstreamproxy/ws", nil)
+	if err != nil {
+		t.Fatalf("create upstream proxy authentication request: %v", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+sessionIngressToken)
+	request.Header.Set("Upgrade", "websocket")
+	request.Header.Set("Connection", "Upgrade")
+	response, err := app.client.Do(request)
+	if err != nil {
+		t.Fatalf("authenticate upstream proxy websocket: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("upstream proxy authentication status = %d, want 401: %s", response.StatusCode, readAll(t, response.Body))
+	}
 }
 
 func encodeCCRV2TestChunk(data []byte) []byte {

--- a/tests/session_sandbox_recovery_test.go
+++ b/tests/session_sandbox_recovery_test.go
@@ -1,0 +1,334 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/runtime/sandboxruntime"
+)
+
+func TestSessionEventsRetryIdleSandboxResumeAfterProviderFailure(t *testing.T) {
+	ctx := context.Background()
+	app := newTestAppWithStore(t, nil, newFakeStore("sessions-idle-sandbox-resume-bucket"))
+	defer app.close()
+
+	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"sessions-idle-sandbox-resume-agent"}`)
+	defer cleanupAgentRows(t, app.pool, agent.ID)
+	env := createEnvironment(t, app, `{"name":"sessions-idle-sandbox-resume-env"}`)
+	defer cleanupEnvironmentRows(t, app.pool, env.ID)
+	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
+	defer deleteSession(t, app, session.ID)
+	codeSessionID := launchLocalCodeSession(t, app, session.ID)
+
+	sandbox, err := app.db.GetResumableEnvironmentSandboxForCodeSession(ctx, codeSessionID)
+	if err != nil || sandbox.ProviderSandboxID == nil {
+		t.Fatalf("load resumable sandbox = (%+v, %v), want provider sandbox", sandbox, err)
+	}
+	app.sandboxTimeouts.setError(errors.New("provider temporarily unavailable"))
+	sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"first resume attempt"}]}]}`, defaultTestKey)
+
+	app.sandboxTimeouts.setError(nil)
+	sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"second resume attempt"}]}]}`, defaultTestKey)
+
+	calls := app.sandboxTimeouts.snapshotCalls()
+	if len(calls) != 2 {
+		t.Fatalf("sandbox resume calls = %d, want failed attempt followed by retry", len(calls))
+	}
+	for _, call := range calls {
+		if call.sandboxID != *sandbox.ProviderSandboxID || call.timeout != app.cfg.E2B.SandboxTimeout {
+			t.Fatalf("sandbox resume call = %+v, want id %q and timeout %s", call, *sandbox.ProviderSandboxID, app.cfg.E2B.SandboxTimeout)
+		}
+	}
+}
+
+func TestSessionEventsReplaceProviderSandboxAfterItWasDeleted(t *testing.T) {
+	ctx := context.Background()
+	app := newTestAppWithStore(t, nil, newFakeStore("sessions-deleted-sandbox-recovery-bucket"))
+	defer app.close()
+
+	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"sessions-deleted-sandbox-recovery-agent"}`)
+	defer cleanupAgentRows(t, app.pool, agent.ID)
+	env := createEnvironment(t, app, `{"name":"sessions-deleted-sandbox-recovery-env"}`)
+	defer cleanupEnvironmentRows(t, app.pool, env.ID)
+	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
+	defer deleteSession(t, app, session.ID)
+	codeSessionID := launchLocalCodeSession(t, app, session.ID)
+	codeSession, err := getCodeSession(app, ctx, codeSessionID)
+	if err != nil {
+		t.Fatalf("load original code session: %v", err)
+	}
+	oldIngressToken := codeSessionIngressToken(t, app, codeSessionID)
+	if _, err := app.pool.Exec(ctx, `
+		update code_sessions
+		set current_worker_epoch = 1
+		where external_id = $1
+	`, codeSessionID); err != nil {
+		t.Fatalf("seed original worker epoch: %v", err)
+	}
+
+	oldSandbox, err := app.db.GetResumableEnvironmentSandboxForCodeSession(ctx, codeSessionID)
+	if err != nil || oldSandbox.ProviderSandboxID == nil {
+		t.Fatalf("load original sandbox = (%+v, %v), want provider sandbox", oldSandbox, err)
+	}
+	oldProviderSandboxID := *oldSandbox.ProviderSandboxID
+	app.sandboxTimeouts.setError(sandboxruntime.ErrSandboxNotFound)
+	sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"message after sandbox deletion"}]}]}`, defaultTestKey)
+
+	assertQueuedSandboxRecovery(t, app, session.ID, codeSession.UUID, oldProviderSandboxID)
+
+	newProviderSandboxID := oldProviderSandboxID + "-replacement"
+	provider := &recordingRunnerProvider{sandboxID: newProviderSandboxID}
+	recoveryConfig := app.cfg
+	if recoveryConfig.CodeSession.SandboxAPIBaseURL == "" {
+		recoveryConfig.CodeSession.SandboxAPIBaseURL = "http://sandbox-api.example.test"
+	}
+	runner := newManagedAgentRunner(t, app, provider, recoveryConfig)
+	runUntilSandboxCreated(t, ctx, runner, provider)
+
+	newSandbox, err := app.db.GetResumableEnvironmentSandboxForCodeSession(ctx, codeSessionID)
+	if err != nil || newSandbox.ProviderSandboxID == nil || *newSandbox.ProviderSandboxID != newProviderSandboxID {
+		t.Fatalf("replacement sandbox = (%+v, %v), want provider id %q", newSandbox, err, newProviderSandboxID)
+	}
+	assertSingleActiveRecoveredCodeSession(t, app, session.ID)
+	if len(provider.launches) != 1 {
+		t.Fatalf("replacement manager launches = %d, want 1", len(provider.launches))
+	}
+	newIngressToken, workerEpoch := replacementManagerCredentials(t, provider.launches[0].stdin)
+	if workerEpoch != "2" {
+		t.Fatalf("replacement worker epoch = %q, want 2", workerEpoch)
+	}
+	assertWorkerRegistration(t, app, codeSessionID, oldIngressToken, http.StatusUnauthorized, "")
+	assertWorkerRegistration(t, app, codeSessionID, newIngressToken, http.StatusOK, "2")
+	assertWorkerRegistration(t, app, codeSessionID, newIngressToken, http.StatusOK, "2")
+	assertRecoveredWorkPublished(t, app, session.ID)
+	assertRecoveryMessageQueued(t, app, codeSessionID)
+}
+
+func TestFailedReplacementPreservesDurableCodeSession(t *testing.T) {
+	ctx := context.Background()
+	app := newTestAppWithStore(t, nil, newFakeStore("sessions-failed-sandbox-recovery-bucket"))
+	defer app.close()
+
+	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"sessions-failed-sandbox-recovery-agent"}`)
+	defer cleanupAgentRows(t, app.pool, agent.ID)
+	env := createEnvironment(t, app, `{"name":"sessions-failed-sandbox-recovery-env"}`)
+	defer cleanupEnvironmentRows(t, app.pool, env.ID)
+	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
+	defer deleteSession(t, app, session.ID)
+	codeSessionID := launchLocalCodeSession(t, app, session.ID)
+	codeSession, err := getCodeSession(app, ctx, codeSessionID)
+	if err != nil {
+		t.Fatalf("load original code session: %v", err)
+	}
+	oldSandbox, err := app.db.GetResumableEnvironmentSandboxForCodeSession(ctx, codeSessionID)
+	if err != nil || oldSandbox.ProviderSandboxID == nil {
+		t.Fatalf("load original sandbox = (%+v, %v), want provider sandbox", oldSandbox, err)
+	}
+	app.sandboxTimeouts.setError(sandboxruntime.ErrSandboxNotFound)
+	sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"recover after deletion"}]}]}`, defaultTestKey)
+
+	replacementID := *oldSandbox.ProviderSandboxID + "-failed-replacement"
+	provider := &recordingRunnerProvider{
+		sandboxID:         replacementID,
+		failOperation:     "environment-manager",
+		runCommandFailure: errors.New("manager launch failed"),
+	}
+	cfg := app.cfg
+	if cfg.CodeSession.SandboxAPIBaseURL == "" {
+		cfg.CodeSession.SandboxAPIBaseURL = "http://sandbox-api.example.test"
+	}
+	processed, runErr := newManagedAgentRunner(t, app, provider, cfg).RunOnce(ctx, "failed-recovery-test")
+	if !processed || runErr == nil {
+		t.Fatalf("failed recovery RunOnce = (processed=%t, err=%v), want processed error", processed, runErr)
+	}
+
+	recovered, err := getCodeSession(app, ctx, codeSessionID)
+	if err != nil {
+		t.Fatalf("reload code session after failed recovery: %v", err)
+	}
+	if recovered.Status != "active" || recovered.UUID != codeSession.UUID {
+		t.Fatalf("code session after failed recovery = (uuid=%q, status=%q), want original active %q", recovered.UUID, recovered.Status, codeSession.UUID)
+	}
+	assertQueuedSandboxRecovery(t, app, session.ID, codeSession.UUID, replacementID)
+	if len(provider.kills) != 1 || provider.kills[0] != replacementID {
+		t.Fatalf("failed replacement kills = %#v, want [%q]", provider.kills, replacementID)
+	}
+}
+
+func assertQueuedSandboxRecovery(t *testing.T, app *testApp, sessionID, codeSessionUUID, providerSandboxID string) {
+	t.Helper()
+	var workState string
+	if err := app.pool.QueryRow(context.Background(), `
+		select state
+		from environment_work
+		where data->>'id' = $1 and deleted_at is null
+		order by created_at desc
+		limit 1
+	`, sessionID).Scan(&workState); err != nil {
+		t.Fatalf("load queued recovery work: %v", err)
+	}
+	if workState != "queued" {
+		t.Fatalf("recovery work state = %q, want queued", workState)
+	}
+	var activeCodeSessionUUID string
+	if err := app.pool.QueryRow(context.Background(), `
+		select uuid
+		from code_sessions
+		where session_external_id = $1 and status = 'active' and deleted_at is null
+	`, sessionID).Scan(&activeCodeSessionUUID); err != nil {
+		t.Fatalf("load inferred recovery code session: %v", err)
+	}
+	if activeCodeSessionUUID != codeSessionUUID {
+		t.Fatalf("inferred recovery code session = %q, want %q", activeCodeSessionUUID, codeSessionUUID)
+	}
+	var sandboxState string
+	if err := app.pool.QueryRow(context.Background(), `
+		select state
+		from environment_sandboxes
+		where provider_sandbox_id = $1
+	`, providerSandboxID).Scan(&sandboxState); err != nil {
+		t.Fatalf("load failed sandbox: %v", err)
+	}
+	if sandboxState != "failed" {
+		t.Fatalf("sandbox %q state = %q, want failed", providerSandboxID, sandboxState)
+	}
+}
+
+func runUntilSandboxCreated(t *testing.T, ctx context.Context, runner interface {
+	RunOnce(context.Context, string) (bool, error)
+}, provider *recordingRunnerProvider) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for len(provider.creates) == 0 {
+		processed, err := runner.RunOnce(ctx, "sessions-deleted-sandbox-recovery-test")
+		if err != nil && !errors.Is(err, db.ErrNotFound) {
+			t.Fatalf("run replacement sandbox: %v", err)
+		}
+		if !processed && time.Now().After(deadline) {
+			t.Fatal("replacement sandbox was not created before deadline")
+		}
+		if len(provider.creates) == 0 {
+			time.Sleep(25 * time.Millisecond)
+		}
+	}
+}
+
+func assertSingleActiveRecoveredCodeSession(t *testing.T, app *testApp, sessionID string) {
+	t.Helper()
+	var count int
+	if err := app.pool.QueryRow(context.Background(), `
+		select count(*)
+		from code_sessions
+		where session_external_id = $1 and status = 'active' and deleted_at is null
+	`, sessionID).Scan(&count); err != nil {
+		t.Fatalf("count code sessions after recovery: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("active code session count after recovery = %d, want 1", count)
+	}
+}
+
+func replacementManagerCredentials(t *testing.T, payload []byte) (string, string) {
+	t.Helper()
+	var managerPayload struct {
+		StartupContext struct {
+			EnvironmentVariables map[string]any `json:"environment_variables"`
+		} `json:"startup_context"`
+		Auth []struct {
+			Type  string `json:"type"`
+			Token string `json:"token"`
+		} `json:"auth"`
+	}
+	if err := json.Unmarshal(payload, &managerPayload); err != nil {
+		t.Fatalf("decode replacement manager payload: %v", err)
+	}
+	var ingressToken string
+	for _, auth := range managerPayload.Auth {
+		if auth.Type == "session_ingress" {
+			ingressToken = auth.Token
+			break
+		}
+	}
+	if ingressToken == "" {
+		t.Fatal("replacement manager payload has no session_ingress token")
+	}
+	workerEpoch, _ := managerPayload.StartupContext.EnvironmentVariables["CLAUDE_CODE_WORKER_EPOCH"].(string)
+	return ingressToken, workerEpoch
+}
+
+func assertWorkerRegistration(t *testing.T, app *testApp, codeSessionID, token string, wantStatus int, wantEpoch string) {
+	t.Helper()
+	req, err := http.NewRequest(
+		http.MethodPost,
+		app.baseURL+"/v1/code/sessions/"+codeSessionID+"/worker/register",
+		strings.NewReader(`{"session_id":`+quoteJSON(codeSessionID)+`}`),
+	)
+	if err != nil {
+		t.Fatalf("create worker register request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.client.Do(req)
+	if err != nil {
+		t.Fatalf("register recovered worker: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read worker register response: %v", err)
+	}
+	if resp.StatusCode != wantStatus {
+		t.Fatalf("register worker status = %d, want %d: %s", resp.StatusCode, wantStatus, body)
+	}
+	if wantEpoch == "" {
+		return
+	}
+	var result struct {
+		WorkerEpoch string `json:"worker_epoch"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("decode worker register response: %v", err)
+	}
+	if result.WorkerEpoch != wantEpoch {
+		t.Fatalf("registered worker epoch = %q, want %q", result.WorkerEpoch, wantEpoch)
+	}
+}
+
+func assertRecoveredWorkPublished(t *testing.T, app *testApp, sessionID string) {
+	t.Helper()
+	var state string
+	if err := app.pool.QueryRow(context.Background(), `
+		select state
+		from environment_work
+		where data->>'id' = $1 and deleted_at is null
+		order by created_at desc
+		limit 1
+	`, sessionID).Scan(&state); err != nil {
+		t.Fatalf("load recovered work: %v", err)
+	}
+	if state != "active" {
+		t.Fatalf("recovered work state = %q, want active", state)
+	}
+}
+
+func assertRecoveryMessageQueued(t *testing.T, app *testApp, codeSessionID string) {
+	t.Helper()
+	inbound, err := app.db.ListQueuedCodeSessionInboundEvents(context.Background(), codeSessionID)
+	if err != nil {
+		t.Fatalf("list recovery inbound events: %v", err)
+	}
+	for _, event := range inbound {
+		if bytes.Contains(event.Payload, []byte("message after sandbox deletion")) {
+			return
+		}
+	}
+	t.Fatalf("replacement code session queue = %#v, want post-deletion message", inbound)
+}

--- a/tests/session_sandbox_recovery_test.go
+++ b/tests/session_sandbox_recovery_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -27,6 +28,15 @@ func TestSessionEventsRetryIdleSandboxResumeAfterProviderFailure(t *testing.T) {
 	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
 	defer deleteSession(t, app, session.ID)
 	codeSessionID := launchLocalCodeSession(t, app, session.ID)
+	workerEpoch := registerCodeSessionWorker(t, app, codeSessionID)
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"idle"}`)
+	if _, err := app.pool.Exec(ctx, `
+		update code_sessions
+		set worker_lease_expires_at = now() - interval '15 seconds'
+		where external_id = $1
+	`, codeSessionID); err != nil {
+		t.Fatalf("expire worker lease beyond heartbeat grace: %v", err)
+	}
 
 	sandbox, err := app.db.GetResumableEnvironmentSandboxForCodeSession(ctx, codeSessionID)
 	if err != nil || sandbox.ProviderSandboxID == nil {
@@ -34,9 +44,23 @@ func TestSessionEventsRetryIdleSandboxResumeAfterProviderFailure(t *testing.T) {
 	}
 	app.sandboxTimeouts.setError(errors.New("provider temporarily unavailable"))
 	sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"first resume attempt"}]}]}`, defaultTestKey)
+	failed, err := getCodeSession(app, ctx, codeSessionID)
+	if err != nil {
+		t.Fatalf("load worker lease after failed resume: %v", err)
+	}
+	if failed.WorkerLeaseExpiresAt == nil || !failed.WorkerLeaseExpiresAt.Before(time.Now().UTC()) {
+		t.Fatalf("failed provider resume renewed worker lease to %v", failed.WorkerLeaseExpiresAt)
+	}
 
 	app.sandboxTimeouts.setError(nil)
 	sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"second resume attempt"}]}]}`, defaultTestKey)
+	resumed, err := getCodeSession(app, ctx, codeSessionID)
+	if err != nil {
+		t.Fatalf("load worker lease after successful retry: %v", err)
+	}
+	if resumed.WorkerLeaseExpiresAt == nil || !resumed.WorkerLeaseExpiresAt.After(time.Now().UTC()) {
+		t.Fatalf("successful provider resume left worker lease at %v", resumed.WorkerLeaseExpiresAt)
+	}
 
 	calls := app.sandboxTimeouts.snapshotCalls()
 	if len(calls) != 2 {
@@ -46,6 +70,94 @@ func TestSessionEventsRetryIdleSandboxResumeAfterProviderFailure(t *testing.T) {
 		if call.sandboxID != *sandbox.ProviderSandboxID || call.timeout != app.cfg.E2B.SandboxTimeout {
 			t.Fatalf("sandbox resume call = %+v, want id %q and timeout %s", call, *sandbox.ProviderSandboxID, app.cfg.E2B.SandboxTimeout)
 		}
+	}
+}
+
+func TestSessionEventResumeRearmsExpiredWorkerLeaseWithoutChangingEpoch(t *testing.T) {
+	ctx := context.Background()
+	app := newTestAppWithStore(t, nil, newFakeStore("sessions-resume-expired-worker-lease-bucket"))
+	defer app.close()
+
+	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"sessions-resume-expired-worker-lease-agent"}`)
+	defer cleanupAgentRows(t, app.pool, agent.ID)
+	env := createEnvironment(t, app, `{"name":"sessions-resume-expired-worker-lease-env"}`)
+	defer cleanupEnvironmentRows(t, app.pool, env.ID)
+	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
+	defer deleteSession(t, app, session.ID)
+	codeSessionID := launchLocalCodeSession(t, app, session.ID)
+	workerEpoch := registerCodeSessionWorker(t, app, codeSessionID)
+	putCodeSessionWorkerState(t, app, codeSessionID, `{"worker_epoch":`+workerEpoch+`,"worker_status":"idle"}`)
+
+	if _, err := app.pool.Exec(ctx, `
+		update code_sessions
+		set worker_lease_expires_at = now() - interval '15 seconds'
+		where external_id = $1
+	`, codeSessionID); err != nil {
+		t.Fatalf("expire worker lease beyond heartbeat grace: %v", err)
+	}
+	expired, err := getCodeSession(app, ctx, codeSessionID)
+	if err != nil {
+		t.Fatalf("load expired worker lease: %v", err)
+	}
+
+	sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"resume after a long pause"}]}]}`, defaultTestKey)
+
+	resumed, err := getCodeSession(app, ctx, codeSessionID)
+	if err != nil {
+		t.Fatalf("load resumed worker lease: %v", err)
+	}
+	if resumed.CurrentWorkerEpoch != expired.CurrentWorkerEpoch {
+		t.Fatalf("resume changed worker epoch from %d to %d", expired.CurrentWorkerEpoch, resumed.CurrentWorkerEpoch)
+	}
+	if resumed.WorkerLeaseExpiresAt == nil || !resumed.WorkerLeaseExpiresAt.After(time.Now().UTC()) {
+		t.Fatalf("resumed worker lease expiry = %v, want future deadline", resumed.WorkerLeaseExpiresAt)
+	}
+	assertCodeSessionWorkerHeartbeat(t, app, codeSessionID, workerEpoch)
+}
+
+func TestWorkerStreamWithoutEpochQueryReplaysUnackedMessageAfterResume(t *testing.T) {
+	ctx := context.Background()
+	app := newTestAppWithStore(t, nil, newFakeStore("sessions-resumed-worker-stream-replay-bucket"))
+	defer app.close()
+
+	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"sessions-resumed-worker-stream-replay-agent"}`)
+	defer cleanupAgentRows(t, app.pool, agent.ID)
+	env := createEnvironment(t, app, `{"name":"sessions-resumed-worker-stream-replay-env"}`)
+	defer cleanupEnvironmentRows(t, app.pool, env.ID)
+	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
+	defer deleteSession(t, app, session.ID)
+	codeSessionID := launchLocalCodeSession(t, app, session.ID)
+	workerEpochText := registerCodeSessionWorker(t, app, codeSessionID)
+	workerEpoch, err := strconv.ParseInt(workerEpochText, 10, 64)
+	if err != nil {
+		t.Fatalf("parse worker epoch: %v", err)
+	}
+
+	const message = "replay after resumed worker stream"
+	frames := readCodeSessionWorkerSSEFramesAfterConnect(t, app, codeSessionID, "events/stream", message, func() {
+		sendSessionEvents(t, app, session.ID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"`+message+`"}]}]}`, defaultTestKey)
+	})
+	frameData := decodeWorkerSSEFrameData(t, frames[len(frames)-1])
+	payloadUUID, _ := frameData["event_id"].(string)
+	if payloadUUID == "" {
+		t.Fatalf("worker SSE frame has no event id: %s", frames[len(frames)-1])
+	}
+
+	var eventExternalID string
+	if err := app.pool.QueryRow(ctx, `
+		select external_id
+		from code_session_inbound_events
+		where code_session_external_id = $1
+		  and payload_uuid = $2
+		  and deleted_at is null
+	`, codeSessionID, payloadUUID).Scan(&eventExternalID); err != nil {
+		t.Fatalf("load delivered inbound event: %v", err)
+	}
+	waitInboundDeliveryStatusForEpoch(t, app, eventExternalID, "sent", workerEpoch)
+
+	replayed := readCodeSessionWorkerSSEFramesFromSuffix(t, app, codeSessionID, "events/stream", message)
+	if !strings.Contains(replayed[len(replayed)-1], payloadUUID) {
+		t.Fatalf("resumed worker stream did not replay event %q: %#v", payloadUUID, replayed)
 	}
 }
 

--- a/tests/sessions_api_test.go
+++ b/tests/sessions_api_test.go
@@ -3996,6 +3996,7 @@ func codeSessionIngressTokenNoFatal(app *testApp, codeSessionID string) (string,
 		OrganizationUUID: credentialContext.OrganizationUUID,
 		WorkspaceUUID:    credentialContext.WorkspaceUUID,
 		AccountEmail:     credentialContext.AccountEmail,
+		WorkerEpoch:      record.CurrentWorkerEpoch,
 	})
 }
 


### PR DESCRIPTION
## Summary
- Improve managed agent code-session lifecycle handling and runtime authentication
- Add sandbox recovery, environment management, and worker heartbeat support
- Extend CCR v2 proxy, metrics, configuration, and persistence behavior
- Expand unit and integration coverage for session, runtime, mapper, and proxy flows

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandboxes now pause after 30 seconds of inactivity and can resume when new session activity arrives.
  * Unavailable Sandboxes can be replaced while preserving durable Code Sessions and queued work.
  * Worker credentials rotate during recovery, invalidating older credentials.
  * Resumed workers preserve their epoch and replay unacknowledged events.

* **Bug Fixes**
  * Failed replacements no longer terminate durable Code Sessions; eligible work is safely requeued.

* **Documentation**
  * Updated configuration and lifecycle guidance for timeout, recovery, and credential behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->