### PR TITLE
Ignore web dependencies in Go module metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/superduck-ai/open-managed-agents
 
 go 1.27.0
 
+ignore ./web/node_modules
+
 tool github.com/superduck-ai/yourbatis/cmd/sqlmapgen
 
 require (


### PR DESCRIPTION
## Summary

- Exclude `web/node_modules` from Go module tooling paths.

## Testing

- Not run (not requested)