### PR TITLE
fix(db): SetSessionStatus 增加状态转换合法性校验（#247）

### DIFF
--- a/docs/design/be/session-status-transition.md
+++ b/docs/design/be/session-status-transition.md
@@ -1,0 +1,54 @@
+# Session 状态转换合法性校验
+
+> Issue: #247
+> 日期: 2026-08-16
+> 分支: `fix/session-status-transition`
+
+## 背景
+
+官方 Claude Managed Agents 的 session 有明确生命周期：`idle` / `running` / `rescheduling` / `terminated`，终态（terminated）后不应再变回。OMA 的 `SetSessionStatus`（`internal/db/sessions.go:253`）当前**无条件 UPDATE**（`session_mapper.xml:93-99` 无旧状态限制）——**可从 terminated 改回 idle**，状态机被破坏。
+
+官方还有两个相关契约：
+- **running 的 session 不能归档/删除**（需先 interrupt）
+- **归档的 session 不能接受新事件**
+
+## 方案
+
+### 1. 定义合法状态转换表
+
+```text
+idle        → running, rescheduling, terminated
+running     → idle, rescheduling, terminated
+rescheduling→ idle, running, terminated
+terminated  → （终态，不可回退）
+```
+
+### 2. `SetSessionStatus` 增加旧状态校验
+
+`internal/db/sessions.go` 的 `SetSessionStatus`：
+- SQL 加 `WHERE status IN (合法前驱状态)`（应用层先读再判更简单，但 SQL 层原子性更好）
+- 采用 SQL 方案：`session_mapper.xml` 的 `SetStatus` 加 `AND status IN (...)`，rowsAffected==0 时区分「不存在」和「非法转换」
+
+### 3. 区分错误
+
+- 不存在 → `ErrNotFound`（既有）
+- 非法转换 → 新 sentinel `ErrInvalidStateTransition`
+
+## 测试
+
+- 合法转换（idle→running、running→idle）通过
+- 非法转换（terminated→idle）报 `ErrInvalidStateTransition`
+- 不存在报 `ErrNotFound`（回归）
+- mapper contract 测试更新
+
+## 验收
+
+- `terminated` 的 session 无法通过 `SetSessionStatus` 改回活跃状态
+- 非法转换返回明确错误（区别于 not found）
+- 正常状态流转不受影响
+
+
+## 范围外（后续工作）
+
+- 运行中 session 的归档/删除拒绝（官方「running 需先 interrupt」）走独立的 Archive/Delete mapper 路径，本 PR 未覆盖，见 PR 描述。
+- terminated session 的事件追加边界（AppendSessionEvents 目前只拒 archived）属事件路径工作，同样不在本 PR。

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -25,6 +25,7 @@ import (
 var (
 	ErrNotFound                 = platform.ErrNotFound
 	ErrInvalidState             = errors.New("invalid state")
+	ErrInvalidStateTransition   = errors.New("invalid state transition")
 	ErrPreconditionFailed       = errors.New("precondition failed")
 	ErrDuplicate                = errors.New("duplicate")
 	ErrVersionConflict          = errors.New("version conflict")
@@ -40,6 +41,10 @@ var (
 	ErrStaleSchedule            = errors.New("stale deployment schedule")
 	ErrWorkspaceArchived        = errors.New("workspace archived")
 )
+
+func newInvalidStateTransition(from, to string) error {
+	return fmt.Errorf("%w: cannot transition from %q to %q", ErrInvalidStateTransition, from, to)
+}
 
 type DB struct {
 	pool     *pgxpool.Pool

--- a/internal/db/session_mapper.xml
+++ b/internal/db/session_mapper.xml
@@ -104,6 +104,10 @@
         WHERE workspace_uuid = #{workspaceUUID}
         AND external_id = #{sessionExternalID}
         AND deleted_at IS NULL
+        AND (
+            status IN ('idle', 'running', 'rescheduling')
+            OR status = #{status}
+        )
     </update>
 
     <update id="Archive" result="returning" resultType="sessionRow">

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -274,7 +274,14 @@ func (d *DB) SetSessionStatus(ctx context.Context, workspaceUUID string, externa
 		return err
 	}
 	if rowsAffected == 0 {
-		return ErrNotFound
+		current, found, err := d.GetSession(ctx, workspaceUUID, externalID)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return ErrNotFound
+		}
+		return newInvalidStateTransition(current.Status, status)
 	}
 	return nil
 }

--- a/internal/db/sessions_mapper_test.go
+++ b/internal/db/sessions_mapper_test.go
@@ -240,3 +240,11 @@ func TestSessionTableMappersPropagateExecutionErrors(t *testing.T) {
 		t.Run(test.statementID, func(t *testing.T) { assertMapperExecutionError(t, test) })
 	}
 }
+
+func TestSessionMapperSetStatusRestrictsPredecessors(t *testing.T) {
+	// 回归守卫：SetStatus 只允许从活跃状态（idle/running/rescheduling）转换，
+	// terminated 是终态不可回退。
+	bound := buildSessionMapperSetStatus(yourbatis.DialectPostgres, "workspace-uuid", "ses_test", "running")
+	assertMapperSQLContains(t, bound, "status IN ('idle', 'running', 'rescheduling')")
+	assertMapperSQLContains(t, bound, "OR status = $4")
+}

--- a/internal/sessions/event_effects.go
+++ b/internal/sessions/event_effects.go
@@ -66,7 +66,7 @@ func (h *Handler) applySessionEventProjection(ctx context.Context, event db.Sess
 			return err
 		}
 	}
-	if err := h.db.SetSessionStatus(ctx, event.WorkspaceUUID, event.SessionExternalID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
+	if err := h.db.SetSessionStatus(ctx, event.WorkspaceUUID, event.SessionExternalID, status); err != nil && !ignoreSessionStatusMutationError(err) {
 		return err
 	}
 	return nil
@@ -96,7 +96,7 @@ func (h *Handler) projectAggregatedSessionStatus(ctx context.Context, workspaceU
 		switch thread.Status {
 		case "running":
 			status = "running"
-			if err := h.db.SetSessionStatus(ctx, workspaceUUID, sessionID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
+			if err := h.db.SetSessionStatus(ctx, workspaceUUID, sessionID, status); err != nil && !ignoreSessionStatusMutationError(err) {
 				return err
 			}
 			return nil
@@ -110,7 +110,7 @@ func (h *Handler) projectAggregatedSessionStatus(ctx context.Context, workspaceU
 			}
 		}
 	}
-	if err := h.db.SetSessionStatus(ctx, workspaceUUID, sessionID, status); err != nil && !errors.Is(err, db.ErrNotFound) {
+	if err := h.db.SetSessionStatus(ctx, workspaceUUID, sessionID, status); err != nil && !ignoreSessionStatusMutationError(err) {
 		return err
 	}
 	return nil
@@ -176,4 +176,8 @@ func (h *Handler) simpleSessionEvent(eventType, sessionID string, threadID *stri
 		ProcessedAt:      now,
 		CreatedAt:        now,
 	}, nil
+}
+
+func ignoreSessionStatusMutationError(err error) bool {
+	return errors.Is(err, db.ErrNotFound) || errors.Is(err, db.ErrInvalidStateTransition)
 }

--- a/tests/session_status_transition_test.go
+++ b/tests/session_status_transition_test.go
@@ -1,0 +1,33 @@
+package tests
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+)
+
+func TestSetSessionStatusRejectsTerminalToActive(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("status-transition-bucket"))
+	defer app.close()
+	ctx := t.Context()
+
+	defaultIDs := getDefaultDBIDs(t, app.pool)
+	agent := createAgent(t, app, `{"model":"claude-opus-4-8","name":"status-transition-agent"}`)
+	env := createEnvironment(t, app, `{"name":"status-transition-env"}`)
+	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
+
+	if err := app.db.SetSessionStatus(ctx, defaultIDs.WorkspaceUUID, session.ID, "running"); err != nil {
+		t.Fatalf("idle → running: %v", err)
+	}
+	if err := app.db.SetSessionStatus(ctx, defaultIDs.WorkspaceUUID, session.ID, "terminated"); err != nil {
+		t.Fatalf("running → terminated: %v", err)
+	}
+	err := app.db.SetSessionStatus(ctx, defaultIDs.WorkspaceUUID, session.ID, "idle")
+	if !errors.Is(err, db.ErrInvalidStateTransition) {
+		t.Fatalf("terminated → idle: err = %v, want ErrInvalidStateTransition", err)
+	}
+	if err := app.db.SetSessionStatus(ctx, defaultIDs.WorkspaceUUID, "sesn_missing", "idle"); !errors.Is(err, db.ErrNotFound) {
+		t.Fatalf("missing session: err = %v, want ErrNotFound", err)
+	}
+}


### PR DESCRIPTION
## 改动

- `SetStatus` SQL 增加 CAS 守卫：`AND (status IN ('idle','running','rescheduling') OR status = #{status})`——活跃三态之间可流转、同状态幂等更新可命中，terminated 等终态不可回退（原子，无先读后写竞态）
- `rowsAffected == 0` 时回读区分错误：不存在 → `ErrNotFound`；存在 → `ErrInvalidStateTransition`（命名构造 `newInvalidStateTransition`），错误合同集中在 db 层
- `event_effects.go` 的事件投影路径：`ErrInvalidStateTransition` 与 `ErrNotFound` 一并忽略——事件乱序导致的状态回退不应中断事件处理

## 现状问题

此前 `UPDATE sessions SET status = ?` 无条件更新，terminated 的 session 可被 API 改回 idle 继续使用，状态机语义被破坏。

## 范围说明

issue 中「归档/删除前校验 running」不在本 PR：归档/删除走独立 mapper 路径，需单独处理，避免本 PR 范围膨胀。

## 测试

- `TestSessionMapperSetStatusRestrictsPredecessors`：SQL 守卫断言（生成 SQL + 参数绑定）
- `TestSetSessionStatusRejectsTerminalToActive`：E2E 守卫（API 创建 session → running → terminated → 断言回退 idle 报 `ErrInvalidStateTransition`，附带 `ErrNotFound` 路径）
- `go test ./internal/db/ ./internal/sessions/`、`just lint` 通过；已 rebase 到最新 main 并在干净库上验证

Part of #247（本 PR 完成 SetSessionStatus 转换校验；归档/删除前 running 校验为 #247 剩余范围，见正文）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for session status changes.
  - Prevented terminated sessions from returning to earlier states.
  - Added clearer error reporting for unavailable sessions and invalid status changes.
- **Bug Fixes**
  - Improved handling of status updates when sessions are missing or already in an invalid state.
  - Prevented invalid status events from disrupting session status updates.
- **Documentation**
  - Added documentation describing valid and invalid session status transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->