### PR TITLE
Use string UUIDs across admin database models

### DIFF
--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -52,7 +52,7 @@ func (s *Service) GetCurrentOrganization(ctx context.Context, principal auth.Pri
 	if err != nil {
 		return organizationResponse{}, mapAdminDBError(err, "Organization not found")
 	}
-	return organizationResponse{ID: org.UUID.String(), Name: org.Name, Type: "organization"}, nil
+	return organizationResponse{ID: org.UUID, Name: org.Name, Type: "organization"}, nil
 }
 
 func (s *Service) CreateInvite(ctx context.Context, principal auth.Principal, req createInviteRequest) (inviteResponse, error) {
@@ -74,7 +74,7 @@ func (s *Service) CreateInvite(ctx context.Context, principal auth.Principal, re
 	}
 	invite, err := s.db.CreateAdminInvite(ctx, db.AdminInvite{
 		ExternalID:       externalID,
-		OrganizationUUID: organizationUUID,
+		OrganizationUUID: organizationUUID.String(),
 		Email:            email,
 		Role:             req.Role,
 		Status:           "pending",
@@ -205,9 +205,9 @@ func (s *Service) CreateWorkspace(ctx context.Context, principal auth.Principal,
 		return workspaceResponse{}, mapAdminDBError(db.ErrNotFound, "Organization not found")
 	}
 	record, err := s.db.CreateAdminWorkspace(ctx, db.AdminWorkspace{
-		UUID:             uuid.New(),
+		UUID:             uuid.NewString(),
 		ExternalID:       workspaceID,
-		OrganizationUUID: organizationUUID,
+		OrganizationUUID: organizationUUID.String(),
 		Name:             name,
 		CreatedAt:        now,
 		CompartmentID:    uuid.NewString(),
@@ -371,7 +371,7 @@ func (s *Service) ListWorkspaceMembers(ctx context.Context, principal auth.Princ
 	}
 	records, hasMore, err := s.db.ListAdminWorkspaceMembersPage(ctx, db.ListAdminMembersParams{
 		OrganizationUUID: principal.OrganizationUUID,
-		WorkspaceUUID:    workspace.UUID.String(),
+		WorkspaceUUID:    workspace.UUID,
 		AfterID:          afterID,
 		BeforeID:         beforeID,
 		Limit:            limit,
@@ -493,7 +493,7 @@ func (s *Service) CreateExternalKey(ctx context.Context, principal auth.Principa
 	}
 	key, err := s.db.CreateAdminExternalKey(ctx, db.AdminExternalKey{
 		ExternalID:       externalID,
-		OrganizationUUID: organizationUUID,
+		OrganizationUUID: organizationUUID.String(),
 		DisplayName:      displayName,
 		Geo:              geo,
 		ProviderConfig:   providerConfig,

--- a/internal/api/platform_mcp_vault_auth.go
+++ b/internal/api/platform_mcp_vault_auth.go
@@ -166,7 +166,7 @@ func (s *Server) handlePlatformMCPVaultAuthStart(w http.ResponseWriter, r *http.
 		return
 	}
 
-	vault, err := s.db.GetVaultByExternalIDOrUUID(r.Context(), workspace.UUID.String(), req.VaultID)
+	vault, err := s.db.GetVaultByExternalIDOrUUID(r.Context(), workspace.UUID, req.VaultID)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			writePlatformMCPVaultAuthError(w, http.StatusNotFound, platformMCPVaultAuthVerificationRequestFailed, "")
@@ -182,7 +182,7 @@ func (s *Server) handlePlatformMCPVaultAuthStart(w http.ResponseWriter, r *http.
 	}
 
 	credentials, _, err := s.db.ListVaultCredentialsPage(r.Context(), db.ListVaultCredentialsPageParams{
-		WorkspaceUUID:   workspace.UUID.String(),
+		WorkspaceUUID:   workspace.UUID,
 		VaultExternalID: vault.ExternalID,
 		Limit:           50,
 		IncludeArchived: false,
@@ -241,7 +241,7 @@ func (s *Server) handlePlatformMCPVaultAuthStart(w http.ResponseWriter, r *http.
 		UUID:                      uuid.NewString(),
 		ExternalID:                flowID,
 		OrganizationUUID:          principal.OrganizationUUID,
-		WorkspaceUUID:             workspace.UUID.String(),
+		WorkspaceUUID:             workspace.UUID,
 		VaultUUID:                 vault.UUID,
 		VaultExternalID:           vault.ExternalID,
 		UserUUID:                  principal.UserUUID,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -454,7 +454,7 @@ func (s *Server) authenticatePlatformSession(r *http.Request) (auth.Principal, *
 	if workspace.ArchivedAt != nil {
 		return auth.Principal{}, httpapi.NewError(http.StatusForbidden, "permission_error", "Workspace is archived")
 	}
-	principal.WorkspaceUUID = workspace.UUID.String()
+	principal.WorkspaceUUID = workspace.UUID
 	principal.WorkspaceExternalID = workspace.ExternalID
 	return principal, nil
 }

--- a/internal/db/admin_api_keys.go
+++ b/internal/db/admin_api_keys.go
@@ -5,23 +5,21 @@ import (
 	"errors"
 	"slices"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type AdminAPIKey struct {
-	UUID                    uuid.UUID     `db:"uuid"`
-	ExternalID              string        `db:"external_id"`
-	WorkspaceUUID           uuid.UUID     `db:"workspace_uuid"`
-	WorkspaceExternalID     string        `db:"workspace_external_id"`
-	CreatedByUserUUID       uuid.NullUUID `db:"created_by_user_uuid"`
-	CreatedByUserExternalID *string       `db:"created_by_user_external_id"`
-	Name                    string        `db:"name"`
-	PartialKeyHint          string        `db:"partial_key_hint"`
-	Status                  string        `db:"status"`
-	CreatedAt               time.Time     `db:"created_at"`
-	UpdatedAt               time.Time     `db:"updated_at"`
-	ExpiresAt               *time.Time    `db:"expires_at"`
+	UUID                    string     `db:"uuid"`
+	ExternalID              string     `db:"external_id"`
+	WorkspaceUUID           string     `db:"workspace_uuid"`
+	WorkspaceExternalID     string     `db:"workspace_external_id"`
+	CreatedByUserUUID       *string    `db:"created_by_user_uuid"`
+	CreatedByUserExternalID *string    `db:"created_by_user_external_id"`
+	Name                    string     `db:"name"`
+	PartialKeyHint          string     `db:"partial_key_hint"`
+	Status                  string     `db:"status"`
+	CreatedAt               time.Time  `db:"created_at"`
+	UpdatedAt               time.Time  `db:"updated_at"`
+	ExpiresAt               *time.Time `db:"expires_at"`
 }
 
 type ListAdminAPIKeysParams struct {

--- a/internal/db/admin_api_keys_mapper_test.go
+++ b/internal/db/admin_api_keys_mapper_test.go
@@ -24,7 +24,7 @@ func TestAdminAPIKeyMapperFindByExternalID(t *testing.T) {
 			organizationUUID,
 			"api_key_default",
 		)
-		if err != nil || found || key.UUID != uuid.Nil {
+		if err != nil || found || key.UUID != "" {
 			t.Fatalf("FindByExternalID() = (%+v, %t, %v), want zero, false, nil", key, found, err)
 		}
 		assertMapperTestExecution(

--- a/internal/db/admin_external_keys.go
+++ b/internal/db/admin_external_keys.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type AdminExternalKey struct {
-	UUID             uuid.UUID       `db:"uuid"`
+	UUID             string          `db:"uuid"`
 	ExternalID       string          `db:"external_id"`
-	OrganizationUUID uuid.UUID       `db:"organization_uuid"`
+	OrganizationUUID string          `db:"organization_uuid"`
 	DisplayName      string          `db:"display_name"`
 	Geo              string          `db:"geo"`
 	ProviderConfig   json.RawMessage `db:"provider_config"`
@@ -29,7 +27,7 @@ func (d *DB) CreateAdminExternalKey(ctx context.Context, key AdminExternalKey) (
 	mapper := NewAdminExternalKeyMapper(d.mapperDB)
 	created, err := mapper.Insert(ctx, insertAdminExternalKeyParams{
 		ExternalID:       key.ExternalID,
-		OrganizationUUID: key.OrganizationUUID.String(),
+		OrganizationUUID: key.OrganizationUUID,
 		DisplayName:      key.DisplayName,
 		Geo:              key.Geo,
 		ProviderConfig:   key.ProviderConfig,

--- a/internal/db/admin_external_keys_mapper_postgres_test.go
+++ b/internal/db/admin_external_keys_mapper_postgres_test.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"github.com/superduck-ai/open-managed-agents/internal/config"
-
-	"github.com/google/uuid"
 )
 
 func TestAdminExternalKeyMapperPostgreSQL(t *testing.T) {
@@ -98,7 +96,7 @@ func TestAdminExternalKeyMapperPostgreSQL(t *testing.T) {
 			ProviderConfig:   json.RawMessage(`{"type":"aws","region":"us-east-1"}`),
 			CreatedAt:        createdAt,
 		})
-		if createErr != nil || created.ExternalID != "key_mapper_fixture" || created.UUID == uuid.Nil {
+		if createErr != nil || created.ExternalID != "key_mapper_fixture" || created.UUID == "" {
 			t.Fatalf("Insert() = (%+v, %v)", created, createErr)
 		}
 		assertAdminExternalKeyProviderType(t, created.ProviderConfig, "aws")

--- a/internal/db/admin_external_keys_mapper_test.go
+++ b/internal/db/admin_external_keys_mapper_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/superduck-ai/yourbatis"
 )
@@ -94,7 +93,7 @@ func TestAdminExternalKeyMapperFindByExternalID(t *testing.T) {
 			organizationUUID,
 			"key_external",
 		)
-		if !errors.Is(err, sql.ErrNoRows) || key.UUID != uuid.Nil {
+		if !errors.Is(err, sql.ErrNoRows) || key.UUID != "" {
 			t.Fatalf("FindByExternalID() = (%+v, %v), want zero and sql.ErrNoRows", key, err)
 		}
 		assertMapperTestExecution(

--- a/internal/db/admin_organization_invites.go
+++ b/internal/db/admin_organization_invites.go
@@ -3,14 +3,12 @@ package db
 import (
 	"context"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type AdminInvite struct {
-	UUID             uuid.UUID `db:"uuid"`
+	UUID             string    `db:"uuid"`
 	ExternalID       string    `db:"external_id"`
-	OrganizationUUID uuid.UUID `db:"organization_uuid"`
+	OrganizationUUID string    `db:"organization_uuid"`
 	Email            string    `db:"email"`
 	Role             string    `db:"role"`
 	Status           string    `db:"status"`
@@ -29,7 +27,7 @@ func (d *DB) CreateAdminInvite(ctx context.Context, invite AdminInvite) (AdminIn
 	mapper := NewAdminInviteMapper(d.mapperDB)
 	created, err := mapper.Insert(ctx, insertAdminInviteParams{
 		ExternalID:       invite.ExternalID,
-		OrganizationUUID: invite.OrganizationUUID.String(),
+		OrganizationUUID: invite.OrganizationUUID,
 		Email:            invite.Email,
 		Role:             invite.Role,
 		Status:           invite.Status,

--- a/internal/db/admin_organization_invites_mapper_test.go
+++ b/internal/db/admin_organization_invites_mapper_test.go
@@ -92,7 +92,7 @@ func TestAdminInviteMapperFindByExternalID(t *testing.T) {
 			organizationUUID,
 			"invite_mapper",
 		)
-		if !errors.Is(err, sql.ErrNoRows) || invite.UUID != uuid.Nil {
+		if !errors.Is(err, sql.ErrNoRows) || invite.UUID != "" {
 			t.Fatalf("FindByExternalID() = (%+v, %v), want zero and sql.ErrNoRows", invite, err)
 		}
 		assertMapperTestExecution(
@@ -276,7 +276,7 @@ func TestAdminInviteMapperSoftDeleteByExternalID(t *testing.T) {
 			organizationUUID,
 			"invite_mapper",
 		)
-		if !errors.Is(err, sql.ErrNoRows) || invite.UUID != uuid.Nil {
+		if !errors.Is(err, sql.ErrNoRows) || invite.UUID != "" {
 			t.Fatalf("SoftDeleteByExternalID() = (%+v, %v), want zero and sql.ErrNoRows", invite, err)
 		}
 		assertMapperTestExecution(

--- a/internal/db/admin_organizations.go
+++ b/internal/db/admin_organizations.go
@@ -8,7 +8,7 @@ import (
 )
 
 type AdminOrganization struct {
-	UUID      uuid.UUID `db:"uuid"`
+	UUID      string    `db:"uuid"`
 	Name      string    `db:"name"`
 	CreatedAt time.Time `db:"created_at"`
 }

--- a/internal/db/admin_organizations_mapper_test.go
+++ b/internal/db/admin_organizations_mapper_test.go
@@ -9,13 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/yourbatis"
 )
 
 func TestAdminOrganizationMapperFindByUUID(t *testing.T) {
 	organizationUUID := "22222222-2222-4222-8222-222222222222"
-	wantUUID := uuid.MustParse(organizationUUID)
 	wantValues := []any{organizationUUID}
 
 	t.Run("query error", func(t *testing.T) {
@@ -42,7 +40,7 @@ func TestAdminOrganizationMapperFindByUUID(t *testing.T) {
 			context.Background(),
 			organizationUUID,
 		)
-		if !errors.Is(err, sql.ErrNoRows) || organization.UUID != uuid.Nil {
+		if !errors.Is(err, sql.ErrNoRows) || organization.UUID != "" {
 			t.Fatalf("FindByUUID() = (%+v, %v), want zero and sql.ErrNoRows", organization, err)
 		}
 		assertMapperTestExecution(
@@ -72,7 +70,7 @@ func TestAdminOrganizationMapperFindByUUID(t *testing.T) {
 			context.Background(),
 			organizationUUID,
 		)
-		if err != nil || organization.UUID != wantUUID || organization.Name != "Mapper organization" {
+		if err != nil || organization.UUID != organizationUUID || organization.Name != "Mapper organization" {
 			t.Fatalf("FindByUUID() = (%+v, %v)", organization, err)
 		}
 		assertMapperTestExecution(

--- a/internal/db/admin_users.go
+++ b/internal/db/admin_users.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/yourbatis"
 )
 
 type AdminUser struct {
-	UUID             uuid.UUID `db:"uuid"`
+	UUID             string    `db:"uuid"`
 	ExternalID       string    `db:"external_id"`
-	OrganizationUUID uuid.UUID `db:"organization_uuid"`
+	OrganizationUUID string    `db:"organization_uuid"`
 	Email            string    `db:"email"`
 	Name             string    `db:"name"`
 	Role             string    `db:"role"`
@@ -78,7 +77,7 @@ func (d *DB) DeleteAdminUser(ctx context.Context, organizationUUID, externalID s
 		if deleteErr = mapper.SoftDeleteWorkspaceMembersByUserUUID(
 			ctx,
 			organizationUUID,
-			deleted.UUID.String(),
+			deleted.UUID,
 		); deleteErr != nil {
 			return deleteErr
 		}

--- a/internal/db/admin_users_mapper_test.go
+++ b/internal/db/admin_users_mapper_test.go
@@ -25,7 +25,7 @@ func TestAdminUserMapperFindByExternalID(t *testing.T) {
 			organizationUUID,
 			"user_mapper",
 		)
-		if !errors.Is(err, sql.ErrNoRows) || user.UUID != uuid.Nil {
+		if !errors.Is(err, sql.ErrNoRows) || user.UUID != "" {
 			t.Fatalf("FindByExternalID() = (%+v, %v), want zero and sql.ErrNoRows", user, err)
 		}
 		assertMapperTestExecution(

--- a/internal/db/admin_workspace_members.go
+++ b/internal/db/admin_workspace_members.go
@@ -3,17 +3,15 @@ package db
 import (
 	"context"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type AdminWorkspaceMember struct {
-	UUID                uuid.UUID `db:"uuid"`
+	UUID                string    `db:"uuid"`
 	ExternalID          string    `db:"external_id"`
-	OrganizationUUID    uuid.UUID `db:"organization_uuid"`
-	WorkspaceUUID       uuid.UUID `db:"workspace_uuid"`
+	OrganizationUUID    string    `db:"organization_uuid"`
+	WorkspaceUUID       string    `db:"workspace_uuid"`
 	WorkspaceExternalID string    `db:"workspace_external_id"`
-	UserUUID            uuid.UUID `db:"user_uuid"`
+	UserUUID            string    `db:"user_uuid"`
 	UserExternalID      string    `db:"user_external_id"`
 	WorkspaceRole       string    `db:"workspace_role"`
 	CreatedAt           time.Time `db:"created_at"`
@@ -32,10 +30,10 @@ func (d *DB) CreateAdminWorkspaceMember(ctx context.Context, member AdminWorkspa
 	mapper := NewAdminWorkspaceMemberMapper(d.mapperDB)
 	created, err := mapper.Insert(ctx, insertAdminWorkspaceMemberParams{
 		ExternalID:          member.ExternalID,
-		OrganizationUUID:    member.OrganizationUUID.String(),
-		WorkspaceUUID:       member.WorkspaceUUID.String(),
+		OrganizationUUID:    member.OrganizationUUID,
+		WorkspaceUUID:       member.WorkspaceUUID,
 		WorkspaceExternalID: member.WorkspaceExternalID,
-		UserUUID:            member.UserUUID.String(),
+		UserUUID:            member.UserUUID,
 		UserExternalID:      member.UserExternalID,
 		WorkspaceRole:       member.WorkspaceRole,
 		CreatedAt:           member.CreatedAt,

--- a/internal/db/admin_workspace_members_mapper_test.go
+++ b/internal/db/admin_workspace_members_mapper_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/superduck-ai/yourbatis"
 )
@@ -53,7 +52,7 @@ func TestAdminWorkspaceMemberMapperInsert(t *testing.T) {
 			rows:    [][]driver.Value{adminWorkspaceMemberMapperTestRow(params.UserExternalID, createdAt)},
 		})
 		member, err := NewAdminWorkspaceMemberMapper(executor).Insert(context.Background(), params)
-		if err != nil || member.UserExternalID != params.UserExternalID || member.UUID == uuid.Nil {
+		if err != nil || member.UserExternalID != params.UserExternalID || member.UUID == "" {
 			t.Fatalf("Insert() = (%+v, %v)", member, err)
 		}
 		assertMapperTestExecution(
@@ -89,7 +88,7 @@ func TestAdminWorkspaceMemberMapperFindByUserExternalID(t *testing.T) {
 			"wrkspc_mapper",
 			"user_mapper",
 		)
-		if !errors.Is(err, sql.ErrNoRows) || member.UUID != uuid.Nil {
+		if !errors.Is(err, sql.ErrNoRows) || member.UUID != "" {
 			t.Fatalf("FindByUserExternalID() = (%+v, %v), want zero and sql.ErrNoRows", member, err)
 		}
 		assertMapperTestExecution(

--- a/internal/db/admin_workspaces.go
+++ b/internal/db/admin_workspaces.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type AdminWorkspace struct {
-	UUID             uuid.UUID       `db:"uuid"`
+	UUID             string          `db:"uuid"`
 	ExternalID       string          `db:"external_id"`
-	OrganizationUUID uuid.UUID       `db:"organization_uuid"`
+	OrganizationUUID string          `db:"organization_uuid"`
 	Name             string          `db:"name"`
 	CreatedAt        time.Time       `db:"created_at"`
 	UpdatedAt        time.Time       `db:"updated_at"`
@@ -34,9 +32,9 @@ type ListAdminWorkspacesParams struct {
 func (d *DB) CreateAdminWorkspace(ctx context.Context, workspace AdminWorkspace) (AdminWorkspace, error) {
 	mapper := NewAdminWorkspaceMapper(d.mapperDB)
 	created, err := mapper.Insert(ctx, insertAdminWorkspaceParams{
-		UUID:             workspace.UUID.String(),
+		UUID:             workspace.UUID,
 		ExternalID:       workspace.ExternalID,
-		OrganizationUUID: workspace.OrganizationUUID.String(),
+		OrganizationUUID: workspace.OrganizationUUID,
 		Name:             workspace.Name,
 		CreatedAt:        workspace.CreatedAt,
 		CompartmentID:    workspace.CompartmentID,

--- a/internal/db/admin_workspaces_mapper_postgres_test.go
+++ b/internal/db/admin_workspaces_mapper_postgres_test.go
@@ -132,7 +132,7 @@ func TestAdminWorkspaceMappersPostgreSQL(t *testing.T) {
 				DataResidency:    json.RawMessage(`{"region":"us"}`),
 				Tags:             json.RawMessage(`[{"key":"team","value":"platform"}]`),
 			})
-			if createErr != nil || created.UUID != id || created.ExternalKeyID != nil {
+			if createErr != nil || created.UUID != id.String() || created.ExternalKeyID != nil {
 				t.Fatalf("Insert() = (%+v, %v)", created, createErr)
 			}
 			assertAdminWorkspaceJSONField(t, created.DataResidency, "region", "us")
@@ -144,7 +144,7 @@ func TestAdminWorkspaceMappersPostgreSQL(t *testing.T) {
 			"wrkspc_mapper_a",
 			"",
 		)
-		if findErr != nil || foundByExternalID.UUID != workspaceUUID {
+		if findErr != nil || foundByExternalID.UUID != workspaceUUID.String() {
 			t.Fatalf("FindByIdentifier(external ID) = (%+v, %v)", foundByExternalID, findErr)
 		}
 		foundByUUID, findErr := workspaceMapper.FindByIdentifier(
@@ -237,7 +237,7 @@ func TestAdminWorkspaceMappersPostgreSQL(t *testing.T) {
 				WorkspaceRole:       "workspace_developer",
 				CreatedAt:           baseTime.Add(time.Duration(index) * time.Minute),
 			})
-			if createErr != nil || created.UserUUID != userUUID {
+			if createErr != nil || created.UserUUID != userUUID.String() {
 				t.Fatalf("Insert() = (%+v, %v)", created, createErr)
 			}
 		}

--- a/internal/db/admin_workspaces_mapper_test.go
+++ b/internal/db/admin_workspaces_mapper_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/superduck-ai/yourbatis"
 )
@@ -57,7 +56,7 @@ func TestAdminWorkspaceMapperInsert(t *testing.T) {
 			rows:    [][]driver.Value{adminWorkspaceMapperTestRow(params.ExternalID, createdAt)},
 		})
 		workspace, err := NewAdminWorkspaceMapper(executor).Insert(context.Background(), params)
-		if err != nil || workspace.ExternalID != params.ExternalID || workspace.UUID == uuid.Nil {
+		if err != nil || workspace.ExternalID != params.ExternalID || workspace.UUID == "" {
 			t.Fatalf("Insert() = (%+v, %v)", workspace, err)
 		}
 		assertMapperTestExecution(
@@ -98,7 +97,7 @@ func TestAdminWorkspaceMapperFindByIdentifier(t *testing.T) {
 			"wrkspc_mapper",
 			workspaceUUID,
 		)
-		if !errors.Is(err, sql.ErrNoRows) || workspace.UUID != uuid.Nil {
+		if !errors.Is(err, sql.ErrNoRows) || workspace.UUID != "" {
 			t.Fatalf("FindByIdentifier() = (%+v, %v), want zero and sql.ErrNoRows", workspace, err)
 		}
 		assertMapperTestExecution(

--- a/tests/uuid_boundary_postgres_test.go
+++ b/tests/uuid_boundary_postgres_test.go
@@ -16,10 +16,10 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/secrets"
 )
 
-// TestTypedUUIDAuthAndAdminPostgres is intentionally backed by PostgreSQL.
-// It exercises Mapper UUID binding/scanning and the string-based HTTP protocol
-// boundary used by API key authentication and Admin responses.
-func TestTypedUUIDAuthAndAdminPostgres(t *testing.T) {
+// TestUUIDAuthAndStringAdminPostgres is intentionally backed by PostgreSQL.
+// It exercises Mapper UUID binding/string scanning and the string-based HTTP
+// protocol boundary used by API key authentication and Admin responses.
+func TestUUIDAuthAndStringAdminPostgres(t *testing.T) {
 	app := newTestAppWithStore(t, nil, newFakeStore("typed-uuid-auth-admin"))
 	defer app.close()
 
@@ -36,7 +36,7 @@ func TestTypedUUIDAuthAndAdminPostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load organization with typed UUID parameter: %v", err)
 	}
-	if organization.UUID != key.OrganizationUUID {
+	if organization.UUID != key.OrganizationUUID.String() {
 		t.Fatalf("organization UUID = %s, want %s", organization.UUID, key.OrganizationUUID)
 	}
 
@@ -51,11 +51,11 @@ func TestTypedUUIDAuthAndAdminPostgres(t *testing.T) {
 	}
 }
 
-// TestTypedUUIDAdminConsoleWorkbenchPostgres keeps the three phase-two paths in
+// TestStringUUIDAdminConsoleWorkbenchPostgres keeps the three phase-two paths in
 // one PostgreSQL transaction surface while still exercising their public DB
 // methods. The created records use unique protocol IDs so this remains safe
 // against a developer's existing local test database.
-func TestTypedUUIDAdminConsoleWorkbenchPostgres(t *testing.T) {
+func TestStringUUIDAdminConsoleWorkbenchPostgres(t *testing.T) {
 	app := newTestAppWithStore(t, nil, newFakeStore("typed-uuid-admin-console-workbench"))
 	defer app.close()
 
@@ -66,8 +66,8 @@ func TestTypedUUIDAdminConsoleWorkbenchPostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load Admin workspace through typed UUID row: %v", err)
 	}
-	if workspace.UUID == uuid.Nil || workspace.OrganizationUUID == uuid.Nil {
-		t.Fatalf("Admin workspace returned nil UUIDs: %+v", workspace)
+	if workspace.UUID == "" || workspace.OrganizationUUID == "" {
+		t.Fatalf("Admin workspace returned empty UUIDs: %+v", workspace)
 	}
 
 	adminKeys, _, err := app.db.ListAdminAPIKeysPage(ctx, db.ListAdminAPIKeysParams{
@@ -77,8 +77,8 @@ func TestTypedUUIDAdminConsoleWorkbenchPostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list Admin API keys through typed UUID rows: %v", err)
 	}
-	if len(adminKeys) == 0 || adminKeys[0].WorkspaceUUID == uuid.Nil {
-		t.Fatalf("Admin API key rows did not include typed workspace UUID: %+v", adminKeys)
+	if len(adminKeys) == 0 || adminKeys[0].WorkspaceUUID == "" {
+		t.Fatalf("Admin API key rows did not include workspace UUID: %+v", adminKeys)
 	}
 
 	consoleWorkspaces, err := app.db.ListConsoleWorkspaces(ctx, ids.OrganizationUUID, false)


### PR DESCRIPTION
## Summary

- Replace typed UUID fields in admin database models with strings
- Update admin, platform MCP, and authentication flows to pass UUID strings consistently
- Adjust mapper and PostgreSQL boundary tests for string-based UUID scanning

## Testing

Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when handling UUID values across administration, authentication, workspace, invitation, member, and API key workflows.
  * Prevented potential mismatches when creating or retrieving organizations, workspaces, credentials, and related records.

* **Tests**
  * Updated validation to confirm UUIDs are correctly returned as non-empty string values.
  * Expanded coverage for authentication, administration, and workspace-related database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->