### PR TITLE
Clear stale Yourbatis generated mappers before regenerate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@
 ## 测试要求
 
 - 测试组织顺序应先写失败场景，再写成功场景。
-- `*.gen.go` 不纳入版本控制；干净 checkout 在直接运行 Go 编译、测试或静态分析前先执行 `./scripts/generate-go.sh`（内部为 `go generate ./internal/db`）。仓库标准 `just` 命令会自动完成生成。
+- `*.gen.go` 不纳入版本控制；干净 checkout 在直接运行 Go 编译、测试或静态分析前先执行 `./scripts/generate-go.sh`（先清空 `internal/db/**/*.sqlmap.gen.go`，再 `go generate ./internal/db`，避免已删除 Mapper 的残留生成文件参与编译）。仓库标准 `just` 命令会自动完成生成。
 - 修改 `web/` 下的文件后，运行 `just web-format-check`，确保 Prettier 格式门禁通过。
 - 修改 Go 代码后，运行 `just lint`；该命令使用仓库根目录的 `.golangci.yml` 执行与 CI 相同的静态分析和格式检查。
 - 修改 schema 或 handler 后，运行 `just test`（等价于先生成 Go 源码，再运行 `go test ./... -count=1`）。

--- a/docs/design/development-quality-gates.md
+++ b/docs/design/development-quality-gates.md
@@ -15,7 +15,7 @@
 
 ## 配置与执行
 
-- yourbatis 根据 `internal/db/*.xml` 生成的 `*.sqlmap.gen.go` 不提交；`scripts/generate-go.sh` 是统一生成入口。Go lint、死代码、复杂度、测试、开发启动和 Docker 构建在类型检查或编译前调用该入口，避免本地残留的 ignored 文件掩盖干净 checkout 中的缺失生成代码。
+- yourbatis 根据 `internal/db/*.xml` 生成的 `*.sqlmap.gen.go` 不提交；`scripts/generate-go.sh` 是统一生成入口。该脚本会先删除 `internal/db` 下已有的 `*.sqlmap.gen.go`，再执行 `go generate ./internal/db`，避免已删除 Mapper 留下的 ignored 生成文件继续参与编译。Go lint、死代码、复杂度、测试、开发启动和 Docker 构建在类型检查或编译前调用该入口，避免本地残留的 ignored 文件掩盖干净 checkout 中的缺失生成代码。
 - `.golangci.yml` 是常规 Go lint 规则来源；复杂度和死代码等需要不同扫描范围的专项门禁使用独立的固定配置。
 - `just lint` 在本地对所有 Go package（包括测试）运行相同配置。
 - `.golangci-dead-code.yml` 单独启用 golangci-lint 的 `unused` 分析器并覆盖测试代码；`just dead-code` 通过 `scripts/go-dead-code.sh` 枚举当前 Go module 的仓库 package，避免本地前端依赖中的第三方 Go 示例污染结果。

--- a/justfile
+++ b/justfile
@@ -45,7 +45,7 @@ test: generate
 
 # Regenerate DB mappers with the version pinned by go.mod's tool directive.
 generate-yourbatis-mappers:
-  go generate ./internal/db
+  ./scripts/generate-go.sh
 
 # Run the repository's configured Go static-analysis and formatting checks.
 lint: generate

--- a/scripts/generate-go.sh
+++ b/scripts/generate-go.sh
@@ -4,4 +4,6 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+find ./internal/db -type f -name '*.sqlmap.gen.go' -delete
+
 go generate ./internal/db


### PR DESCRIPTION
## Summary
- Make `scripts/generate-go.sh` delete existing `internal/db/**/*.sqlmap.gen.go` files before `go generate`, so removed mappers cannot leave ignored generated sources that break local builds.
- Document the cleanup behavior in `AGENTS.md` and `docs/design/development-quality-gates.md`.

## Why
`*.sqlmap.gen.go` is gitignored. `go generate` only rewrites files named by current `//go:generate` directives, so deleting a mapper leaves orphan generated Go that still compiles into `internal/db` (for example `undefined: CodeSessionOutboundEventMapper`).

## Test plan
- [x] `./scripts/generate-go.sh` succeeds
- [x] Planting a stale `code_session_outbound_event_mapper.sqlmap.gen.go` fails `go build ./internal/db` before cleanup, and passes after `./scripts/generate-go.sh`
- [ ] CI on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale generated database mapper files from affecting builds, tests, linting, and static analysis.
  * Standardized code-generation commands to consistently clean outdated generated files first.

* **Documentation**
  * Clarified the code-generation workflow and its use across quality checks, development startup, and Docker builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->