### PR TITLE
fix(environments): remove legacy E2B volume mount

### DIFF
--- a/internal/runtime/e2bruntime/runtime.go
+++ b/internal/runtime/e2bruntime/runtime.go
@@ -18,11 +18,6 @@ import (
 	e2b "github.com/superduck-ai/e2b-go-sdk"
 )
 
-const (
-	sandboxUserDataVolumeName = "user-data"
-	sandboxUserDataMountPath  = "/mnt/user-data"
-)
-
 type Resolution struct {
 	Template            string
 	Metadata            map[string]string
@@ -134,9 +129,6 @@ func (p *E2BProvider) Create(ctx context.Context, env db.Environment, work *db.E
 		TimeoutMs:           &timeoutMs,
 		AllowInternetAccess: &allowInternet,
 		Network:             resolved.Network,
-	}
-	if volumeMounts := p.sandboxVolumeMounts(work); len(volumeMounts) > 0 {
-		opts.VolumeMounts = volumeMounts
 	}
 	sandbox, err := e2b.Create(ctx, resolved.Template, opts)
 	if err != nil {
@@ -491,10 +483,4 @@ func mcpAllowedHostsFromWork(work *db.EnvironmentWork) ([]string, error) {
 		return nil, nil
 	}
 	return networkpolicy.ParseWorkMetadataMCPAllowedHosts(work.Metadata)
-}
-
-func (p *E2BProvider) sandboxVolumeMounts(_ *db.EnvironmentWork) map[string]any {
-	return map[string]any{
-		sandboxUserDataMountPath: sandboxUserDataVolumeName,
-	}
 }

--- a/internal/runtime/e2bruntime/runtime_test.go
+++ b/internal/runtime/e2bruntime/runtime_test.go
@@ -223,30 +223,6 @@ func (p *recordingCommandProcess) record(kill bool) int {
 	return p.sequence
 }
 
-func TestSandboxVolumeMountsOnlyIncludeUserData(t *testing.T) {
-	tests := []struct {
-		name string
-		cfg  config.E2BConfig
-	}{
-		{name: "hosted", cfg: config.E2BConfig{Domain: "e2b.example.test"}},
-		{name: "local endpoint", cfg: config.E2BConfig{APIURL: "http://127.0.0.1:3000"}},
-		{name: "debug", cfg: config.E2BConfig{Debug: true}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			provider := NewProvider(tt.cfg)
-			mounts := provider.sandboxVolumeMounts(nil)
-			if got := mounts[sandboxUserDataMountPath]; got != sandboxUserDataVolumeName {
-				t.Fatalf("mount %s = %v, want %s", sandboxUserDataMountPath, got, sandboxUserDataVolumeName)
-			}
-			if len(mounts) != 1 {
-				t.Fatalf("mounts = %#v, want only user-data", mounts)
-			}
-		})
-	}
-}
-
 func TestResolveLimitedNetworkFailsClosedOnInvalidAllowedHost(t *testing.T) {
 	provider := NewProvider(config.E2BConfig{})
 	_, err := provider.Resolve(db.Environment{


### PR DESCRIPTION
## Summary

- Stop attaching the obsolete shared `user-data` E2B volume when creating sandbox.
- Remove the unit test that enforced the retired volume-mount behavior.

## Testing

- `go test ./internal/runtime/e2bruntime ./internal/environments -count=1`
- Managed pre-commit hooks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic user-data volume mounting during sandbox creation.
  * Sandbox environments no longer receive the previously configured user-data volume mount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->