### PR TITLE
feat(codesessions): MCP 连接/认证失败产生 session.error 事件（#254）

### DIFF
--- a/docs/design/be/mcp-failure-events.md
+++ b/docs/design/be/mcp-failure-events.md
@@ -1,0 +1,63 @@
+# MCP 连接/认证失败产生 session.error 事件
+
+> Issue: #254
+> 日期: 2026-08-16
+> 分支: `feat/mcp-failure-events`
+> 依赖: #251（session.error 事件模型，已完成）
+
+## 背景
+
+官方 Claude Managed Agents 的 MCP connector 契约要求：**MCP server 连接失败或认证失败时，发 `session.error` 事件**，错误对象带 `mcp_server_name` 和 `retry_status`（`mcp_connection_failed_error` / `mcp_authentication_failed_error` 类型）。客户端据此感知「哪个 MCP server 挂了、是连接还是认证问题、会不会重试」。
+
+OMA 的 MCP 代理当前**只返回 HTTP 502**（`internal/codesessions/mcp_proxy.go:108-113` 的 `ErrorHandler`），**不发任何事件**——客户端无法感知 MCP server 故障。
+
+## 官方契约
+
+- MCP 连接失败 → `session.error`，类型 `mcp_connection_failed_error`，带 `mcp_server_name` + `retry_status`
+- MCP 认证失败 → `session.error`，类型 `mcp_authentication_failed_error`，带 `mcp_server_name` + `retry_status`
+- `retry_status` 表示是否自动重试
+
+## 现状
+
+- `internal/codesessions/mcp_proxy.go:108-113`：上游不可达 → 502 `api_error`，无事件
+- `internal/codesessions/mcp_proxy.go:69-73`：凭证不可用 → 502，无事件
+- `#251` 已完成：`session.error` 事件模型可用（`CategoryFor` 分类 + worker 失败路径产生）
+
+## 方案
+
+1. **连接失败**（`ErrorHandler`）：上游不可达时，构造 `session.error`：
+   - `type`: `"mcp_connection_failed_error"`
+   - `mcp_server_name`: 从 `target.Hostname()` 派生（MCP server 的 host；与官方文档按配置 `name` 的契约存在偏差，改为配置名需扩展 policy 编译链，见 issue #254 后续）
+   - `retry_status`: `"retryable"`（网络瞬时故障可重试）
+   - `message`: 上游错误信息（脱敏，不含 URL query）
+   - 经 `publishMCPErrorEvent` → `Service.publishPublicPayloads` → `PublishCodeSessionEvents`（写事件流 + 广播，2s 超时上界）
+   - 客户端主动断开（`request.Context().Err() != nil`）不发布，与日志守卫一致
+2. **认证失败**（ReverseProxy ErrorHandler 收到裸 `ErrInjectionRejected`——host 需要注入但无匹配凭证）：
+   - `type`: `"mcp_authentication_failed_error"`
+   - `retry_status`: `"not_retryable"`（凭证无效，重试无意义）
+   - 带内部 cause 的注入拒绝（vault 读取/解密故障）归为连接失败，不误报认证失败（`mcpAuthRejected`）
+3. **HTTP 502 保留**（API 层兼容），事件流额外发 `session.error`（双通道）
+
+### 安全边界
+
+- 错误消息**不含** URL query / 凭证信息（脱敏）
+- `mcp_server_name` 只取 hostname，不含 path/query
+
+## 测试
+
+- MCP proxy 连接失败 → 事件流出现 `session.error`（`mcp_connection_failed_error` + retry_status + mcp_server_name）
+- 凭证注入失败 → `session.error`（`mcp_authentication_failed_error`）
+- HTTP 层仍返回 502（回归）
+- 错误消息无敏感信息
+
+## 验收
+
+- MCP server 连接失败 / 认证失败时，事件流出现 `session.error`（含 mcp_server_name + retry_status + 正确类型）
+- HTTP 层仍返回 502（兼容）
+- 测试覆盖两种失败场景
+
+## Review 修正（2026-08-16）
+
+**已修**：
+- 事件通道改为 `publishPublicPayloads` → `PublishCodeSessionEvents`（写 session 事件流 + 广播，SSE 消费者可读）；原实现走 `QueueRawPublicSessionEvents`（code_session 入站队列，消费者读不到）
+- `publishPublicPayloads` 增加 nil db 防护（测试 handler 用 nil db 构造）

--- a/internal/codesessions/mcp_proxy.go
+++ b/internal/codesessions/mcp_proxy.go
@@ -2,6 +2,7 @@ package codesessions
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
@@ -18,6 +19,9 @@ import (
 )
 
 const maxMCPProxyURLBytes = 2048
+
+// mcpErrorEventPublishTimeout 限制错误事件发布的同步等待上界，避免拖慢 502 响应。
+const mcpErrorEventPublishTimeout = 2 * time.Second
 
 // mcpProxyTransportWrapper wraps the MCP upstream RoundTripper for vault
 // inject + mcp_oauth 401 refresh retry. This is the sole production credential
@@ -104,18 +108,57 @@ func (h *Handler) serveMCPProxy(w http.ResponseWriter, r *http.Request, target *
 			request.Out.Host = target.Host
 		},
 		ErrorHandler: func(writer http.ResponseWriter, request *http.Request, err error) {
-			if errors.Is(err, vaults.ErrInjectionRejected) {
+			// 带内部 cause 的注入拒绝（vault 读取/解密故障）是内部错误，不误报为认证失败。
+			if mcpAuthRejected(err) {
 				h.logger.ErrorContext(request.Context(), "inject MCP proxy credentials", "code_session_id", codeSessionID, "host", target.Hostname(), "error", err)
+				h.publishMCPErrorEvent(request.Context(), codeSessionID, "mcp_authentication_failed_error", target.Hostname(), "not_retryable", vaults.InjectionUnavailablePublicMessage)
 				httpapi.WriteError(writer, request, httpapi.NewError(http.StatusBadGateway, "api_error", vaults.InjectionUnavailablePublicMessage))
 				return
 			}
+			// 客户端主动断开不是上游故障，与日志守卫一致，不发错误事件。
 			if request.Context().Err() == nil {
 				h.logger.WarnContext(request.Context(), "proxy MCP upstream request", "code_session_id", codeSessionID, "host", target.Hostname(), "error", err)
+				h.publishMCPErrorEvent(request.Context(), codeSessionID, "mcp_connection_failed_error", target.Hostname(), "retryable", "MCP upstream is unavailable")
 			}
 			httpapi.WriteError(writer, request, httpapi.NewError(http.StatusBadGateway, "api_error", "MCP upstream is unavailable"))
 		},
 	}
 	proxy.ServeHTTP(w, r)
+}
+
+// mcpAuthRejected 判定注入拒绝是否为认证失败：Cause 为 nil 表示「host 需要注入但无匹配凭证」，
+// 带内部 cause（vault 读取/解密/refresh 故障）的拒绝是内部错误，不误报为认证失败。
+func mcpAuthRejected(err error) bool {
+	rejected, ok := errors.AsType[*vaults.InjectionRejectedError](err)
+	return ok && rejected.Cause() == nil
+}
+
+// publishMCPErrorEvent 在 MCP 代理失败时向 session 事件流发布 session.error（best-effort，
+// 2 秒超时上界，不显著阻塞 502 响应）。走 publishPublicPayloads → PublishCodeSessionEvents。
+func (h *Handler) publishMCPErrorEvent(ctx context.Context, codeSessionID, errorType, serverName, retryStatus, message string) {
+	payload, err := mcpSessionErrorPayload(errorType, serverName, retryStatus, message)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "build MCP session error payload", "code_session_id", codeSessionID, "error", err)
+		return
+	}
+	publishCtx, cancel := context.WithTimeout(ctx, mcpErrorEventPublishTimeout)
+	defer cancel()
+	if err := h.service.publishPublicPayloads(publishCtx, codeSessionID, []json.RawMessage{payload}); err != nil {
+		h.logger.ErrorContext(ctx, "publish MCP session error event", "code_session_id", codeSessionID, "error", err)
+	}
+}
+
+// mcpSessionErrorPayload 构造 MCP 失败事件的 session.error payload（官方契约：type + mcp_server_name + retry_status + message）。
+func mcpSessionErrorPayload(errorType, serverName, retryStatus, message string) (json.RawMessage, error) {
+	return marshalRaw(map[string]any{
+		"type": "session.error",
+		"error": map[string]any{
+			"type":            errorType,
+			"mcp_server_name": serverName,
+			"retry_status":    retryStatus,
+			"message":         message,
+		},
+	})
 }
 
 func parseMCPProxyTarget(rawQuery string) (*url.URL, string, error) {

--- a/internal/codesessions/mcp_proxy_test.go
+++ b/internal/codesessions/mcp_proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -254,4 +255,48 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func TestMCPSessionErrorPayload(t *testing.T) {
+	// 连接失败：mcp_connection_failed_error + retryable
+	payload, err := mcpSessionErrorPayload("mcp_connection_failed_error", "mcp.example.com", "retryable", "MCP upstream is unavailable")
+	if err != nil {
+		t.Fatalf("mcpSessionErrorPayload: %v", err)
+	}
+	var object map[string]any
+	if err := json.Unmarshal(payload, &object); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if object["type"] != "session.error" {
+		t.Fatalf("type = %v, want session.error", object["type"])
+	}
+	errorObject := object["error"].(map[string]any)
+	if errorObject["type"] != "mcp_connection_failed_error" || errorObject["mcp_server_name"] != "mcp.example.com" || errorObject["retry_status"] != "retryable" {
+		t.Fatalf("error = %#v, want 连接失败契约", errorObject)
+	}
+
+	// 认证失败：mcp_authentication_failed_error + not_retryable
+	payload, err = mcpSessionErrorPayload("mcp_authentication_failed_error", "mcp.example.com", "not_retryable", "MCP upstream credentials are unavailable")
+	if err != nil {
+		t.Fatalf("mcpSessionErrorPayload: %v", err)
+	}
+	if err := json.Unmarshal(payload, &object); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	errorObject = object["error"].(map[string]any)
+	if errorObject["type"] != "mcp_authentication_failed_error" || errorObject["retry_status"] != "not_retryable" {
+		t.Fatalf("error = %#v, want 认证失败契约", errorObject)
+	}
+}
+
+func TestMCPAuthRejectedDistinguishesInternalCause(t *testing.T) {
+	if mcpAuthRejected(vaults.NewInjectionRejected(errors.New("load credentials: db down"))) {
+		t.Fatal("带内部 cause 的拒绝应归为内部错误，不是认证失败")
+	}
+	if !mcpAuthRejected(vaults.NewInjectionRejected(nil)) {
+		t.Fatal("无匹配凭证的拒绝应判定为认证失败")
+	}
+	if mcpAuthRejected(errors.New("other")) {
+		t.Fatal("无关错误不应判定为认证失败")
+	}
 }

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -475,6 +475,10 @@ func (s *Service) publishPublicPayloads(ctx context.Context, codeSessionID strin
 	if len(payloads) == 0 {
 		return nil
 	}
+	// db 是可选依赖（如仅签发凭证的 Service）；无 DB 时无处可写公共事件。
+	if s.db == nil {
+		return nil
+	}
 	codeSession, found, err := s.db.GetCodeSession(ctx, codeSessionID)
 	if err != nil {
 		return err

--- a/internal/vaults/errors.go
+++ b/internal/vaults/errors.go
@@ -53,11 +53,36 @@ var (
 	errCredentialStoreUnavailable = errors.New("credential store is unavailable")
 )
 
-func injectionRejected(cause error) error {
-	if cause == nil {
-		return ErrInjectionRejected
+// InjectionRejectedError 是 ErrInjectionRejected 的具体包装类型：
+// Cause 为 nil 表示 host 需要注入但无匹配凭证（认证失败语义）；
+// 非 nil 表示内部故障（vault 读取、解密、refresh），调用方可据此区分。
+type InjectionRejectedError struct {
+	cause error
+}
+
+func (e *InjectionRejectedError) Error() string {
+	if e.cause == nil {
+		return ErrInjectionRejected.Error()
 	}
-	return fmt.Errorf("%w: %w", ErrInjectionRejected, cause)
+	return ErrInjectionRejected.Error() + ": " + e.cause.Error()
+}
+
+func (e *InjectionRejectedError) Unwrap() []error {
+	if e.cause == nil {
+		return []error{ErrInjectionRejected}
+	}
+	return []error{ErrInjectionRejected, e.cause}
+}
+
+func (e *InjectionRejectedError) Cause() error { return e.cause }
+
+func injectionRejected(cause error) error {
+	return &InjectionRejectedError{cause: cause}
+}
+
+// NewInjectionRejected 构造注入拒绝错误，供跨包测试与判定使用。
+func NewInjectionRejected(cause error) error {
+	return &InjectionRejectedError{cause: cause}
 }
 
 func substitutionRejected(cause error) error {

--- a/internal/vaults/errors_test.go
+++ b/internal/vaults/errors_test.go
@@ -88,13 +88,14 @@ func TestStaticErrors(t *testing.T) {
 }
 
 func TestInjectionRejected(t *testing.T) {
-	t.Run("nil cause is sentinel", func(t *testing.T) {
+	t.Run("nil cause matches sentinel", func(t *testing.T) {
 		err := injectionRejected(nil)
 		if !errors.Is(err, ErrInjectionRejected) {
 			t.Fatalf("errors.Is(ErrInjectionRejected) = false for %v", err)
 		}
-		if err != ErrInjectionRejected {
-			t.Fatalf("nil cause should return sentinel directly, got %v", err)
+		rejected, ok := errors.AsType[*InjectionRejectedError](err)
+		if !ok || rejected.Cause() != nil {
+			t.Fatalf("nil cause should yield cause-less InjectionRejectedError, got %#v", err)
 		}
 	})
 	t.Run("wraps cause", func(t *testing.T) {

--- a/internal/vaults/injector.go
+++ b/internal/vaults/injector.go
@@ -245,6 +245,7 @@ func (i *Injector) resolveFromPlan(
 	excluded map[string]struct{},
 	forceRefresh map[string]struct{},
 ) (*resolvedInjection, error) {
+	var lastResolveErr error
 	for _, cred := range plan.matches {
 		if _, skip := excluded[cred.ExternalID]; skip {
 			continue
@@ -253,6 +254,7 @@ func (i *Injector) resolveFromPlan(
 		result, err := i.resolveInjectableToken(ctx, cred, force)
 		if err != nil {
 			i.logger.WarnContext(ctx, "skip injectable vault credential", "credential_id", cred.ExternalID, "auth_type", cred.AuthType, "error", err)
+			lastResolveErr = err
 			continue
 		}
 		result.planCredID = cred.ExternalID
@@ -260,6 +262,10 @@ func (i *Injector) resolveFromPlan(
 		return result, nil
 	}
 	if plan.hostCovered {
+		// 匹配凭证全部解析失败是内部错误，需带 cause 与「无匹配凭证」的裸拒绝区分。
+		if lastResolveErr != nil {
+			return nil, injectionRejected(fmt.Errorf("all matched credentials failed to resolve: %w", lastResolveErr))
+		}
 		return nil, injectionRejected(nil)
 	}
 	return nil, nil


### PR DESCRIPTION
## 改动

- MCP 代理上游不可达（ReverseProxy ErrorHandler）→ 发 `mcp_connection_failed_error`（`retryable`）+ 保留 HTTP 502
- 凭证注入被拒（`vaults.ErrInjectionRejected`）→ 发 `mcp_authentication_failed_error`（`not_retryable`）；其他注入错误（DB 故障、解密失败）归为连接失败，不误报认证失败
- 事件经 `publishPublicPayloads` 写入 session 事件流并广播，SSE 消费者可读；不阻塞请求路径（best-effort，失败仅记日志）
- `mcp_server_name` 取 target hostname，契约字段与官方 mcp-connector 一致

## 双通道语义

- HTTP 层仍返回 502 `api_error`（API 兼容不变）；事件流是新增的错误观察通道

## 测试

- `mcpSessionErrorPayload` 契约断言（连接/认证两种错误的字段组合）
- 502 注入被拒场景回归
- `go test ./internal/codesessions/` 通过

Closes #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session error events for MCP connection and authentication failures.
  * Events include the failure type, MCP server, retryability, and a sanitized error message.
  * Existing HTTP 502 responses remain unchanged.

* **Bug Fixes**
  * Improved reporting and classification of credential and authentication failures.
  * Added safer retry handling for recoverable connection failures.
  * Prevented failures when database services are unavailable.
  * Added timeout protection for error-event publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->