### PR TITLE
统一全局 Toast 并修复弹窗遮罩遮挡

### DIFF
--- a/docs/design/fe/llm-models-page.md
+++ b/docs/design/fe/llm-models-page.md
@@ -10,6 +10,8 @@ LLM 模型页是工作区的模型目录，而不是 Provider 卡片墙。
 
 保存只提交表单中的模型 ID；点击页面刷新时才请求 `POST .../llm_providers/{id}/models/sync`，把上游列表合并进该 Provider 的 `model_ids`，随后重拉 Provider 列表。同步响应存在 `skipped_model_ids` 时，用 toast 提示有模型因已归属其他 Provider 而跳过。模型 ID 可以为空：Provider 仍保留在轨道和目录中，`/v1/models` 返回空数组，页面显示明确的“尚未配置模型”状态。获取上游列表或刷新失败时，用可关闭、数秒后自动消失的 toast 提示，不挡住目录和表单。
 
+toast 由 App 根部唯一的共享 Toaster 承载，各功能页面只调用全局 `toast` API，不再重复挂载通知宿主。Toaster 通过 Portal 直接挂到 `body` 并统一显示在右下角，使通知脱离 `#root` 的隔离层叠上下文；Dialog 遮罩打开时，toast 仍位于遮罩和弹窗之上，不会被 backdrop blur 模糊。
+
 ```mermaid
 flowchart LR
   Page[LLM models page] --> Providers[Console providers API]

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -2,8 +2,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from '@tanstack/react-router';
 import { router } from './router';
 import { AuthProvider } from '../shared/auth/AuthProvider';
-import { I18nProvider } from '../shared/i18n';
+import { I18nProvider, useI18n } from '../shared/i18n';
 import { ThemeProvider } from '../shared/theme/ThemeProvider';
+import { Toaster } from '../shared/ui/sonner';
 import { WorkspaceProvider } from '../shared/workspaces/WorkspaceProvider';
 
 const queryClient = new QueryClient({
@@ -20,6 +21,7 @@ export function App() {
   return (
     <I18nProvider>
       <ThemeProvider>
+        <AppToaster />
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
             <WorkspaceProvider>
@@ -29,5 +31,18 @@ export function App() {
         </QueryClientProvider>
       </ThemeProvider>
     </I18nProvider>
+  );
+}
+
+function AppToaster() {
+  const { msg } = useI18n();
+
+  return (
+    <Toaster
+      duration={4000}
+      closeButton
+      containerAriaLabel={msg('common.notifications', 'Notifications')}
+      toastOptions={{ closeButtonAriaLabel: msg('common.close', 'Close') }}
+    />
   );
 }

--- a/web/src/features/dashboard/DashboardPage.test.tsx
+++ b/web/src/features/dashboard/DashboardPage.test.tsx
@@ -11,6 +11,7 @@ import { useEffect, type ReactNode } from 'react';
 import { AuthContext, type AuthContextValue } from '../../shared/auth/context';
 import { I18nProvider, type Locale } from '../../shared/i18n';
 import { setConsoleRequestContext } from '../../shared/api/client';
+import { Toaster } from '../../shared/ui/sonner';
 import { defaultWorkspace, type Workspace } from '../../shared/workspaces/api';
 import { WorkspaceContext, type WorkspaceContextValue } from '../../shared/workspaces/context';
 import { resetTestDom } from '../../test/setup';
@@ -1844,7 +1845,10 @@ function renderDashboardPage(
         <I18nProvider initialLocale={locale}>
           <AuthContext.Provider value={authValue}>
             <WorkspaceContext.Provider value={value}>
-              <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+              <QueryClientProvider client={queryClient}>
+                <Toaster closeButton toastOptions={{ closeButtonAriaLabel: 'Close' }} />
+                {children}
+              </QueryClientProvider>
             </WorkspaceContext.Provider>
           </AuthContext.Provider>
         </I18nProvider>

--- a/web/src/features/dashboard/files.tsx
+++ b/web/src/features/dashboard/files.tsx
@@ -13,7 +13,7 @@ import {
   dataTableHeaderRowClassName,
 } from '@/shared/ui/data-table-interactions';
 import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/shared/ui/table';
-import { toast, Toaster } from '@/shared/ui/sonner';
+import { toast } from '@/shared/ui/sonner';
 import { useI18n } from '../../shared/i18n';
 import { ConsolePageFrame, CursorPagination, TableEmptyRow, TableErrorRow, TableLoadingRow } from './frame';
 import {
@@ -130,12 +130,6 @@ export function FilesPage() {
 
   return (
     <>
-      <Toaster
-        position="top-right"
-        duration={2200}
-        closeButton
-        toastOptions={{ closeButtonAriaLabel: msg('common.close', 'Close') }}
-      />
       <ConsolePageFrame
         title={msg('files.title', 'Files')}
         icon={FileText}

--- a/web/src/features/llm-providers/LLMModelsPage.test.tsx
+++ b/web/src/features/llm-providers/LLMModelsPage.test.tsx
@@ -11,7 +11,7 @@ import { useEffect, type ReactNode } from 'react';
 import { AuthContext, type AuthContextValue } from '../../shared/auth/context';
 import { I18nProvider } from '../../shared/i18n';
 import type { Locale } from '../../shared/i18n';
-import { toast } from '../../shared/ui/sonner';
+import { toast, Toaster } from '../../shared/ui/sonner';
 import { defaultWorkspace } from '../../shared/workspaces/api';
 import { WorkspaceContext, type WorkspaceContextValue } from '../../shared/workspaces/context';
 import { resetTestDom } from '../../test/setup';
@@ -371,7 +371,13 @@ describe('LLM models page', () => {
     fireEvent.click(within(dialog).getByRole('button', { name: 'Fetch model list' }));
 
     const toastTitle = await screen.findByText('Could not list models from this provider.', {}, { timeout: 2000 });
-    expect(toastTitle.closest('[data-sonner-toast]')?.getAttribute('data-type')).toBe('error');
+    const toastElement = toastTitle.closest('[data-sonner-toast]');
+    const toaster = toastElement?.closest('[data-sonner-toaster]');
+    const toastRegion = toastElement?.closest('section');
+    expect(toastElement?.getAttribute('data-type')).toBe('error');
+    expect(toastRegion?.parentElement === document.body).toBeTrue();
+    expect(toaster?.getAttribute('data-x-position')).toBe('right');
+    expect(toaster?.getAttribute('data-y-position')).toBe('bottom');
     expect(screen.getByRole('dialog', { name: 'Add provider' })).toBeTruthy();
     expect(within(dialog).queryByText('not found')).toBeNull();
     expect(screen.queryByText('not found')).toBeNull();
@@ -470,6 +476,7 @@ function renderPage(locale: Locale = 'en', role = 'admin') {
         <AuthContext.Provider value={authValue}>
           <WorkspaceContext.Provider value={workspaceValue}>
             <QueryClientProvider client={queryClient}>
+              <Toaster closeButton toastOptions={{ closeButtonAriaLabel: 'Close' }} />
               <LLMModelsPage />
             </QueryClientProvider>
           </WorkspaceContext.Provider>

--- a/web/src/features/llm-providers/LLMModelsPage.tsx
+++ b/web/src/features/llm-providers/LLMModelsPage.tsx
@@ -12,7 +12,7 @@ import { Badge } from '../../shared/ui/badge';
 import { Button } from '../../shared/ui/button';
 import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '../../shared/ui/empty';
 import { Skeleton } from '../../shared/ui/skeleton';
-import { toast, Toaster } from '../../shared/ui/sonner';
+import { toast } from '../../shared/ui/sonner';
 import {
   createLLMProvider,
   deleteLLMProvider,
@@ -236,13 +236,6 @@ function LLMModelsAdminPage() {
 
   return (
     <section className="w-full max-w-none" data-testid="llm-models-page">
-      <Toaster
-        position="top-right"
-        duration={4000}
-        closeButton
-        containerAriaLabel={msg('common.notifications', 'Notifications')}
-        toastOptions={{ closeButtonAriaLabel: msg('common.close', 'Close') }}
-      />
       <div className="mb-5 flex flex-col items-start justify-between gap-3 sm:flex-row">
         <div>
           <div className="flex items-center gap-2">

--- a/web/src/features/managed-agents/ManagedAgentsPage.test-utils.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.test-utils.tsx
@@ -14,6 +14,7 @@ const { defaultWorkspace } = await import('../../shared/workspaces/api');
 const { setConsoleRequestContext } = await import('../../shared/api/client');
 const { resetMcpDirectoryCacheForTests } = await import('./agents/tools/api');
 const { I18nProvider } = await import('../../shared/i18n');
+const { Toaster } = await import('../../shared/ui/sonner');
 const { AuthContext } = await import('../../shared/auth/context');
 const { QueryClient, QueryClientProvider } = await import('@tanstack/react-query');
 const { RouterContextProvider, createBrowserHistory, createRootRoute, createRoute, createRouter } =
@@ -75,7 +76,10 @@ export function render(
   }
   return testingLibrary.render(
     <AuthContext.Provider value={queryOptions.auth ?? managedAgentsAuthContextValue}>
-      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <Toaster portal={false} closeButton toastOptions={{ closeButtonAriaLabel: 'Close' }} />
+        {ui}
+      </QueryClientProvider>
     </AuthContext.Provider>,
     options,
   );

--- a/web/src/features/managed-agents/ManagedAgentsPage.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.tsx
@@ -1,5 +1,3 @@
-import { useI18n } from '../../shared/i18n';
-import { Toaster } from '../../shared/ui/sonner';
 import { useWorkspace } from '../../shared/workspaces/context';
 import { useEffect } from 'react';
 import { AgentQuickstartPage } from './quickstart/AgentQuickstartPage';
@@ -8,19 +6,8 @@ import { type ManagedAgentSection } from './types';
 import { currentPathname, managedWorkspaceIdFromPath } from './utils';
 
 export function ManagedAgentsPage({ section }: { section: ManagedAgentSection }) {
-  const { msg } = useI18n();
   const { activeWorkspaceId, selectWorkspace } = useWorkspace();
   const routeWorkspaceId = managedWorkspaceIdFromPath(currentPathname());
-  const notifications = (
-    <Toaster
-      position="top-right"
-      duration={2200}
-      closeButton
-      containerAriaLabel={msg('common.notifications', 'Notifications')}
-      toastOptions={{ closeButtonAriaLabel: msg('common.close', 'Close') }}
-    />
-  );
-
   useEffect(() => {
     if (routeWorkspaceId && routeWorkspaceId !== activeWorkspaceId) {
       selectWorkspace(routeWorkspaceId);
@@ -28,29 +15,14 @@ export function ManagedAgentsPage({ section }: { section: ManagedAgentSection })
   }, [activeWorkspaceId, routeWorkspaceId, selectWorkspace]);
 
   if (section === 'quickstart') {
-    return (
-      <>
-        {notifications}
-        <AgentQuickstartPage />
-      </>
-    );
+    return <AgentQuickstartPage />;
   }
 
   if (section === 'dreams') {
-    return (
-      <>
-        {notifications}
-        <DreamingPage />
-      </>
-    );
+    return <DreamingPage />;
   }
 
-  return (
-    <>
-      {notifications}
-      <ManagedResourcePage config={resourceConfigs[section]} routeWorkspaceId={routeWorkspaceId} />
-    </>
-  );
+  return <ManagedResourcePage config={resourceConfigs[section]} routeWorkspaceId={routeWorkspaceId} />;
 }
 
 export type { ManagedAgentSection } from './types';

--- a/web/src/features/settings/OrganizationMembersPage.test.tsx
+++ b/web/src/features/settings/OrganizationMembersPage.test.tsx
@@ -86,7 +86,7 @@ describe('Organization members settings', () => {
     await waitFor(() => expect(api.inviteListRequests).toBe(2));
   });
 
-  test('mounts a shared toaster for invite actions instead of inline status chrome', async () => {
+  test('does not render inline status chrome for invite actions', async () => {
     resetTestDom('https://oma.duck.ai/settings/members');
     mockMembersApi();
 
@@ -97,7 +97,6 @@ describe('Organization members settings', () => {
     );
 
     expect(await screen.findByRole('heading', { name: 'Members 3' })).toBeTruthy();
-    expect(screen.getByLabelText('Notifications alt+T')).toBeTruthy();
     expect(container.querySelector('[role="status"]')).toBeNull();
     expect(container.querySelector('.text-emerald-600')).toBeNull();
   });

--- a/web/src/features/settings/OrganizationMembersPage.tsx
+++ b/web/src/features/settings/OrganizationMembersPage.tsx
@@ -28,7 +28,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../shared/ui/table';
 import { Textarea } from '../../shared/ui/textarea';
 import { Skeleton } from '../../shared/ui/skeleton';
-import { toast, Toaster } from '../../shared/ui/sonner';
+import { toast } from '../../shared/ui/sonner';
 import { useAuth } from '../../shared/auth/context';
 import { canManageMembers } from '../../shared/permissions/members';
 import { roleOptions, type PlatformRole } from '../../shared/permissions/roles';
@@ -266,7 +266,6 @@ export function OrganizationMembersPage() {
 
   return (
     <section className="mx-auto w-full max-w-[1180px]" data-testid="organization-members-page">
-      <Toaster position="top-right" duration={2200} closeButton toastOptions={{ closeButtonAriaLabel: 'Close' }} />
       <div className="mb-6 flex min-h-9 items-center justify-between gap-4">
         <h1 className="flex min-w-0 items-center gap-2 text-xl font-semibold tracking-normal text-foreground">
           <span>Members</span>

--- a/web/src/shared/ui/sonner.tsx
+++ b/web/src/shared/ui/sonner.tsx
@@ -1,17 +1,23 @@
 import { CircleCheck, Info, Loader2, OctagonX, TriangleAlert } from 'lucide-react';
 import { type CSSProperties } from 'react';
+import { createPortal } from 'react-dom';
 import { Toaster as Sonner, toast, type ToasterProps } from 'sonner';
 import { useTheme } from '../theme/context';
 
 export { toast };
 
-export function Toaster(props: ToasterProps) {
+type SharedToasterProps = ToasterProps & {
+  portal?: boolean;
+};
+
+export function Toaster({ portal = true, ...props }: SharedToasterProps) {
   const { resolvedTheme } = useTheme();
   const { style, ...rest } = props;
 
-  return (
+  const toaster = (
     <Sonner
       theme={resolvedTheme}
+      position="bottom-right"
       className="toaster group"
       icons={{
         success: <CircleCheck className="size-4" />,
@@ -32,4 +38,6 @@ export function Toaster(props: ToasterProps) {
       {...rest}
     />
   );
+
+  return portal ? createPortal(toaster, document.body) : toaster;
 }


### PR DESCRIPTION
## 变更

- 将 Toaster 提升为 App 根部的全局单例，删除 Files、LLM Models、Members 和 Managed Agents 页面中的重复通知宿主
- 通过 Portal 将 Toaster 挂载到 `body`，避免受到 `#root` 隔离层叠上下文和 Dialog backdrop blur 影响
- 统一 toast 显示在右下角，并保留本地化通知标签、关闭按钮和主题样式
- 调整页面测试宿主，补充 Provider 弹窗打开时 toast 挂载位置及右下角定位回归测试
- 同步更新 LLM Models 前端设计文档

## 验证

- `bun test`（459 通过，0 失败）
- `bun run format:check`
- `bun run lint:complexity`
- `bun run lint:duplicates`
- `bun run build`
- `just large-files`
- 提交阶段受管 pre-commit hooks

## 已知环境限制

- `just hooks-run` 的前端与通用文件检查均通过；全仓 Go lint、dead-code 和 complexity 检查受本机 golangci-lint 构建版本为 Go 1.26、低于仓库目标 Go 1.27 阻断，本次提交不包含 Go 文件。
- 全文件格式检查会改写两处未由本 PR 修改的既有 Go 文件；这些无关改写未纳入提交，针对本次暂存文件的 pre-commit hook 已全部通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a shared notification area available throughout the app.
  - Notifications now appear consistently in the lower-right corner, above dialogs and overlays.
  - Added localized notification labels and a close button, with automatic dismissal after four seconds.

- **Bug Fixes**
  - Prevented notifications from being obscured or visually affected by modal backdrops.
  - Standardized notification behavior across dashboard, model, agent, and settings pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->