### PR TITLE
Use session UUIDs consistently for environment work and sandbox recovery

### DIFF
--- a/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
+++ b/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
@@ -103,7 +103,7 @@ worker 心跳状态直接使用 `code_sessions` 现有列：
 - `connection_status`
 - `updated_at`
 
-本流程不增加数据库列或 migration。Code Session 通过受信任的 Session Work 数据关联 `environment_work`，再通过 `work_id` 定位 `environment_sandboxes` 中最新的 `running` Sandbox；查询同时约束 organization、workspace 和 environment，并要求 `provider_sandbox_id` 非空。heartbeat 调用只查询 `worker_status=running`；Session 用户事件唤醒路径允许 `idle`、`running` 和 `requires_action`，从而既不让空闲 heartbeat 无限续期，又能在新工作到达时恢复 Sandbox。未关联活动 Sandbox 的独立 Code Session 只更新自身队列或 worker lease，不调用 Provider。worker 是否已注册由以下条件判断：
+heartbeat 状态机本身不增加 `code_sessions` 列。迁移 `00052` 将 Environment Work 的 Session 关联从 `data.id` JSONB 查询改为必填 `environment_work.session_uuid`；Code Session 现在通过同一 organization、workspace、environment 范围内的 `session_uuid` 关联 Work，再通过 `work_uuid` 定位 `environment_sandboxes` 中最新的 `running` Sandbox，并要求 `provider_sandbox_id` 非空。关联不依赖 Session 是否已软删除，也不解析 Work JSON。heartbeat 调用只查询 `worker_status=running`；Session 用户事件唤醒路径允许 `idle`、`running` 和 `requires_action`，从而既不让空闲 heartbeat 无限续期，又能在新工作到达时恢复 Sandbox。未关联活动 Sandbox 的独立 Code Session 只更新自身队列或 worker lease，不调用 Provider。worker 是否已注册由以下条件判断：
 
 - `current_worker_epoch > 0`
 - `worker_lease_expires_at is not null`

--- a/docs/design/be/database-identifier-references.md
+++ b/docs/design/be/database-identifier-references.md
@@ -100,6 +100,7 @@ identity 静默带入新结构。PostgreSQL schema 仍不创建外键约束。
 | Console 与 Workbench（`00044`） | `console_api_keys`、`workbench_prompts`、`workbench_prompt_revisions`、`workbench_prompt_kv`、`workbench_evaluations`、`workbench_generated_test_cases` | organization、workspace、API key、user、prompt、revision 引用 |
 | Admin Tunnel（`00045`） | `mcp_tunnels`、`mcp_tunnel_certificates` | organization、workspace、tunnel 引用 |
 | Console/Workbench 兼容展示（`00046`） | `console_api_keys`、`workbench_prompts` | 将非权威文本列明确命名为 `workspace_display_id`；资源定位仍只使用 `workspace_uuid` |
+| Environment Work Session 关联（`00052`） | `environment_work` | 用必填 `session_uuid` 替代 Session external ID 的 JSONB 间接关联 |
 
 例如 `skill_versions.skill_uuid`、`deployment_runs.deployment_uuid`、
 `session_events.session_uuid` 和 `workbench_evaluations.revision_ref_uuid` 都直接引用父资源的稳定 UUID，
@@ -110,6 +111,27 @@ identity 静默带入新结构。PostgreSQL schema 仍不创建外键约束。
 对于 nullable 引用（例如 session 的 deployment、memory 的 current version、sandbox 的 work），
 迁移保留可空语义；非空旧值无法映射时仍会失败。父子关系和租户归属通过写入 SQL、迁移校验以及
 集成测试保证。
+
+### Environment Work 的 Session 强类型关联
+
+迁移 `00052_use_session_uuid_for_environment_work.sql` 将 `environment_work.data jsonb` 替换为
+`session_uuid uuid not null`。Environment Work 自此只承载 Session Work，不再接受任意 Work payload。
+迁移要求每条历史 `data` 都是只包含 `type`、`id` 的对象，且 `type=session`；随后按 organization、
+workspace、environment 与 Session external ID 唯一回填 Session UUID。非 Session、附带未知字段、
+无法映射或无法唯一映射的数据都会让迁移明确失败。软删除 Session 仍参与回填与回滚，保证历史 Work
+不因 Session 生命周期而丢失关联。
+
+数据库内部的 Session 删除、Work 恢复、Sandbox/Code Session 关联与 Runner 加载全部使用
+`session_uuid`。Work 查询在相同 organization、workspace、environment 范围内关联 `sessions`，一次性
+投影协议所需的 Session external ID；写入和状态更新不会解析 JSON，也不会产生列表 N+1 查询。
+对外 Environment Work API 合同保持不变，仍由 HTTP DTO 构造：
+
+```json
+{"data":{"type":"session","id":"sesn_..."}}
+```
+
+`metadata jsonb` 不在本次迁移范围内。schema 仍不添加 PostgreSQL 外键，关联完整性由 Session 创建
+事务、带租户范围的 Mapper SQL、迁移校验和 PostgreSQL 测试保证。
 
 ## 应用查询边界
 
@@ -198,6 +220,7 @@ Console 与 Workbench 的 workspace 路由仍需兼容协议 external ID 和 `de
 - 默认 seed、Platform 登录、Console Workspace、Admin Workspace、API Key 鉴权、Filestore 和 Code Session 的租户关联继续通过；
 - `files` 到 `message_batches` 的资源主表，以及它们的资源子表，不再保存目标表 bigint identity；
 - deployments/session、Code Session/runtime、jobs/statistics、Console/Workbench 的跨表引用均为 UUID；
+- `environment_work` 只保存必填 `session_uuid`，不再保存 `data jsonb`，而 API 仍返回兼容的 Session Work `data`；
 - 目标表的应用模型、过滤条件、父子关联与稳定排序不读取 bigint identity；
 - nullable UUID 引用保留原有可空语义，必填或已有非空引用无法映射时 migration 失败；
 - DB 输入参数由上层边界按需校验；Mapper 的 UUID/nullable UUID 字段使用字符串类型，普通 SQL

--- a/internal/db/code_session_mapper.xml
+++ b/internal/db/code_session_mapper.xml
@@ -307,8 +307,7 @@
                 AND work.workspace_uuid = code_session.workspace_uuid
                 AND work.environment_uuid = code_session.environment_uuid
                 AND work.environment_external_id = code_session.environment_external_id
-                AND work.data-&gt;&gt;'type' = 'session'
-                AND work.data-&gt;&gt;'id' = code_session.session_external_id
+                AND work.session_uuid = code_session.session_uuid
                 AND work.state = 'active'
                 AND work.deleted_at IS NULL
           )

--- a/internal/db/code_session_mapper_test.go
+++ b/internal/db/code_session_mapper_test.go
@@ -142,7 +142,8 @@ func TestCodeSessionMapperBuilderContracts(t *testing.T) {
 			},
 			wantSQLFragments: []string{
 				"UPDATE code_sessions", "current_worker_epoch > 0", "worker_lease_expires_at IS NOT NULL",
-				"JOIN environment_sandboxes", "provider_sandbox_id = $6", "work.state = 'active'",
+				"work.session_uuid = code_session.session_uuid", "JOIN environment_sandboxes",
+				"provider_sandbox_id = $6", "work.state = 'active'",
 			},
 		}},
 		{"update worker state", mapperBuilderContract{

--- a/internal/db/environment_mapper_test.go
+++ b/internal/db/environment_mapper_test.go
@@ -159,14 +159,18 @@ func TestEnvironmentWorkMapperBuilderContracts(t *testing.T) {
 	}{
 		{"insert", mapperBuilderContract{
 			statement: environmentWorkMapperInsertStatement, bound: buildEnvironmentWorkMapperInsert(yourbatis.DialectPostgres, params),
-			wantID: "EnvironmentWorkMapper.Insert", wantKind: yourbatis.StatementInsert,
+			wantID: "EnvironmentWorkMapper.Insert", wantKind: yourbatis.StatementSelect,
 			wantArgumentNames: []string{
 				"params.UUID", "params.ExternalID", "params.OrganizationUUID", "params.WorkspaceUUID",
-				"params.EnvironmentUUID", "params.EnvironmentExternalID", "params.Data", "params.Metadata",
+				"params.EnvironmentUUID", "params.EnvironmentExternalID", "params.SessionUUID", "params.Metadata",
 				"params.Secret", "params.State", "params.CreatedAt", "params.CreatedAt",
+				"params.OrganizationUUID", "params.WorkspaceUUID", "params.EnvironmentUUID", "params.SessionUUID",
 			},
-			wantSensitiveArgumentNames: []string{"params.Data", "params.Metadata", "params.Secret"},
-			wantSQLFragments:           []string{"INSERT INTO environment_work", "CAST($7 AS jsonb)", "RETURNING"},
+			wantSensitiveArgumentNames: []string{"params.Metadata", "params.Secret"},
+			wantSQLFragments: []string{
+				"WITH changed AS", "INSERT INTO environment_work", "session_uuid", "CAST($8 AS jsonb)",
+				"FROM sessions source_session", "source_session.uuid = $16", "RETURNING", "JOIN sessions session",
+			},
 		}},
 		{"count active", mapperBuilderContract{
 			statement: environmentWorkMapperCountActiveStatement,
@@ -178,14 +182,14 @@ func TestEnvironmentWorkMapperBuilderContracts(t *testing.T) {
 			statement: environmentWorkMapperFindByExternalIDStatement,
 			bound:     buildEnvironmentWorkMapperFindByExternalID(yourbatis.DialectPostgres, params.WorkspaceUUID, params.EnvironmentExternalID, params.ExternalID),
 			wantID:    "EnvironmentWorkMapper.FindByExternalID", wantKind: yourbatis.StatementSelect,
-			wantArgumentNames: []string{"workspaceUUID", "environmentExternalID", "workExternalID"}, wantSQLFragments: []string{"FROM environment_work", "external_id = $3"},
+			wantArgumentNames: []string{"workspaceUUID", "environmentExternalID", "workExternalID"}, wantSQLFragments: []string{"FROM environment_work", "JOIN sessions session", "session.external_id AS session_external_id", "external_id = $3"},
 		}},
 		{"find latest", mapperBuilderContract{
-			statement: environmentWorkMapperFindLatestByDataStatement,
-			bound:     buildEnvironmentWorkMapperFindLatestByData(yourbatis.DialectPostgres, params.WorkspaceUUID, params.EnvironmentExternalID, "session", "ses_test"),
-			wantID:    "EnvironmentWorkMapper.FindLatestByData", wantKind: yourbatis.StatementSelect,
-			wantArgumentNames: []string{"workspaceUUID", "environmentExternalID", "dataType", "dataID"},
-			wantSQLFragments:  []string{"data->>'type' = $3", "ORDER BY created_at DESC"},
+			statement: environmentWorkMapperFindLatestBySessionStatement,
+			bound:     buildEnvironmentWorkMapperFindLatestBySession(yourbatis.DialectPostgres, params.WorkspaceUUID, params.EnvironmentExternalID, params.SessionUUID),
+			wantID:    "EnvironmentWorkMapper.FindLatestBySession", wantKind: yourbatis.StatementSelect,
+			wantArgumentNames: []string{"workspaceUUID", "environmentExternalID", "sessionUUID"},
+			wantSQLFragments:  []string{"work.session_uuid = $3", "ORDER BY work.created_at DESC", "JOIN sessions session"},
 		}},
 		{"list page", mapperBuilderContract{
 			statement: environmentWorkMapperListPageStatement, bound: buildEnvironmentWorkMapperListPage(yourbatis.DialectPostgres, page),
@@ -194,21 +198,21 @@ func TestEnvironmentWorkMapperBuilderContracts(t *testing.T) {
 				"params.WorkspaceUUID", "params.EnvironmentExternalID", "params.Cursor.CreatedAt",
 				"params.Cursor.UUID", "params.FetchLimit",
 			},
-			wantSQLFragments: []string{"(created_at, uuid) < ($3, $4)", "LIMIT $5"},
+			wantSQLFragments: []string{"(work.created_at, work.uuid) < ($3, $4)", "LIMIT $5"},
 		}},
 		{"claim for environment", mapperBuilderContract{
 			statement: environmentWorkMapperClaimForEnvironmentStatement,
 			bound:     buildEnvironmentWorkMapperClaimForEnvironment(yourbatis.DialectPostgres, params.WorkspaceUUID, params.EnvironmentExternalID, &workerID, now),
-			wantID:    "EnvironmentWorkMapper.ClaimForEnvironment", wantKind: yourbatis.StatementUpdate,
+			wantID:    "EnvironmentWorkMapper.ClaimForEnvironment", wantKind: yourbatis.StatementSelect,
 			wantArgumentNames: []string{"workerID", "claimExpiresAt", "workspaceUUID", "environmentExternalID"},
-			wantSQLFragments:  []string{"FOR UPDATE SKIP LOCKED", "RETURNING"},
+			wantSQLFragments:  []string{"WITH changed AS", "FOR UPDATE SKIP LOCKED", "RETURNING", "JOIN sessions session"},
 		}},
 		{"claim next", mapperBuilderContract{
 			statement: environmentWorkMapperClaimNextStatement,
-			bound:     buildEnvironmentWorkMapperClaimNext(yourbatis.DialectPostgres, &workerID, now, false),
-			wantID:    "EnvironmentWorkMapper.ClaimNext", wantKind: yourbatis.StatementUpdate,
+			bound:     buildEnvironmentWorkMapperClaimNext(yourbatis.DialectPostgres, &workerID, now),
+			wantID:    "EnvironmentWorkMapper.ClaimNext", wantKind: yourbatis.StatementSelect,
 			wantArgumentNames: []string{"workerID", "claimExpiresAt"},
-			wantSQLFragments:  []string{"COALESCE(data->>'type', '') <> 'session'", "FOR UPDATE SKIP LOCKED"},
+			wantSQLFragments:  []string{"WITH changed AS", "FOR UPDATE SKIP LOCKED", "RETURNING", "JOIN sessions session"},
 		}},
 		{"lock", mapperBuilderContract{
 			statement: environmentWorkMapperLockByExternalIDStatement,
@@ -219,17 +223,17 @@ func TestEnvironmentWorkMapperBuilderContracts(t *testing.T) {
 		{"ack", mapperBuilderContract{
 			statement: environmentWorkMapperAckByExternalIDStatement,
 			bound:     buildEnvironmentWorkMapperAckByExternalID(yourbatis.DialectPostgres, params.WorkspaceUUID, params.EnvironmentExternalID, params.ExternalID),
-			wantID:    "EnvironmentWorkMapper.AckByExternalID", wantKind: yourbatis.StatementUpdate,
-			wantArgumentNames: []string{"workspaceUUID", "environmentExternalID", "workExternalID"}, wantSQLFragments: []string{"acknowledged_at = COALESCE", "RETURNING"},
+			wantID:    "EnvironmentWorkMapper.AckByExternalID", wantKind: yourbatis.StatementSelect,
+			wantArgumentNames: []string{"workspaceUUID", "environmentExternalID", "workExternalID"}, wantSQLFragments: []string{"WITH changed AS", "acknowledged_at = COALESCE", "RETURNING", "JOIN sessions session"},
 		}},
 		{"metadata", mapperBuilderContract{
 			statement: environmentWorkMapperUpdateMetadataStatement,
 			bound:     buildEnvironmentWorkMapperUpdateMetadata(yourbatis.DialectPostgres, metadataParams),
-			wantID:    "EnvironmentWorkMapper.UpdateMetadata", wantKind: yourbatis.StatementUpdate,
+			wantID:    "EnvironmentWorkMapper.UpdateMetadata", wantKind: yourbatis.StatementSelect,
 			wantArgumentNames: []string{
 				"params.Metadata", "params.WorkspaceUUID", "params.EnvironmentExternalID", "params.WorkExternalID",
 			},
-			wantSensitiveArgumentNames: []string{"params.Metadata"}, wantSQLFragments: []string{"CAST($1 AS jsonb)", "RETURNING"},
+			wantSensitiveArgumentNames: []string{"params.Metadata"}, wantSQLFragments: []string{"WITH changed AS", "CAST($1 AS jsonb)", "RETURNING", "JOIN sessions session"},
 		}},
 		{"requeue recoverable work", mapperBuilderContract{
 			statement: environmentWorkMapperRequeueIfRecoverableStatement,
@@ -241,25 +245,25 @@ func TestEnvironmentWorkMapperBuilderContracts(t *testing.T) {
 			},
 			wantSQLFragments: []string{
 				"state = 'queued'", "claim_expires_at = $1", "state IN ('starting', 'active')",
-				"EXISTS", "code_session.session_external_id = environment_work.data->>'id'",
+				"EXISTS", "code_session.session_uuid = environment_work.session_uuid",
 			},
 		}},
 		{"heartbeat", mapperBuilderContract{
 			statement: environmentWorkMapperHeartbeatStatement,
 			bound:     buildEnvironmentWorkMapperHeartbeat(yourbatis.DialectPostgres, heartbeatParams),
-			wantID:    "EnvironmentWorkMapper.Heartbeat", wantKind: yourbatis.StatementUpdate,
+			wantID:    "EnvironmentWorkMapper.Heartbeat", wantKind: yourbatis.StatementSelect,
 			wantArgumentNames: []string{
 				"params.State", "params.TTLSeconds", "params.WorkUUID", "params.WorkspaceUUID", "params.EnvironmentExternalID",
 			},
-			wantSQLFragments: []string{"latest_heartbeat_at = NOW()", "uuid = $3", "RETURNING"},
+			wantSQLFragments: []string{"WITH changed AS", "latest_heartbeat_at = NOW()", "uuid = $3", "RETURNING", "JOIN sessions session"},
 		}},
 		{"stop", mapperBuilderContract{
 			statement: environmentWorkMapperStopStatement, bound: buildEnvironmentWorkMapperStop(yourbatis.DialectPostgres, stopParams),
-			wantID: "EnvironmentWorkMapper.Stop", wantKind: yourbatis.StatementUpdate,
+			wantID: "EnvironmentWorkMapper.Stop", wantKind: yourbatis.StatementSelect,
 			wantArgumentNames: []string{
 				"params.State", "params.State", "params.WorkspaceUUID", "params.EnvironmentExternalID", "params.WorkExternalID",
 			},
-			wantSQLFragments: []string{"WHEN $2 = 'stopped'", "RETURNING"},
+			wantSQLFragments: []string{"WITH changed AS", "WHEN $2 = 'stopped'", "RETURNING", "JOIN sessions session"},
 		}},
 		{"stats", mapperBuilderContract{
 			statement: environmentWorkMapperStatsStatement,
@@ -270,15 +274,14 @@ func TestEnvironmentWorkMapperBuilderContracts(t *testing.T) {
 		}},
 	}
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) { assertMapperBuilderContract(t, test.contract) })
+		t.Run(test.name, func(t *testing.T) {
+			assertMapperBuilderContract(t, test.contract)
+			if strings.Contains(test.contract.bound.SQL, "data->>") ||
+				strings.Contains(test.contract.bound.SQL, "work.data") {
+				t.Fatalf("Environment Work SQL still reads JSON data: %q", test.contract.bound.SQL)
+			}
+		})
 	}
-
-	t.Run("claim next includes session work", func(t *testing.T) {
-		bound := buildEnvironmentWorkMapperClaimNext(yourbatis.DialectPostgres, &workerID, now, true)
-		if strings.Contains(bound.SQL, "data->>'type'") {
-			t.Fatalf("SQL unexpectedly filters session work: %q", bound.SQL)
-		}
-	})
 }
 
 func TestEnvironmentSandboxMapperBuilderContracts(t *testing.T) {
@@ -336,7 +339,8 @@ func TestEnvironmentSandboxMapperBuilderContracts(t *testing.T) {
 			wantID: "EnvironmentSandboxMapper.FindActiveByCodeSessionExternalIDAndWorkerStatuses", wantKind: yourbatis.StatementSelect,
 			wantArgumentNames: []string{"codeSessionExternalID", "workerStatus", "workerStatus", "workerStatus"},
 			wantSQLFragments: []string{
-				"JOIN environment_work", "JOIN environment_sandboxes", "worker_status IN ( $2 , $3 , $4 )",
+				"JOIN environment_work", "work.session_uuid = code_session.session_uuid",
+				"JOIN environment_sandboxes", "worker_status IN ( $2 , $3 , $4 )",
 			},
 		}},
 		{"schedule recovery for code session", mapperBuilderContract{
@@ -353,7 +357,7 @@ func TestEnvironmentSandboxMapperBuilderContracts(t *testing.T) {
 			wantSensitiveArgumentNames: []string{"params.LastError"},
 			wantSQLFragments: []string{
 				"WITH recovery_target AS", "FOR UPDATE OF code_session, work, sandbox",
-				"state = 'failed'", "state = 'queued'",
+				"work.session_uuid = code_session.session_uuid", "state = 'failed'", "state = 'queued'",
 			},
 		}},
 	}
@@ -494,7 +498,8 @@ func environmentWorkMapperTestWriteParams(now time.Time) environmentWorkWritePar
 		OrganizationUUID: "00000000-0000-4000-8000-000000000001",
 		WorkspaceUUID:    "00000000-0000-4000-8000-000000000002",
 		EnvironmentUUID:  "00000000-0000-4000-8000-000000000003", EnvironmentExternalID: "env_test",
-		Data: []byte(`{"type":"session"}`), Metadata: []byte(`{}`), Secret: &secret, State: "queued", CreatedAt: now,
+		SessionUUID: "00000000-0000-4000-8000-000000000006",
+		Metadata:    []byte(`{}`), Secret: &secret, State: "queued", CreatedAt: now,
 	}
 }
 
@@ -533,7 +538,7 @@ func environmentMapperTestRow() []driver.Value {
 func environmentWorkMapperTestColumns() []string {
 	return []string{
 		"uuid", "external_id", "organization_uuid", "workspace_uuid", "environment_uuid",
-		"environment_external_id", "data", "metadata", "secret", "state", "claimed_by_worker_id",
+		"environment_external_id", "session_uuid", "session_external_id", "metadata", "secret", "state", "claimed_by_worker_id",
 		"claim_expires_at", "acknowledged_at", "started_at", "latest_heartbeat_at", "heartbeat_ttl_seconds",
 		"stop_requested_at", "stopped_at", "created_at", "updated_at", "deleted_at",
 	}
@@ -544,6 +549,6 @@ func environmentWorkMapperTestRow() []driver.Value {
 	return []driver.Value{
 		"00000000-0000-4000-8000-000000000004", "work_test", "00000000-0000-4000-8000-000000000001",
 		"00000000-0000-4000-8000-000000000002", "00000000-0000-4000-8000-000000000003", "env_test",
-		[]byte(`{"type":"session"}`), []byte(`{}`), "secret", "queued", nil, nil, nil, nil, nil, nil, nil, nil, now, now, nil,
+		"00000000-0000-4000-8000-000000000006", "ses_test", []byte(`{}`), "secret", "queued", nil, nil, nil, nil, nil, nil, nil, nil, now, now, nil,
 	}
 }

--- a/internal/db/environment_sandbox_mapper.xml
+++ b/internal/db/environment_sandbox_mapper.xml
@@ -96,8 +96,7 @@
             AND work.workspace_uuid = code_session.workspace_uuid
             AND work.environment_uuid = code_session.environment_uuid
             AND work.environment_external_id = code_session.environment_external_id
-            AND work.data-&gt;&gt;'type' = 'session'
-            AND work.data-&gt;&gt;'id' = code_session.session_external_id
+            AND work.session_uuid = code_session.session_uuid
             AND work.deleted_at IS NULL
             JOIN environment_sandboxes sandbox
             ON sandbox.organization_uuid = code_session.organization_uuid
@@ -127,8 +126,7 @@
             AND work.workspace_uuid = code_session.workspace_uuid
             AND work.environment_uuid = code_session.environment_uuid
             AND work.environment_external_id = code_session.environment_external_id
-            AND work.data-&gt;&gt;'type' = 'session'
-            AND work.data-&gt;&gt;'id' = code_session.session_external_id
+            AND work.session_uuid = code_session.session_uuid
             AND work.state = 'active'
             AND work.deleted_at IS NULL
             JOIN environment_sandboxes sandbox

--- a/internal/db/environment_work_mapper.go
+++ b/internal/db/environment_work_mapper.go
@@ -14,7 +14,8 @@ type environmentWorkMapperRow struct {
 	WorkspaceUUID         string     `db:"workspace_uuid"`
 	EnvironmentUUID       string     `db:"environment_uuid"`
 	EnvironmentExternalID string     `db:"environment_external_id"`
-	Data                  []byte     `db:"data"`
+	SessionUUID           string     `db:"session_uuid"`
+	SessionExternalID     string     `db:"session_external_id"`
 	Metadata              []byte     `db:"metadata"`
 	Secret                *string    `db:"secret"`
 	State                 string     `db:"state"`
@@ -38,7 +39,7 @@ type environmentWorkWriteParams struct {
 	WorkspaceUUID         string
 	EnvironmentUUID       string
 	EnvironmentExternalID string
-	Data                  []byte
+	SessionUUID           string
 	Metadata              []byte
 	Secret                *string
 	State                 string
@@ -102,10 +103,10 @@ type EnvironmentWorkMapper interface {
 	Insert(ctx context.Context, params environmentWorkWriteParams) (environmentWorkMapperRow, error)
 	CountActive(ctx context.Context, workspaceUUID, environmentUUID string) (int, error)
 	FindByExternalID(ctx context.Context, workspaceUUID, environmentExternalID, workExternalID string) (environmentWorkMapperRow, error)
-	FindLatestByData(ctx context.Context, workspaceUUID, environmentExternalID, dataType, dataID string) (environmentWorkMapperRow, error)
+	FindLatestBySession(ctx context.Context, workspaceUUID, environmentExternalID, sessionUUID string) (environmentWorkMapperRow, error)
 	ListPage(ctx context.Context, params environmentWorkPageMapperParams) ([]environmentWorkMapperRow, error)
 	ClaimForEnvironment(ctx context.Context, workspaceUUID, environmentExternalID string, workerID *string, claimExpiresAt time.Time) (environmentWorkMapperRow, error)
-	ClaimNext(ctx context.Context, workerID *string, claimExpiresAt time.Time, includeSessionWork bool) (environmentWorkMapperRow, error)
+	ClaimNext(ctx context.Context, workerID *string, claimExpiresAt time.Time) (environmentWorkMapperRow, error)
 	LockByExternalID(ctx context.Context, workspaceUUID, environmentExternalID, workExternalID string) (environmentWorkMapperRow, error)
 	AckByExternalID(ctx context.Context, workspaceUUID, environmentExternalID, workExternalID string) (environmentWorkMapperRow, error)
 	UpdateMetadata(ctx context.Context, params environmentWorkMetadataParams) (environmentWorkMapperRow, error)
@@ -113,6 +114,6 @@ type EnvironmentWorkMapper interface {
 	RequeueIfRecoverable(ctx context.Context, params environmentWorkRecoveryRetryParams) (int64, error)
 	Heartbeat(ctx context.Context, params environmentWorkHeartbeatParams) (environmentWorkMapperRow, error)
 	Stop(ctx context.Context, params environmentWorkStopParams) (environmentWorkMapperRow, error)
-	StopForDeletedSession(ctx context.Context, workspaceUUID, environmentExternalID, sessionExternalID string) (int64, error)
+	StopForDeletedSession(ctx context.Context, workspaceUUID, environmentExternalID, sessionUUID string) (int64, error)
 	Stats(ctx context.Context, workspaceUUID, environmentExternalID string) (environmentWorkStatsMapperRow, error)
 }

--- a/internal/db/environment_work_mapper.xml
+++ b/internal/db/environment_work_mapper.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mapper namespace="EnvironmentWorkMapper">
-    <sql id="columns">
+    <sql id="storageColumns">
         uuid,
         external_id,
         organization_uuid,
         workspace_uuid,
         environment_uuid,
         environment_external_id,
-        data,
+        session_uuid,
         metadata,
         secret,
         state,
@@ -24,37 +24,82 @@
         deleted_at
     </sql>
 
-    <insert id="Insert" result="returning" resultType="environmentWorkMapperRow">
-        INSERT INTO environment_work (
+    <sql id="columns">
+        work.uuid AS uuid,
+        work.external_id AS external_id,
+        work.organization_uuid AS organization_uuid,
+        work.workspace_uuid AS workspace_uuid,
+        work.environment_uuid AS environment_uuid,
+        work.environment_external_id AS environment_external_id,
+        work.session_uuid AS session_uuid,
+        session.external_id AS session_external_id,
+        work.metadata AS metadata,
+        work.secret AS secret,
+        work.state AS state,
+        work.claimed_by_worker_id AS claimed_by_worker_id,
+        work.claim_expires_at AS claim_expires_at,
+        work.acknowledged_at AS acknowledged_at,
+        work.started_at AS started_at,
+        work.latest_heartbeat_at AS latest_heartbeat_at,
+        work.heartbeat_ttl_seconds AS heartbeat_ttl_seconds,
+        work.stop_requested_at AS stop_requested_at,
+        work.stopped_at AS stopped_at,
+        work.created_at AS created_at,
+        work.updated_at AS updated_at,
+        work.deleted_at AS deleted_at
+    </sql>
+
+    <sql id="sessionJoin">
+        JOIN sessions session
+          ON session.organization_uuid = work.organization_uuid
+         AND session.workspace_uuid = work.workspace_uuid
+         AND session.environment_uuid = work.environment_uuid
+         AND session.uuid = work.session_uuid
+    </sql>
+
+    <select id="Insert" resultType="environmentWorkMapperRow">
+        WITH changed AS (
+            INSERT INTO environment_work (
             uuid,
             external_id,
             organization_uuid,
             workspace_uuid,
             environment_uuid,
             environment_external_id,
-            data,
+            session_uuid,
             metadata,
             secret,
             state,
             created_at,
             updated_at
-        ) VALUES (
+            )
+            SELECT
             #{params.UUID},
             #{params.ExternalID},
             #{params.OrganizationUUID},
             #{params.WorkspaceUUID},
             #{params.EnvironmentUUID},
             #{params.EnvironmentExternalID},
-            CAST(#{params.Data,sensitive=true} AS jsonb),
+            #{params.SessionUUID},
             CAST(#{params.Metadata,sensitive=true} AS jsonb),
             #{params.Secret,sensitive=true},
             #{params.State},
             #{params.CreatedAt},
             #{params.CreatedAt}
+            FROM sessions source_session
+            WHERE source_session.organization_uuid = #{params.OrganizationUUID}
+              AND source_session.workspace_uuid = #{params.WorkspaceUUID}
+              AND source_session.environment_uuid = #{params.EnvironmentUUID}
+              AND source_session.uuid = #{params.SessionUUID}
+              AND source_session.deleted_at IS NULL
+            RETURNING
+            <include refid="storageColumns"/>
         )
-        RETURNING
+        SELECT
         <include refid="columns"/>
-    </insert>
+        FROM changed work
+        <include refid="sessionJoin"/>
+    </select>
 
     <select id="CountActive" result="scalar">
         SELECT COUNT(*)
@@ -68,123 +113,147 @@
     <select id="FindByExternalID" resultType="environmentWorkMapperRow">
         SELECT
         <include refid="columns"/>
-        FROM environment_work
-        WHERE workspace_uuid = #{workspaceUUID}
-        AND environment_external_id = #{environmentExternalID}
-        AND external_id = #{workExternalID}
-        AND deleted_at IS NULL
+        FROM environment_work work
+        <include refid="sessionJoin"/>
+        WHERE work.workspace_uuid = #{workspaceUUID}
+        AND work.environment_external_id = #{environmentExternalID}
+        AND work.external_id = #{workExternalID}
+        AND work.deleted_at IS NULL
     </select>
 
-    <select id="FindLatestByData" resultType="environmentWorkMapperRow">
+    <select id="FindLatestBySession" resultType="environmentWorkMapperRow">
         SELECT
         <include refid="columns"/>
-        FROM environment_work
-        WHERE workspace_uuid = #{workspaceUUID}
-        AND environment_external_id = #{environmentExternalID}
-        AND data-&gt;&gt;'type' = #{dataType}
-        AND data-&gt;&gt;'id' = #{dataID}
-        AND deleted_at IS NULL
-        ORDER BY created_at DESC, uuid DESC
+        FROM environment_work work
+        <include refid="sessionJoin"/>
+        WHERE work.workspace_uuid = #{workspaceUUID}
+        AND work.environment_external_id = #{environmentExternalID}
+        AND work.session_uuid = #{sessionUUID}
+        AND work.deleted_at IS NULL
+        ORDER BY work.created_at DESC, work.uuid DESC
         LIMIT 1
     </select>
 
     <select id="ListPage" resultType="environmentWorkMapperRow">
         SELECT
         <include refid="columns"/>
-        FROM environment_work
+        FROM environment_work work
+        <include refid="sessionJoin"/>
         <where>
-            workspace_uuid = #{params.WorkspaceUUID}
-            AND environment_external_id = #{params.EnvironmentExternalID}
-            AND deleted_at IS NULL
+            work.workspace_uuid = #{params.WorkspaceUUID}
+            AND work.environment_external_id = #{params.EnvironmentExternalID}
+            AND work.deleted_at IS NULL
             <if test="params.Cursor != nil">
-                AND (created_at, uuid) &lt; (#{params.Cursor.CreatedAt}, #{params.Cursor.UUID})
+                AND (work.created_at, work.uuid) &lt; (#{params.Cursor.CreatedAt}, #{params.Cursor.UUID})
             </if>
         </where>
-        ORDER BY created_at DESC, uuid DESC
+        ORDER BY work.created_at DESC, work.uuid DESC
         LIMIT #{params.FetchLimit}
     </select>
 
-    <update id="ClaimForEnvironment" result="returning" resultType="environmentWorkMapperRow">
-        UPDATE environment_work
-        SET claimed_by_worker_id = #{workerID},
-            claim_expires_at = #{claimExpiresAt},
-            updated_at = NOW()
-        WHERE uuid = (
-            SELECT uuid
-            FROM environment_work
-            WHERE workspace_uuid = #{workspaceUUID}
-            AND environment_external_id = #{environmentExternalID}
-            AND deleted_at IS NULL
-            AND state = 'queued'
-            AND (claim_expires_at IS NULL OR claim_expires_at &lt;= NOW())
-            ORDER BY created_at ASC, uuid ASC
-            LIMIT 1
-            FOR UPDATE SKIP LOCKED
+    <select id="ClaimForEnvironment" resultType="environmentWorkMapperRow">
+        WITH changed AS (
+            UPDATE environment_work
+            SET claimed_by_worker_id = #{workerID},
+                claim_expires_at = #{claimExpiresAt},
+                updated_at = NOW()
+            WHERE uuid = (
+                SELECT uuid
+                FROM environment_work
+                WHERE workspace_uuid = #{workspaceUUID}
+                AND environment_external_id = #{environmentExternalID}
+                AND deleted_at IS NULL
+                AND state = 'queued'
+                AND (claim_expires_at IS NULL OR claim_expires_at &lt;= NOW())
+                ORDER BY created_at ASC, uuid ASC
+                LIMIT 1
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING
+            <include refid="storageColumns"/>
         )
-        RETURNING
+        SELECT
         <include refid="columns"/>
-    </update>
+        FROM changed work
+        <include refid="sessionJoin"/>
+    </select>
 
-    <update id="ClaimNext" result="returning" resultType="environmentWorkMapperRow">
-        UPDATE environment_work
-        SET claimed_by_worker_id = #{workerID},
-            claim_expires_at = #{claimExpiresAt},
-            updated_at = NOW()
-        WHERE uuid = (
-            SELECT uuid
-            FROM environment_work
-            WHERE deleted_at IS NULL
-            AND state = 'queued'
-            AND (claim_expires_at IS NULL OR claim_expires_at &lt;= NOW())
-            <if test="!includeSessionWork">
-                AND COALESCE(data-&gt;&gt;'type', '') &lt;&gt; 'session'
-            </if>
-            ORDER BY created_at ASC, uuid ASC
-            LIMIT 1
-            FOR UPDATE SKIP LOCKED
+    <select id="ClaimNext" resultType="environmentWorkMapperRow">
+        WITH changed AS (
+            UPDATE environment_work
+            SET claimed_by_worker_id = #{workerID},
+                claim_expires_at = #{claimExpiresAt},
+                updated_at = NOW()
+            WHERE uuid = (
+                SELECT uuid
+                FROM environment_work
+                WHERE deleted_at IS NULL
+                AND state = 'queued'
+                AND (claim_expires_at IS NULL OR claim_expires_at &lt;= NOW())
+                ORDER BY created_at ASC, uuid ASC
+                LIMIT 1
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING
+            <include refid="storageColumns"/>
         )
-        RETURNING
+        SELECT
         <include refid="columns"/>
-    </update>
+        FROM changed work
+        <include refid="sessionJoin"/>
+    </select>
 
     <select id="LockByExternalID" resultType="environmentWorkMapperRow">
         SELECT
         <include refid="columns"/>
-        FROM environment_work
-        WHERE workspace_uuid = #{workspaceUUID}
-        AND environment_external_id = #{environmentExternalID}
-        AND external_id = #{workExternalID}
-        AND deleted_at IS NULL
-        FOR UPDATE
+        FROM environment_work work
+        <include refid="sessionJoin"/>
+        WHERE work.workspace_uuid = #{workspaceUUID}
+        AND work.environment_external_id = #{environmentExternalID}
+        AND work.external_id = #{workExternalID}
+        AND work.deleted_at IS NULL
+        FOR UPDATE OF work
     </select>
 
-    <update id="AckByExternalID" result="returning" resultType="environmentWorkMapperRow">
-        UPDATE environment_work
-        SET state = CASE WHEN state = 'queued' THEN 'starting' ELSE state END,
-            acknowledged_at = COALESCE(acknowledged_at, NOW()),
-            started_at = COALESCE(started_at, NOW()),
-            claim_expires_at = NULL,
-            updated_at = NOW()
-        WHERE workspace_uuid = #{workspaceUUID}
-        AND environment_external_id = #{environmentExternalID}
-        AND external_id = #{workExternalID}
-        AND deleted_at IS NULL
-        AND state IN ('queued', 'starting', 'active')
-        RETURNING
+    <select id="AckByExternalID" resultType="environmentWorkMapperRow">
+        WITH changed AS (
+            UPDATE environment_work
+            SET state = CASE WHEN state = 'queued' THEN 'starting' ELSE state END,
+                acknowledged_at = COALESCE(acknowledged_at, NOW()),
+                started_at = COALESCE(started_at, NOW()),
+                claim_expires_at = NULL,
+                updated_at = NOW()
+            WHERE workspace_uuid = #{workspaceUUID}
+            AND environment_external_id = #{environmentExternalID}
+            AND external_id = #{workExternalID}
+            AND deleted_at IS NULL
+            AND state IN ('queued', 'starting', 'active')
+            RETURNING
+            <include refid="storageColumns"/>
+        )
+        SELECT
         <include refid="columns"/>
-    </update>
+        FROM changed work
+        <include refid="sessionJoin"/>
+    </select>
 
-    <update id="UpdateMetadata" result="returning" resultType="environmentWorkMapperRow">
-        UPDATE environment_work
-        SET metadata = CAST(#{params.Metadata,sensitive=true} AS jsonb),
-            updated_at = NOW()
-        WHERE workspace_uuid = #{params.WorkspaceUUID}
-        AND environment_external_id = #{params.EnvironmentExternalID}
-        AND external_id = #{params.WorkExternalID}
-        AND deleted_at IS NULL
-        RETURNING
+    <select id="UpdateMetadata" resultType="environmentWorkMapperRow">
+        WITH changed AS (
+            UPDATE environment_work
+            SET metadata = CAST(#{params.Metadata,sensitive=true} AS jsonb),
+                updated_at = NOW()
+            WHERE workspace_uuid = #{params.WorkspaceUUID}
+            AND environment_external_id = #{params.EnvironmentExternalID}
+            AND external_id = #{params.WorkExternalID}
+            AND deleted_at IS NULL
+            RETURNING
+            <include refid="storageColumns"/>
+        )
+        SELECT
         <include refid="columns"/>
-    </update>
+        FROM changed work
+        <include refid="sessionJoin"/>
+    </select>
 
     <update id="MergeMetadata" result="rows">
         UPDATE environment_work
@@ -213,48 +282,59 @@
           AND uuid = #{params.WorkUUID}
           AND state IN ('starting', 'active')
           AND deleted_at IS NULL
-          AND data-&gt;&gt;'type' = 'session'
           AND EXISTS (
               SELECT 1
               FROM code_sessions code_session
               WHERE code_session.organization_uuid = environment_work.organization_uuid
                 AND code_session.workspace_uuid = environment_work.workspace_uuid
                 AND code_session.environment_uuid = environment_work.environment_uuid
-                AND code_session.session_external_id = environment_work.data-&gt;&gt;'id'
+                AND code_session.session_uuid = environment_work.session_uuid
                 AND code_session.status = 'active'
                 AND code_session.deleted_at IS NULL
           )
     </update>
 
-    <update id="Heartbeat" result="returning" resultType="environmentWorkMapperRow">
-        UPDATE environment_work
-        SET state = #{params.State},
-            latest_heartbeat_at = NOW(),
-            heartbeat_ttl_seconds = #{params.TTLSeconds},
-            updated_at = NOW()
-        WHERE uuid = #{params.WorkUUID}
-        AND workspace_uuid = #{params.WorkspaceUUID}
-        AND environment_external_id = #{params.EnvironmentExternalID}
-        RETURNING
+    <select id="Heartbeat" resultType="environmentWorkMapperRow">
+        WITH changed AS (
+            UPDATE environment_work
+            SET state = #{params.State},
+                latest_heartbeat_at = NOW(),
+                heartbeat_ttl_seconds = #{params.TTLSeconds},
+                updated_at = NOW()
+            WHERE uuid = #{params.WorkUUID}
+            AND workspace_uuid = #{params.WorkspaceUUID}
+            AND environment_external_id = #{params.EnvironmentExternalID}
+            RETURNING
+            <include refid="storageColumns"/>
+        )
+        SELECT
         <include refid="columns"/>
-    </update>
+        FROM changed work
+        <include refid="sessionJoin"/>
+    </select>
 
-    <update id="Stop" result="returning" resultType="environmentWorkMapperRow">
-        UPDATE environment_work
-        SET state = #{params.State},
-            stop_requested_at = COALESCE(stop_requested_at, NOW()),
-            stopped_at = CASE
-                WHEN #{params.State} = 'stopped' THEN COALESCE(stopped_at, NOW())
-                ELSE stopped_at
-            END,
-            updated_at = NOW()
-        WHERE workspace_uuid = #{params.WorkspaceUUID}
-        AND environment_external_id = #{params.EnvironmentExternalID}
-        AND external_id = #{params.WorkExternalID}
-        AND deleted_at IS NULL
-        RETURNING
+    <select id="Stop" resultType="environmentWorkMapperRow">
+        WITH changed AS (
+            UPDATE environment_work
+            SET state = #{params.State},
+                stop_requested_at = COALESCE(stop_requested_at, NOW()),
+                stopped_at = CASE
+                    WHEN #{params.State} = 'stopped' THEN COALESCE(stopped_at, NOW())
+                    ELSE stopped_at
+                END,
+                updated_at = NOW()
+            WHERE workspace_uuid = #{params.WorkspaceUUID}
+            AND environment_external_id = #{params.EnvironmentExternalID}
+            AND external_id = #{params.WorkExternalID}
+            AND deleted_at IS NULL
+            RETURNING
+            <include refid="storageColumns"/>
+        )
+        SELECT
         <include refid="columns"/>
-    </update>
+        FROM changed work
+        <include refid="sessionJoin"/>
+    </select>
 
     <update id="StopForDeletedSession" result="rows">
         UPDATE environment_work
@@ -263,7 +343,7 @@
             updated_at = NOW()
         WHERE workspace_uuid = #{workspaceUUID}
         AND environment_external_id = #{environmentExternalID}
-        AND data-&gt;&gt;'id' = #{sessionExternalID}
+        AND session_uuid = #{sessionUUID}
         AND deleted_at IS NULL
         AND state &lt;&gt; 'stopped'
     </update>

--- a/internal/db/environments.go
+++ b/internal/db/environments.go
@@ -59,7 +59,8 @@ type EnvironmentWork struct {
 	WorkspaceUUID         string
 	EnvironmentUUID       string
 	EnvironmentExternalID string
-	Data                  json.RawMessage
+	SessionUUID           string
+	SessionExternalID     string
 	Metadata              json.RawMessage
 	Secret                *string
 	State                 string
@@ -230,12 +231,8 @@ func (d *DB) GetEnvironmentKey(ctx context.Context, keyHash string) (Environment
 
 func (d *DB) CreateEnvironmentWork(ctx context.Context, work EnvironmentWork) (EnvironmentWork, error) {
 	work.State = coalesceWorkState(work.State)
-	mapper := NewEnvironmentWorkMapper(d.mapperDB)
-	row, err := mapper.Insert(ctx, environmentWorkWriteParamsFrom(work))
-	if err != nil {
-		return EnvironmentWork{}, err
-	}
-	return row.work(), nil
+	row, err := NewEnvironmentWorkMapper(d.mapperDB).Insert(ctx, environmentWorkWriteParamsFrom(work))
+	return row.work(), err
 }
 
 func (d *DB) GetEnvironmentWork(ctx context.Context, workspaceUUID string, environmentExternalID, workExternalID string) (EnvironmentWork, error) {
@@ -247,9 +244,9 @@ func (d *DB) GetEnvironmentWork(ctx context.Context, workspaceUUID string, envir
 	return row.work(), nil
 }
 
-func (d *DB) GetLatestEnvironmentWorkByData(ctx context.Context, workspaceUUID string, environmentExternalID, dataType, dataID string) (EnvironmentWork, error) {
+func (d *DB) GetLatestEnvironmentWorkForSession(ctx context.Context, workspaceUUID string, environmentExternalID, sessionUUID string) (EnvironmentWork, error) {
 	mapper := NewEnvironmentWorkMapper(d.mapperDB)
-	row, err := mapper.FindLatestByData(ctx, workspaceUUID, environmentExternalID, dataType, dataID)
+	row, err := mapper.FindLatestBySession(ctx, workspaceUUID, environmentExternalID, sessionUUID)
 	if err != nil {
 		return EnvironmentWork{}, mapNoRows(err)
 	}
@@ -307,15 +304,14 @@ func (d *DB) PollEnvironmentWork(ctx context.Context, workspaceUUID string, envi
 }
 
 func (d *DB) PollNextEnvironmentWork(ctx context.Context, workerID string, claimFor time.Duration) (*EnvironmentWork, error) {
-	return d.PollNextEnvironmentWorkForRunner(ctx, workerID, claimFor, true)
-}
-
-func (d *DB) PollNextEnvironmentWorkForRunner(ctx context.Context, workerID string, claimFor time.Duration, includeSessionWork bool) (*EnvironmentWork, error) {
 	if claimFor <= 0 {
 		claimFor = 5 * time.Second
 	}
-	mapper := NewEnvironmentWorkMapper(d.mapperDB)
-	row, err := mapper.ClaimNext(ctx, nullableWorkerID(workerID), time.Now().UTC().Add(claimFor), includeSessionWork)
+	row, err := NewEnvironmentWorkMapper(d.mapperDB).ClaimNext(
+		ctx,
+		nullableWorkerID(workerID),
+		time.Now().UTC().Add(claimFor),
+	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -336,24 +332,21 @@ func (d *DB) GetEnvironmentByUUID(ctx context.Context, workspaceUUID, environmen
 }
 
 func (d *DB) AckEnvironmentWork(ctx context.Context, workspaceUUID string, environmentExternalID, workExternalID string) (EnvironmentWork, error) {
-	mapper := NewEnvironmentWorkMapper(d.mapperDB)
-	row, err := mapper.AckByExternalID(ctx, workspaceUUID, environmentExternalID, workExternalID)
-	if err != nil {
-		return EnvironmentWork{}, mapNoRows(err)
-	}
-	return row.work(), nil
+	row, err := NewEnvironmentWorkMapper(d.mapperDB).AckByExternalID(
+		ctx,
+		workspaceUUID,
+		environmentExternalID,
+		workExternalID,
+	)
+	return row.work(), mapNoRows(err)
 }
 
 func (d *DB) UpdateEnvironmentWorkMetadata(ctx context.Context, workspaceUUID string, environmentExternalID, workExternalID string, metadata json.RawMessage) (EnvironmentWork, error) {
-	mapper := NewEnvironmentWorkMapper(d.mapperDB)
-	row, err := mapper.UpdateMetadata(ctx, environmentWorkMetadataParams{
+	row, err := NewEnvironmentWorkMapper(d.mapperDB).UpdateMetadata(ctx, environmentWorkMetadataParams{
 		WorkspaceUUID: workspaceUUID, EnvironmentExternalID: environmentExternalID,
 		WorkExternalID: workExternalID, Metadata: agentJSONArg(metadata),
 	})
-	if err != nil {
-		return EnvironmentWork{}, mapNoRows(err)
-	}
-	return row.work(), nil
+	return row.work(), mapNoRows(err)
 }
 
 func (d *DB) HeartbeatEnvironmentWork(ctx context.Context, workspaceUUID string, environmentExternalID, workExternalID, expectedLastHeartbeat string, ttlSeconds int, format func(time.Time) string) (WorkHeartbeatResult, error) {
@@ -400,15 +393,11 @@ func (d *DB) StopEnvironmentWork(ctx context.Context, workspaceUUID string, envi
 	if !force {
 		nextState = "stopping"
 	}
-	mapper := NewEnvironmentWorkMapper(d.mapperDB)
-	row, err := mapper.Stop(ctx, environmentWorkStopParams{
+	row, err := NewEnvironmentWorkMapper(d.mapperDB).Stop(ctx, environmentWorkStopParams{
 		WorkspaceUUID: workspaceUUID, EnvironmentExternalID: environmentExternalID,
 		WorkExternalID: workExternalID, State: nextState,
 	})
-	if err != nil {
-		return EnvironmentWork{}, mapNoRows(err)
-	}
-	return row.work(), nil
+	return row.work(), mapNoRows(err)
 }
 
 func (d *DB) RequeueEnvironmentWorkIfRecoverable(ctx context.Context, work EnvironmentWork, retryAt time.Time) (bool, error) {
@@ -598,7 +587,7 @@ func environmentWorkWriteParamsFrom(work EnvironmentWork) environmentWorkWritePa
 		UUID: work.UUID, ExternalID: work.ExternalID, OrganizationUUID: work.OrganizationUUID,
 		WorkspaceUUID: work.WorkspaceUUID, EnvironmentUUID: work.EnvironmentUUID,
 		EnvironmentExternalID: work.EnvironmentExternalID,
-		Data:                  agentJSONArg(work.Data), Metadata: agentJSONArg(work.Metadata),
+		SessionUUID:           work.SessionUUID, Metadata: agentJSONArg(work.Metadata),
 		Secret: work.Secret, State: work.State, CreatedAt: work.CreatedAt,
 	}
 }
@@ -660,8 +649,10 @@ func (r environmentWorkMapperRow) work() EnvironmentWork {
 	return EnvironmentWork{
 		UUID: r.UUID, ExternalID: r.ExternalID, OrganizationUUID: r.OrganizationUUID,
 		WorkspaceUUID: r.WorkspaceUUID, EnvironmentUUID: r.EnvironmentUUID,
-		EnvironmentExternalID: r.EnvironmentExternalID, Data: bytes.Clone(r.Data), Metadata: bytes.Clone(r.Metadata),
-		Secret: r.Secret, State: r.State, ClaimedByWorkerID: r.ClaimedByWorkerID,
+		EnvironmentExternalID: r.EnvironmentExternalID,
+		SessionUUID:           r.SessionUUID, SessionExternalID: r.SessionExternalID,
+		Metadata: bytes.Clone(r.Metadata),
+		Secret:   r.Secret, State: r.State, ClaimedByWorkerID: r.ClaimedByWorkerID,
 		ClaimExpiresAt: r.ClaimExpiresAt, AcknowledgedAt: r.AcknowledgedAt, StartedAt: r.StartedAt,
 		LatestHeartbeatAt: r.LatestHeartbeatAt, HeartbeatTTLSeconds: r.HeartbeatTTLSeconds,
 		StopRequestedAt: r.StopRequestedAt, StoppedAt: r.StoppedAt,

--- a/internal/db/migrations/00052_use_session_uuid_for_environment_work.sql
+++ b/internal/db/migrations/00052_use_session_uuid_for_environment_work.sql
@@ -1,0 +1,96 @@
+-- +goose Up
+
+alter table environment_work add column session_uuid uuid;
+
+-- +goose StatementBegin
+do $$
+begin
+	if exists (
+		select 1
+		from environment_work work
+		where jsonb_typeof(work.data) is distinct from 'object'
+	) then
+		raise exception 'environment_work data must be a JSON object';
+	end if;
+
+	if exists (
+		select 1
+		from environment_work work
+		where work.data->>'type' is distinct from 'session'
+			or jsonb_typeof(work.data->'id') is distinct from 'string'
+			or nullif(work.data->>'id', '') is null
+			or exists (
+				select 1
+				from jsonb_object_keys(work.data) field(key)
+				where field.key not in ('id', 'type')
+			)
+	) then
+		raise exception 'environment_work contains non-session or unsupported data';
+	end if;
+
+	if exists (
+		select 1
+		from environment_work work
+		where (
+			select count(*)
+			from sessions session
+			where session.organization_uuid = work.organization_uuid
+				and session.workspace_uuid = work.workspace_uuid
+				and session.environment_uuid = work.environment_uuid
+				and session.external_id = work.data->>'id'
+		) <> 1
+	) then
+		raise exception 'environment_work data cannot be uniquely mapped to a Session';
+	end if;
+end $$;
+-- +goose StatementEnd
+
+update environment_work work
+set session_uuid = session.uuid
+from sessions session
+where session.organization_uuid = work.organization_uuid
+	and session.workspace_uuid = work.workspace_uuid
+	and session.environment_uuid = work.environment_uuid
+	and session.external_id = work.data->>'id';
+
+-- +goose StatementBegin
+do $$
+begin
+	if exists (select 1 from environment_work where session_uuid is null) then
+		raise exception 'environment_work contains data that cannot be mapped to a Session';
+	end if;
+end $$;
+-- +goose StatementEnd
+
+alter table environment_work alter column session_uuid set not null;
+
+create index environment_work_session_v1_idx
+	on environment_work (workspace_uuid, session_uuid)
+	where deleted_at is null;
+
+alter table environment_work drop column data;
+
+-- +goose Down
+
+alter table environment_work add column data jsonb;
+
+update environment_work work
+set data = jsonb_build_object('id', session.external_id, 'type', 'session')
+from sessions session
+where session.organization_uuid = work.organization_uuid
+	and session.workspace_uuid = work.workspace_uuid
+	and session.environment_uuid = work.environment_uuid
+	and session.uuid = work.session_uuid;
+
+-- +goose StatementBegin
+do $$
+begin
+	if exists (select 1 from environment_work where data is null) then
+		raise exception 'environment_work contains a Session reference that cannot be restored';
+	end if;
+end $$;
+-- +goose StatementEnd
+
+alter table environment_work alter column data set not null;
+drop index environment_work_session_v1_idx;
+alter table environment_work drop column session_uuid;

--- a/internal/db/migrations_postgres_test.go
+++ b/internal/db/migrations_postgres_test.go
@@ -324,6 +324,270 @@ func TestUnifySessionResourcesAndFilesMigration(t *testing.T) {
 	assertSessionResourceRuntimeWriteAfterUUIDMigration(t, ctx, standardDB)
 }
 
+func TestEnvironmentWorkSessionUUIDMigration(t *testing.T) {
+	databaseURL := os.Getenv("TEST_MIGRATION_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("TEST_MIGRATION_DATABASE_URL is not set")
+	}
+
+	t.Run("backfills active and deleted Sessions and round trips", func(t *testing.T) {
+		ctx, database, provider := newIsolatedMigrationTestDatabase(t, databaseURL)
+		if _, err := provider.UpTo(ctx, 51); err != nil {
+			t.Fatalf("migrate fixture database to 51: %v", err)
+		}
+		seedEnvironmentWorkMigrationSessions(t, ctx, database)
+		if _, err := database.ExecContext(ctx, `
+			insert into environment_work (
+				uuid, external_id, organization_uuid, workspace_uuid,
+				environment_uuid, environment_external_id, data
+			) values
+				(
+					'52000000-0000-0000-0000-000000000101', 'work_migration_active',
+					'52000000-0000-0000-0000-000000000001', '52000000-0000-0000-0000-000000000002',
+					'52000000-0000-0000-0000-000000000003', 'env_migration_work',
+					'{"type":"session","id":"sesn_migration_work_active"}'
+				),
+				(
+					'52000000-0000-0000-0000-000000000102', 'work_migration_deleted',
+					'52000000-0000-0000-0000-000000000001', '52000000-0000-0000-0000-000000000002',
+					'52000000-0000-0000-0000-000000000003', 'env_migration_work',
+					'{"type":"session","id":"sesn_migration_work_deleted"}'
+				)
+		`); err != nil {
+			t.Fatalf("seed Environment Work: %v", err)
+		}
+
+		if _, err := provider.UpTo(ctx, 52); err != nil {
+			t.Fatalf("migrate Environment Work to Session UUID: %v", err)
+		}
+		assertEnvironmentWorkSessionMigrationState(t, ctx, database)
+
+		if _, err := provider.Down(ctx); err != nil {
+			t.Fatalf("roll back Environment Work Session UUID migration: %v", err)
+		}
+		var activeData, deletedData string
+		if err := database.QueryRowContext(ctx, `
+			select cast(data as text) from environment_work where external_id = 'work_migration_active'
+		`).Scan(&activeData); err != nil {
+			t.Fatalf("load restored active Work data: %v", err)
+		}
+		if err := database.QueryRowContext(ctx, `
+			select cast(data as text) from environment_work where external_id = 'work_migration_deleted'
+		`).Scan(&deletedData); err != nil {
+			t.Fatalf("load restored deleted-Session Work data: %v", err)
+		}
+		for name, restored := range map[string]string{"active": activeData, "deleted": deletedData} {
+			var data map[string]string
+			if err := json.Unmarshal([]byte(restored), &data); err != nil {
+				t.Fatalf("decode restored %s Work data: %v", name, err)
+			}
+			if data["type"] != "session" || data["id"] != "sesn_migration_work_"+name {
+				t.Fatalf("restored %s Work data = %#v", name, data)
+			}
+		}
+		assertMigrationColumnExists(t, ctx, database, "environment_work", "data", true)
+		assertMigrationColumnExists(t, ctx, database, "environment_work", "session_uuid", false)
+
+		if _, err := provider.Up(ctx); err != nil {
+			t.Fatalf("reapply Environment Work Session UUID migration: %v", err)
+		}
+		assertEnvironmentWorkSessionMigrationState(t, ctx, database)
+	})
+
+	invalidCases := []struct {
+		name      string
+		data      string
+		wantError string
+	}{
+		{name: "non Session type", data: `{"type":"task","id":"sesn_migration_work_active"}`, wantError: "non-session or unsupported data"},
+		{name: "non string Session ID", data: `{"type":"session","id":42}`, wantError: "non-session or unsupported data"},
+		{name: "extra field", data: `{"type":"session","id":"sesn_migration_work_active","custom":true}`, wantError: "non-session or unsupported data"},
+		{name: "unmapped Session", data: `{"type":"session","id":"sesn_missing"}`, wantError: "cannot be uniquely mapped"},
+		{name: "non object", data: `[]`, wantError: "must be a JSON object"},
+	}
+	for _, test := range invalidCases {
+		t.Run("rejects "+test.name, func(t *testing.T) {
+			ctx, database, provider := newIsolatedMigrationTestDatabase(t, databaseURL)
+			if _, err := provider.UpTo(ctx, 51); err != nil {
+				t.Fatalf("migrate fixture database to 51: %v", err)
+			}
+			seedEnvironmentWorkMigrationSessions(t, ctx, database)
+			if _, err := database.ExecContext(ctx, `
+				insert into environment_work (
+					uuid, external_id, organization_uuid, workspace_uuid,
+					environment_uuid, environment_external_id, data
+				) values (
+					'52000000-0000-0000-0000-000000000103', 'work_migration_invalid',
+					'52000000-0000-0000-0000-000000000001', '52000000-0000-0000-0000-000000000002',
+					'52000000-0000-0000-0000-000000000003', 'env_migration_work', cast($1 as jsonb)
+				)
+			`, test.data); err != nil {
+				t.Fatalf("seed invalid Environment Work: %v", err)
+			}
+			if _, err := provider.UpTo(ctx, 52); err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("migration error = %v, want containing %q", err, test.wantError)
+			}
+			assertMigrationColumnExists(t, ctx, database, "environment_work", "data", true)
+			assertMigrationColumnExists(t, ctx, database, "environment_work", "session_uuid", false)
+		})
+	}
+}
+
+func newIsolatedMigrationTestDatabase(
+	t *testing.T,
+	databaseURL string,
+) (context.Context, *sql.DB, *goose.Provider) {
+	t.Helper()
+	ctx := context.Background()
+	adminPool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Fatalf("open migration administration database: %v", err)
+	}
+	schema := "migration_environment_work_" + strings.ReplaceAll(time.Now().UTC().Format("20060102150405.000000000"), ".", "")
+	if _, err := adminPool.Exec(ctx, "create schema "+schema); err != nil {
+		adminPool.Close()
+		t.Fatalf("create isolated migration schema: %v", err)
+	}
+	poolConfig, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		_, _ = adminPool.Exec(ctx, "drop schema "+schema+" cascade")
+		adminPool.Close()
+		t.Fatalf("parse migration database URL: %v", err)
+	}
+	poolConfig.ConnConfig.RuntimeParams["search_path"] = schema
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		_, _ = adminPool.Exec(ctx, "drop schema "+schema+" cascade")
+		adminPool.Close()
+		t.Fatalf("open isolated migration database: %v", err)
+	}
+	standardDB := stdlib.OpenDBFromPool(pool)
+	t.Cleanup(func() {
+		_ = standardDB.Close()
+		pool.Close()
+		_, _ = adminPool.Exec(context.Background(), "drop schema "+schema+" cascade")
+		adminPool.Close()
+	})
+	return ctx, standardDB, newMigrationTestProvider(t, standardDB)
+}
+
+func seedEnvironmentWorkMigrationSessions(t *testing.T, ctx context.Context, database *sql.DB) {
+	t.Helper()
+	if _, err := database.ExecContext(ctx, `
+		insert into sessions (
+			uuid, external_id, organization_uuid, workspace_uuid, created_by_api_key_uuid,
+			environment_uuid, environment_external_id, agent_uuid, agent_external_id,
+			agent_version, agent_snapshot, deleted_at
+		) values
+			(
+				'52000000-0000-0000-0000-000000000011', 'sesn_migration_work_active',
+				'52000000-0000-0000-0000-000000000001', '52000000-0000-0000-0000-000000000002',
+				'52000000-0000-0000-0000-000000000004', '52000000-0000-0000-0000-000000000003',
+				'env_migration_work', '52000000-0000-0000-0000-000000000005', 'agent_migration_work',
+				1, '{}', null
+			),
+			(
+				'52000000-0000-0000-0000-000000000012', 'sesn_migration_work_deleted',
+				'52000000-0000-0000-0000-000000000001', '52000000-0000-0000-0000-000000000002',
+				'52000000-0000-0000-0000-000000000004', '52000000-0000-0000-0000-000000000003',
+				'env_migration_work', '52000000-0000-0000-0000-000000000005', 'agent_migration_work',
+				1, '{}', now()
+			)
+	`); err != nil {
+		t.Fatalf("seed migration Sessions: %v", err)
+	}
+}
+
+func assertEnvironmentWorkSessionMigrationState(t *testing.T, ctx context.Context, database *sql.DB) {
+	t.Helper()
+	rows, err := database.QueryContext(ctx, `
+		select external_id, cast(session_uuid as text)
+		from environment_work
+		order by external_id
+	`)
+	if err != nil {
+		t.Fatalf("load migrated Environment Work: %v", err)
+	}
+	defer rows.Close()
+	got := make(map[string]string)
+	for rows.Next() {
+		var externalID, sessionUUID string
+		if err := rows.Scan(&externalID, &sessionUUID); err != nil {
+			t.Fatalf("scan migrated Environment Work: %v", err)
+		}
+		got[externalID] = sessionUUID
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate migrated Environment Work: %v", err)
+	}
+	want := map[string]string{
+		"work_migration_active":  "52000000-0000-0000-0000-000000000011",
+		"work_migration_deleted": "52000000-0000-0000-0000-000000000012",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("migrated Environment Work = %#v, want %#v", got, want)
+	}
+	for externalID, sessionUUID := range want {
+		if got[externalID] != sessionUUID {
+			t.Fatalf("migrated %s Session UUID = %q, want %q", externalID, got[externalID], sessionUUID)
+		}
+	}
+	assertMigrationColumnExists(t, ctx, database, "environment_work", "data", false)
+	assertMigrationColumnExists(t, ctx, database, "environment_work", "session_uuid", true)
+	var nullable string
+	if err := database.QueryRowContext(ctx, `
+		select is_nullable
+		from information_schema.columns
+		where table_schema = current_schema()
+			and table_name = 'environment_work'
+			and column_name = 'session_uuid'
+	`).Scan(&nullable); err != nil {
+		t.Fatalf("check Environment Work Session nullability: %v", err)
+	}
+	if nullable != "NO" {
+		t.Fatalf("environment_work.session_uuid is_nullable = %q, want NO", nullable)
+	}
+	var indexDefinition string
+	if err := database.QueryRowContext(ctx, `
+		select indexdef
+		from pg_indexes
+		where schemaname = current_schema()
+			and indexname = 'environment_work_session_v1_idx'
+	`).Scan(&indexDefinition); err != nil {
+		t.Fatalf("load Environment Work Session index: %v", err)
+	}
+	if !strings.Contains(indexDefinition, "(workspace_uuid, session_uuid)") ||
+		!strings.Contains(indexDefinition, "WHERE (deleted_at IS NULL)") {
+		t.Fatalf("Environment Work Session index = %q", indexDefinition)
+	}
+}
+
+func assertMigrationColumnExists(
+	t *testing.T,
+	ctx context.Context,
+	database *sql.DB,
+	tableName string,
+	columnName string,
+	want bool,
+) {
+	t.Helper()
+	var exists bool
+	if err := database.QueryRowContext(ctx, `
+		select exists (
+			select 1
+			from information_schema.columns
+			where table_schema = current_schema()
+				and table_name = $1
+				and column_name = $2
+		)
+	`, tableName, columnName).Scan(&exists); err != nil {
+		t.Fatalf("check migration column %s.%s: %v", tableName, columnName, err)
+	}
+	if exists != want {
+		t.Fatalf("migration column %s.%s exists = %t, want %t", tableName, columnName, exists, want)
+	}
+}
+
 func assertSessionResourceRuntimeWriteAfterUUIDMigration(
 	t *testing.T,
 	ctx context.Context,

--- a/internal/db/session_mapper.go
+++ b/internal/db/session_mapper.go
@@ -95,6 +95,7 @@ type sessionPageMapperParams struct {
 type SessionMapper interface {
 	Insert(ctx context.Context, params sessionWriteParams) (sessionRow, error)
 	FindByExternalID(ctx context.Context, workspaceUUID, sessionExternalID string) (sessionRow, bool, error)
+	FindByUUID(ctx context.Context, workspaceUUID, sessionUUID string) (sessionRow, bool, error)
 	UpdateByExternalID(ctx context.Context, params sessionUpdateParams) (sessionRow, error)
 	PatchMetadata(ctx context.Context, workspaceUUID, sessionExternalID string, metadataPatch []byte) (sessionRow, error)
 	SetOutcomeEvaluations(ctx context.Context, workspaceUUID, sessionExternalID string, evaluations []byte) (sessionRow, error)

--- a/internal/db/session_mapper.xml
+++ b/internal/db/session_mapper.xml
@@ -55,6 +55,14 @@
         AND deleted_at IS NULL
     </select>
 
+    <select id="FindByUUID" resultType="sessionRow">
+        SELECT <include refid="columns"/>
+        FROM sessions
+        WHERE workspace_uuid = #{workspaceUUID}
+        AND uuid = #{sessionUUID}
+        AND deleted_at IS NULL
+    </select>
+
     <update id="UpdateByExternalID" result="returning" resultType="sessionRow">
         UPDATE sessions
         SET agent_snapshot = CAST(#{params.AgentSnapshot,sensitive=true} AS jsonb),

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -225,6 +225,15 @@ func (d *DB) GetSession(ctx context.Context, workspaceUUID string, externalID st
 	return row.session(), true, nil
 }
 
+func (d *DB) GetSessionByUUID(ctx context.Context, workspaceUUID string, sessionUUID string) (Session, bool, error) {
+	mapper := NewSessionMapper(d.mapperDB)
+	row, found, err := mapper.FindByUUID(ctx, workspaceUUID, sessionUUID)
+	if err != nil || !found {
+		return Session{}, found, err
+	}
+	return row.session(), true, nil
+}
+
 func (d *DB) UpdateSession(ctx context.Context, workspaceUUID string, externalID string, next Session) (Session, error) {
 	mapper := NewSessionMapper(d.mapperDB)
 	row, err := mapper.UpdateByExternalID(ctx, sessionUpdateParams{
@@ -318,7 +327,7 @@ func (d *DB) DeleteSession(ctx context.Context, workspaceUUID string, externalID
 		if _, txErr = eventMapper.SoftDeleteBySession(ctx, workspaceUUID, externalID); txErr != nil {
 			return txErr
 		}
-		_, txErr = workMapper.StopForDeletedSession(ctx, workspaceUUID, session.EnvironmentExternalID, externalID)
+		_, txErr = workMapper.StopForDeletedSession(ctx, workspaceUUID, session.EnvironmentExternalID, session.UUID)
 		return txErr
 	})
 	return session, err

--- a/internal/db/sessions_helpers.go
+++ b/internal/db/sessions_helpers.go
@@ -78,6 +78,7 @@ func insertSessionTx(
 		resources = append(resources, created)
 	}
 
+	input.Work.SessionUUID = session.UUID
 	workRow, err := workMapper.Insert(ctx, environmentWorkWriteParamsFrom(input.Work))
 	if err != nil {
 		return Session{}, SessionThread{}, nil, EnvironmentWork{}, err

--- a/internal/db/sessions_mapper_test.go
+++ b/internal/db/sessions_mapper_test.go
@@ -75,6 +75,13 @@ func TestSessionTableMapperWriteBuilderContracts(t *testing.T) {
 			wantSQLFragments: []string{"INSERT INTO sessions", "CAST($11 AS jsonb)", "RETURNING", "uuid, external_id"},
 		},
 		{
+			statement: sessionMapperFindByUUIDStatement,
+			bound:     buildSessionMapperFindByUUID(yourbatis.DialectPostgres, "workspace-uuid", "session-uuid"),
+			wantID:    "SessionMapper.FindByUUID", wantKind: yourbatis.StatementSelect,
+			wantArgumentNames: []string{"workspaceUUID", "sessionUUID"},
+			wantSQLFragments:  []string{"FROM sessions", "workspace_uuid = $1", "uuid = $2", "deleted_at IS NULL"},
+		},
+		{
 			statement: sessionThreadMapperInsertIfAbsentStatement,
 			bound:     buildSessionThreadMapperInsertIfAbsent(yourbatis.DialectPostgres, threadParams),
 			wantID:    "SessionThreadMapper.InsertIfAbsent", wantKind: yourbatis.StatementSelect,

--- a/internal/deployments/execution.go
+++ b/internal/deployments/execution.go
@@ -23,11 +23,6 @@ type preparedDeploymentExecution struct {
 	Events  []db.SessionEvent
 }
 
-type deploymentSessionWork struct {
-	ID   string `json:"id"`
-	Type string `json:"type"`
-}
-
 func prepareDeploymentExecution(
 	deployment db.Deployment,
 	createdByAPIKeyUUID string,
@@ -46,10 +41,6 @@ func prepareDeploymentExecution(
 		return preparedDeploymentExecution{}, err
 	}
 	deploymentID := deployment.ExternalID
-	workData, err := jsonx.Encode(deploymentSessionWork{ID: sessionID, Type: "session"})
-	if err != nil {
-		return preparedDeploymentExecution{}, err
-	}
 	return preparedDeploymentExecution{
 		RunID:  runID,
 		Events: events,
@@ -77,7 +68,7 @@ func prepareDeploymentExecution(
 				UUID: uuid.NewString(), ExternalID: workID,
 				OrganizationUUID: deployment.OrganizationUUID, WorkspaceUUID: deployment.WorkspaceUUID,
 				EnvironmentUUID: deployment.EnvironmentUUID, EnvironmentExternalID: deployment.EnvironmentExternalID,
-				Data: workData, Metadata: json.RawMessage(`{}`), State: "queued", CreatedAt: now, UpdatedAt: now,
+				Metadata: json.RawMessage(`{}`), State: "queued", CreatedAt: now, UpdatedAt: now,
 			},
 		},
 	}, nil

--- a/internal/environments/handler.go
+++ b/internal/environments/handler.go
@@ -75,11 +75,17 @@ type deleteResponse struct {
 	Type string `json:"type"`
 }
 
+// SessionWorkData is the stable public identity envelope for Session Work.
+type SessionWorkData struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
 type workResponse struct {
 	ID                string          `json:"id"`
 	AcknowledgedAt    *string         `json:"acknowledged_at"`
 	CreatedAt         string          `json:"created_at"`
-	Data              json.RawMessage `json:"data"`
+	Data              SessionWorkData `json:"data"`
 	EnvironmentID     string          `json:"environment_id"`
 	LatestHeartbeatAt *string         `json:"latest_heartbeat_at"`
 	Metadata          json.RawMessage `json:"metadata"`
@@ -778,7 +784,7 @@ func responseFromWork(work db.EnvironmentWork) workResponse {
 		ID:                work.ExternalID,
 		AcknowledgedAt:    optionalTime(work.AcknowledgedAt),
 		CreatedAt:         formatTime(work.CreatedAt),
-		Data:              work.Data,
+		Data:              SessionWorkData{ID: work.SessionExternalID, Type: "session"},
 		EnvironmentID:     work.EnvironmentExternalID,
 		LatestHeartbeatAt: optionalTime(work.LatestHeartbeatAt),
 		Metadata:          work.Metadata,
@@ -955,7 +961,7 @@ func (h *Handler) fixtureWork(environmentID, workID, state string) workResponse 
 	return workResponse{
 		ID:            workID,
 		CreatedAt:     now,
-		Data:          json.RawMessage(`{"type":"session","id":"session_id"}`),
+		Data:          SessionWorkData{ID: "session_id", Type: "session"},
 		EnvironmentID: environmentID,
 		Metadata:      json.RawMessage(`{}`),
 		State:         state,

--- a/internal/environments/runner.go
+++ b/internal/environments/runner.go
@@ -185,7 +185,7 @@ func (r *Runner) loop(ctx context.Context, workerID string) {
 func (r *Runner) RunOnce(ctx context.Context, workerID string) (bool, error) {
 	// 每次最多领取一条 queued Work。数据库使用 FOR UPDATE SKIP LOCKED
 	// 避免并发 worker 领取同一条记录，并以 5 秒 claim 为 Ack 前的短暂保护。
-	work, err := r.db.PollNextEnvironmentWorkForRunner(ctx, workerID, 5*time.Second, true)
+	work, err := r.db.PollNextEnvironmentWork(ctx, workerID, 5*time.Second)
 	if err != nil || work == nil {
 		// false 表示本轮没有取得 Work：可能是队列为空，也可能是领取 SQL 失败。
 		return false, err
@@ -223,8 +223,8 @@ func (r *Runner) RunOnce(ctx context.Context, workerID string) (bool, error) {
 	}
 
 	// Cloud Session Work 还要读取 Session、resources、events 和 skills，准备
-	// rclone 与 Environment Manager 的启动数据。普通 Work 返回 nil preparation，
-	// 后续只创建 Sandbox，不进入 Managed Agent 专属分支。
+	// rclone 与 Environment Manager 的启动数据。非 Cloud Environment 不进入
+	// Managed Agent runtime 分支。
 	preparation, err := r.prepareManagedAgentLaunch(ctx, env, work)
 	if err != nil {
 		r.failWorkBeforeSandbox(ctx, *work)
@@ -326,8 +326,7 @@ func (r *Runner) RunOnce(ctx context.Context, workerID string) (bool, error) {
 		return true, err
 	}
 
-	// 普通 Work 到这里已经完成。Cloud Session 还需创建 Code Session，并在
-	// Sandbox 内启动 Environment Manager。
+	// Cloud Session 还需创建 Code Session，并在 Sandbox 内启动 Environment Manager。
 	if preparation != nil {
 		launch, err := r.createManagedAgentRuntimeLaunch(ctx, env, *work, *preparation)
 		if err != nil {
@@ -527,11 +526,10 @@ func (r *Runner) prepareManagedAgentLaunch(
 	if r == nil || work == nil {
 		return nil, nil
 	}
-	sessionID, ok := sessionIDFromEnvironmentWork(*work)
-	if !ok || !cloudEnvironment(env) {
+	if !cloudEnvironment(env) {
 		return nil, nil
 	}
-	session, found, err := r.db.GetSession(ctx, work.WorkspaceUUID, sessionID)
+	session, found, err := r.db.GetSessionByUUID(ctx, work.WorkspaceUUID, work.SessionUUID)
 	if err != nil {
 		return nil, fmt.Errorf("load managed agent Session: %w", err)
 	}
@@ -796,11 +794,7 @@ func (r *Runner) prepareManagedAgentNetworkMetadata(ctx context.Context, env db.
 	}
 	hosts := []string{}
 	if policyConfig.Type == networkpolicy.TypeLimited && policyConfig.AllowMCPServers {
-		sessionID, ok := sessionIDFromEnvironmentWork(*work)
-		if !ok {
-			return fmt.Errorf("limited managed-agent MCP policy requires session work identity")
-		}
-		session, found, err := r.db.GetSession(ctx, work.WorkspaceUUID, sessionID)
+		session, found, err := r.db.GetSessionByUUID(ctx, work.WorkspaceUUID, work.SessionUUID)
 		if err != nil {
 			return err
 		}
@@ -879,20 +873,6 @@ func (r *Runner) replaceRuntimeSkillArchives(
 		return fmt.Errorf("replace managed agent Skill Archive Resources: %w", err)
 	}
 	return nil
-}
-
-func sessionIDFromEnvironmentWork(work db.EnvironmentWork) (string, bool) {
-	var data struct {
-		Type string `json:"type"`
-		ID   string `json:"id"`
-	}
-	if err := json.Unmarshal(work.Data, &data); err != nil {
-		return "", false
-	}
-	if strings.TrimSpace(data.Type) != "session" || strings.TrimSpace(data.ID) == "" {
-		return "", false
-	}
-	return strings.TrimSpace(data.ID), true
 }
 
 func cloudEnvironment(env db.Environment) bool {

--- a/internal/sessions/service.go
+++ b/internal/sessions/service.go
@@ -85,7 +85,6 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return mapResourceBuildError(err)
 	}
-	workData, _ := httpapi.MarshalRaw(map[string]any{"id": sessionID, "type": "session"})
 	created, thread, _, _, err := h.db.CreateSession(r.Context(), db.CreateSessionInput{
 		Session: db.Session{
 			UUID:                  uuid.NewString(),
@@ -129,7 +128,6 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 			WorkspaceUUID:         principal.WorkspaceUUID,
 			EnvironmentUUID:       env.UUID,
 			EnvironmentExternalID: env.ExternalID,
-			Data:                  workData,
 			Metadata:              json.RawMessage(`{}`),
 			State:                 "queued",
 			CreatedAt:             now,

--- a/tests/environments_api_test.go
+++ b/tests/environments_api_test.go
@@ -202,17 +202,21 @@ func TestEnvironmentsAPI(t *testing.T) {
 		}, auth.HashAPIKey(envKey)); err != nil {
 			t.Fatalf("create environment key: %v", err)
 		}
-		workID := createEnvironmentWork(t, app, record)
+		workID, workSessionID := createEnvironmentWork(t, app, record)
 		defer cleanupEnvironmentWorkRows(t, app.pool, workID)
 
 		polled := pollEnvironmentWork(t, app, configured.ID, envKey)
 		if polled.ID != workID || polled.State != "queued" {
 			t.Fatalf("unexpected polled work: %+v", polled)
 		}
+		assertEnvironmentSessionWorkData(t, polled, workSessionID)
+		retrieved := retrieveEnvironmentWork(t, app, configured.ID, workID, envKey)
+		assertEnvironmentSessionWorkData(t, retrieved, workSessionID)
 		acked := postEnvironmentWork(t, app, configured.ID, workID, "ack", nil, envKey)
 		if acked.State != "starting" || acked.AcknowledgedAt == nil || acked.StartedAt == nil {
 			t.Fatalf("unexpected acked work: %+v", acked)
 		}
+		assertEnvironmentSessionWorkData(t, acked, workSessionID)
 		heartbeat := heartbeatEnvironmentWork(t, app, configured.ID, workID, "NO_HEARTBEAT", envKey)
 		if heartbeat.Type != "work_heartbeat" || heartbeat.State != "active" || heartbeat.LastHeartbeat == "" || heartbeat.TTLSeconds != 60 {
 			t.Fatalf("unexpected heartbeat: %+v", heartbeat)
@@ -222,10 +226,12 @@ func TestEnvironmentsAPI(t *testing.T) {
 
 		updatedWork := updateEnvironmentWork(t, app, configured.ID, workID, `{"metadata":{"state":"seen"}}`, envKey)
 		assertRawContains(t, updatedWork.Metadata, `"state":"seen"`)
+		assertEnvironmentSessionWorkData(t, updatedWork, workSessionID)
 		workPage := listEnvironmentWork(t, app, configured.ID, envKey)
 		if len(workPage.Data) != 1 || workPage.Data[0].ID != workID {
 			t.Fatalf("unexpected work page: %+v", workPage)
 		}
+		assertEnvironmentSessionWorkData(t, workPage.Data[0], workSessionID)
 		stats := environmentWorkStats(t, app, configured.ID, envKey)
 		if stats.Type != "work_queue_stats" || stats.Pending != 1 || stats.WorkersPolling == nil || *stats.WorkersPolling != 1 {
 			t.Fatalf("unexpected work stats: %+v", stats)
@@ -234,6 +240,7 @@ func TestEnvironmentsAPI(t *testing.T) {
 		if stopped.State != "stopped" || stopped.StoppedAt == nil {
 			t.Fatalf("unexpected stopped work: %+v", stopped)
 		}
+		assertEnvironmentSessionWorkData(t, stopped, workSessionID)
 
 		deleteEnvironment(t, app, configured.ID)
 	})
@@ -455,6 +462,18 @@ func pollEnvironmentWork(t *testing.T, app *testApp, envID, envKey string) envir
 	return work
 }
 
+func retrieveEnvironmentWork(t *testing.T, app *testApp, envID, workID, envKey string) environmentWorkAPIResponse {
+	t.Helper()
+	resp := doEnvironmentBearerRequest(t, app, http.MethodGet, "/v1/environments/"+envID+"/work/"+workID+"?beta=true", nil, envKey, true)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("retrieve work status = %d, want 200: %s", resp.StatusCode, readAll(t, resp.Body))
+	}
+	var work environmentWorkAPIResponse
+	decodeJSON(t, resp.Body, &work)
+	return work
+}
+
 func postEnvironmentWork(t *testing.T, app *testApp, envID, workID, action string, body io.Reader, envKey string) environmentWorkAPIResponse {
 	t.Helper()
 	resp := doEnvironmentBearerRequest(t, app, http.MethodPost, "/v1/environments/"+envID+"/work/"+workID+"/"+action+"?beta=true", body, envKey, true)
@@ -515,27 +534,55 @@ func environmentWorkStats(t *testing.T, app *testApp, envID, envKey string) envi
 	return stats
 }
 
-func createEnvironmentWork(t *testing.T, app *testApp, env db.Environment) string {
+func createEnvironmentWork(t *testing.T, app *testApp, env db.Environment) (string, string) {
 	t.Helper()
+	now := time.Now().UTC()
+	dbIDs := getDefaultDBIDs(t, app.pool)
 	workID, err := ids.New("work_")
 	if err != nil {
 		t.Fatalf("new work id: %v", err)
 	}
-	if _, err := app.db.CreateEnvironmentWork(context.Background(), db.EnvironmentWork{
-		UUID:                  uuid.NewString(),
-		ExternalID:            workID,
-		OrganizationUUID:      env.OrganizationUUID,
-		WorkspaceUUID:         env.WorkspaceUUID,
-		EnvironmentUUID:       env.UUID,
-		EnvironmentExternalID: env.ExternalID,
-		Data:                  json.RawMessage(`{"type":"session","id":"session_test"}`),
-		Metadata:              json.RawMessage(`{}`),
-		State:                 "queued",
-		CreatedAt:             time.Now().UTC(),
-	}); err != nil {
-		t.Fatalf("create environment work: %v", err)
+	sessionID := "sesn_environment_work_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	sessionUUID := uuid.NewString()
+	_, _, _, work, err := app.db.CreateSession(context.Background(), db.CreateSessionInput{
+		Session: db.Session{
+			UUID: sessionUUID, ExternalID: sessionID, OrganizationUUID: env.OrganizationUUID,
+			WorkspaceUUID: env.WorkspaceUUID, CreatedByAPIKeyUUID: dbIDs.APIKeyUUID,
+			EnvironmentUUID: env.UUID, EnvironmentExternalID: env.ExternalID,
+			AgentUUID: uuid.NewString(), AgentExternalID: "agent_environment_work_test", AgentVersion: 1,
+			AgentSnapshot: json.RawMessage(`{}`), Metadata: json.RawMessage(`{}`), VaultIDs: json.RawMessage(`[]`),
+			Status: "idle", Usage: json.RawMessage(`{}`), Stats: json.RawMessage(`{}`),
+			OutcomeEvaluations: json.RawMessage(`[]`), CreatedAt: now, UpdatedAt: now,
+		},
+		Thread: db.SessionThread{
+			UUID: uuid.NewString(), ExternalID: "sthr_environment_work_" + strings.ReplaceAll(uuid.NewString(), "-", ""),
+			OrganizationUUID: env.OrganizationUUID, WorkspaceUUID: env.WorkspaceUUID,
+			AgentSnapshot: json.RawMessage(`{}`), Status: "idle", Usage: json.RawMessage(`{}`), Stats: json.RawMessage(`{}`), CreatedAt: now,
+		},
+		Work: db.EnvironmentWork{
+			UUID: uuid.NewString(), ExternalID: workID, OrganizationUUID: env.OrganizationUUID,
+			WorkspaceUUID: env.WorkspaceUUID, EnvironmentUUID: env.UUID, EnvironmentExternalID: env.ExternalID,
+			Metadata: json.RawMessage(`{}`), State: "queued", CreatedAt: now,
+		},
+	})
+	if err != nil {
+		t.Fatalf("create environment session work: %v", err)
 	}
-	return workID
+	if work.SessionUUID != sessionUUID || work.SessionExternalID != sessionID {
+		t.Fatalf("created environment work session link = (%q, %q), want (%q, %q)", work.SessionUUID, work.SessionExternalID, sessionUUID, sessionID)
+	}
+	return workID, sessionID
+}
+
+func assertEnvironmentSessionWorkData(t *testing.T, work environmentWorkAPIResponse, sessionID string) {
+	t.Helper()
+	var data map[string]string
+	if err := json.Unmarshal(work.Data, &data); err != nil {
+		t.Fatalf("decode environment work data: %v", err)
+	}
+	if len(data) != 2 || data["id"] != sessionID || data["type"] != "session" {
+		t.Fatalf("environment work data = %+v, want session %q", data, sessionID)
+	}
 }
 
 func containsEnvironment(environments []environmentAPIResponse, id string) bool {

--- a/tests/environments_e2b_integration_test.go
+++ b/tests/environments_e2b_integration_test.go
@@ -5,31 +5,19 @@ package tests
 import (
 	"context"
 	"encoding/json"
-	"io"
-	"log/slog"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/superduck-ai/open-managed-agents/internal/api"
-	"github.com/superduck-ai/open-managed-agents/internal/auth"
-	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
-	"github.com/superduck-ai/open-managed-agents/internal/environments"
-	"github.com/superduck-ai/open-managed-agents/internal/filestore"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
 	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
-	skillsapi "github.com/superduck-ai/open-managed-agents/internal/skills"
 
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
 	e2b "github.com/superduck-ai/e2b-go-sdk"
 )
 
-func TestE2BEnvironmentRunnerIntegration(t *testing.T) {
+func TestE2BProviderLifecycleIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping real E2B integration test in short mode")
 	}
@@ -54,33 +42,6 @@ func TestE2BEnvironmentRunnerIntegration(t *testing.T) {
 		cfg.E2B.SandboxTimeout = time.Minute
 	}
 
-	database, err := db.Open(ctx, cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if err != nil {
-		t.Fatalf("open database: %v", err)
-	}
-	defer database.Close()
-	if err := database.Migrate(ctx); err != nil {
-		t.Fatalf("migrate database: %v", err)
-	}
-	pool := openTestPool(t, cfg)
-	if err := database.Seed(ctx, cfg.Bootstrap.SeedAPIKeys); err != nil {
-		t.Fatalf("seed database: %v", err)
-	}
-	credentials, err := codesessions.NewSessionCredentials(cfg)
-	if err != nil {
-		t.Fatalf("create code session credentials: %v", err)
-	}
-	filestoreCredentials, err := filestore.NewTokenCredentials(cfg)
-	if err != nil {
-		t.Fatalf("create filestore credentials: %v", err)
-	}
-	objectStore := newFakeStore("e2b-integration-fake")
-
-	apiKey, err := database.GetAPIKey(ctx, auth.HashAPIKey(config.DefaultAPIKey))
-	if err != nil {
-		t.Fatalf("load default api key: %v", err)
-	}
-
 	template := strings.TrimSpace(cfg.E2B.Template)
 	if template == "" {
 		template = config.DefaultE2BTemplate
@@ -93,81 +54,43 @@ func TestE2BEnvironmentRunnerIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create work id: %v", err)
 	}
-	envConfig := mustJSON(t, map[string]any{
+	envConfig, err := json.Marshal(map[string]any{
 		"type":       "cloud",
 		"runtime":    "self_hosted",
 		"image":      template,
 		"packages":   []any{},
 		"networking": map[string]any{"type": "unrestricted"},
 	})
-	now := time.Now().UTC()
-	env, err := database.CreateEnvironment(ctx, db.Environment{
-		UUID:              uuid.NewString(),
-		ExternalID:        envID,
-		OrganizationID:    apiKey.OrganizationID,
-		WorkspaceID:       apiKey.WorkspaceID,
-		CreatedByAPIKeyID: apiKey.ID,
-		Name:              "e2b-integration-" + envID[len("env_"):len("env_")+8],
-		Description:       "Real E2B integration smoke test",
-		Config:            envConfig,
-		Metadata:          mustJSON(t, map[string]any{"source": "e2b_integration_test"}),
-		Provider:          "e2b",
-		ResolvedTemplate:  template,
-		CreatedAt:         now,
-	})
 	if err != nil {
-		t.Fatalf("create environment: %v", err)
+		t.Fatalf("marshal Environment config: %v", err)
 	}
-	defer cleanupE2BIntegrationRows(t, pool, env.ExternalID, workID)
-
-	work, err := database.CreateEnvironmentWork(ctx, db.EnvironmentWork{
-		UUID:                  uuid.NewString(),
+	env := db.Environment{
+		ExternalID:       envID,
+		WorkspaceUUID:    "e2b-integration-workspace",
+		Config:           envConfig,
+		Provider:         "e2b",
+		ResolvedTemplate: template,
+	}
+	work := db.EnvironmentWork{
 		ExternalID:            workID,
-		OrganizationID:        env.OrganizationID,
-		WorkspaceID:           env.WorkspaceID,
-		EnvironmentID:         env.ID,
-		EnvironmentExternalID: env.ExternalID,
-		Data:                  mustJSON(t, map[string]any{"task": "e2b integration smoke"}),
-		Metadata:              mustJSON(t, map[string]any{"source": "e2b_integration_test"}),
-		State:                 "queued",
-		CreatedAt:             now,
-	})
-	if err != nil {
-		t.Fatalf("create environment work: %v", err)
+		EnvironmentExternalID: envID,
+		Metadata:              json.RawMessage(`{"source":"e2b_integration_test"}`),
 	}
 
 	provider := e2bruntime.NewProvider(cfg.E2B)
-	runner, err := environments.NewRunner(environments.RunnerDependencies{
-		DB:              database,
-		Provider:        provider,
-		Config:          cfg,
-		CodeSessions:    codesessions.NewServiceWithCredentials(database, credentials, nil),
-		Skills:          skillsapi.NewRuntimeResolver(database),
-		FilestoreTokens: filestoreCredentials,
-	})
+	resolution, err := provider.Resolve(env, &work)
 	if err != nil {
-		t.Fatalf("create environment runner: %v", err)
+		t.Fatalf("resolve E2B sandbox: %v", err)
 	}
-	processed, err := runner.RunOnce(ctx, "e2b-integration-test")
+	if resolution.Template != template {
+		t.Fatalf("resolved template = %q, want %q", resolution.Template, template)
+	}
+	sandbox, err := provider.Create(ctx, env, &work, resolution)
 	if err != nil {
-		t.Fatalf("run environment runner once: %v", err)
+		t.Fatalf("create E2B sandbox: %v", err)
 	}
-	if !processed {
-		t.Fatal("environment runner did not process queued work")
-	}
-
-	sandboxID, _, sandboxState, sandboxTemplate, sandboxLastError := loadE2BSandboxRow(t, pool, env.ExternalID, work.ExternalID)
-	if sandboxLastError != "" {
-		t.Fatalf("sandbox row has last_error: %s", sandboxLastError)
-	}
-	if sandboxState != "running" {
-		t.Fatalf("sandbox state = %s, want running", sandboxState)
-	}
-	if sandboxTemplate != template {
-		t.Fatalf("sandbox template = %s, want %s", sandboxTemplate, template)
-	}
-	if strings.TrimSpace(sandboxID) == "" {
-		t.Fatal("provider sandbox id was not recorded")
+	if strings.TrimSpace(sandbox.ID) == "" {
+		t.Fatal("created E2B sandbox ID is empty")
 	}
 
 	killed := false
@@ -175,120 +98,31 @@ func TestE2BEnvironmentRunnerIntegration(t *testing.T) {
 		if !killed {
 			killCtx, cancelKill := context.WithTimeout(context.Background(), 2*time.Minute)
 			defer cancelKill()
-			_ = provider.Kill(killCtx, sandboxID)
+			_ = provider.Kill(killCtx, sandbox.ID)
 		}
 	}()
 
-	connected, err := e2b.Connect(ctx, sandboxID, &e2b.SandboxConnectOpts{
-		ConnectionOpts: e2bruntime.ConnectionOptsFromConfig(cfg.E2B),
+	result, err := provider.RunCommand(ctx, sandbox.ID, e2bruntime.CommandRequest{
+		Command: `printf 'sandbox-ok\n'`,
+		Timeout: 30 * time.Second,
 	})
 	if err != nil {
-		t.Fatalf("connect to real sandbox %s: %v", sandboxID, err)
+		t.Fatalf("run command in real sandbox %s: %v", sandbox.ID, err)
 	}
-	commandTimeoutMs := 30_000
-	execution, err := connected.Commands.Run(ctx, `printf 'sandbox-ok\n'`, &e2b.CommandStartOpts{
-		TimeoutMs: &commandTimeoutMs,
-	})
-	if err != nil {
-		t.Fatalf("run command in real sandbox %s: %v", sandboxID, err)
-	}
-	result, ok := execution.(*e2b.CommandResult)
-	if !ok {
-		t.Fatalf("command execution type = %T, want *e2b.CommandResult", execution)
-	}
-	if got := strings.TrimSpace(result.Stdout); got != "sandbox-ok" {
+	if got := strings.TrimSpace(string(result.Stdout)); got != "sandbox-ok" {
 		t.Fatalf("sandbox command stdout = %q, want sandbox-ok; stderr=%q", got, result.Stderr)
 	}
 
-	server := httptest.NewServer(api.NewServer(api.ServerDeps{
-		Config:                 cfg,
-		DB:                     database,
-		ObjectStore:            objectStore,
-		Logger:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
-		CodeSessionCredentials: credentials,
-		FilestoreCredentials:   filestoreCredentials,
-	}))
-	defer server.Close()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/v1/environments/"+env.ExternalID+"/work/"+work.ExternalID+"/stop?beta=true", strings.NewReader(`{"force":true}`))
-	if err != nil {
-		t.Fatalf("new stop request: %v", err)
-	}
-	req.Header.Set("X-Api-Key", config.DefaultAPIKey)
-	req.Header.Set("anthropic-beta", "managed-agents-2026-04-01")
-	req.Header.Set("anthropic-version", "2023-06-01")
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := server.Client().Do(req)
-	if err != nil {
-		t.Fatalf("stop work request: %v", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("stop work status = %d, want 200: %s", resp.StatusCode, readAll(t, resp.Body))
+	if err := provider.Kill(ctx, sandbox.ID); err != nil {
+		t.Fatalf("kill E2B sandbox %s: %v", sandbox.ID, err)
 	}
 	killed = true
 
-	_, _, stoppedSandboxState, _, stoppedSandboxLastError := loadE2BSandboxRow(t, pool, env.ExternalID, work.ExternalID)
-	if stoppedSandboxLastError != "" {
-		t.Fatalf("stopped sandbox row has last_error: %s", stoppedSandboxLastError)
-	}
-	if stoppedSandboxState != "stopped" {
-		t.Fatalf("sandbox state after stop = %s, want stopped", stoppedSandboxState)
-	}
-	stoppedWork, err := database.GetEnvironmentWork(ctx, env.WorkspaceID, env.ExternalID, work.ExternalID)
-	if err != nil {
-		t.Fatalf("load stopped work: %v", err)
-	}
-	if stoppedWork.State != "stopped" {
-		t.Fatalf("work state after stop = %s, want stopped", stoppedWork.State)
-	}
-
-	_, err = e2b.Connect(ctx, sandboxID, &e2b.SandboxConnectOpts{
+	_, err = e2b.Connect(ctx, sandbox.ID, &e2b.SandboxConnectOpts{
 		ConnectionOpts: e2bruntime.ConnectionOptsFromConfig(cfg.E2B),
 	})
 	if err == nil {
-		_ = provider.Kill(context.Background(), sandboxID)
-		t.Fatalf("connect to sandbox %s after kill succeeded, want failure", sandboxID)
-	}
-}
-
-func mustJSON(t *testing.T, value any) json.RawMessage {
-	t.Helper()
-	data, err := json.Marshal(value)
-	if err != nil {
-		t.Fatalf("marshal json: %v", err)
-	}
-	return data
-}
-
-func loadE2BSandboxRow(t *testing.T, pool *pgxpool.Pool, envID, workID string) (providerSandboxID, externalID, state, template, lastError string) {
-	t.Helper()
-	var lastErrorPtr *string
-	if err := pool.QueryRow(context.Background(), `
-		select coalesce(provider_sandbox_id, ''), external_id, state, template, last_error
-		from environment_sandboxes
-		where environment_external_id = $1 and work_external_id = $2
-		order by created_at desc, id desc
-		limit 1
-	`, envID, workID).Scan(&providerSandboxID, &externalID, &state, &template, &lastErrorPtr); err != nil {
-		t.Fatalf("load sandbox row: %v", err)
-	}
-	if lastErrorPtr != nil {
-		lastError = *lastErrorPtr
-	}
-	return providerSandboxID, externalID, state, template, lastError
-}
-
-func cleanupE2BIntegrationRows(t *testing.T, pool *pgxpool.Pool, envID, workID string) {
-	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	if _, err := pool.Exec(ctx, `delete from environment_sandboxes where environment_external_id = $1 or work_external_id = $2`, envID, workID); err != nil {
-		t.Fatalf("cleanup integration sandbox rows: %v", err)
-	}
-	if _, err := pool.Exec(ctx, `delete from environment_work where environment_external_id = $1 or external_id = $2`, envID, workID); err != nil {
-		t.Fatalf("cleanup integration work rows: %v", err)
-	}
-	if _, err := pool.Exec(ctx, `delete from environments where external_id = $1`, envID); err != nil {
-		t.Fatalf("cleanup integration environment rows: %v", err)
+		_ = provider.Kill(context.Background(), sandbox.ID)
+		t.Fatalf("connect to sandbox %s after kill succeeded, want failure", sandbox.ID)
 	}
 }

--- a/tests/environments_runner_cloud_test.go
+++ b/tests/environments_runner_cloud_test.go
@@ -707,7 +707,11 @@ func TestEnvironmentRunnerKillsSandboxWhenRcloneReadyFails(t *testing.T) {
 	defer client.Beta.Sessions.Delete(context.Background(), session.ID, anthropic.BetaSessionDeleteParams{})
 
 	ids := getDefaultDBIDs(t, app.pool)
-	work, err := app.db.GetLatestEnvironmentWorkByData(ctx, ids.WorkspaceUUID, environment.ID, "session", session.ID)
+	sessionRecord, found, err := app.db.GetSession(ctx, ids.WorkspaceUUID, session.ID)
+	if err != nil || !found {
+		t.Fatalf("load queued session: found=%v error=%v", found, err)
+	}
+	work, err := app.db.GetLatestEnvironmentWorkForSession(ctx, ids.WorkspaceUUID, environment.ID, sessionRecord.UUID)
 	if err != nil {
 		t.Fatalf("load queued environment work: %v", err)
 	}
@@ -1144,7 +1148,11 @@ func TestEnvironmentRunnerClearsStaleMCPHosts(t *testing.T) {
 			defer client.Beta.Sessions.Delete(context.Background(), session.ID, anthropic.BetaSessionDeleteParams{})
 
 			ids := getDefaultDBIDs(t, app.pool)
-			work, err := app.db.GetLatestEnvironmentWorkByData(ctx, ids.WorkspaceUUID, environment.ID, "session", session.ID)
+			sessionRecord, found, err := app.db.GetSession(ctx, ids.WorkspaceUUID, session.ID)
+			if err != nil || !found {
+				t.Fatalf("load environment session: found=%v error=%v", found, err)
+			}
+			work, err := app.db.GetLatestEnvironmentWorkForSession(ctx, ids.WorkspaceUUID, environment.ID, sessionRecord.UUID)
 			if err != nil {
 				t.Fatalf("load environment work: %v", err)
 			}

--- a/tests/filestore_db_test.go
+++ b/tests/filestore_db_test.go
@@ -1397,7 +1397,6 @@ func filestoreSessionCreateInput(organizationUUID, workspaceUUID, apiKeyUUID str
 			WorkspaceUUID:         workspaceUUID,
 			EnvironmentUUID:       environmentUUID,
 			EnvironmentExternalID: environmentExternalID,
-			Data:                  json.RawMessage(`{"id":"` + sessionExternalID + `","type":"session"}`),
 			Metadata:              json.RawMessage(`{}`),
 			State:                 "queued",
 			CreatedAt:             now,

--- a/tests/session_sandbox_recovery_test.go
+++ b/tests/session_sandbox_recovery_test.go
@@ -279,10 +279,15 @@ func assertQueuedSandboxRecovery(t *testing.T, app *testApp, sessionID, codeSess
 	t.Helper()
 	var workState string
 	if err := app.pool.QueryRow(context.Background(), `
-		select state
-		from environment_work
-		where data->>'id' = $1 and deleted_at is null
-		order by created_at desc
+		select work.state
+		from environment_work work
+		join sessions session
+			on session.organization_uuid = work.organization_uuid
+			and session.workspace_uuid = work.workspace_uuid
+			and session.environment_uuid = work.environment_uuid
+			and session.uuid = work.session_uuid
+		where session.external_id = $1 and work.deleted_at is null
+		order by work.created_at desc
 		limit 1
 	`, sessionID).Scan(&workState); err != nil {
 		t.Fatalf("load queued recovery work: %v", err)
@@ -418,10 +423,15 @@ func assertRecoveredWorkPublished(t *testing.T, app *testApp, sessionID string) 
 	t.Helper()
 	var state string
 	if err := app.pool.QueryRow(context.Background(), `
-		select state
-		from environment_work
-		where data->>'id' = $1 and deleted_at is null
-		order by created_at desc
+		select work.state
+		from environment_work work
+		join sessions session
+			on session.organization_uuid = work.organization_uuid
+			and session.workspace_uuid = work.workspace_uuid
+			and session.environment_uuid = work.environment_uuid
+			and session.uuid = work.session_uuid
+		where session.external_id = $1 and work.deleted_at is null
+		order by work.created_at desc
 		limit 1
 	`, sessionID).Scan(&state); err != nil {
 		t.Fatalf("load recovered work: %v", err)

--- a/tests/sessions_api_test.go
+++ b/tests/sessions_api_test.go
@@ -4692,10 +4692,15 @@ func sessionWorkData(t *testing.T, app *testApp, sessionID string) (string, stri
 	t.Helper()
 	var workType, workSessionID, state string
 	if err := app.pool.QueryRow(context.Background(), `
-		select data->>'type', data->>'id', state
-		from environment_work
-		where data->>'id' = $1 and deleted_at is null
-		order by created_at desc
+		select 'session', session.external_id, work.state
+		from environment_work work
+		join sessions session
+			on session.organization_uuid = work.organization_uuid
+			and session.workspace_uuid = work.workspace_uuid
+			and session.environment_uuid = work.environment_uuid
+			and session.uuid = work.session_uuid
+		where session.external_id = $1 and work.deleted_at is null
+		order by work.created_at desc
 		limit 1
 	`, sessionID).Scan(&workType, &workSessionID, &state); err != nil {
 		t.Fatalf("load session work: %v", err)


### PR DESCRIPTION
## Summary

- Migrate environment work references from session IDs to session UUIDs.
- Update Yourbatis mappers, database access, deployment execution, and environment/session services accordingly.
- Improve environment runner heartbeat and sandbox recovery handling.
- Add and update design documentation, migrations, and integration coverage.

## Testing

- Updated database mapper, migration, session, environment, filestore, and cloud runner tests.
- Added coverage for environment APIs, session sandbox recovery, and E2B integration flows.