### PR TITLE
feat(codesessions): task_notification 失败时产生 session.error 事件（#251）

### DIFF
--- a/docs/design/be/session-error-event.md
+++ b/docs/design/be/session-error-event.md
@@ -1,0 +1,46 @@
+# session.error 事件（类型化错误对象）
+
+> Issue: #251
+> 日期: 2026-08-16
+> 分支: `feat/session-error-event`
+
+## 背景
+
+官方 Claude Managed Agents 的事件类型表里有 `session.error` 事件：session 处理出错时，平台发一个类型化错误对象，含 `type`（错误类型）和 `retry_status`（是否自动重试）。这是客户端**观察错误的主通道**——流式示例都按 `event.error.message` 读取。
+
+OMA 当前**不产生 `session.error`**：`managedagentsevents/events.go:32` 只有分类，无构造点；worker 错误被映射为 `session.thread_status_terminated`（``systemPublicPayloadCandidates` 的 task_notification 分支`），客户端只能靠「线程终止」推断出错。
+
+## 官方契约
+
+- `session.error` 事件：类型化 error 对象
+- 字段：`type`（错误类型）、`retry_status`（是否自动重试）、`message`
+- 触发时机：session 处理出错时（含 MCP 连接失败、模型错误、内部错误等）
+
+## 现状
+
+- `managedagentsevents/events.go:32`：`session.error` 仅分类（CategorySessionStatus），无产生
+- `codesessions/`systemPublicPayloadCandidates` 的 task_notification 分支`：`task_notification` 的 status 为 `failed`/`error`/`terminated` → 映射为 `session.thread_status_terminated`
+- `codesessions/status.go:27-36`：`publicEventTypeFromWorkerStatus` 只映射 running/idle/requires_action（worker 只上报这三种）
+- 无 `retry_status` 概念
+
+## 方案
+
+1. **`CategoryFor` 已有 `session.error` 分类**（无需改）
+2. **`mapper.go` 的 `task_notification` 分支**：status 为 `failed`/`error`/`terminated` 时，**同时产生 `session.error` 事件**：
+   - `type`：`schema.Status` 小写化派生（`failed` / `error` / `terminated`）
+   - `retry_status`：`"not_retryable"`（worker 上报 failed/error 表示不可自动重试；可重试错误走 rescheduled）
+   - `message`：`schema.Summary`（task_notification 已带 summary）
+   - `session_thread_id` / `task_id` / `tool_use_id`：与 thread_status_terminated 同源
+3. **事件顺序**：`session.error` 在 `session.thread_status_terminated` 之前发出（官方「先 error 后终止」语义）
+
+## 测试
+
+- `mapper.go`：task_notification 的 status=failed/error/terminated → 产生 session.error（type/retry_status/message 正确）+ thread_status_terminated
+- status=completed/succeeded → 不产生 session.error
+- `CategoryFor("session.error")` 回归
+
+## 验收
+
+- worker 上报 failed/error 的 task_notification 时，事件流出现 `session.error`（带 type/retry_status/message）
+- 可重试错误（rescheduled）不产生 error 事件（走 rescheduling 语义）
+- 官方 SDK 的 `session.error` 处理分支可正常工作

--- a/internal/codesessions/mapper.go
+++ b/internal/codesessions/mapper.go
@@ -615,7 +615,9 @@ func systemPublicPayloadCandidates(codeSessionID string, object map[string]any, 
 			return []publicPayloadCandidate{{payload: publicPayloadWithType(object, "system.message")}}
 		}
 		statusEventType := "session.thread_status_idle"
-		if status := strings.ToLower(schema.Status); status == "failed" || status == "error" || status == "terminated" {
+		workerStatus := strings.ToLower(schema.Status)
+		failed := workerStatus == "failed" || workerStatus == "error" || workerStatus == "terminated"
+		if failed {
 			statusEventType = "session.thread_status_terminated"
 		}
 		status := publicPayloadWithType(object, statusEventType)
@@ -626,7 +628,23 @@ func systemPublicPayloadCandidates(codeSessionID string, object map[string]any, 
 			"type":   firstNonEmpty(schema.Status, "completed"),
 			"detail": schema.Summary,
 		}
-		return []publicPayloadCandidate{{payload: status, seedSuffix: "task_notification:thread_status:" + threadID}}
+		if !failed {
+			return []publicPayloadCandidate{{payload: status, seedSuffix: "task_notification:thread_status:" + threadID}}
+		}
+		// error.type 与 stop_reason.type 同源（schema.Status），保持两事件表述一致。
+		errorEvent := publicPayloadWithType(object, "session.error")
+		errorEvent["session_thread_id"] = threadID
+		errorEvent["task_id"] = schema.TaskID
+		errorEvent["tool_use_id"] = schema.ToolUseID
+		errorEvent["error"] = map[string]any{
+			"type":         workerStatus,
+			"retry_status": "not_retryable",
+			"message":      firstNonEmpty(schema.Summary, "task "+workerStatus),
+		}
+		return []publicPayloadCandidate{
+			{payload: errorEvent, seedSuffix: "task_notification:error:" + threadID},
+			{payload: status, seedSuffix: "task_notification:thread_status:" + threadID, timeOffset: time.Millisecond},
+		}
 	default:
 		return []publicPayloadCandidate{{payload: publicPayloadWithType(object, "system.message")}}
 	}

--- a/internal/codesessions/mapper_test.go
+++ b/internal/codesessions/mapper_test.go
@@ -628,3 +628,93 @@ func mustRawJSON(t *testing.T, value any) json.RawMessage {
 func ptrString(value string) *string {
 	return &value
 }
+
+func TestTaskNotificationFailureEmitsSessionError(t *testing.T) {
+	// 失败场景先行：task_notification 的 status 为 failed/error/terminated 时，
+	// 事件流必须出现 session.error（带 type/retry_status/message），且先于 thread_status_terminated。
+	for _, status := range []string{"failed", "error", "terminated"} {
+		t.Run(status, func(t *testing.T) {
+			payloads, ok, err := publicPayloadsFromWorkerEvent("csev_test", db.CodeSessionEvent{
+				ExternalID:     "csev_err_" + status,
+				EventType:      "system",
+				IdempotencyKey: "err_" + status,
+				CreatedAt:      time.Date(2026, 6, 16, 1, 10, 5, 0, time.UTC),
+			}, mustRawJSON(t, map[string]any{
+				"type":        "system",
+				"uuid":        "system-err-" + status,
+				"subtype":     "task_notification",
+				"task_id":     "abc123",
+				"tool_use_id": "tool_translate",
+				"status":      status,
+				"summary":     "something broke",
+			}))
+			if err != nil {
+				t.Fatalf("task_notification(%s) mapping error: %v", status, err)
+			}
+			if !ok {
+				t.Fatal("task_notification mapping ok = false, want true")
+			}
+			objects := decodePublicPayloads(t, payloads)
+			if len(objects) != 2 {
+				t.Fatalf("task_notification(%s) payloads = %#v, want 2 (error + terminated)", status, objects)
+			}
+			errorEvent := objects[0]
+			if errorEvent["type"] != "session.error" {
+				t.Fatalf("第一个事件应为 session.error, got %v", errorEvent["type"])
+			}
+			errorObject, ok := errorEvent["error"].(map[string]any)
+			if !ok {
+				t.Fatalf("session.error 缺 error 对象: %#v", errorEvent)
+			}
+			if errorObject["retry_status"] != "not_retryable" {
+				t.Fatalf("retry_status = %v, want not_retryable", errorObject["retry_status"])
+			}
+			if errorObject["message"] != "something broke" {
+				t.Fatalf("message = %v, want something broke", errorObject["message"])
+			}
+			if errorObject["type"] != status {
+				t.Fatalf("error.type = %v, want %v（与 status 同源）", errorObject["type"], status)
+			}
+			if objects[1]["type"] != "session.thread_status_terminated" {
+				t.Fatalf("第二个事件应为 thread_status_terminated, got %v", objects[1]["type"])
+			}
+			stopReason := objects[1]["stop_reason"].(map[string]any)
+			if stopReason["type"] != status {
+				t.Fatalf("stop_reason.type = %v, want %v", stopReason["type"], status)
+			}
+			errorAt, _ := time.Parse(time.RFC3339Nano, objects[0]["processed_at"].(string))
+			terminatedAt, _ := time.Parse(time.RFC3339Nano, objects[1]["processed_at"].(string))
+			if !errorAt.Before(terminatedAt) {
+				t.Fatalf("session.error 应先于 thread_status_terminated: %v vs %v", errorAt, terminatedAt)
+			}
+		})
+	}
+}
+
+func TestTaskNotificationSuccessNoSessionError(t *testing.T) {
+	// 成功场景：completed 的 task_notification 不产生 session.error
+	payloads, ok, err := publicPayloadsFromWorkerEvent("csev_test", db.CodeSessionEvent{
+		ExternalID:     "csev_ok",
+		EventType:      "system",
+		IdempotencyKey: "ok",
+		CreatedAt:      time.Date(2026, 6, 16, 1, 10, 5, 0, time.UTC),
+	}, mustRawJSON(t, map[string]any{
+		"type":        "system",
+		"uuid":        "system-ok",
+		"subtype":     "task_notification",
+		"task_id":     "abc123",
+		"tool_use_id": "tool_translate",
+		"status":      "completed",
+		"summary":     "done",
+	}))
+	if err != nil {
+		t.Fatalf("task_notification mapping error: %v", err)
+	}
+	if !ok {
+		t.Fatal("task_notification mapping ok = false, want true")
+	}
+	objects := decodePublicPayloads(t, payloads)
+	if len(objects) != 1 || objects[0]["type"] != "session.thread_status_idle" {
+		t.Fatalf("completed 应只有 thread_status_idle, got %#v", objects)
+	}
+}


### PR DESCRIPTION
## 改动

- `task_notification` 的 status 为 `failed` / `error` / `terminated` 时，事件流先发 `session.error`（类型化错误对象：`type` / `retry_status` / `message`），再发 `session.thread_status_terminated`（`timeOffset` 保证顺序）
- `error.type` 与 `stop_reason.type` 同源派生（schema.Status），两事件表述一致
- `retry_status` 固定 `not_retryable`：worker 上报的失败态不可自动重试；可重试错误走 rescheduled 语义，不产生 error 事件

## 对齐官方

- 官方事件表中 `session.error` 是客户端观察错误的主通道（流式示例按 `event.error.message` 读取），此前 OMA 完全不产生该事件，SDK 的 error 分支永远不触发

## 测试

- 失败先行：failed/error/terminated 三态 → `session.error`（契约字段断言）+ terminated，顺序断言
- 成功场景：completed 不产生 `session.error`
- `go test ./internal/codesessions/` 通过

Closes #251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `session.error` notifications for failed, errored, and terminated tasks.
  * Notifications include task status, retry information, and an error message before the termination update.
  * Successful and retryable tasks continue without an error notification.

* **Documentation**
  * Added documentation covering error event behavior and acceptance criteria.

* **Tests**
  * Added coverage for successful, failed, errored, and terminated task notification scenarios.
  * Verified that error notifications are delivered before termination updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->