### PR TITLE
Route just generate-yourbatis-mappers through generate

### DIFF
--- a/justfile
+++ b/justfile
@@ -43,9 +43,8 @@ restart-web:
 test: generate
   go test ./... -count=1
 
-# Regenerate DB mappers with the version pinned by go.mod's tool directive.
-generate-yourbatis-mappers:
-  go generate ./internal/db
+# Same as `generate`. Kept so documented `just generate-yourbatis-mappers` still works.
+generate-yourbatis-mappers: generate
 
 # Run the repository's configured Go static-analysis and formatting checks.
 lint: generate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep the documented `just generate-yourbatis-mappers` recipe, but make it an alias of `just generate`.
- Mapper regeneration now goes through `scripts/generate-go.sh` instead of calling `go generate ./internal/db` directly, so it shares the same cleanup path as `just generate`, `just test`, `just lint`, and `just restart-server`.

## Why
`just generate-yourbatis-mappers` was a bypass of the unified generate script. Docs such as `docs/design/be/filestore.md` still name this recipe, so it stays as a compatibility alias rather than being deleted.

## Test plan
- [x] `justfile` uses the same dependency-only recipe pattern as `complexity`
- [ ] CI on this PR

设计文档无需更新：`just generate-yourbatis-mappers` 对外命令不变，只是改为走已有的统一生成入口。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21446e00-9375-409f-8445-d9fac04918c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21446e00-9375-409f-8445-d9fac04918c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

