### PR TITLE
Migrate UUID usage to the local package and string identifiers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/aws/smithy-go v1.27.3
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
@@ -50,6 +49,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -7,13 +7,12 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
-
-	"github.com/google/uuid"
 )
 
 type Service struct {
@@ -37,8 +36,8 @@ func NewService(cfg config.Config, database *db.DB) *Service {
 
 func principalOrganizationUUID(principal auth.Principal) (uuid.UUID, error) {
 	organizationUUID, err := uuid.Parse(strings.TrimSpace(principal.OrganizationUUID))
-	if err != nil || organizationUUID == uuid.Nil {
-		return uuid.Nil, db.ErrNotFound
+	if err != nil || organizationUUID == uuid.Nil() {
+		return uuid.Nil(), db.ErrNotFound
 	}
 	return organizationUUID, nil
 }
@@ -205,12 +204,12 @@ func (s *Service) CreateWorkspace(ctx context.Context, principal auth.Principal,
 		return workspaceResponse{}, mapAdminDBError(db.ErrNotFound, "Organization not found")
 	}
 	record, err := s.db.CreateAdminWorkspace(ctx, db.AdminWorkspace{
-		UUID:             uuid.NewString(),
+		UUID:             uuid.NewV4().String(),
 		ExternalID:       workspaceID,
 		OrganizationUUID: organizationUUID.String(),
 		Name:             name,
 		CreatedAt:        now,
-		CompartmentID:    uuid.NewString(),
+		CompartmentID:    uuid.NewV4().String(),
 		DisplayColor:     "#6C5BB9",
 		DataResidency:    residencyJSON,
 		ExternalKeyID:    normalizedOptionalString(req.ExternalKeyID),
@@ -704,7 +703,7 @@ func (s *Service) CreateTunnelCertificate(ctx context.Context, principal auth.Pr
 	if tunnel.ArchivedAt != nil {
 		return tunnelCertificateResponse{}, conflict("Tunnel is archived")
 	}
-	count, err := s.db.CountActiveAdminTunnelCertificates(ctx, principal.OrganizationUUID, tunnel.UUID.String())
+	count, err := s.db.CountActiveAdminTunnelCertificates(ctx, principal.OrganizationUUID, tunnel.UUID)
 	if err != nil {
 		return tunnelCertificateResponse{}, err
 	}
@@ -750,7 +749,7 @@ func (s *Service) ListTunnelCertificates(ctx context.Context, principal auth.Pri
 	}
 	records, hasMore, err := s.db.ListAdminTunnelCertificatesPage(ctx, db.ListAdminTunnelCertificatesParams{
 		OrganizationUUID: principal.OrganizationUUID,
-		TunnelUUID:       tunnel.UUID.String(),
+		TunnelUUID:       tunnel.UUID,
 		IncludeArchived:  includeArchived,
 		Limit:            limit,
 		Offset:           offset,

--- a/internal/agents/handler.go
+++ b/internal/agents/handler.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -21,7 +22,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/modelmapping"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 const (
@@ -151,7 +151,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 	}
 	now := time.Now().UTC()
 	created, err := h.db.CreateAgent(r.Context(), db.Agent{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          agentID,
 		WorkspaceUUID:       principal.WorkspaceUUID,
 		CreatedByAPIKeyUUID: principal.APIKeyUUID,

--- a/internal/api/filestore_auth_test.go
+++ b/internal/api/filestore_auth_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
@@ -22,7 +23,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/filestore"
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -334,8 +334,8 @@ func TestFilestoreJWTAuthentication(t *testing.T) {
 		name   string
 		mutate func(*filestore.TokenIdentity)
 	}{
-		{name: "account", mutate: func(identity *filestore.TokenIdentity) { identity.AccountUUID = uuid.NewString() }},
-		{name: "workspace", mutate: func(identity *filestore.TokenIdentity) { identity.WorkspaceUUID = uuid.NewString() }},
+		{name: "account", mutate: func(identity *filestore.TokenIdentity) { identity.AccountUUID = uuid.NewV4().String() }},
+		{name: "workspace", mutate: func(identity *filestore.TokenIdentity) { identity.WorkspaceUUID = uuid.NewV4().String() }},
 		{name: "workspace tagged id", mutate: func(identity *filestore.TokenIdentity) { identity.WorkspaceTaggedID = "workspace_other" }},
 		{name: "filesystem", mutate: func(identity *filestore.TokenIdentity) { identity.FilesystemID = "fs_other" }},
 		{name: "organization taints", mutate: func(identity *filestore.TokenIdentity) { identity.OrgTaints = []string{"restricted"} }},
@@ -437,12 +437,12 @@ func TestFilestoreJWTAuthentication(t *testing.T) {
 	})
 
 	t.Run("failure real filesystem from another workspace", func(t *testing.T) {
-		suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
-		otherWorkspaceUUID := uuid.NewString()
+		suffix := strings.ReplaceAll(uuid.NewV4().String(), "-", "")
+		otherWorkspaceUUID := uuid.NewV4().String()
 		otherWorkspaceExternalID := "workspace_filestore_cross_" + suffix
-		otherSessionUUID := uuid.NewString()
+		otherSessionUUID := uuid.NewV4().String()
 		otherSessionExternalID := "sesn_filestore_cross_" + suffix
-		otherFilesystemUUID := uuid.NewString()
+		otherFilesystemUUID := uuid.NewV4().String()
 		otherFilesystemExternalID := "fs_filestore_cross_" + suffix
 
 		if _, err := pool.Exec(context.Background(), `
@@ -464,8 +464,8 @@ func TestFilestoreJWTAuthentication(t *testing.T) {
 			)
 			values ($1, $2, $3, $4, $5, $6, $7, $8, $9, 1, '{}'::jsonb, 'running')
 		`, otherSessionUUID, otherSessionExternalID, fixture.tokenIdentity.OrgUUID, otherWorkspaceUUID,
-			uuid.NewString(), uuid.NewString(), "env_filestore_cross_"+suffix,
-			uuid.NewString(), "agent_filestore_cross_"+suffix); err != nil {
+			uuid.NewV4().String(), uuid.NewV4().String(), "env_filestore_cross_"+suffix,
+			uuid.NewV4().String(), "agent_filestore_cross_"+suffix); err != nil {
 			t.Fatalf("insert other workspace session: %v", err)
 		}
 		if _, err := pool.Exec(context.Background(), `
@@ -576,16 +576,16 @@ func newFilestoreAuthDatabaseFixture(t *testing.T) (*db.DB, *pgxpool.Pool, confi
 		t.Fatalf("open filestore auth test pool: %v", err)
 	}
 
-	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
-	organizationUUID := uuid.NewString()
-	workspaceUUID := uuid.NewString()
+	suffix := strings.ReplaceAll(uuid.NewV4().String(), "-", "")
+	organizationUUID := uuid.NewV4().String()
+	workspaceUUID := uuid.NewV4().String()
 	workspaceExternalID := "workspace_filestore_auth_" + suffix
-	accountUUID := uuid.NewString()
+	accountUUID := uuid.NewV4().String()
 	accountExternalID := "user_filestore_auth_" + suffix
 	publicSessionID := "sesn_filestore_auth_" + suffix
 	codeSessionID := "cse_filestore_auth_" + suffix
 	filesystemID := "fs_filestore_auth_" + suffix
-	filesystemUUID := uuid.NewString()
+	filesystemUUID := uuid.NewV4().String()
 	agentID := "agent_filestore_auth_" + suffix
 	environmentID := "env_filestore_auth_" + suffix
 	workspaceAPIKey := "sk-ant-api03-filestore-auth-" + suffix
@@ -616,7 +616,7 @@ func newFilestoreAuthDatabaseFixture(t *testing.T) (*db.DB, *pgxpool.Pool, confi
 	`, workspaceUUID, workspaceExternalID, organizationUUID, "Filestore auth test"); err != nil {
 		t.Fatalf("insert filestore auth workspace: %v", err)
 	}
-	apiKeyUUID := uuid.NewString()
+	apiKeyUUID := uuid.NewV4().String()
 	if _, err := pool.Exec(context.Background(), `
 		insert into api_keys (uuid, external_id, workspace_uuid, key_hash, status)
 		values ($1, $2, $3, $4, 'active')
@@ -629,9 +629,9 @@ func newFilestoreAuthDatabaseFixture(t *testing.T) (*db.DB, *pgxpool.Pool, confi
 	`, accountUUID, accountExternalID, organizationUUID, accountExternalID+"@example.com", "Filestore auth account"); err != nil {
 		t.Fatalf("insert filestore auth account: %v", err)
 	}
-	sessionUUID := uuid.NewString()
-	environmentUUID := uuid.NewString()
-	agentUUID := uuid.NewString()
+	sessionUUID := uuid.NewV4().String()
+	environmentUUID := uuid.NewV4().String()
+	agentUUID := uuid.NewV4().String()
 	if _, err := pool.Exec(context.Background(), `
 		insert into sessions (
 			uuid, external_id, organization_uuid, workspace_uuid,
@@ -644,7 +644,7 @@ func newFilestoreAuthDatabaseFixture(t *testing.T) (*db.DB, *pgxpool.Pool, confi
 		environmentUUID, environmentID, agentUUID, agentID, "Filestore auth test"); err != nil {
 		t.Fatalf("insert filestore auth session: %v", err)
 	}
-	codeSessionUUID := uuid.NewString()
+	codeSessionUUID := uuid.NewV4().String()
 	if _, err := pool.Exec(context.Background(), `
 		insert into code_sessions (
 			uuid, external_id, organization_uuid, workspace_uuid,

--- a/internal/api/platform_mcp_vault_auth.go
+++ b/internal/api/platform_mcp_vault_auth.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
@@ -24,7 +25,6 @@ import (
 	vaultsapi "github.com/superduck-ai/open-managed-agents/internal/vaults"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 const (
@@ -197,7 +197,7 @@ func (s *Server) handlePlatformMCPVaultAuthStart(w http.ResponseWriter, r *http.
 		return
 	}
 
-	flowID := uuid.NewString()
+	flowID := uuid.NewV4().String()
 	discovery, err := s.discoverPlatformMCPOAuth(r.Context(), platformMCPVaultAuthHTTPClient, mcpServerURL)
 	if err != nil {
 		s.logger.ErrorContext(r.Context(), "discover mcp oauth", "mcp_server_host", platformMCPLogHost(mcpServerURL), "error", err)
@@ -238,7 +238,7 @@ func (s *Server) handlePlatformMCPVaultAuthStart(w http.ResponseWriter, r *http.
 		displayName = defaultPlatformMCPVaultCredentialName(mcpServerURL)
 	}
 	if _, err := s.db.CreateMCPOAuthFlow(r.Context(), db.MCPOAuthFlow{
-		UUID:                      uuid.NewString(),
+		UUID:                      uuid.NewV4().String(),
 		ExternalID:                flowID,
 		OrganizationUUID:          principal.OrganizationUUID,
 		WorkspaceUUID:             workspace.UUID,
@@ -401,7 +401,7 @@ func (s *Server) handlePlatformMCPVaultAuthCallback(w http.ResponseWriter, r *ht
 		metadata = json.RawMessage(`{}`)
 	}
 	credential := db.VaultCredential{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          credentialID,
 		OrganizationUUID:    flow.OrganizationUUID,
 		WorkspaceUUID:       flow.WorkspaceUUID,

--- a/internal/batches/handler.go
+++ b/internal/batches/handler.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -22,7 +23,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 const messageBatchesBeta = "message-batches-2024-09-24"
@@ -167,7 +167,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request, isBeta bool, be
 		anthropicVersion = "2023-06-01"
 	}
 	record := db.MessageBatch{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          externalID,
 		WorkspaceUUID:       principal.WorkspaceUUID,
 		CreatedByAPIKeyUUID: principal.APIKeyUUID,

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -12,13 +12,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 const (
@@ -1562,14 +1562,14 @@ func diagLogEvent(line any) (json.RawMessage, error) {
 	if object, ok := line.(map[string]any); ok {
 		if strings.TrimSpace(stringField(object, "type")) == "env_manager_log" {
 			if stringField(object, "uuid") == "" {
-				object["uuid"] = uuid.NewString()
+				object["uuid"] = uuid.NewV4().String()
 			}
 			return marshalRaw(object)
 		}
 	}
 	return marshalRaw(map[string]any{
 		"type": "env_manager_log",
-		"uuid": uuid.NewString(),
+		"uuid": uuid.NewV4().String(),
 		"data": line,
 	})
 }

--- a/internal/codesessions/mapper.go
+++ b/internal/codesessions/mapper.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
-
-	"github.com/google/uuid"
 )
 
 func workerPayloadForPublicEvent(codeSessionID string, raw json.RawMessage, fallback time.Time) (json.RawMessage, error) {
@@ -27,7 +26,7 @@ func workerPayloadForPublicEvent(codeSessionID string, raw json.RawMessage, fall
 	}
 	switch schema.Type {
 	case "user.message":
-		eventUUID := firstNonEmpty(schema.UUID, schema.ID, uuid.NewString())
+		eventUUID := firstNonEmpty(schema.UUID, schema.ID, uuid.NewV4().String())
 		payload := map[string]any{
 			"type":               "user",
 			"uuid":               eventUUID,
@@ -47,7 +46,7 @@ func workerPayloadForPublicEvent(codeSessionID string, raw json.RawMessage, fall
 		return marshalRaw(payload)
 	default:
 		if schema.UUID == "" {
-			setRawJSONField(fields, "uuid", firstNonEmpty(schema.ID, uuid.NewString()))
+			setRawJSONField(fields, "uuid", firstNonEmpty(schema.ID, uuid.NewV4().String()))
 		}
 		if schema.SessionID == "" {
 			setRawJSONField(fields, "session_id", codeSessionID)
@@ -79,7 +78,7 @@ func normalizeWorkerOutboundPayload(codeSessionID string, raw json.RawMessage, f
 		now = time.Now().UTC()
 	}
 	if schema.Type != "keep_alive" && schema.UUID == "" {
-		setRawJSONField(fields, "uuid", uuid.NewString())
+		setRawJSONField(fields, "uuid", uuid.NewV4().String())
 	}
 	if schema.SessionID == "" {
 		setRawJSONField(fields, "session_id", codeSessionID)
@@ -237,7 +236,7 @@ func normalizePublicInternalSubagentPayload(codeSessionID string, event db.CodeS
 		payload["id"] = stablePublicEventID(codeSessionID, "internal-subagent\x00"+threadID+"\x00"+seed)
 	}
 	if stringField(payload, "uuid") == "" {
-		payload["uuid"] = firstNonEmpty(stringField(payload, "id"), uuid.NewString())
+		payload["uuid"] = firstNonEmpty(stringField(payload, "id"), uuid.NewV4().String())
 	}
 	if stringField(payload, "session_id") == "" {
 		payload["session_id"] = codeSessionID
@@ -289,7 +288,7 @@ func normalizePublicWorkerPayload(codeSessionID string, event db.CodeSessionEven
 		payload["id"] = stablePublicEventID(codeSessionID, seed)
 	}
 	if stringField(payload, "uuid") == "" {
-		payload["uuid"] = firstNonEmpty(stringField(payload, "id"), uuid.NewString())
+		payload["uuid"] = firstNonEmpty(stringField(payload, "id"), uuid.NewV4().String())
 	}
 	createdAt := firstPayloadTime(payload, event.CreatedAt)
 	if createdAt.IsZero() {

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -10,14 +10,13 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
 	"github.com/superduck-ai/open-managed-agents/internal/logging"
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 	"github.com/superduck-ai/open-managed-agents/internal/runtime/sandboxruntime"
-
-	"github.com/google/uuid"
 )
 
 // Service 封装会被 sessions、environment runner 与 code-session HTTP handler 共同复用的业务能力。
@@ -406,7 +405,7 @@ func transientWorkerEvent(meta EventMetadata, createdAt time.Time) db.CodeSessio
 
 func (s *Service) queueInitialize(ctx context.Context, codeSession db.CodeSession, configRaw json.RawMessage, now time.Time) error {
 	configObject := rawObject(configRaw)
-	requestID := "initialize_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	requestID := "initialize_" + strings.ReplaceAll(uuid.NewV4().String(), "-", "")
 	request := map[string]any{
 		"subtype": "initialize",
 	}
@@ -418,7 +417,7 @@ func (s *Service) queueInitialize(ctx context.Context, codeSession db.CodeSessio
 	}
 	payload, err := marshalRaw(map[string]any{
 		"type":       "control_request",
-		"uuid":       uuid.NewString(),
+		"uuid":       uuid.NewV4().String(),
 		"session_id": codeSession.ExternalID,
 		"created_at": formatTime(now),
 		"timestamp":  formatTime(now),

--- a/internal/codesessions/tool_permissions.go
+++ b/internal/codesessions/tool_permissions.go
@@ -2,14 +2,14 @@ package codesessions
 
 import (
 	"context"
+	"crypto/sha1"
 	"encoding/json"
 	"errors"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
-
-	"github.com/google/uuid"
 )
 
 type resolvedToolPermission string
@@ -327,7 +327,7 @@ func (s *Service) respondToToolPermissionRequest(ctx context.Context, codeSessio
 	now := time.Now().UTC()
 	payloadObject := map[string]any{
 		"type":       "control_response",
-		"uuid":       uuid.NewSHA1(uuid.NameSpaceOID, []byte(codeSessionID+"\x00control_response\x00"+request.RequestID)).String(),
+		"uuid":       controlResponseUUID(codeSessionID, request.RequestID),
 		"session_id": codeSessionID,
 		"created_at": formatTime(now),
 		"timestamp":  formatTime(now),
@@ -351,6 +351,23 @@ func (s *Service) respondToToolPermissionRequest(ctx context.Context, codeSessio
 		return err
 	}
 	return nil
+}
+
+// controlResponseUUID preserves the UUIDv5 output previously produced with the
+// OID namespace. SHA-1 is required by UUIDv5 and is not used for security here.
+func controlResponseUUID(codeSessionID, requestID string) string {
+	namespace := uuid.UUID{0x6b, 0xa7, 0xb8, 0x12, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	name := codeSessionID + "\x00control_response\x00" + requestID
+	payload := make([]byte, 0, len(namespace)+len(name))
+	payload = append(payload, namespace[:]...)
+	payload = append(payload, name...)
+	digest := sha1.Sum(payload)
+
+	var result uuid.UUID
+	copy(result[:], digest[:])
+	result[6] = (result[6] & 0x0f) | 0x50
+	result[8] = (result[8] & 0x3f) | 0x80
+	return result.String()
 }
 
 func (s *Service) publishToolPermissionRequiresAction(ctx context.Context, codeSessionID string, payload *workerControlRequestPayload, meta EventMetadata, identity toolIdentity) error {

--- a/internal/codesessions/tool_permissions_test.go
+++ b/internal/codesessions/tool_permissions_test.go
@@ -3,7 +3,22 @@ package codesessions
 import (
 	"encoding/json"
 	"testing"
+	"uuid"
 )
+
+func TestControlResponseUUIDMatchesExistingUUIDv5(t *testing.T) {
+	t.Parallel()
+
+	const want = "f2342556-f950-52b1-9f44-b34130c2bfd5"
+	got := controlResponseUUID("codeses_test", "request_test")
+	if got != want {
+		t.Fatalf("control response UUID = %q, want %q", got, want)
+	}
+	parsed := uuid.MustParse(got)
+	if version := parsed[6] >> 4; version != 5 {
+		t.Fatalf("control response UUID version = %d, want 5", version)
+	}
+}
 
 func TestResolveToolPermissionFromAgentSnapshot(t *testing.T) {
 	t.Parallel()

--- a/internal/db/admin_api_keys_mapper_postgres_test.go
+++ b/internal/db/admin_api_keys_mapper_postgres_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/yourbatis"
 )
 
@@ -240,9 +239,9 @@ func seedAdminAPIKeyMapperPostgreSQLFixture(
 			"apikey_mapper_oldest",
 		},
 	}
-	workspaceUUID := uuid.MustParse("33333333-3333-4333-8333-333333333333")
-	otherWorkspaceUUID := uuid.MustParse("44444444-4444-4444-8444-444444444444")
-	userUUID := uuid.MustParse("55555555-5555-4555-8555-555555555555")
+	workspaceUUID := "33333333-3333-4333-8333-333333333333"
+	otherWorkspaceUUID := "44444444-4444-4444-8444-444444444444"
+	userUUID := "55555555-5555-4555-8555-555555555555"
 	execMapperFixtureSQL(t, ctx, executor, `
 		INSERT INTO workspaces (uuid, external_id, organization_uuid)
 		VALUES ($1, $2, $3), ($4, $5, $6)
@@ -253,11 +252,11 @@ func seedAdminAPIKeyMapperPostgreSQLFixture(
 		VALUES ($1, $2)
 	`, userUUID, fixture.userExternalID)
 
-	keyUUIDs := []uuid.UUID{
-		uuid.MustParse("66666666-6666-4666-8666-666666666666"),
-		uuid.MustParse("77777777-7777-4777-8777-777777777777"),
-		uuid.MustParse("88888888-8888-4888-8888-888888888888"),
-		uuid.MustParse("99999999-9999-4999-8999-999999999999"),
+	keyUUIDs := []string{
+		"66666666-6666-4666-8666-666666666666",
+		"77777777-7777-4777-8777-777777777777",
+		"88888888-8888-4888-8888-888888888888",
+		"99999999-9999-4999-8999-999999999999",
 	}
 	baseCreatedAt := time.Date(2026, time.August, 2, 1, 2, 3, 0, time.UTC)
 	for index, externalID := range fixture.keyIDs {

--- a/internal/db/admin_api_keys_mapper_test.go
+++ b/internal/db/admin_api_keys_mapper_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/yourbatis"
 )
 
@@ -341,7 +341,7 @@ func adminAPIKeyMapperTestRow(externalID string, createdAt time.Time) []driver.V
 func TestListAdminAPIKeysPageRejectsConflictingCursors(t *testing.T) {
 	database := &DB{}
 	_, _, err := database.ListAdminAPIKeysPage(context.Background(), ListAdminAPIKeysParams{
-		OrganizationUUID: uuid.NewString(),
+		OrganizationUUID: uuid.NewV4().String(),
 		AfterID:          "api_key_after",
 		BeforeID:         "api_key_before",
 		Limit:            10,

--- a/internal/db/admin_mcp_tunnel_certificate_mapper_test.go
+++ b/internal/db/admin_mcp_tunnel_certificate_mapper_test.go
@@ -140,7 +140,7 @@ func TestAdminMCPTunnelCertificateMapperResultSemantics(t *testing.T) {
 	})
 	row, err := NewAdminMCPTunnelCertificateMapper(executor).Insert(ctx, insertAdminTunnelCertificateParams{})
 	certificate, err := adminTunnelCertificateFromMapperRow(row, err)
-	if err != nil || certificate.UUID.String() != row.UUID || certificate.ExpiresAt != nil {
+	if err != nil || certificate.UUID != row.UUID || certificate.ExpiresAt != nil {
 		t.Fatalf("Insert() = (%+v, %v)", certificate, err)
 	}
 
@@ -171,12 +171,6 @@ func TestAdminMCPTunnelCertificateMapperResultSemantics(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid UUID", func(t *testing.T) {
-		_, err := adminTunnelCertificateFromMapperRow(adminMCPTunnelCertificateRow{UUID: "invalid"}, nil)
-		if err == nil {
-			t.Fatal("adminTunnelCertificateFromMapperRow() error = nil, want invalid UUID")
-		}
-	})
 }
 
 func TestAdminMCPTunnelCertificateMapperPropagatesExecutionErrors(t *testing.T) {

--- a/internal/db/admin_mcp_tunnel_certificates.go
+++ b/internal/db/admin_mcp_tunnel_certificates.go
@@ -3,15 +3,13 @@ package db
 import (
 	"context"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type AdminTunnelCertificate struct {
-	UUID             uuid.UUID
+	UUID             string
 	ExternalID       string
-	OrganizationUUID uuid.UUID
-	TunnelUUID       uuid.UUID
+	OrganizationUUID string
+	TunnelUUID       string
 	TunnelExternalID string
 	CACertificatePEM string
 	Fingerprint      string
@@ -32,8 +30,8 @@ func (d *DB) CreateAdminTunnelCertificate(ctx context.Context, cert AdminTunnelC
 	mapper := NewAdminMCPTunnelCertificateMapper(d.mapperDB)
 	row, err := mapper.Insert(ctx, insertAdminTunnelCertificateParams{
 		ExternalID:       cert.ExternalID,
-		OrganizationUUID: cert.OrganizationUUID.String(),
-		TunnelUUID:       cert.TunnelUUID.String(),
+		OrganizationUUID: cert.OrganizationUUID,
+		TunnelUUID:       cert.TunnelUUID,
 		TunnelExternalID: cert.TunnelExternalID,
 		CACertificatePEM: cert.CACertificatePEM,
 		Fingerprint:      cert.Fingerprint,
@@ -86,23 +84,11 @@ func adminTunnelCertificateFromMapperRow(row adminMCPTunnelCertificateRow, err e
 	if err != nil {
 		return AdminTunnelCertificate{}, mapNoRows(err)
 	}
-	certificateUUID, err := uuid.Parse(row.UUID)
-	if err != nil {
-		return AdminTunnelCertificate{}, err
-	}
-	organizationUUID, err := uuid.Parse(row.OrganizationUUID)
-	if err != nil {
-		return AdminTunnelCertificate{}, err
-	}
-	tunnelUUID, err := uuid.Parse(row.TunnelUUID)
-	if err != nil {
-		return AdminTunnelCertificate{}, err
-	}
 	return AdminTunnelCertificate{
-		UUID:             certificateUUID,
+		UUID:             row.UUID,
 		ExternalID:       row.ExternalID,
-		OrganizationUUID: organizationUUID,
-		TunnelUUID:       tunnelUUID,
+		OrganizationUUID: row.OrganizationUUID,
+		TunnelUUID:       row.TunnelUUID,
 		TunnelExternalID: row.TunnelExternalID,
 		CACertificatePEM: row.CACertificatePEM,
 		Fingerprint:      row.Fingerprint,

--- a/internal/db/admin_mcp_tunnel_mapper_test.go
+++ b/internal/db/admin_mcp_tunnel_mapper_test.go
@@ -113,7 +113,7 @@ func TestAdminMCPTunnelMapperResultSemantics(t *testing.T) {
 	})
 	row, err := NewAdminMCPTunnelMapper(executor).FindByExternalID(ctx, "org", "tunnel_test")
 	tunnel, err := adminTunnelFromMapperRow(row, err)
-	if err != nil || tunnel.UUID.String() != row.UUID || !tunnel.WorkspaceUUID.Valid {
+	if err != nil || tunnel.UUID != row.UUID || tunnel.WorkspaceUUID == nil || *tunnel.WorkspaceUUID != "33333333-3333-4333-8333-333333333333" {
 		t.Fatalf("FindByExternalID() = (%+v, %v)", tunnel, err)
 	}
 	if tunnel.TunnelToken == nil || *tunnel.TunnelToken != "secret-token" {
@@ -129,12 +129,6 @@ func TestAdminMCPTunnelMapperResultSemantics(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid UUID", func(t *testing.T) {
-		_, err := adminTunnelFromMapperRow(adminMCPTunnelRow{UUID: "invalid"}, nil)
-		if err == nil {
-			t.Fatal("adminTunnelFromMapperRow() error = nil, want invalid UUID")
-		}
-	})
 }
 
 func TestAdminMCPTunnelMapperPropagatesExecutionErrors(t *testing.T) {

--- a/internal/db/admin_mcp_tunnels.go
+++ b/internal/db/admin_mcp_tunnels.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/yourbatis"
 )
 
 type AdminTunnel struct {
-	UUID                uuid.UUID
+	UUID                string
 	ExternalID          string
-	OrganizationUUID    uuid.UUID
-	WorkspaceUUID       uuid.NullUUID
+	OrganizationUUID    string
+	WorkspaceUUID       *string
 	WorkspaceExternalID *string
 	DisplayName         *string
 	Domain              string
@@ -89,23 +88,11 @@ func adminTunnelFromMapperRow(row adminMCPTunnelRow, err error) (AdminTunnel, er
 	if err != nil {
 		return AdminTunnel{}, mapNoRows(err)
 	}
-	tunnelUUID, err := uuid.Parse(row.UUID)
-	if err != nil {
-		return AdminTunnel{}, err
-	}
-	organizationUUID, err := uuid.Parse(row.OrganizationUUID)
-	if err != nil {
-		return AdminTunnel{}, err
-	}
-	workspaceUUID, err := nullableAdminTunnelUUID(row.WorkspaceUUID)
-	if err != nil {
-		return AdminTunnel{}, err
-	}
 	return AdminTunnel{
-		UUID:                tunnelUUID,
+		UUID:                row.UUID,
 		ExternalID:          row.ExternalID,
-		OrganizationUUID:    organizationUUID,
-		WorkspaceUUID:       workspaceUUID,
+		OrganizationUUID:    row.OrganizationUUID,
+		WorkspaceUUID:       row.WorkspaceUUID,
 		WorkspaceExternalID: row.WorkspaceExternalID,
 		DisplayName:         row.DisplayName,
 		Domain:              row.Domain,
@@ -127,15 +114,4 @@ func adminTunnelsFromMapperRows(rows []adminMCPTunnelRow) ([]AdminTunnel, error)
 		tunnels[index] = tunnel
 	}
 	return tunnels, nil
-}
-
-func nullableAdminTunnelUUID(value *string) (uuid.NullUUID, error) {
-	if value == nil {
-		return uuid.NullUUID{}, nil
-	}
-	parsed, err := uuid.Parse(*value)
-	if err != nil {
-		return uuid.NullUUID{}, err
-	}
-	return uuid.NullUUID{UUID: parsed, Valid: true}, nil
 }

--- a/internal/db/admin_organization_invites_mapper_test.go
+++ b/internal/db/admin_organization_invites_mapper_test.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/superduck-ai/yourbatis"
 )

--- a/internal/db/admin_organizations.go
+++ b/internal/db/admin_organizations.go
@@ -3,8 +3,7 @@ package db
 import (
 	"context"
 	"time"
-
-	"github.com/google/uuid"
+	"uuid"
 )
 
 type AdminOrganization struct {

--- a/internal/db/admin_users_mapper_test.go
+++ b/internal/db/admin_users_mapper_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/yourbatis"
 )
 

--- a/internal/db/admin_workspaces_mapper_postgres_test.go
+++ b/internal/db/admin_workspaces_mapper_postgres_test.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 )
 

--- a/internal/db/console_api_keys.go
+++ b/internal/db/console_api_keys.go
@@ -7,11 +7,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
 
-	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/superduck-ai/yourbatis"
 )
@@ -52,7 +52,7 @@ func (d *DB) CreateConsoleAPIKey(ctx context.Context, input platform.CreateConso
 		keySuffix = keySuffix[len(keySuffix)-6:]
 	}
 	externalID := consolePrefixedID("apikey", 18)
-	workspaceAPIKeyUUID := uuid.NewString()
+	workspaceAPIKeyUUID := uuid.NewV4().String()
 	keyHash := auth.HashAPIKey(rawKey)
 
 	var key platform.ConsoleAPIKey
@@ -185,7 +185,7 @@ func (d *DB) CreateConsoleWorkspace(ctx context.Context, input platform.CreateCo
 	}
 	mapper := NewConsoleWorkspaceMapper(d.mapperDB)
 	row, err := mapper.Upsert(ctx, upsertConsoleWorkspaceParams{
-		UUID:          uuid.NewString(),
+		UUID:          uuid.NewV4().String(),
 		ExternalID:    externalID,
 		OrgUUID:       input.OrgUUID,
 		Name:          input.Name,
@@ -338,7 +338,7 @@ func consolePrefixedID(prefix string, bytes int) string {
 func consoleRandomToken(bytes int) string {
 	raw := make([]byte, bytes)
 	if _, err := rand.Read(raw); err != nil {
-		return strings.ReplaceAll(uuid.NewString(), "-", "")
+		return strings.ReplaceAll(uuid.NewV4().String(), "-", "")
 	}
 	return base64.RawURLEncoding.EncodeToString(raw)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -10,6 +10,7 @@ import (
 	"os/user"
 	"slices"
 	"strings"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -17,7 +18,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
 	"github.com/superduck-ai/yourbatis"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 )

--- a/internal/db/filestore_filesystems.go
+++ b/internal/db/filestore_filesystems.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/yourbatis"
 )
 

--- a/internal/db/platform_auth.go
+++ b/internal/db/platform_auth.go
@@ -3,11 +3,10 @@ package db
 import (
 	"context"
 	"strings"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/platformsession"
 	"github.com/superduck-ai/yourbatis"
-
-	"github.com/google/uuid"
 )
 
 type PlatformAuthUserContext struct {
@@ -181,7 +180,7 @@ func (d *DB) ResolvePlatformSessionIdentity(ctx context.Context, input platforms
 		return platformsession.Session{}, mapNoRows(err)
 	}
 	session := row.session()
-	sessionUUID := uuid.NewString()
+	sessionUUID := uuid.NewV4().String()
 	session.ExternalID = "platform_session_" + strings.ReplaceAll(sessionUUID, "-", "")
 	session.ExpiresAt = input.ExpiresAt
 	return session, nil

--- a/internal/db/session_resource_file_helpers.go
+++ b/internal/db/session_resource_file_helpers.go
@@ -9,11 +9,11 @@ import (
 	"path"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/filestorepath"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/yourbatis"
 )
 
@@ -360,7 +360,7 @@ func newSessionResourceIdentity() (resourceUUID, resourceExternalID string, err 
 	if err != nil {
 		return "", "", err
 	}
-	return uuid.NewString(), resourceExternalID, nil
+	return uuid.NewV4().String(), resourceExternalID, nil
 }
 
 // newFileIdentity 在应用层生成真实 File 的 uuid 与 file_ external ID。
@@ -369,7 +369,7 @@ func newFileIdentity() (fileUUID, fileExternalID string, err error) {
 	if err != nil {
 		return "", "", err
 	}
-	return uuid.NewString(), fileExternalID, nil
+	return uuid.NewV4().String(), fileExternalID, nil
 }
 
 func filestoreFileWriteMapperParams(filesystem FilestoreFilesystem, input putFilestoreFileTxInput) sessionResourceFileWriteParams {

--- a/internal/db/session_skill_archive_resources.go
+++ b/internal/db/session_skill_archive_resources.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/yourbatis"
 )
 

--- a/internal/db/uuid.go
+++ b/internal/db/uuid.go
@@ -3,13 +3,12 @@ package db
 import (
 	"fmt"
 	"strings"
-
-	"github.com/google/uuid"
+	"uuid"
 )
 
 func tryParseDBUUIDIdentifierString(value string) string {
 	parsed, err := uuid.Parse(strings.TrimSpace(value))
-	if err != nil || parsed == uuid.Nil {
+	if err != nil || parsed == uuid.Nil() {
 		return ""
 	}
 	return parsed.String()
@@ -17,8 +16,8 @@ func tryParseDBUUIDIdentifierString(value string) string {
 
 func parseDBUUID(name, value string) (uuid.UUID, error) {
 	parsed, err := uuid.Parse(strings.TrimSpace(value))
-	if err != nil || parsed == uuid.Nil {
-		return uuid.Nil, fmt.Errorf("%s must be a non-nil UUID", name)
+	if err != nil || parsed == uuid.Nil() {
+		return uuid.Nil(), fmt.Errorf("%s must be a non-nil UUID", name)
 	}
 	return parsed, nil
 }

--- a/internal/db/uuid_test.go
+++ b/internal/db/uuid_test.go
@@ -2,12 +2,11 @@ package db
 
 import (
 	"testing"
-
-	"github.com/google/uuid"
+	"uuid"
 )
 
 func TestParseDBUUIDRejectsInvalidValues(t *testing.T) {
-	for _, value := range []string{"", "not-a-uuid", uuid.Nil.String()} {
+	for _, value := range []string{"", "not-a-uuid", uuid.Nil().String()} {
 		if _, err := parseDBUUID("workspace_uuid", value); err == nil {
 			t.Fatalf("parseDBUUID(%q) error = nil, want validation error", value)
 		}
@@ -19,7 +18,7 @@ func TestTryParseDBUUIDIdentifierStringPreservesCompatibilityLookup(t *testing.T
 	if valid == "" {
 		t.Fatal("tryParseDBUUIDIdentifierString(valid UUID) returned empty")
 	}
-	for _, value := range []string{"", "external_id", uuid.Nil.String()} {
+	for _, value := range []string{"", "external_id", uuid.Nil().String()} {
 		if got := tryParseDBUUIDIdentifierString(value); got != "" {
 			t.Fatalf("tryParseDBUUIDIdentifierString(%q) = %q, want empty", value, got)
 		}

--- a/internal/deployments/execution.go
+++ b/internal/deployments/execution.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/open-managed-agents/internal/common/jsonx"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 )
@@ -55,7 +55,7 @@ func prepareDeploymentExecution(
 		Events: events,
 		Session: db.CreateSessionInput{
 			Session: db.Session{
-				UUID: uuid.NewString(), ExternalID: sessionID,
+				UUID: uuid.NewV4().String(), ExternalID: sessionID,
 				OrganizationUUID: deployment.OrganizationUUID, WorkspaceUUID: deployment.WorkspaceUUID,
 				CreatedByAPIKeyUUID: createdByAPIKeyUUID,
 				EnvironmentUUID:     deployment.EnvironmentUUID, EnvironmentExternalID: deployment.EnvironmentExternalID,
@@ -67,14 +67,14 @@ func prepareDeploymentExecution(
 				OutcomeEvaluations: outcomes, CreatedAt: now, UpdatedAt: now,
 			},
 			Thread: db.SessionThread{
-				UUID: uuid.NewString(), ExternalID: threadID,
+				UUID: uuid.NewV4().String(), ExternalID: threadID,
 				OrganizationUUID: deployment.OrganizationUUID, WorkspaceUUID: deployment.WorkspaceUUID,
 				AgentSnapshot: deployment.AgentSnapshot, Status: "idle",
 				Usage: json.RawMessage(`{}`), Stats: json.RawMessage(`{}`), CreatedAt: now, UpdatedAt: now,
 			},
 			Resources: resources,
 			Work: db.EnvironmentWork{
-				UUID: uuid.NewString(), ExternalID: workID,
+				UUID: uuid.NewV4().String(), ExternalID: workID,
 				OrganizationUUID: deployment.OrganizationUUID, WorkspaceUUID: deployment.WorkspaceUUID,
 				EnvironmentUUID: deployment.EnvironmentUUID, EnvironmentExternalID: deployment.EnvironmentExternalID,
 				Data: workData, Metadata: json.RawMessage(`{}`), State: "queued", CreatedAt: now, UpdatedAt: now,

--- a/internal/deployments/handler.go
+++ b/internal/deployments/handler.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+	"uuid"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 	"github.com/superduck-ai/open-managed-agents/internal/agentsnapshot"
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/common/jsonx"
@@ -360,7 +360,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 	}
 	now := time.Now().UTC()
 	created, err := h.db.CreateDeployment(r.Context(), db.Deployment{
-		UUID:                  uuid.NewString(),
+		UUID:                  uuid.NewV4().String(),
 		ExternalID:            deploymentID,
 		OrganizationUUID:      principal.OrganizationUUID,
 		WorkspaceUUID:         principal.WorkspaceUUID,
@@ -642,7 +642,7 @@ func (h *Handler) runRoute(w http.ResponseWriter, r *http.Request) error {
 		Session:              preparedRun.Session,
 		Events:               preparedRun.Events,
 		Run: db.DeploymentRun{
-			UUID:                uuid.NewString(),
+			UUID:                uuid.NewV4().String(),
 			ExternalID:          preparedRun.RunID,
 			CreatedByAPIKeyUUID: principal.APIKeyUUID,
 			TriggerType:         "manual",
@@ -701,7 +701,7 @@ func (h *Handler) writeRunReferenceFailure(w http.ResponseWriter, r *http.Reques
 		return internalError("Could not create deployment run", fmt.Errorf("encode failed deployment run %q error: %w", runID, err))
 	}
 	run, err := h.db.CreateDeploymentRunFailure(r.Context(), deployment, db.DeploymentRun{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          runID,
 		CreatedByAPIKeyUUID: principal.APIKeyUUID,
 		Error:               runErrorJSON,
@@ -1093,7 +1093,7 @@ func sessionEventsFromInitialEvents(raw json.RawMessage, now time.Time) ([]db.Se
 			return nil, nil, err
 		}
 		events = append(events, db.SessionEvent{
-			UUID:        uuid.NewString(),
+			UUID:        uuid.NewV4().String(),
 			ExternalID:  eventID,
 			EventType:   input.Type,
 			Payload:     payloadRaw,

--- a/internal/deployments/resources.go
+++ b/internal/deployments/resources.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 	"unicode/utf8"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
@@ -17,8 +18,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/sandboxmount"
 	"github.com/superduck-ai/open-managed-agents/internal/sessioncontract"
 	"github.com/superduck-ai/open-managed-agents/internal/sessionresource"
-
-	"github.com/google/uuid"
 )
 
 type normalizedDeploymentResource struct {
@@ -405,7 +404,7 @@ func sessionResourcesFromDeployment(
 		}
 		resources = append(resources, db.CreateSessionResourceInput{
 			Resource: db.SessionResource{
-				UUID:             uuid.NewString(),
+				UUID:             uuid.NewV4().String(),
 				ExternalID:       resourceID,
 				OrganizationUUID: deployment.OrganizationUUID,
 				WorkspaceUUID:    deployment.WorkspaceUUID,

--- a/internal/deployments/scheduler.go
+++ b/internal/deployments/scheduler.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverdatabasesql"
 	"github.com/riverqueue/river/rivermigrate"
@@ -250,7 +250,7 @@ func (w *scheduledDeploymentWorker) Work(ctx context.Context, job *river.Job[sch
 		Deployment: deployment, ScheduledAt: scheduledAt,
 		Session: &preparedRun.Session, Events: preparedRun.Events,
 		Run: db.DeploymentRun{
-			UUID: uuid.NewString(), ExternalID: preparedRun.RunID,
+			UUID: uuid.NewV4().String(), ExternalID: preparedRun.RunID,
 		},
 		Now: now,
 	})
@@ -291,7 +291,7 @@ func (w *scheduledDeploymentWorker) recordFailure(
 	return w.applyOccurrence(ctx, db.ApplyScheduledOccurrenceInput{
 		Deployment: deployment, ScheduledAt: scheduledAt,
 		Run: db.DeploymentRun{
-			UUID: uuid.NewString(), ExternalID: runID, Error: runErrorJSON,
+			UUID: uuid.NewV4().String(), ExternalID: runID, Error: runErrorJSON,
 		},
 		AutoPauseReason: pausedReasonJSON, Now: now,
 	})

--- a/internal/environments/handler.go
+++ b/internal/environments/handler.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -23,7 +24,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 const maxEnvironmentBodySize = 4 << 20
@@ -188,7 +188,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 	}
 	now := time.Now().UTC()
 	created, err := h.db.CreateEnvironment(r.Context(), db.Environment{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          envID,
 		OrganizationUUID:    principal.OrganizationUUID,
 		WorkspaceUUID:       principal.WorkspaceUUID,

--- a/internal/environments/runner.go
+++ b/internal/environments/runner.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
 	"github.com/superduck-ai/open-managed-agents/internal/common/collections"
@@ -20,8 +21,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/networkpolicy"
 	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
 	skillsapi "github.com/superduck-ai/open-managed-agents/internal/skills"
-
-	"github.com/google/uuid"
 )
 
 var (
@@ -234,7 +233,7 @@ func (r *Runner) RunOnce(ctx context.Context, workerID string) (bool, error) {
 	// 先落一条 creating 状态的本地 Sandbox 记录，再请求 E2B 创建远端 Sandbox。
 	// 这样即使远端创建失败，数据库中仍有可查询的启动尝试和失败状态。
 	record, err := r.db.CreateEnvironmentSandbox(ctx, db.EnvironmentSandbox{
-		UUID:                  uuid.NewString(),
+		UUID:                  uuid.NewV4().String(),
 		ExternalID:            sandboxID,
 		OrganizationUUID:      work.OrganizationUUID,
 		WorkspaceUUID:         work.WorkspaceUUID,

--- a/internal/files/handler.go
+++ b/internal/files/handler.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -26,7 +27,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 const filesBeta = "files-api-2025-04-14"
@@ -130,7 +130,7 @@ func (h *Handler) upload(w http.ResponseWriter, r *http.Request) {
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusInternalServerError, "api_error", "Could not generate file ID"))
 		return
 	}
-	fileUUID := uuid.NewString()
+	fileUUID := uuid.NewV4().String()
 	contentType := detectContentType(header)
 	objectKey := fmt.Sprintf("workspaces/%s/files/%s/%s", principal.WorkspaceUUID, fileUUID, sanitizeForKey(filename))
 

--- a/internal/files/platform.go
+++ b/internal/files/platform.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
@@ -28,7 +29,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 const (
@@ -127,7 +127,7 @@ func (h *Handler) uploadBase64(w http.ResponseWriter, r *http.Request) {
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusInternalServerError, "api_error", "Could not generate file ID"))
 		return
 	}
-	fileUUID := uuid.NewString()
+	fileUUID := uuid.NewV4().String()
 	contentType := detectBase64ContentType(filename, content)
 	imageWidth, imageHeight, primaryColor := imageAssetInfoFromBytes(content)
 	thumbnail, hasThumbnail, thumbnailErr := buildPlatformThumbnail(contentType, content)

--- a/internal/filestore/cleanup.go
+++ b/internal/filestore/cleanup.go
@@ -7,12 +7,11 @@ import (
 	"log/slog"
 	"os"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/logging"
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
-
-	"github.com/google/uuid"
 )
 
 const (
@@ -52,7 +51,7 @@ func (w *CleanupWorker) Start(ctx context.Context) {
 	if w == nil || w.database == nil || w.client == nil {
 		return
 	}
-	workerID := fmt.Sprintf("filestore-cleanup-%d-%s", os.Getpid(), uuid.NewString())
+	workerID := fmt.Sprintf("filestore-cleanup-%d-%s", os.Getpid(), uuid.NewV4().String())
 	go w.runLoop(ctx, workerID)
 }
 

--- a/internal/filestore/service.go
+++ b/internal/filestore/service.go
@@ -13,12 +13,11 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
-
-	"github.com/google/uuid"
 )
 
 const (
@@ -506,7 +505,7 @@ func (s *Service) stageFilestoreObject(
 	now time.Time,
 	write func(string) (objectWriteResult, *apiError),
 ) (stagedFilestoreObject, *apiError) {
-	blobUUID := uuid.NewString()
+	blobUUID := uuid.NewV4().String()
 	key := filestoreObjectKey(principal.WorkspaceUUID, filesystem.UUID, blobUUID)
 	cleanupJob, apiErr := s.enqueueOrphanCleanup(ctx, principal, filesystem, blobUUID, key, now)
 	if apiErr != nil {

--- a/internal/filestore/service_test.go
+++ b/internal/filestore/service_test.go
@@ -12,12 +12,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
-
-	"github.com/google/uuid"
 )
 
 var serviceTestNow = time.Date(2026, time.July, 21, 12, 30, 0, 123456789, time.UTC)

--- a/internal/filestore/service_test_support_test.go
+++ b/internal/filestore/service_test_support_test.go
@@ -11,12 +11,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
-
-	"github.com/google/uuid"
 )
 
 func newServiceUnderTest(cfg config.Config, database filestoreDatabase, store storage.ObjectStore) *Service {
@@ -91,7 +90,7 @@ func serviceTestFileEntry(filesystem db.FilestoreFilesystem, entryPath string, c
 func serviceTestFileEntryFromBlob(filesystem db.FilestoreFilesystem, externalID, entryPath string, blob db.FilestoreFileBlob) db.SessionResourceFile {
 	return db.SessionResourceFile{
 		ID:                    60,
-		UUID:                  uuid.NewString(),
+		UUID:                  uuid.NewV4().String(),
 		ExternalID:            externalID,
 		OrganizationUUID:      serviceTestPrincipal().OrganizationUUID,
 		WorkspaceUUID:         serviceTestPrincipal().WorkspaceUUID,

--- a/internal/memory/handler.go
+++ b/internal/memory/handler.go
@@ -18,6 +18,7 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -28,7 +29,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -218,7 +218,7 @@ func (h *Handler) createStore(w http.ResponseWriter, r *http.Request) {
 	}
 	now := time.Now().UTC()
 	created, err := h.db.CreateMemoryStore(r.Context(), db.MemoryStore{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          storeID,
 		OrganizationUUID:    principal.OrganizationUUID,
 		WorkspaceUUID:       principal.WorkspaceUUID,
@@ -777,7 +777,7 @@ func (h *Handler) updateMemory(w http.ResponseWriter, r *http.Request, storeID, 
 			writeAPIError(w, r, "Could not generate memory version ID")
 			return
 		}
-		versionUUID := uuid.NewString()
+		versionUUID := uuid.NewV4().String()
 		objectKey := memoryObjectKey(principal.WorkspaceUUID, store.UUID, record.UUID, versionUUID)
 		contentBytes := []byte(targetContent)
 		contentSHA := sha256Hex(contentBytes)
@@ -858,7 +858,7 @@ func (h *Handler) deleteMemory(w http.ResponseWriter, r *http.Request, storeID, 
 		WorkspaceUUID:         principal.WorkspaceUUID,
 		MemoryStoreExternalID: storeID,
 		MemoryExternalID:      memoryID,
-		VersionUUID:           uuid.NewString(),
+		VersionUUID:           uuid.NewV4().String(),
 		VersionExternalID:     versionID,
 		ExpectedContentSHA256: expected,
 		Actor:                 apiActor(principal),
@@ -1058,8 +1058,8 @@ func (h *Handler) newMemoryObjectIDs(workspaceUUID, storeUUID string) (memoryID,
 	if err != nil {
 		return "", "", "", "", "", err
 	}
-	memoryUUID = uuid.NewString()
-	versionUUID = uuid.NewString()
+	memoryUUID = uuid.NewV4().String()
+	versionUUID = uuid.NewV4().String()
 	objectKey = memoryObjectKey(workspaceUUID, storeUUID, memoryUUID, versionUUID)
 	return memoryID, versionID, memoryUUID, versionUUID, objectKey, nil
 }
@@ -1545,7 +1545,10 @@ func decodeStoreCursor(raw string) (*db.MemoryStorePageCursor, error) {
 	}
 	resourceUUID, ok := payload["uuid"].(string)
 	createdRaw, _ := payload["created_at"].(string)
-	if !ok || uuid.Validate(resourceUUID) != nil || createdRaw == "" {
+	if !ok || createdRaw == "" {
+		return nil, errors.New("page is invalid")
+	}
+	if _, err := uuid.Parse(resourceUUID); err != nil {
 		return nil, errors.New("page is invalid")
 	}
 	createdAt, err := time.Parse(time.RFC3339Nano, createdRaw)
@@ -1571,7 +1574,10 @@ func decodeMemoryCursor(raw string) (*db.MemoryPageCursor, error) {
 	}
 	path, _ := payload["path"].(string)
 	resourceUUID, ok := payload["uuid"].(string)
-	if !ok || uuid.Validate(resourceUUID) != nil {
+	if !ok {
+		return nil, errors.New("page is invalid")
+	}
+	if _, err := uuid.Parse(resourceUUID); err != nil {
 		return nil, errors.New("page is invalid")
 	}
 	cursor := &db.MemoryPageCursor{Path: path, UUID: resourceUUID}
@@ -1603,7 +1609,10 @@ func decodeVersionCursor(raw string) (*db.MemoryVersionPageCursor, error) {
 	}
 	resourceUUID, ok := payload["uuid"].(string)
 	createdRaw, _ := payload["created_at"].(string)
-	if !ok || uuid.Validate(resourceUUID) != nil || createdRaw == "" {
+	if !ok || createdRaw == "" {
+		return nil, errors.New("page is invalid")
+	}
+	if _, err := uuid.Parse(resourceUUID); err != nil {
 		return nil, errors.New("page is invalid")
 	}
 	createdAt, err := time.Parse(time.RFC3339Nano, createdRaw)

--- a/internal/platformapi/platform_auth_routes.go
+++ b/internal/platformapi/platform_auth_routes.go
@@ -9,11 +9,11 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/platformsession"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 type CodeConfiguration struct {
@@ -125,7 +125,7 @@ func handleVerifyMagicLink(store OrganizationStore, authService platformMagicLin
 		}
 
 		created := true
-		sessionKey := "sk-ant-sid-session-key-" + uuid.NewString()
+		sessionKey := "sk-ant-sid-session-key-" + uuid.NewV4().String()
 		expiresAt := time.Now().UTC().Add(time.Duration(25920000) * time.Second)
 		session, err := authService.ResolvePlatformSessionIdentity(r.Context(), platformsession.CreateInput{
 			SessionKey: sessionKey,

--- a/internal/platformapi/platform_environment_tokens.go
+++ b/internal/platformapi/platform_environment_tokens.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"uuid"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 const platformEnvironmentTokenExpirySeconds = 60 * 60 * 24 * 365
@@ -76,7 +76,7 @@ func handleCreatePlatformEnvironmentToken(w http.ResponseWriter, r *http.Request
 	now := time.Now().UTC()
 	expiresAt := now.Add(time.Duration(platformEnvironmentTokenExpirySeconds) * time.Second)
 	token := platformEnvironmentToken{
-		ID:        uuid.NewString(),
+		ID:        uuid.NewV4().String(),
 		Name:      platformEnvironmentTokenName(body),
 		CreatedAt: formatJSISOString(now),
 		ExpiresAt: formatJSISOString(expiresAt),

--- a/internal/platformauth/service.go
+++ b/internal/platformauth/service.go
@@ -6,13 +6,12 @@ import (
 	"encoding/base64"
 	"errors"
 	"strings"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
 	"github.com/superduck-ai/open-managed-agents/internal/platformsession"
-
-	"github.com/google/uuid"
 )
 
 type Store interface {
@@ -88,7 +87,7 @@ func createDefaultUserOrganization(ctx context.Context, tx db.PlatformAuthTxStor
 		return db.PlatformAuthUserContext{}, err
 	}
 
-	userUUID := uuid.NewString()
+	userUUID := uuid.NewV4().String()
 	userExternalID := taggedExternalUserID(userUUID)
 	user, err := tx.InsertUser(ctx, db.PlatformAuthUserInput{
 		UUID:             userUUID,
@@ -103,11 +102,11 @@ func createDefaultUserOrganization(ctx context.Context, tx db.PlatformAuthTxStor
 	}
 
 	workspace, err := tx.InsertWorkspace(ctx, db.PlatformAuthWorkspaceInput{
-		UUID:             uuid.NewString(),
+		UUID:             uuid.NewV4().String(),
 		ExternalID:       workspaceExternalID,
 		OrganizationUUID: org.UUID,
 		Name:             "default",
-		CompartmentID:    uuid.NewString(),
+		CompartmentID:    uuid.NewV4().String(),
 	})
 	if err != nil {
 		return db.PlatformAuthUserContext{}, err
@@ -175,7 +174,7 @@ func taggedExternalUserID(userUUID string) string {
 func randomToken(bytes int) string {
 	raw := make([]byte, bytes)
 	if _, err := rand.Read(raw); err != nil {
-		return strings.ReplaceAll(uuid.NewString(), "-", "")
+		return strings.ReplaceAll(uuid.NewV4().String(), "-", "")
 	}
 	return base64.RawURLEncoding.EncodeToString(raw)
 }

--- a/internal/sessionfanout/bus.go
+++ b/internal/sessionfanout/bus.go
@@ -8,10 +8,10 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/logging"
 
-	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -122,7 +122,7 @@ func NewRedis(ctx context.Context, client *redis.Client, logger *slog.Logger) (*
 		return nil, errors.New("redis client is required")
 	}
 	listenCtx, cancel := context.WithCancel(ctx)
-	instanceChannel := instanceChannelPrefix + uuid.NewString()
+	instanceChannel := instanceChannelPrefix + uuid.NewV4().String()
 	pubsub := client.Subscribe(listenCtx, instanceChannel)
 	if _, err := pubsub.Receive(listenCtx); err != nil {
 		cancel()

--- a/internal/sessions/event_effects.go
+++ b/internal/sessions/event_effects.go
@@ -5,14 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/agentsnapshot"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
-
-	"github.com/google/uuid"
 )
 
 func (h *Handler) applySessionEventProjection(ctx context.Context, event db.SessionEvent) error {
@@ -136,7 +135,7 @@ func (h *Handler) sessionUpdatedEvent(session db.Session) (db.SessionEvent, erro
 		return db.SessionEvent{}, err
 	}
 	return db.SessionEvent{
-		UUID:              uuid.NewString(),
+		UUID:              uuid.NewV4().String(),
 		ExternalID:        eventID,
 		OrganizationUUID:  session.OrganizationUUID,
 		WorkspaceUUID:     session.WorkspaceUUID,
@@ -169,7 +168,7 @@ func (h *Handler) simpleSessionEvent(eventType, sessionID string, threadID *stri
 		return db.SessionEvent{}, err
 	}
 	return db.SessionEvent{
-		UUID:             uuid.NewString(),
+		UUID:             uuid.NewV4().String(),
 		ExternalID:       eventID,
 		ThreadExternalID: threadID,
 		EventType:        eventType,

--- a/internal/sessions/event_mapper.go
+++ b/internal/sessions/event_mapper.go
@@ -8,14 +8,13 @@ import (
 	"errors"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/agentsnapshot"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
-
-	"github.com/google/uuid"
 )
 
 func rawSessionEventType(raw json.RawMessage) string {
@@ -72,7 +71,7 @@ func (h *Handler) streamDeltaEventFromCodeSessionPayload(ctx context.Context, se
 		return db.SessionEvent{}, err
 	}
 	return db.SessionEvent{
-		UUID:              uuid.NewString(),
+		UUID:              uuid.NewV4().String(),
 		ExternalID:        eventID,
 		OrganizationUUID:  session.OrganizationUUID,
 		WorkspaceUUID:     session.WorkspaceUUID,
@@ -148,7 +147,7 @@ func (h *Handler) sessionEventsFromCodeSessionPayload(ctx context.Context, sessi
 			return nil, err
 		}
 		events = append(events, db.SessionEvent{
-			UUID:              uuid.NewString(),
+			UUID:              uuid.NewV4().String(),
 			ExternalID:        spec.EventID,
 			OrganizationUUID:  session.OrganizationUUID,
 			WorkspaceUUID:     session.WorkspaceUUID,
@@ -400,7 +399,7 @@ func (h *Handler) ensurePrimarySessionThread(ctx context.Context, session db.Ses
 	}
 	now := time.Now().UTC()
 	return h.db.CreateSessionThreadIfAbsent(ctx, db.SessionThread{
-		UUID:              uuid.NewString(),
+		UUID:              uuid.NewV4().String(),
 		ExternalID:        threadID,
 		OrganizationUUID:  session.OrganizationUUID,
 		WorkspaceUUID:     session.WorkspaceUUID,
@@ -460,7 +459,7 @@ func (h *Handler) ensureSessionThread(ctx context.Context, session db.Session, t
 		now = time.Now().UTC()
 	}
 	_, err = h.db.CreateSessionThreadIfAbsent(ctx, db.SessionThread{
-		UUID:                   uuid.NewString(),
+		UUID:                   uuid.NewV4().String(),
 		ExternalID:             threadID,
 		OrganizationUUID:       session.OrganizationUUID,
 		WorkspaceUUID:          session.WorkspaceUUID,

--- a/internal/sessions/event_payload.go
+++ b/internal/sessions/event_payload.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
@@ -377,7 +377,10 @@ func decodeCursor(raw string) (*time.Time, string, error) {
 		CreatedAt string `json:"created_at"`
 		UUID      string `json:"uuid"`
 	}
-	if err := json.Unmarshal(data, &payload); err != nil || uuid.Validate(payload.UUID) != nil || payload.CreatedAt == "" {
+	if err := json.Unmarshal(data, &payload); err != nil || payload.CreatedAt == "" {
+		return nil, "", errors.New("page cursor is invalid")
+	}
+	if _, err := uuid.Parse(payload.UUID); err != nil {
 		return nil, "", errors.New("page cursor is invalid")
 	}
 	createdAt, err := time.Parse(time.RFC3339Nano, payload.CreatedAt)

--- a/internal/sessions/fixtures.go
+++ b/internal/sessions/fixtures.go
@@ -5,13 +5,12 @@ import (
 	"errors"
 	"net/http"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
-
-	"github.com/google/uuid"
 )
 
 func (h *Handler) isOfficialSDKFixturePrincipal(principal auth.Principal) bool {
@@ -73,7 +72,7 @@ func normalizeFixtureEvent(raw json.RawMessage, now time.Time) (json.RawMessage,
 func (h *Handler) fixtureDBSession(principal auth.Principal) db.Session {
 	now := time.Now().UTC()
 	return db.Session{
-		UUID:                  uuid.NewString(),
+		UUID:                  uuid.NewV4().String(),
 		ExternalID:            h.cfg.SDKFixtures.SessionID,
 		OrganizationUUID:      principal.OrganizationUUID,
 		WorkspaceUUID:         principal.WorkspaceUUID,

--- a/internal/sessions/service.go
+++ b/internal/sessions/service.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
@@ -16,7 +17,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/webhooks"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
@@ -88,7 +88,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 	workData, _ := httpapi.MarshalRaw(map[string]any{"id": sessionID, "type": "session"})
 	created, thread, _, _, err := h.db.CreateSession(r.Context(), db.CreateSessionInput{
 		Session: db.Session{
-			UUID:                  uuid.NewString(),
+			UUID:                  uuid.NewV4().String(),
 			ExternalID:            sessionID,
 			OrganizationUUID:      principal.OrganizationUUID,
 			WorkspaceUUID:         principal.WorkspaceUUID,
@@ -110,7 +110,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 			UpdatedAt:             now,
 		},
 		Thread: db.SessionThread{
-			UUID:             uuid.NewString(),
+			UUID:             uuid.NewV4().String(),
 			ExternalID:       threadID,
 			OrganizationUUID: principal.OrganizationUUID,
 			WorkspaceUUID:    principal.WorkspaceUUID,
@@ -123,7 +123,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 		},
 		Resources: resourceInputs,
 		Work: db.EnvironmentWork{
-			UUID:                  uuid.NewString(),
+			UUID:                  uuid.NewV4().String(),
 			ExternalID:            workID,
 			OrganizationUUID:      principal.OrganizationUUID,
 			WorkspaceUUID:         principal.WorkspaceUUID,

--- a/internal/sessions/service_helpers.go
+++ b/internal/sessions/service_helpers.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/agentsnapshot"
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
@@ -16,8 +17,6 @@ import (
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 	"github.com/superduck-ai/open-managed-agents/internal/sandboxmount"
 	"github.com/superduck-ai/open-managed-agents/internal/sessionresource"
-
-	"github.com/google/uuid"
 )
 
 func (h *Handler) resolveAgent(r *http.Request, principal auth.Principal, raw json.RawMessage) (db.Agent, json.RawMessage, error) {
@@ -217,7 +216,7 @@ func (h *Handler) resourceFromRequest(
 	}
 	return normalizedSessionResource{
 		resource: db.SessionResource{
-			UUID:              uuid.NewString(),
+			UUID:              uuid.NewV4().String(),
 			ExternalID:        resourceID,
 			OrganizationUUID:  session.OrganizationUUID,
 			WorkspaceUUID:     session.WorkspaceUUID,
@@ -290,7 +289,7 @@ func normalizeInputEvent(
 		return db.SessionEvent{}, nil, false, err
 	}
 	return db.SessionEvent{
-		UUID:              uuid.NewString(),
+		UUID:              uuid.NewV4().String(),
 		ExternalID:        eventID,
 		OrganizationUUID:  session.OrganizationUUID,
 		WorkspaceUUID:     session.WorkspaceUUID,

--- a/internal/skills/handler.go
+++ b/internal/skills/handler.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -25,7 +26,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 const (
@@ -141,8 +141,8 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return internalError("Could not generate skill version ID", fmt.Errorf("generate skill version ID: %w", err))
 	}
-	skillUUID := uuid.NewString()
-	versionUUID := uuid.NewString()
+	skillUUID := uuid.NewV4().String()
+	versionUUID := uuid.NewV4().String()
 	versionValue := newVersionString()
 	objectKey := fmt.Sprintf("workspaces/%s/skills/%s/versions/%s/%s.zip", principal.WorkspaceUUID, skillUUID, versionValue, sanitizeForKey(pkg.Directory))
 
@@ -416,7 +416,7 @@ func (h *Handler) createVersion(w http.ResponseWriter, r *http.Request, skillID 
 	if err != nil {
 		return internalError("Could not generate skill version ID", fmt.Errorf("generate skill version ID: %w", err))
 	}
-	versionUUID := uuid.NewString()
+	versionUUID := uuid.NewV4().String()
 	versionValue := newVersionString()
 	objectKey := fmt.Sprintf("workspaces/%s/skills/%s/versions/%s/%s.zip", principal.WorkspaceUUID, skill.UUID, versionValue, sanitizeForKey(pkg.Directory))
 	if _, err := h.store.Upload(r.Context(), objectKey, bytes.NewReader(pkg.Zip), storage.UploadOptions{Size: pkg.Size, ContentType: skillArchiveContentType}); err != nil {

--- a/internal/vaults/handler.go
+++ b/internal/vaults/handler.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -22,7 +23,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/webhooks"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 const maxVaultBodySize = 4 << 20
@@ -206,7 +206,7 @@ func (h *Handler) createVault(w http.ResponseWriter, r *http.Request) error {
 	}
 	now := time.Now().UTC()
 	created, err := h.db.CreateVault(r.Context(), db.Vault{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          vaultID,
 		OrganizationUUID:    principal.OrganizationUUID,
 		WorkspaceUUID:       principal.WorkspaceUUID,
@@ -407,7 +407,7 @@ func (h *Handler) createCredentialRoute(w http.ResponseWriter, r *http.Request) 
 	}
 	now := time.Now().UTC()
 	credential := db.VaultCredential{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          credentialID,
 		OrganizationUUID:    vault.OrganizationUUID,
 		WorkspaceUUID:       principal.WorkspaceUUID,
@@ -870,7 +870,10 @@ func decodeVaultCursor(raw string) (*db.VaultPageCursor, error) {
 		return nil, errors.New("page is invalid")
 	}
 	var payload pageCursorPayload
-	if err := json.Unmarshal(data, &payload); err != nil || uuid.Validate(payload.UUID) != nil || payload.CreatedAt == "" {
+	if err := json.Unmarshal(data, &payload); err != nil || payload.CreatedAt == "" {
+		return nil, errors.New("page is invalid")
+	}
+	if _, err := uuid.Parse(payload.UUID); err != nil {
 		return nil, errors.New("page is invalid")
 	}
 	createdAt, err := time.Parse(time.RFC3339Nano, payload.CreatedAt)
@@ -894,7 +897,10 @@ func decodeCredentialCursor(raw string) (*db.VaultCredentialPageCursor, error) {
 		return nil, errors.New("page is invalid")
 	}
 	var payload pageCursorPayload
-	if err := json.Unmarshal(data, &payload); err != nil || uuid.Validate(payload.UUID) != nil || payload.CreatedAt == "" {
+	if err := json.Unmarshal(data, &payload); err != nil || payload.CreatedAt == "" {
+		return nil, errors.New("page is invalid")
+	}
+	if _, err := uuid.Parse(payload.UUID); err != nil {
 		return nil, errors.New("page is invalid")
 	}
 	createdAt, err := time.Parse(time.RFC3339Nano, payload.CreatedAt)

--- a/internal/webhooks/handler.go
+++ b/internal/webhooks/handler.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -22,7 +23,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/logging"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 const (
@@ -160,7 +160,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) error {
 	}
 	now := time.Now().UTC()
 	created, err := h.db.CreateWebhookEndpoint(r.Context(), db.WebhookEndpoint{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          webhookID,
 		OrganizationUUID:    principal.OrganizationUUID,
 		WorkspaceUUID:       principal.WorkspaceUUID,

--- a/internal/workbench/console_platform_workbench.go
+++ b/internal/workbench/console_platform_workbench.go
@@ -14,13 +14,13 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/modelmapping"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 	"github.com/samber/lo"
 )
 
@@ -170,7 +170,7 @@ func (h *workbenchHandler) handleCreateWorkbenchPrompt(w http.ResponseWriter, r 
 		}
 	}
 	if revisionBody, ok := body["latest_revision"].(map[string]any); ok {
-		revision := h.revisionFromBody(r, revisionBody, "workbench-revision-"+uuid.NewString(), true, false)
+		revision := h.revisionFromBody(r, revisionBody, "workbench-revision-"+uuid.NewV4().String(), true, false)
 		if err := h.storeRevision(r, promptID, revision); workbenchWritePersistenceError(w, err) {
 			return
 		}
@@ -310,7 +310,7 @@ func (h *workbenchHandler) handleCreateWorkbenchPromptRevision(w http.ResponseWr
 		writeWorkbenchPromptNotFound(w)
 		return
 	}
-	revision := h.revisionFromBody(r, body, "workbench-revision-"+uuid.NewString(), true, false)
+	revision := h.revisionFromBody(r, body, "workbench-revision-"+uuid.NewV4().String(), true, false)
 	if err := h.storeRevision(r, promptID, revision); workbenchWritePersistenceError(w, err) {
 		return
 	}
@@ -2346,7 +2346,7 @@ func (h *workbenchHandler) storedKV(r *http.Request, promptID string, key string
 func workbenchEvaluationFromBody(r *http.Request, body map[string]any, revisionID string) map[string]any {
 	evaluationID := strings.TrimSpace(workbenchString(body["id"]))
 	if evaluationID == "" {
-		evaluationID = "eval_local_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+		evaluationID = "eval_local_" + strings.ReplaceAll(uuid.NewV4().String(), "-", "")
 	}
 	testCaseID := strings.TrimSpace(workbenchString(body["test_case_id"]))
 	if testCaseID == "" {

--- a/tests/admin_api_test.go
+++ b/tests/admin_api_test.go
@@ -16,10 +16,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -876,7 +876,7 @@ func containsAdminObject(items []adminObject, id string) bool {
 }
 
 func uniqueAdminSuffix() string {
-	return strings.ReplaceAll(uuid.NewString(), "-", "")
+	return strings.ReplaceAll(uuid.NewV4().String(), "-", "")
 }
 
 func partialTestKeyHint(key string) string {

--- a/tests/deployments_api_test.go
+++ b/tests/deployments_api_test.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	deploymentsapi "github.com/superduck-ai/open-managed-agents/internal/deployments"
 )
@@ -383,7 +383,7 @@ func TestDeploymentsAPI(t *testing.T) {
 		scheduledAt := time.Now().UTC().Truncate(time.Minute)
 		err = applyScheduledOccurrence(ctx, app.db, db.ApplyScheduledOccurrenceInput{
 			Deployment: deployment, ScheduledAt: scheduledAt,
-			Run: db.DeploymentRun{UUID: uuid.NewString(), ExternalID: "drun_stale_" + uuid.NewString()},
+			Run: db.DeploymentRun{UUID: uuid.NewV4().String(), ExternalID: "drun_stale_" + uuid.NewV4().String()},
 			Now: scheduledAt,
 		})
 		if !errors.Is(err, db.ErrStaleSchedule) {
@@ -415,7 +415,7 @@ func TestDeploymentsAPI(t *testing.T) {
 		input := db.ApplyScheduledOccurrenceInput{
 			Deployment: deployment, ScheduledAt: scheduledAt,
 			Run: db.DeploymentRun{
-				UUID: uuid.NewString(), ExternalID: "drun_periodic_" + uuid.NewString(),
+				UUID: uuid.NewV4().String(), ExternalID: "drun_periodic_" + uuid.NewV4().String(),
 				Error: json.RawMessage(`{"type":"unknown_error","message":"test"}`),
 			},
 			Now: scheduledAt,
@@ -423,8 +423,8 @@ func TestDeploymentsAPI(t *testing.T) {
 		if err := applyScheduledOccurrence(ctx, app.db, input); err != nil {
 			t.Fatalf("apply first scheduled occurrence: %v", err)
 		}
-		input.Run.UUID = uuid.NewString()
-		input.Run.ExternalID = "drun_periodic_" + uuid.NewString()
+		input.Run.UUID = uuid.NewV4().String()
+		input.Run.ExternalID = "drun_periodic_" + uuid.NewV4().String()
 		if err := applyScheduledOccurrence(ctx, app.db, input); !errors.Is(err, db.ErrStaleSchedule) {
 			t.Fatalf("apply duplicate scheduled occurrence error = %v, want ErrStaleSchedule", err)
 		}

--- a/tests/environments_api_test.go
+++ b/tests/environments_api_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -17,7 +18,6 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -522,7 +522,7 @@ func createEnvironmentWork(t *testing.T, app *testApp, env db.Environment) strin
 		t.Fatalf("new work id: %v", err)
 	}
 	if _, err := app.db.CreateEnvironmentWork(context.Background(), db.EnvironmentWork{
-		UUID:                  uuid.NewString(),
+		UUID:                  uuid.NewV4().String(),
 		ExternalID:            workID,
 		OrganizationUUID:      env.OrganizationUUID,
 		WorkspaceUUID:         env.WorkspaceUUID,

--- a/tests/environments_e2b_integration_test.go
+++ b/tests/environments_e2b_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/api"
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
@@ -24,7 +25,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
 	skillsapi "github.com/superduck-ai/open-managed-agents/internal/skills"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	e2b "github.com/superduck-ai/e2b-go-sdk"
 )
@@ -102,7 +102,7 @@ func TestE2BEnvironmentRunnerIntegration(t *testing.T) {
 	})
 	now := time.Now().UTC()
 	env, err := database.CreateEnvironment(ctx, db.Environment{
-		UUID:              uuid.NewString(),
+		UUID:              uuid.NewV4().String(),
 		ExternalID:        envID,
 		OrganizationID:    apiKey.OrganizationID,
 		WorkspaceID:       apiKey.WorkspaceID,
@@ -121,7 +121,7 @@ func TestE2BEnvironmentRunnerIntegration(t *testing.T) {
 	defer cleanupE2BIntegrationRows(t, pool, env.ExternalID, workID)
 
 	work, err := database.CreateEnvironmentWork(ctx, db.EnvironmentWork{
-		UUID:                  uuid.NewString(),
+		UUID:                  uuid.NewV4().String(),
 		ExternalID:            workID,
 		OrganizationID:        env.OrganizationID,
 		WorkspaceID:           env.WorkspaceID,

--- a/tests/files_api_test.go
+++ b/tests/files_api_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/api"
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
@@ -34,7 +35,6 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/secrets"
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -141,7 +141,7 @@ func TestV1AuthModes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load config: %v", err)
 	}
-	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
+	suffix := strings.ReplaceAll(uuid.NewV4().String(), "-", "")
 	platformSessionKey := "session-auth-modes-" + suffix
 	app := newTestAppWithStore(t, &cfg, newFakeStore("auth-modes-bucket"))
 	defer app.close()
@@ -223,7 +223,7 @@ func TestPlatformUploadB64FilesAPI(t *testing.T) {
 	defaultIDs := getDefaultDBIDs(t, app.pool)
 	workspacePath := "/api/" + defaultIDs.WorkspaceUUID
 	organizationPath := "/api/" + defaultIDs.OrganizationUUID
-	sessionKey := "session-platform-upload-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	sessionKey := "session-platform-upload-" + strings.ReplaceAll(uuid.NewV4().String(), "-", "")
 	cookies := []*http.Cookie{{Name: "sessionKey", Value: sessionKey}}
 	app.seedPlatformSession(t, sessionKey)
 	pngBytes := generatedPNG(t, 800, 600)
@@ -236,7 +236,7 @@ func TestPlatformUploadB64FilesAPI(t *testing.T) {
 	})
 
 	t.Run("failure unknown organization", func(t *testing.T) {
-		resp := app.platformAPIRequest(t, "platform.claude.com", http.MethodPost, "/api/"+uuid.NewString()+"/upload_b64", strings.NewReader(validPayload), cookies)
+		resp := app.platformAPIRequest(t, "platform.claude.com", http.MethodPost, "/api/"+uuid.NewV4().String()+"/upload_b64", strings.NewReader(validPayload), cookies)
 		assertError(t, resp, http.StatusForbidden, "permission_error")
 	})
 
@@ -709,7 +709,7 @@ func TestFilesAPI(t *testing.T) {
 			t.Fatalf("before_id page length = %d, want 1", len(pageBefore.Data))
 		}
 
-		scopeID := "session_scope_" + uuid.NewString()
+		scopeID := "session_scope_" + uuid.NewV4().String()
 		scopedID := createMetadataOnlyFile(t, app, scopeID)
 		defer softDeleteFile(t, app, scopedID)
 		scopedPage := listFiles(t, app, "scope_id="+scopeID)
@@ -723,7 +723,7 @@ func TestFilesAPI(t *testing.T) {
 	})
 
 	t.Run("success before_id returns nearest previous pages", func(t *testing.T) {
-		scopeID := "pagination_" + uuid.NewString()
+		scopeID := "pagination_" + uuid.NewV4().String()
 		fileIDs := make([]string, 6)
 		for index := range fileIDs {
 			fileIDs[index] = createMetadataOnlyFile(t, app, scopeID)
@@ -876,7 +876,7 @@ func TestObjectCleanupJobAttemptsIncrementOnFailure(t *testing.T) {
 
 	ctx := context.Background()
 	defaultIDs := getDefaultDBIDs(t, app.pool)
-	objectKey := "attempts-test/" + uuid.NewString()
+	objectKey := "attempts-test/" + uuid.NewV4().String()
 	if err := app.db.EnqueueObjectCleanupJob(ctx, defaultIDs.WorkspaceUUID, app.store.Name(), objectKey, "file_attempts_test"); err != nil {
 		t.Fatalf("enqueue cleanup job: %v", err)
 	}
@@ -1335,7 +1335,7 @@ func createMetadataOnlyFile(t *testing.T, app *testApp, scopeID string) string {
 	defaultIDs := getDefaultDBIDs(t, app.pool)
 	scopeType := "session"
 	if err := app.db.CreateFile(context.Background(), db.FileRecord{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          fileExternalID,
 		WorkspaceUUID:       defaultIDs.WorkspaceUUID,
 		Filename:            "scoped.txt",
@@ -1361,7 +1361,7 @@ func createDownloadableFile(t *testing.T, app *testApp, filename, contentType st
 	if err != nil {
 		t.Fatalf("new file id: %v", err)
 	}
-	fileUUID := uuid.NewString()
+	fileUUID := uuid.NewV4().String()
 	defaultIDs := getDefaultDBIDs(t, app.pool)
 	objectKey := "workspaces/" + defaultIDs.WorkspaceUUID + "/files/" + fileUUID + "/" + filename
 	if _, err := app.store.Upload(context.Background(), objectKey, bytes.NewReader(content), storage.UploadOptions{Size: int64(len(content)), ContentType: contentType}); err != nil {

--- a/tests/filestore_db_test.go
+++ b/tests/filestore_db_test.go
@@ -12,10 +12,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
-
-	"github.com/google/uuid"
 )
 
 func TestSessionNamespaceUsesResourcesAndFiles(t *testing.T) {
@@ -64,7 +63,7 @@ func TestCreateSessionRejectsFileResourcesAboveDBLimit(t *testing.T) {
 		resourceID := fmt.Sprintf("sesrsc_file_limit_%03d", index)
 		input.Resources = append(input.Resources, db.CreateSessionResourceInput{
 			Resource: db.SessionResource{
-				UUID:             uuid.NewString(),
+				UUID:             uuid.NewV4().String(),
 				ExternalID:       resourceID,
 				OrganizationUUID: organizationUUID,
 				WorkspaceUUID:    workspaceUUID,
@@ -102,7 +101,7 @@ func TestCreateSessionRollsBackWhenFilesystemScopeIsInvalid(t *testing.T) {
 	t.Cleanup(app.close)
 	_, _, organizationUUID, workspaceUUID, _, _, _, _, _, apiKeyUUID := seedFilestoreLookupScope(t, app)
 	input := filestoreSessionCreateInput(organizationUUID, workspaceUUID, apiKeyUUID)
-	input.Session.CreatedByAPIKeyUUID = uuid.NewString()
+	input.Session.CreatedByAPIKeyUUID = uuid.NewV4().String()
 
 	if _, _, _, _, err := app.db.CreateSession(context.Background(), input); !errors.Is(err, db.ErrPreconditionFailed) {
 		t.Fatalf("CreateSession() error = %v, want ErrPreconditionFailed", err)
@@ -269,7 +268,7 @@ func TestCreateSessionProvisionsFilesystem(t *testing.T) {
 	}
 	for attempt := 1; attempt <= 2; attempt++ {
 		if _, err := app.db.CreateCodeSession(context.Background(), db.CreateCodeSessionInput{
-			ExternalID:            fmt.Sprintf("cse_filestore_retry_%d_%s", attempt, uuid.NewString()),
+			ExternalID:            fmt.Sprintf("cse_filestore_retry_%d_%s", attempt, uuid.NewV4().String()),
 			OrganizationUUID:      organizationUUID,
 			WorkspaceUUID:         workspaceUUID,
 			SessionUUID:           created.UUID,
@@ -278,7 +277,7 @@ func TestCreateSessionProvisionsFilesystem(t *testing.T) {
 			EnvironmentExternalID: created.EnvironmentExternalID,
 			Status:                "active",
 			Metadata:              json.RawMessage(`{}`),
-			OAuthAccessTokenHash:  fmt.Sprintf("filestore-retry-hash-%d-%s", attempt, uuid.NewString()),
+			OAuthAccessTokenHash:  fmt.Sprintf("filestore-retry-hash-%d-%s", attempt, uuid.NewV4().String()),
 		}); err != nil {
 			t.Fatalf("create Code Session attempt %d: %v", attempt, err)
 		}
@@ -292,8 +291,8 @@ func TestCreateSessionProvisionsFilesystem(t *testing.T) {
 	}
 
 	_, provisioned, err := app.db.ProvisionFilestoreFilesystem(context.Background(), db.ProvisionFilestoreFilesystemInput{
-		UUID:                uuid.NewString(),
-		ExternalID:          "fs_second_" + uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
+		ExternalID:          "fs_second_" + uuid.NewV4().String(),
 		OrganizationUUID:    organizationUUID,
 		WorkspaceUUID:       workspaceUUID,
 		SessionUUID:         created.UUID,
@@ -441,8 +440,8 @@ func TestFilestoreObjectCleanupJobStopsAfterRepeatedExpiredLeases(t *testing.T) 
 	ctx := context.Background()
 	_, _, organizationUUID, workspaceUUID, _, _, _, sessionUUID, _, apiKeyUUID := seedFilestoreLookupScope(t, app)
 	filesystem, created, err := app.db.ProvisionFilestoreFilesystem(ctx, db.ProvisionFilestoreFilesystemInput{
-		UUID:                uuid.NewString(),
-		ExternalID:          "claude_chat_expired_leases_" + uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
+		ExternalID:          "claude_chat_expired_leases_" + uuid.NewV4().String(),
 		OrganizationUUID:    organizationUUID,
 		WorkspaceUUID:       workspaceUUID,
 		SessionUUID:         sessionUUID,
@@ -523,8 +522,8 @@ func TestFilestoreObjectCleanupJobMapperLifecycle(t *testing.T) {
 	ctx := context.Background()
 	_, _, organizationUUID, workspaceUUID, _, _, _, sessionUUID, _, apiKeyUUID := seedFilestoreLookupScope(t, app)
 	filesystem, created, err := app.db.ProvisionFilestoreFilesystem(ctx, db.ProvisionFilestoreFilesystemInput{
-		UUID:                uuid.NewString(),
-		ExternalID:          "claude_chat_mapper_" + uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
+		ExternalID:          "claude_chat_mapper_" + uuid.NewV4().String(),
 		OrganizationUUID:    organizationUUID,
 		WorkspaceUUID:       workspaceUUID,
 		SessionUUID:         sessionUUID,
@@ -631,8 +630,8 @@ func TestConcurrentProvisionCreatesOneSessionFilesystem(t *testing.T) {
 			defer workers.Done()
 			<-start
 			_, created, err := app.db.ProvisionFilestoreFilesystem(context.Background(), db.ProvisionFilestoreFilesystemInput{
-				UUID:                uuid.NewString(),
-				ExternalID:          fmt.Sprintf("claude_chat_concurrent_%d_%s", attempt, uuid.NewString()),
+				UUID:                uuid.NewV4().String(),
+				ExternalID:          fmt.Sprintf("claude_chat_concurrent_%d_%s", attempt, uuid.NewV4().String()),
 				OrganizationUUID:    organizationUUID,
 				WorkspaceUUID:       workspaceUUID,
 				SessionUUID:         sessionUUID,
@@ -894,9 +893,9 @@ func TestFilestoreSkillArchivesUseResources(t *testing.T) {
 		t.Fatalf("legacy archive table still exists: %s", *legacyTable)
 	}
 
-	versionUUID := uuid.NewString()
-	skillUUID := uuid.NewString()
-	skillExternalID := "skill_" + uuid.NewString()
+	versionUUID := uuid.NewV4().String()
+	skillUUID := uuid.NewV4().String()
+	skillExternalID := "skill_" + uuid.NewV4().String()
 	if err := app.pool.QueryRow(context.Background(), `
 		insert into skills (
 			uuid, external_id, workspace_uuid, source, display_title,
@@ -915,7 +914,7 @@ func TestFilestoreSkillArchivesUseResources(t *testing.T) {
 		)
 		values ($1, $2, $3, $4, $5, 'v1', 'Demo', 'demo',
 			'filestore-archive-entry', 'catalog/demo.zip', 128, $6, $7)
-	`, versionUUID, "skver_"+uuid.NewString(), workspaceUUID, skillUUID,
+	`, versionUUID, "skver_"+uuid.NewV4().String(), workspaceUUID, skillUUID,
 		skillExternalID, strings.Repeat("a", 64), apiKeyUUID); err != nil {
 		t.Fatalf("insert archive test skill version: %v", err)
 	}
@@ -1087,8 +1086,8 @@ func seedFilestoreSkillVersion(
 	checksum string,
 ) string {
 	t.Helper()
-	skillUUID := uuid.NewString()
-	skillExternalID := "skill_" + uuid.NewString()
+	skillUUID := uuid.NewV4().String()
+	skillExternalID := "skill_" + uuid.NewV4().String()
 	if err := app.pool.QueryRow(context.Background(), `
 		insert into skills (
 			uuid, external_id, workspace_uuid, source, display_title,
@@ -1099,7 +1098,7 @@ func seedFilestoreSkillVersion(
 	`, skillUUID, skillExternalID, workspaceUUID, directory, apiKeyUUID).Scan(&skillUUID); err != nil {
 		t.Fatalf("insert Filestore skill: %v", err)
 	}
-	versionUUID := uuid.NewString()
+	versionUUID := uuid.NewV4().String()
 	if _, err := app.pool.Exec(context.Background(), `
 		insert into skill_versions (
 			uuid, external_id, workspace_uuid, skill_uuid, skill_external_id,
@@ -1107,7 +1106,7 @@ func seedFilestoreSkillVersion(
 			created_by_api_key_uuid
 		)
 		values ($1, $2, $3, $4, $5, 'v1', $6, $6, $7, $8, $9, $10, $11)
-	`, versionUUID, "skver_"+uuid.NewString(), workspaceUUID, skillUUID, skillExternalID,
+	`, versionUUID, "skver_"+uuid.NewV4().String(), workspaceUUID, skillUUID, skillExternalID,
 		directory, bucket, objectKey, sizeBytes, checksum, apiKeyUUID); err != nil {
 		t.Fatalf("insert Filestore skill version: %v", err)
 	}
@@ -1124,12 +1123,12 @@ func TestFilestoreFilesystemLookupPrefersExactExternalID(t *testing.T) {
 
 	ctx := context.Background()
 	_, _, organizationUUID, workspaceUUID, _, _, _, sessionUUID, codeSessionUUID, apiKeyUUID := seedFilestoreLookupScope(t, app)
-	firstUUID := uuid.NewString()
-	secondUUID := uuid.NewString()
-	firstExternalID := "fs_" + uuid.NewString()
+	firstUUID := uuid.NewV4().String()
+	secondUUID := uuid.NewV4().String()
+	firstExternalID := "fs_" + uuid.NewV4().String()
 	secondExternalID := firstUUID
-	secondSessionUUID := uuid.NewString()
-	secondSessionExternalID := "session_filestore_lookup_second_" + uuid.NewString()
+	secondSessionUUID := uuid.NewV4().String()
+	secondSessionExternalID := "session_filestore_lookup_second_" + uuid.NewV4().String()
 	now := time.Now().UTC()
 	if _, err := app.pool.Exec(ctx, `
 		insert into sessions (
@@ -1139,8 +1138,8 @@ func TestFilestoreFilesystemLookupPrefersExactExternalID(t *testing.T) {
 		)
 		values ($1, $2, $3, $4, $5, $6, $7, $8, $9, 1, '{}'::jsonb, 'idle')
 	`, secondSessionUUID, secondSessionExternalID, organizationUUID, workspaceUUID, apiKeyUUID,
-		uuid.NewString(), "env_filestore_lookup_second",
-		uuid.NewString(), "agent_filestore_lookup_second"); err != nil {
+		uuid.NewV4().String(), "env_filestore_lookup_second",
+		uuid.NewV4().String(), "agent_filestore_lookup_second"); err != nil {
 		t.Fatalf("insert second lookup session: %v", err)
 	}
 
@@ -1187,7 +1186,7 @@ func TestFilestoreFilesystemLookupPrefersExactExternalID(t *testing.T) {
 	assertExternalID("session", filesystem, err)
 
 	filesystem, created, err := app.db.ProvisionFilestoreFilesystem(ctx, db.ProvisionFilestoreFilesystemInput{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          secondExternalID,
 		OrganizationUUID:    organizationUUID,
 		WorkspaceUUID:       workspaceUUID,
@@ -1204,7 +1203,7 @@ func TestFilestoreFilesystemLookupPrefersExactExternalID(t *testing.T) {
 func seedFilestoreLookupScope(t *testing.T, app *testApp) (int64, int64, string, string, int64, int64, int64, string, string, string) {
 	t.Helper()
 	ctx := context.Background()
-	suffix := uuid.NewString()
+	suffix := uuid.NewV4().String()
 	var organizationID, workspaceID, apiKeyID, sessionID, codeSessionID int64
 	var organizationUUID, workspaceUUID, codeSessionUUID string
 	t.Cleanup(func() {
@@ -1245,7 +1244,7 @@ func seedFilestoreLookupScope(t *testing.T, app *testApp) (int64, int64, string,
 	`, "wrkspc_filestore_lookup_"+suffix, organizationID, "Filestore lookup "+suffix).Scan(&workspaceID, &workspaceUUID); err != nil {
 		t.Fatalf("insert lookup workspace: %v", err)
 	}
-	apiKeyUUID := uuid.NewString()
+	apiKeyUUID := uuid.NewV4().String()
 	if err := app.pool.QueryRow(ctx, `
 		insert into api_keys (uuid, external_id, workspace_uuid, key_hash, status)
 		values ($1, $2, $3, $4, 'active')
@@ -1253,7 +1252,7 @@ func seedFilestoreLookupScope(t *testing.T, app *testApp) (int64, int64, string,
 	`, apiKeyUUID, "api_key_filestore_lookup_"+suffix, workspaceUUID, "hash_filestore_lookup_"+suffix).Scan(&apiKeyID); err != nil {
 		t.Fatalf("insert lookup API key: %v", err)
 	}
-	sessionUUID := uuid.NewString()
+	sessionUUID := uuid.NewV4().String()
 	sessionExternalID := "session_filestore_lookup_" + suffix
 	if err := app.pool.QueryRow(ctx, `
 		insert into sessions (
@@ -1264,11 +1263,11 @@ func seedFilestoreLookupScope(t *testing.T, app *testApp) (int64, int64, string,
 		values ($1, $2, $3, $4, $5, $6, $7, $8, $9, 1, '{}'::jsonb, 'idle')
 		returning id
 	`, sessionUUID, sessionExternalID, organizationUUID, workspaceUUID, apiKeyUUID,
-		uuid.NewString(), "env_filestore_lookup_"+suffix,
-		uuid.NewString(), "agent_filestore_lookup_"+suffix).Scan(&sessionID); err != nil {
+		uuid.NewV4().String(), "env_filestore_lookup_"+suffix,
+		uuid.NewV4().String(), "agent_filestore_lookup_"+suffix).Scan(&sessionID); err != nil {
 		t.Fatalf("insert lookup session: %v", err)
 	}
-	codeSessionUUID = uuid.NewString()
+	codeSessionUUID = uuid.NewV4().String()
 	codeSessionExternalID := "codesession_filestore_lookup_" + suffix
 	if err := app.pool.QueryRow(ctx, `
 		insert into code_sessions (
@@ -1278,7 +1277,7 @@ func seedFilestoreLookupScope(t *testing.T, app *testApp) (int64, int64, string,
 		values ($1, $2, $3, $4, $5, $6, $7, $8, 'active')
 		returning id
 	`, codeSessionUUID, codeSessionExternalID, organizationUUID, workspaceUUID, sessionUUID,
-		sessionExternalID, uuid.NewString(), "env_filestore_lookup_"+suffix).Scan(&codeSessionID); err != nil {
+		sessionExternalID, uuid.NewV4().String(), "env_filestore_lookup_"+suffix).Scan(&codeSessionID); err != nil {
 		t.Fatalf("insert lookup code session: %v", err)
 	}
 	return organizationID, workspaceID, organizationUUID, workspaceUUID, apiKeyID, sessionID, codeSessionID, sessionUUID, codeSessionUUID, apiKeyUUID
@@ -1293,8 +1292,8 @@ func insertFilestoreCollisionOwner(
 	filesystemExternalID string,
 ) {
 	t.Helper()
-	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
-	sessionUUID := uuid.NewString()
+	suffix := strings.ReplaceAll(uuid.NewV4().String(), "-", "")
+	sessionUUID := uuid.NewV4().String()
 	if _, err := app.pool.Exec(context.Background(), `
 		insert into sessions (
 			uuid, external_id, organization_uuid, workspace_uuid, created_by_api_key_uuid,
@@ -1303,8 +1302,8 @@ func insertFilestoreCollisionOwner(
 		)
 		values ($1, $2, $3, $4, $5, $6, $7, $8, $9, 1, '{}'::jsonb, 'idle')
 	`, sessionUUID, "sesn_filestore_collision_"+suffix, organizationUUID, workspaceUUID, apiKeyUUID,
-		uuid.NewString(), "env_filestore_collision_"+suffix,
-		uuid.NewString(), "agent_filestore_collision_"+suffix); err != nil {
+		uuid.NewV4().String(), "env_filestore_collision_"+suffix,
+		uuid.NewV4().String(), "agent_filestore_collision_"+suffix); err != nil {
 		t.Fatalf("insert collision owner Session: %v", err)
 	}
 	if _, err := app.pool.Exec(context.Background(), `
@@ -1348,13 +1347,13 @@ func cleanupFilestoreSession(t *testing.T, app *testApp, workspaceUUID string, s
 }
 
 func filestoreSessionCreateInput(organizationUUID, workspaceUUID, apiKeyUUID string) db.CreateSessionInput {
-	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
+	suffix := strings.ReplaceAll(uuid.NewV4().String(), "-", "")
 	now := time.Now().UTC()
 	environmentExternalID := "env_filestore_session_" + suffix
-	environmentUUID := uuid.NewString()
-	agentUUID := uuid.NewString()
+	environmentUUID := uuid.NewV4().String()
+	agentUUID := uuid.NewV4().String()
 	sessionExternalID := "sesn_filestore_session_" + suffix
-	sessionUUID := uuid.NewString()
+	sessionUUID := uuid.NewV4().String()
 	return db.CreateSessionInput{
 		Session: db.Session{
 			UUID:                  sessionUUID,
@@ -1378,7 +1377,7 @@ func filestoreSessionCreateInput(organizationUUID, workspaceUUID, apiKeyUUID str
 			UpdatedAt:             now,
 		},
 		Thread: db.SessionThread{
-			UUID:              uuid.NewString(),
+			UUID:              uuid.NewV4().String(),
 			ExternalID:        "sthr_filestore_session_" + suffix,
 			OrganizationUUID:  organizationUUID,
 			WorkspaceUUID:     workspaceUUID,
@@ -1391,7 +1390,7 @@ func filestoreSessionCreateInput(organizationUUID, workspaceUUID, apiKeyUUID str
 			CreatedAt:         now,
 		},
 		Work: db.EnvironmentWork{
-			UUID:                  uuid.NewString(),
+			UUID:                  uuid.NewV4().String(),
 			ExternalID:            "work_filestore_session_" + suffix,
 			OrganizationUUID:      organizationUUID,
 			WorkspaceUUID:         workspaceUUID,

--- a/tests/filestore_provision_roots_test.go
+++ b/tests/filestore_provision_roots_test.go
@@ -6,8 +6,7 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 )
@@ -236,8 +235,8 @@ func newFilestoreProvisionInput(
 	apiKeyUUID string,
 ) db.ProvisionFilestoreFilesystemInput {
 	return db.ProvisionFilestoreFilesystemInput{
-		UUID:                uuid.NewString(),
-		ExternalID:          "claude_chat_roots_" + uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
+		ExternalID:          "claude_chat_roots_" + uuid.NewV4().String(),
 		OrganizationUUID:    organizationUUID,
 		WorkspaceUUID:       workspaceUUID,
 		SessionUUID:         sessionUUID,

--- a/tests/messages_api_test.go
+++ b/tests/messages_api_test.go
@@ -11,8 +11,7 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/google/uuid"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
@@ -55,7 +54,7 @@ func TestMessagesAPIFailures(t *testing.T) {
 		credential := createMessagesCodeSessionCredential(t, app, messagesTestModel)
 		_, err := app.db.GetCodeSessionCredentialContextForIssue(
 			context.Background(),
-			uuid.NewString(),
+			uuid.NewV4().String(),
 			credential.WorkspaceUUID,
 			credential.CodeSessionID,
 		)
@@ -65,7 +64,7 @@ func TestMessagesAPIFailures(t *testing.T) {
 		_, err = app.db.GetCodeSessionCredentialContextForIssue(
 			context.Background(),
 			credential.OrganizationUUID,
-			uuid.NewString(),
+			uuid.NewV4().String(),
 			credential.CodeSessionID,
 		)
 		if !errors.Is(err, db.ErrNotFound) {

--- a/tests/sessions_api_test.go
+++ b/tests/sessions_api_test.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
-	"github.com/google/uuid"
 )
 
 type sessionAPIResponse struct {
@@ -791,7 +791,7 @@ func TestManagedAgentActivationPreservesLargeHistoryOrder(t *testing.T) {
 	}
 	const eventCount = 501
 	createdAt := time.Now().UTC()
-	uuidPrefix := uuid.New()
+	uuidPrefix := uuid.NewV4()
 	eventIDs := make([]string, 0, eventCount)
 	events := make([]db.SessionEvent, 0, eventCount)
 	for i := range eventCount {
@@ -861,7 +861,7 @@ func TestManagedAgentActivationRollsBackOnHistoryConversionFailure(t *testing.T)
 	}
 	invalidAt := time.Now().UTC().Add(time.Second)
 	if _, err := app.db.AppendSessionEvents(ctx, session.WorkspaceUUID, session.ExternalID, []db.SessionEvent{{
-		UUID:        uuid.NewString(),
+		UUID:        uuid.NewV4().String(),
 		ExternalID:  "sevt_activation_invalid_" + strings.TrimPrefix(codeSessionID, "cse_"),
 		EventType:   "user.interrupt",
 		Payload:     json.RawMessage(`[]`),
@@ -1582,7 +1582,7 @@ func TestSessionEventsListHidesLegacyEnvManagerLog(t *testing.T) {
 	now := time.Now().UTC()
 	if _, err := app.db.AppendSessionEvents(ctx, storedSession.WorkspaceUUID, storedSession.ExternalID, []db.SessionEvent{
 		{
-			UUID:        uuid.NewString(),
+			UUID:        uuid.NewV4().String(),
 			ExternalID:  hiddenEventID,
 			EventType:   "env_manager_log",
 			Payload:     json.RawMessage(`{"id":` + quoteJSON(hiddenEventID) + `,"type":"env_manager_log","content":"Using existing Claude Code installation (version 2.1.120)"}`),
@@ -1590,7 +1590,7 @@ func TestSessionEventsListHidesLegacyEnvManagerLog(t *testing.T) {
 			CreatedAt:   now,
 		},
 		{
-			UUID:        uuid.NewString(),
+			UUID:        uuid.NewV4().String(),
 			ExternalID:  visibleEventID,
 			EventType:   "agent.message",
 			Payload:     json.RawMessage(`{"id":` + quoteJSON(visibleEventID) + `,"type":"agent.message","content":[{"type":"text","text":"visible event after legacy env log"}]}`),

--- a/tests/uuid_boundary_postgres_test.go
+++ b/tests/uuid_boundary_postgres_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/platform"
@@ -28,7 +28,7 @@ func TestUUIDAuthAndStringAdminPostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load API key through typed UUID row: %v", err)
 	}
-	if key.UUID == uuid.Nil || key.OrganizationUUID == uuid.Nil || key.WorkspaceUUID == uuid.Nil {
+	if key.UUID == uuid.Nil() || key.OrganizationUUID == uuid.Nil() || key.WorkspaceUUID == uuid.Nil() {
 		t.Fatalf("GetAPIKey() returned nil UUIDs: %+v", key)
 	}
 
@@ -164,8 +164,8 @@ func TestStringUUIDAdminConsoleWorkbenchPostgres(t *testing.T) {
 		)
 	}
 
-	promptID := "prompt_typed_uuid_" + uuid.NewString()
-	revisionID := "revision_typed_uuid_" + uuid.NewString()
+	promptID := "prompt_typed_uuid_" + uuid.NewV4().String()
+	revisionID := "revision_typed_uuid_" + uuid.NewV4().String()
 	if _, err := app.db.UpsertWorkbenchPrompt(ctx, platform.WorkbenchPromptRecord{
 		OrgUUID:            ids.OrganizationUUID,
 		PromptUUID:         promptID,
@@ -242,7 +242,7 @@ func TestStringUUIDAdminConsoleWorkbenchPostgres(t *testing.T) {
 		t.Fatalf("get Workbench key value with nullable version = (%+v, %v)", keyValue, err)
 	}
 
-	evaluationID := "evaluation_typed_uuid_" + uuid.NewString()
+	evaluationID := "evaluation_typed_uuid_" + uuid.NewV4().String()
 	if err := app.db.UpsertWorkbenchEvaluation(ctx, platform.WorkbenchEvaluationRecord{
 		OrgUUID:        ids.OrganizationUUID,
 		RevisionUUID:   revisionID,
@@ -305,12 +305,12 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 
 	ctx := context.Background()
 	ids := getDefaultDBIDs(t, app.pool)
-	suffix := uuid.NewString()
+	suffix := uuid.NewV4().String()
 	now := time.Now().UTC()
 
 	agentID := "agent_typed_uuid_" + suffix
 	agent, err := app.db.CreateAgent(ctx, db.Agent{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          agentID,
 		WorkspaceUUID:       ids.WorkspaceUUID,
 		CreatedByAPIKeyUUID: ids.APIKeyUUID,
@@ -369,14 +369,14 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 	skillID := "skill_typed_uuid_" + suffix
 	skillTitle := "typed UUID " + suffix
 	skill, skillVersion, err := app.db.CreateSkillWithVersion(ctx, db.Skill{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          skillID,
 		WorkspaceUUID:       ids.WorkspaceUUID,
 		CreatedByAPIKeyUUID: ids.APIKeyUUID,
 		DisplayTitle:        &skillTitle,
 		CreatedAt:           now,
 	}, db.SkillVersion{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          "skillver_typed_uuid_" + suffix,
 		WorkspaceUUID:       ids.WorkspaceUUID,
 		Version:             "1.0.0",
@@ -405,7 +405,7 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 		ids.WorkspaceUUID,
 		skillID,
 		db.SkillVersion{
-			UUID:                uuid.NewString(),
+			UUID:                uuid.NewV4().String(),
 			ExternalID:          "skillver_typed_uuid_second_" + suffix,
 			Version:             "2.0.0",
 			Name:                "typed-uuid-v2",
@@ -431,7 +431,7 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 
 	environmentID := "env_typed_uuid_" + suffix
 	environment, err := app.db.CreateEnvironment(ctx, db.Environment{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          environmentID,
 		OrganizationUUID:    ids.OrganizationUUID,
 		WorkspaceUUID:       ids.WorkspaceUUID,
@@ -449,7 +449,7 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 		t.Fatalf("create Environment through typed UUID parameters: %v", err)
 	}
 	sandbox, err := app.db.CreateEnvironmentSandbox(ctx, db.EnvironmentSandbox{
-		UUID:                  uuid.NewString(),
+		UUID:                  uuid.NewV4().String(),
 		ExternalID:            "sbx_typed_uuid_" + suffix,
 		OrganizationUUID:      ids.OrganizationUUID,
 		WorkspaceUUID:         ids.WorkspaceUUID,
@@ -471,7 +471,7 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 
 	deploymentID := "dep_typed_uuid_" + suffix
 	deployment, err := app.db.CreateDeployment(ctx, db.Deployment{
-		UUID:                  uuid.NewString(),
+		UUID:                  uuid.NewV4().String(),
 		ExternalID:            deploymentID,
 		OrganizationUUID:      ids.OrganizationUUID,
 		WorkspaceUUID:         ids.WorkspaceUUID,
@@ -501,7 +501,7 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 
 	vaultID := "vlt_typed_uuid_" + suffix
 	vault, err := app.db.CreateVault(ctx, db.Vault{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          vaultID,
 		OrganizationUUID:    ids.OrganizationUUID,
 		WorkspaceUUID:       ids.WorkspaceUUID,
@@ -515,7 +515,7 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 		t.Fatalf("create Vault through typed UUID parameters: %v", err)
 	}
 	credential, err := app.db.CreateVaultCredential(ctx, db.VaultCredential{
-		UUID:             uuid.NewString(),
+		UUID:             uuid.NewV4().String(),
 		ExternalID:       "vcrd_typed_uuid_" + suffix,
 		OrganizationUUID: ids.OrganizationUUID,
 		WorkspaceUUID:    ids.WorkspaceUUID,
@@ -542,7 +542,7 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 
 	memoryStoreID := "memstore_typed_uuid_" + suffix
 	memoryStore, err := app.db.CreateMemoryStore(ctx, db.MemoryStore{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          memoryStoreID,
 		OrganizationUUID:    ids.OrganizationUUID,
 		WorkspaceUUID:       ids.WorkspaceUUID,
@@ -561,7 +561,7 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 	memoryBucket := "test"
 	memoryKey := "memory/" + suffix
 	memory, err := app.db.CreateMemory(ctx, db.Memory{
-		UUID:                  uuid.NewString(),
+		UUID:                  uuid.NewV4().String(),
 		ExternalID:            "mem_typed_uuid_" + suffix,
 		WorkspaceUUID:         ids.WorkspaceUUID,
 		MemoryStoreExternalID: memoryStore.ExternalID,
@@ -573,7 +573,7 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 		CreatedAt:             now,
 		UpdatedAt:             now,
 	}, db.MemoryVersion{
-		UUID:             uuid.NewString(),
+		UUID:             uuid.NewV4().String(),
 		ExternalID:       "memver_typed_uuid_" + suffix,
 		Operation:        "created",
 		Path:             &memoryPath,
@@ -589,7 +589,7 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 	}
 
 	batch, err := app.db.CreateMessageBatch(ctx, db.MessageBatch{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          "msgbatch_typed_uuid_" + suffix,
 		WorkspaceUUID:       ids.WorkspaceUUID,
 		CreatedByAPIKeyUUID: ids.APIKeyUUID,
@@ -612,7 +612,7 @@ func TestTypedUUIDResourceFamiliesPostgres(t *testing.T) {
 	}
 
 	endpoint, err := app.db.CreateWebhookEndpoint(ctx, db.WebhookEndpoint{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          "wh_typed_uuid_" + suffix,
 		OrganizationUUID:    ids.OrganizationUUID,
 		WorkspaceUUID:       ids.WorkspaceUUID,
@@ -680,7 +680,7 @@ func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
 	ctx := context.Background()
 	ids := getDefaultDBIDs(t, app.pool)
 	now := time.Now().UTC()
-	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
+	suffix := strings.ReplaceAll(uuid.NewV4().String(), "-", "")
 
 	input := filestoreSessionCreateInput(ids.OrganizationUUID, ids.WorkspaceUUID, ids.APIKeyUUID)
 	session, thread, _, work, err := app.db.CreateSession(ctx, input)
@@ -699,7 +699,7 @@ func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
 		Limit:         10,
 		Cursor: &db.SessionPageCursor{
 			CreatedAt: session.CreatedAt.Add(time.Second),
-			UUID:      uuid.NewString(),
+			UUID:      uuid.NewV4().String(),
 		},
 	})
 	if err != nil || len(sessions) == 0 {
@@ -711,7 +711,7 @@ func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
 		Limit:             10,
 		Cursor: &db.SessionThreadPageCursor{
 			CreatedAt: thread.CreatedAt.Add(time.Second),
-			UUID:      uuid.NewString(),
+			UUID:      uuid.NewV4().String(),
 		},
 	})
 	if err != nil || len(threads) != 1 || threads[0].UUID != thread.UUID {
@@ -720,7 +720,7 @@ func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
 
 	eventExternalID := "sevt_typed_uuid_" + suffix
 	events, err := app.db.AppendSessionEvents(ctx, ids.WorkspaceUUID, session.ExternalID, []db.SessionEvent{{
-		UUID:        uuid.NewString(),
+		UUID:        uuid.NewV4().String(),
 		ExternalID:  eventExternalID,
 		EventType:   "typed_uuid.runtime",
 		Payload:     []byte(`{"typed_uuid":true}`),
@@ -736,7 +736,7 @@ func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
 		Limit:             10,
 		Cursor: &db.SessionEventPageCursor{
 			CreatedAt: now.Add(-time.Second),
-			UUID:      uuid.NewString(),
+			UUID:      uuid.NewV4().String(),
 		},
 	})
 	if err != nil || len(listedEvents) != 1 || listedEvents[0].UUID != events[0].UUID {
@@ -764,7 +764,7 @@ func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
 	}
 	providerSandboxID := "provider_typed_uuid_" + suffix
 	runningSandbox, err := app.db.CreateEnvironmentSandbox(ctx, db.EnvironmentSandbox{
-		UUID:                  uuid.NewString(),
+		UUID:                  uuid.NewV4().String(),
 		ExternalID:            "envsbx_typed_uuid_" + suffix,
 		OrganizationUUID:      ids.OrganizationUUID,
 		WorkspaceUUID:         ids.WorkspaceUUID,
@@ -854,7 +854,7 @@ func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
 		t.Fatalf("find bootstrap platform user: %v", err)
 	}
 	bootstrapUser, err := app.db.GetBootstrapUser(ctx, userExternalID)
-	if err != nil || bootstrapUser == nil || uuid.Validate(bootstrapUser.UUID) != nil {
+	if err != nil || bootstrapUser == nil || !isValidUUID(bootstrapUser.UUID) {
 		t.Fatalf("get bootstrap user through typed UUID row = (%+v, %v)", bootstrapUser, err)
 	}
 	bootstrapOrganization, err := app.db.GetPlatformOrganization(ctx, orgUUID)
@@ -873,7 +873,7 @@ func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
 		ExpiresAt:  &platformExpiresAt,
 	})
 	if err != nil || platformIdentity.OrganizationUUID != orgUUID ||
-		uuid.Validate(platformIdentity.UserUUID) != nil || uuid.Validate(platformIdentity.APIKeyUUID) != nil {
+		!isValidUUID(platformIdentity.UserUUID) || !isValidUUID(platformIdentity.APIKeyUUID) {
 		t.Fatalf("resolve platform identity through typed UUID rows = (%+v, %v)", platformIdentity, err)
 	}
 
@@ -881,12 +881,12 @@ func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
 		Name:        "typed_uuid",
 		Description: "PostgreSQL UUID boundary",
 	}})
-	if err != nil || uuid.Validate(catalog.UUID) != nil {
+	if err != nil || !isValidUUID(catalog.UUID) {
 		t.Fatalf("upsert MCP tool catalog through typed UUID row = (%+v, %v)", catalog, err)
 	}
 
 	vault, err := app.db.CreateVault(ctx, db.Vault{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          "vlt_runtime_typed_uuid_" + suffix,
 		OrganizationUUID:    ids.OrganizationUUID,
 		WorkspaceUUID:       ids.WorkspaceUUID,
@@ -900,7 +900,7 @@ func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
 		t.Fatalf("create runtime Vault: %v", err)
 	}
 	flow, err := app.db.CreateMCPOAuthFlow(ctx, db.MCPOAuthFlow{
-		UUID:                    uuid.NewString(),
+		UUID:                    uuid.NewV4().String(),
 		ExternalID:              "mcpoauth_typed_uuid_" + suffix,
 		OrganizationUUID:        ids.OrganizationUUID,
 		WorkspaceUUID:           ids.WorkspaceUUID,
@@ -941,9 +941,14 @@ func TestTypedUUIDSessionsAndRuntimePostgres(t *testing.T) {
 		SHA256:      strings.Repeat("d", 64),
 		CreatedAt:   now,
 	})
-	if err != nil || uuid.Validate(builtin.UUID) != nil || uuid.Validate(builtinVersion.UUID) != nil {
+	if err != nil || !isValidUUID(builtin.UUID) || !isValidUUID(builtinVersion.UUID) {
 		t.Fatalf("upsert builtin Skill through typed UUID rows = (%+v, %+v, %v)", builtin, builtinVersion, err)
 	}
+}
+
+func isValidUUID(value string) bool {
+	_, err := uuid.Parse(value)
+	return err == nil
 }
 
 // TestTypedUUIDFilesAndFilestorePostgres exercises the final UUID migration
@@ -958,10 +963,10 @@ func TestTypedUUIDFilesAndFilestorePostgres(t *testing.T) {
 		seedFilestoreLookupScope(t, app)
 	ctx := context.Background()
 	now := time.Now().UTC()
-	suffix := uuid.NewString()
+	suffix := uuid.NewV4().String()
 
 	firstFile := db.FileRecord{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          "file_typed_uuid_first_" + suffix,
 		WorkspaceUUID:       workspaceUUID,
 		Filename:            "first.txt",
@@ -975,7 +980,7 @@ func TestTypedUUIDFilesAndFilestorePostgres(t *testing.T) {
 		CreatedAt:           now,
 	}
 	secondFile := firstFile
-	secondFile.UUID = uuid.NewString()
+	secondFile.UUID = uuid.NewV4().String()
 	secondFile.ExternalID = "file_typed_uuid_second_" + suffix
 	secondFile.Filename = "second.txt"
 	secondFile.SizeBytes = 4
@@ -1007,7 +1012,7 @@ func TestTypedUUIDFilesAndFilestorePostgres(t *testing.T) {
 		t.Fatalf("Files page with typed UUID cursor = (%+v, %v)", secondPage, err)
 	}
 
-	filesystemUUID := uuid.NewString()
+	filesystemUUID := uuid.NewV4().String()
 	filesystem, created, err := app.db.ProvisionFilestoreFilesystem(ctx, db.ProvisionFilestoreFilesystemInput{
 		UUID:                filesystemUUID,
 		ExternalID:          "claude_chat_typed_uuid_" + strings.ReplaceAll(suffix, "-", ""),
@@ -1063,7 +1068,7 @@ func TestTypedUUIDFilesAndFilestorePostgres(t *testing.T) {
 		Limit:          1,
 		Cursor: &db.SessionResourceFilePageCursor{
 			Path: "/outputs",
-			UUID: uuid.NewString(),
+			UUID: uuid.NewV4().String(),
 		},
 	})
 	if err != nil || len(page.Entries) != 1 || page.Entries[0].UUID != activeResult.Node.UUID {

--- a/tests/vaults_encryption_test.go
+++ b/tests/vaults_encryption_test.go
@@ -10,12 +10,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
 	"github.com/superduck-ai/open-managed-agents/internal/secrets"
-
-	"github.com/google/uuid"
 )
 
 func TestVaultCredentialEncryptedAtRest(t *testing.T) {
@@ -295,7 +294,7 @@ func insertEnvelopeLessCredential(t *testing.T, app *testApp, vaultID, credentia
 			auth, created_at, updated_at
 		) values ($1, $2, $3::uuid, $4::uuid, $5::uuid, $6, NULL, 'missing envelope', '{}'::jsonb, 'static_bearer', $7,
 			'{"type":"static_bearer","mcp_server_url":"https://mcp.missing-env.example/sse"}'::jsonb, now(), now())
-	`, uuid.NewString(), credentialID, orgUUID, wsUUID, vaultUUID, vaultID, credentialKey)
+	`, uuid.NewV4().String(), credentialID, orgUUID, wsUUID, vaultUUID, vaultID, credentialKey)
 	if err != nil {
 		t.Fatalf("insert envelope-less credential: %v", err)
 	}

--- a/tests/workspace_storage_usage_test.go
+++ b/tests/workspace_storage_usage_test.go
@@ -6,10 +6,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"uuid"
 
 	"github.com/superduck-ai/open-managed-agents/internal/db"
-
-	"github.com/google/uuid"
 )
 
 func TestWorkspaceStorageUsageLedger(t *testing.T) {
@@ -278,12 +277,12 @@ type workspaceStorageFixture struct {
 
 func newWorkspaceStorageFixture(t *testing.T) workspaceStorageFixture {
 	t.Helper()
-	app := newTestAppWithStore(t, nil, newFakeStore("workspace-storage-"+uuid.NewString()))
+	app := newTestAppWithStore(t, nil, newFakeStore("workspace-storage-"+uuid.NewV4().String()))
 	t.Cleanup(app.close)
 	_, _, organizationUUID, workspaceUUID, _, _, _, sessionUUID, codeSessionUUID, apiKeyUUID := seedFilestoreLookupScope(t, app)
 	filesystem, created, err := app.db.ProvisionFilestoreFilesystem(context.Background(), db.ProvisionFilestoreFilesystemInput{
-		UUID:                uuid.NewString(),
-		ExternalID:          "fs_storage_" + strings.ReplaceAll(uuid.NewString(), "-", ""),
+		UUID:                uuid.NewV4().String(),
+		ExternalID:          "fs_storage_" + strings.ReplaceAll(uuid.NewV4().String(), "-", ""),
 		OrganizationUUID:    organizationUUID,
 		WorkspaceUUID:       workspaceUUID,
 		SessionUUID:         sessionUUID,
@@ -306,9 +305,9 @@ func newWorkspaceStorageFixture(t *testing.T) workspaceStorageFixture {
 }
 
 func workspaceStorageFile(workspaceUUID, apiKeyUUID string, sizeBytes int64) db.FileRecord {
-	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
+	suffix := strings.ReplaceAll(uuid.NewV4().String(), "-", "")
 	return db.FileRecord{
-		UUID:                uuid.NewString(),
+		UUID:                uuid.NewV4().String(),
 		ExternalID:          "file_storage_" + suffix,
 		WorkspaceUUID:       workspaceUUID,
 		Filename:            "storage.txt",
@@ -324,7 +323,7 @@ func workspaceStorageFile(workspaceUUID, apiKeyUUID string, sizeBytes int64) db.
 }
 
 func workspaceStorageBlob(sizeBytes int64, expiresAt *time.Time) db.FilestoreFileBlob {
-	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")
+	suffix := strings.ReplaceAll(uuid.NewV4().String(), "-", "")
 	return db.FilestoreFileBlob{
 		SizeBytes: sizeBytes,
 		MediaType: "text/plain",


### PR DESCRIPTION
## Summary

- Replace `github.com/google/uuid` imports with the local `uuid` package
- Use string UUID fields in admin tunnel database models and simplify mapper conversions
- Preserve UUIDv5 control-response compatibility with an explicit SHA-1 implementation
- Update tests and UUID generation calls for the new API

## Testing

- Added coverage verifying control-response UUIDs remain byte-compatible and version 5
- Updated mapper and UUID parsing tests for string-based identifiers