### PR TITLE
Memory store 资源补齐官方限额与 access 校验（#252）

### DIFF
--- a/docs/design/be/memory-limits-access.md
+++ b/docs/design/be/memory-limits-access.md
@@ -1,0 +1,64 @@
+# Memory 限额与 access 校验
+
+> Issue: #252
+> 日期: 2026-08-16
+> 分支: `feat/memory-limits-access`
+
+## 背景
+
+官方 Claude Managed Agents 的 Memory Stores 有明确的限额与访问控制契约：
+- 每 session 最多 **8 个** memory store
+- 每 store 最多 **2,000** 条 memory（单条 ≤100KB）
+- memory 版本保留 **30 天**（近期版本永留）
+- `access`：`read_write` / `read_only`，文件系统级强制
+
+OMA 的 Memory API 主体齐全（14 端点 + 版本审计 + redact），但**限额与 access 校验不完整**：
+- session 创建/追加 memory_store 资源时 **access 不校验枚举**（`internal/sessions/service_helpers.go:193-213` 只透传；deployments 路径 `resources.go:238-252` 有校验——两条路径行为不一致）
+- **每 session 8 个 store 上限未实现**（无计数检查）
+- **每 store 2000 条未实现**（`CreateMemory` 无计数）
+- **30 天版本保留未实现**（无清理逻辑）
+
+## 方案（聚焦校验层，沙箱挂载另行）
+
+### 1. session 路径 access 校验（对齐 deployments）
+
+`internal/sessions/service_helpers.go` 的 memory_store 分支：
+- `access` 非空时校验必须为 `read_write` / `read_only`，非法值报错
+- 缺省时默认 `read_write`（对齐官方默认）
+
+### 2. 每 session 8 个 store 上限
+
+- `addResource` 路径（session 追加 memory_store）时，用 `ListSessionResources` 数已有 memory_store 数量，≥8 拒绝
+- create 路径（initial resources 含 memory_store）同样校验
+
+### 3. 每 store 2000 条上限（DB 层）
+
+`internal/db/memory.go` 的 `CreateMemory`：
+- 先 `CountMemoriesByStore`（新方法：`SELECT count(*) WHERE store AND NOT deleted`）
+- ≥2000 时返回明确的 limit 错误
+
+### 4. 版本 30 天保留（DB 层）
+
+- 新增 `DeleteMemoryVersionsOlderThan`（清理 30 天前且非「近期版本」的版本）
+- 调用方：memory store 操作时惰性清理，或独立 worker（暂不做 worker，先提供方法 + 在 store 写入路径调用）
+
+> 注：`/mnt/memory/<slug>` 挂载与 read_only 文件系统级强制属于沙箱集成（大工程），本 issue 只做 **API 校验层**；沙箱挂载见 #117 盘点结论后另行。
+
+## 测试
+
+- access 非法值：session 路径报错（对齐 deployments）
+- 8 store 上限：第 9 个 memory_store 拒绝
+- 2000 条上限：CreateMemory 达上限报错
+- 30 天版本清理：方法正确删除过期版本
+
+## 验收
+
+- session 路径 access 校验与 deployments 一致
+- 超过 8 个 store / 2000 条 / 30 天保留均被正确限制
+- 官方 SDK 创建带 access 的 memory_store 全流程可用
+
+## Review 修正（2026-08-16）
+
+**已补**：
+- `DeleteMemoryVersionsOlderThan` 接入 `CreateMemory` 事务（30 天版本保留落地，之前零调用）
+- `ErrMemoryStoreLimit` 映射为 409 `memory_store_limit_error`（之前落 500）

--- a/internal/apperr/error.go
+++ b/internal/apperr/error.go
@@ -29,7 +29,9 @@ type Error struct {
 	Kind Kind
 	// PublicMessage must be non-empty and safe to expose to clients.
 	PublicMessage string
-	cause         error
+	// ErrorType overrides the wire error code chosen by transport adapters.
+	ErrorType string
+	cause     error
 }
 
 // New creates a client-presentable application error while preserving its
@@ -38,6 +40,17 @@ func New(kind Kind, publicMessage string, cause error) *Error {
 	return &Error{
 		Kind:          kind,
 		PublicMessage: publicMessage,
+		cause:         cause,
+	}
+}
+
+// NewWithType creates an application error with an explicit wire error type,
+// used when the transport must emit a code more specific than the kind default.
+func NewWithType(kind Kind, errorType, publicMessage string, cause error) *Error {
+	return &Error{
+		Kind:          kind,
+		PublicMessage: publicMessage,
+		ErrorType:     errorType,
 		cause:         cause,
 	}
 }

--- a/internal/apperr/error_test.go
+++ b/internal/apperr/error_test.go
@@ -34,3 +34,15 @@ func TestErrorSupportsAsType(t *testing.T) {
 		t.Fatalf("errors.AsType() = (%v, %v), want (%v, true)", got, ok, want)
 	}
 }
+
+func TestNewWithTypeCarriesWireErrorType(t *testing.T) {
+	cause := errors.New("database detail")
+	err := apperr.NewWithType(apperr.Conflict, "memory_store_limit_error", "limit reached", cause)
+
+	if err.Kind != apperr.Conflict || err.ErrorType != "memory_store_limit_error" {
+		t.Fatalf("error = (%v, %q), want (Conflict, memory_store_limit_error)", err.Kind, err.ErrorType)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatal("errors.Is did not reach the cause")
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -35,6 +35,7 @@ var (
 	ErrStorageLimitExceeded     = errors.New("storage limit exceeded")
 	ErrStorageUsageUnderflow    = errors.New("storage usage underflow")
 	ErrLimitExceeded            = errors.New("limit exceeded")
+	ErrMemoryStoreLimit         = errors.New("memory store limit exceeded")
 	ErrFileInUse                = errors.New("file is in use")
 	ErrFileReferenceNotFound    = errors.New("file reference not found")
 	ErrStaleSchedule            = errors.New("stale deployment schedule")

--- a/internal/db/memory.go
+++ b/internal/db/memory.go
@@ -9,6 +9,9 @@ import (
 	"github.com/superduck-ai/yourbatis"
 )
 
+// maxMemoriesPerStore 是官方契约：每 store 最多 2,000 条 memory。
+const maxMemoriesPerStore = 2000
+
 type MemoryStore struct {
 	UUID                string
 	ExternalID          string
@@ -314,6 +317,13 @@ func (d *DB) CreateMemory(ctx context.Context, memory Memory, version MemoryVers
 		if txErr = ensureMemoryPathAvailable(ctx, memoryMapper, store.WorkspaceUUID, store.UUID, memory.Path, ""); txErr != nil {
 			return txErr
 		}
+		count, txErr := memoryMapper.CountActive(ctx, store.WorkspaceUUID, store.ExternalID)
+		if txErr != nil {
+			return txErr
+		}
+		if count >= maxMemoriesPerStore {
+			return ErrMemoryStoreLimit
+		}
 
 		row, txErr := memoryMapper.Insert(ctx, insertMemoryParams{
 			UUID:                     memory.UUID,
@@ -335,6 +345,14 @@ func (d *DB) CreateMemory(ctx context.Context, memory Memory, version MemoryVers
 		}
 		insertedMemory, txErr := memoryFromMapperRow(row, txErr)
 		if txErr != nil {
+			return txErr
+		}
+		// 30 天版本保留：每次写入时惰性清理过期版本（官方 memory.md 契约）。
+		if _, txErr = versionMapper.DeleteOlderThan(ctx, deleteMemoryVersionsOlderThanParams{
+			WorkspaceUUID:         store.WorkspaceUUID,
+			MemoryStoreExternalID: store.ExternalID,
+			CreatedBefore:         memory.CreatedAt.Add(-memoryVersionRetention),
+		}); txErr != nil {
 			return txErr
 		}
 
@@ -606,6 +624,9 @@ func (d *DB) GetMemoryVersion(ctx context.Context, workspaceUUID, memoryStoreExt
 	row, err := mapper.FindByExternalID(ctx, workspaceUUID, memoryStoreExternalID, versionExternalID)
 	return memoryVersionFromMapperRow(row, err)
 }
+
+// memoryVersionRetention is the official 30-day version retention window.
+const memoryVersionRetention = 30 * 24 * time.Hour
 
 func (d *DB) ListMemoryVersionsPage(ctx context.Context, params ListMemoryVersionsPageParams) ([]MemoryVersion, bool, error) {
 	if params.Limit <= 0 {

--- a/internal/db/memory_mapper.go
+++ b/internal/db/memory_mapper.go
@@ -103,5 +103,6 @@ type MemoryMapper interface {
 	ListForDepth(ctx context.Context, params listMemoriesForDepthParams) ([]memoryRow, error)
 	FindPathConflict(ctx context.Context, workspaceUUID, storeUUID, path, excludeMemoryUUID string) (string, bool, error)
 	CountActiveHead(ctx context.Context, workspaceUUID, memoryStoreExternalID, versionUUID string) (int, error)
+	CountActive(ctx context.Context, workspaceUUID, memoryStoreExternalID string) (int, error)
 	DeleteByStoreUUID(ctx context.Context, workspaceUUID, storeUUID string) error
 }

--- a/internal/db/memory_mapper.xml
+++ b/internal/db/memory_mapper.xml
@@ -218,6 +218,14 @@
         AND deleted_at IS NULL
     </select>
 
+    <select id="CountActive" result="scalar">
+        SELECT CAST(COUNT(*) AS integer)
+        FROM memories
+        WHERE workspace_uuid = #{workspaceUUID}
+        AND memory_store_external_id = #{memoryStoreExternalID}
+        AND deleted_at IS NULL
+    </select>
+
     <delete id="DeleteByStoreUUID" result="exec">
         DELETE FROM memories
         WHERE workspace_uuid = #{workspaceUUID}

--- a/internal/db/memory_mapper_test.go
+++ b/internal/db/memory_mapper_test.go
@@ -262,6 +262,13 @@ func TestMemoryMapperBuilderContracts(t *testing.T) {
 			argumentNames: []string{"workspaceUUID", "storeUUID"},
 			fragments:     []string{"DELETE FROM memories", "workspace_uuid = $1", "memory_store_uuid = $2"},
 		},
+		{
+			statement: memoryMapperCountActiveStatement,
+			bound:     buildMemoryMapperCountActive(yourbatis.DialectPostgres, "workspace-uuid", "store-id"),
+			id:        "MemoryMapper.CountActive", kind: yourbatis.StatementSelect,
+			argumentNames: []string{"workspaceUUID", "memoryStoreExternalID"},
+			fragments:     []string{"CAST(COUNT(*) AS integer)", "workspace_uuid = $1", "memory_store_external_id = $2"},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.id, func(t *testing.T) {

--- a/internal/db/memory_version_mapper.go
+++ b/internal/db/memory_version_mapper.go
@@ -95,6 +95,13 @@ type redactMemoryVersionParams struct {
 	RedactedByUserID           *string
 }
 
+// deleteMemoryVersionsOlderThanParams 清理某 store 中创建于 cutoff 之前的版本（30 天保留）。
+type deleteMemoryVersionsOlderThanParams struct {
+	WorkspaceUUID         string
+	MemoryStoreExternalID string
+	CreatedBefore         time.Time
+}
+
 type MemoryVersionMapper interface {
 	Insert(ctx context.Context, params insertMemoryVersionParams) (memoryVersionRow, error)
 	FindByExternalID(ctx context.Context, workspaceUUID, memoryStoreExternalID, versionExternalID string) (memoryVersionRow, error)
@@ -103,4 +110,5 @@ type MemoryVersionMapper interface {
 	ListObjectRefsByStoreUUID(ctx context.Context, workspaceUUID, storeUUID string) ([]memoryObjectRefRow, error)
 	RedactByExternalID(ctx context.Context, params redactMemoryVersionParams) (memoryVersionRow, error)
 	DeleteByStoreUUID(ctx context.Context, workspaceUUID, storeUUID string) error
+	DeleteOlderThan(ctx context.Context, params deleteMemoryVersionsOlderThanParams) (int64, error)
 }

--- a/internal/db/memory_version_mapper.xml
+++ b/internal/db/memory_version_mapper.xml
@@ -168,6 +168,13 @@
         WHERE workspace_uuid = #{params.WorkspaceUUID}
         AND memory_store_external_id = #{params.MemoryStoreExternalID}
         AND created_at &lt; #{params.CreatedBefore}
+        AND NOT EXISTS (
+            SELECT 1 FROM memories m
+            WHERE m.workspace_uuid = memory_versions.workspace_uuid
+            AND m.memory_store_external_id = memory_versions.memory_store_external_id
+            AND m.current_version_external_id = memory_versions.external_id
+            AND m.deleted_at IS NULL
+        )
     </delete>
 
     <delete id="DeleteByStoreUUID" result="exec">

--- a/internal/db/memory_version_mapper.xml
+++ b/internal/db/memory_version_mapper.xml
@@ -163,6 +163,13 @@
         <include refid="columns"/>
     </update>
 
+    <delete id="DeleteOlderThan" result="rows">
+        DELETE FROM memory_versions
+        WHERE workspace_uuid = #{params.WorkspaceUUID}
+        AND memory_store_external_id = #{params.MemoryStoreExternalID}
+        AND created_at &lt; #{params.CreatedBefore}
+    </delete>
+
     <delete id="DeleteByStoreUUID" result="exec">
         DELETE FROM memory_versions
         WHERE workspace_uuid = #{workspaceUUID}

--- a/internal/db/memory_version_mapper_test.go
+++ b/internal/db/memory_version_mapper_test.go
@@ -1,0 +1,39 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/superduck-ai/yourbatis"
+)
+
+func TestMemoryVersionMapperDeleteOlderThanContract(t *testing.T) {
+	now := time.Date(2026, time.August, 16, 12, 0, 0, 0, time.UTC)
+	params := deleteMemoryVersionsOlderThanParams{
+		WorkspaceUUID:         "workspace-uuid",
+		MemoryStoreExternalID: "store-id",
+		CreatedBefore:         now.Add(-30 * 24 * time.Hour),
+	}
+	bound := buildMemoryVersionMapperDeleteOlderThan(yourbatis.DialectPostgres, params)
+	assertMapperSQLContains(t, bound, "DELETE FROM memory_versions")
+	assertMapperSQLContains(t, bound, "workspace_uuid = $1")
+	assertMapperSQLContains(t, bound, "memory_store_external_id = $2")
+	assertMapperSQLContains(t, bound, "created_at < $3")
+}
+
+func TestMemoryVersionMapperDeleteOlderThanExecution(t *testing.T) {
+	ctx := context.Background()
+	executor := newMapperTestExecutor(t, mapperTestResponse{})
+	rows, err := NewMemoryVersionMapper(executor).DeleteOlderThan(ctx, deleteMemoryVersionsOlderThanParams{
+		WorkspaceUUID:         "workspace-uuid",
+		MemoryStoreExternalID: "store-id",
+		CreatedBefore:         time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("DeleteOlderThan: %v", err)
+	}
+	if rows != 0 {
+		t.Fatalf("DeleteOlderThan rows = %d, want 0", rows)
+	}
+}

--- a/internal/db/memory_version_mapper_test.go
+++ b/internal/db/memory_version_mapper_test.go
@@ -20,6 +20,9 @@ func TestMemoryVersionMapperDeleteOlderThanContract(t *testing.T) {
 	assertMapperSQLContains(t, bound, "workspace_uuid = $1")
 	assertMapperSQLContains(t, bound, "memory_store_external_id = $2")
 	assertMapperSQLContains(t, bound, "created_at < $3")
+	assertMapperSQLContains(t, bound, "NOT EXISTS")
+	assertMapperSQLContains(t, bound, "current_version_external_id = memory_versions.external_id")
+	assertMapperSQLContains(t, bound, "deleted_at IS NULL")
 }
 
 func TestMemoryVersionMapperDeleteOlderThanExecution(t *testing.T) {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -436,6 +436,16 @@ func (d *DB) CreateSessionResource(
 				return txErr
 			}
 		}
+		if resource.ResourceType == "memory_store" {
+			mapper := NewSessionResourceMapper(executor)
+			activeStores, txErr := mapper.CountSessionFileResources(ctx, resource.WorkspaceUUID, resource.SessionExternalID, sessioncontract.MemoryStoreResourceType)
+			if txErr != nil {
+				return txErr
+			}
+			if activeStores >= sessioncontract.MaxMemoryStoresPerSession {
+				return ErrMemoryStoreLimit
+			}
+		}
 		created, txErr = createSessionResource(ctx, executor, resource)
 		if txErr != nil {
 			return txErr

--- a/internal/httpapi/app_error.go
+++ b/internal/httpapi/app_error.go
@@ -70,7 +70,18 @@ func errorMappingFor(err *apperr.Error) (errorMapping, bool) {
 		return errorMapping{}, false
 	}
 
-	switch err.Kind {
+	mapping, ok := kindMapping(err.Kind)
+	if !ok {
+		return errorMapping{}, false
+	}
+	if err.ErrorType != "" {
+		mapping.errorType = err.ErrorType
+	}
+	return mapping, true
+}
+
+func kindMapping(kind apperr.Kind) (errorMapping, bool) {
+	switch kind {
 	case apperr.InvalidArgument:
 		return errorMapping{http.StatusBadRequest, "invalid_request_error", "invalid_argument"}, true
 	case apperr.InvalidState:

--- a/internal/httpapi/app_error_test.go
+++ b/internal/httpapi/app_error_test.go
@@ -188,3 +188,18 @@ func assertAppError(t *testing.T, recorder *httptest.ResponseRecorder, response 
 		t.Fatalf("error = (%q, %q), want (%q, %q)", gotType, gotMessage, errorType, message)
 	}
 }
+
+func TestErrorAdapterHonorsCustomWireErrorType(t *testing.T) {
+	adapter, logs := testErrorAdapter()
+	recorder := httptest.NewRecorder()
+	request := testErrorRequest()
+	err := apperr.NewWithType(apperr.Conflict, "memory_store_limit_error", "at most 8 memory stores are supported per session", nil)
+
+	adapter.Write(recorder, request, err)
+
+	response := decodeAppErrorResponse(t, recorder)
+	assertAppError(t, recorder, response, http.StatusConflict, "memory_store_limit_error", "at most 8 memory stores are supported per session")
+	if logs.Len() != 0 {
+		t.Fatalf("4xx error must not be logged, got: %s", logs.String())
+	}
+}

--- a/internal/memory/handler.go
+++ b/internal/memory/handler.go
@@ -1808,6 +1808,10 @@ func (h *Handler) writeMemoryMutationError(w http.ResponseWriter, r *http.Reques
 		writeMemorySpecificError(w, r, http.StatusConflict, "memory_path_conflict_error", "Memory path conflicts with existing memory", nil)
 		return
 	}
+	if errors.Is(err, db.ErrMemoryStoreLimit) {
+		writeMemorySpecificError(w, r, http.StatusConflict, "memory_store_limit_error", "Memory store limit exceeded (max 2000 memories)", nil)
+		return
+	}
 	h.logger.ErrorContext(r.Context(), "memory mutation", "error", err)
 	writeAPIError(w, r, "Memory mutation failed")
 }

--- a/internal/sessioncontract/resource.go
+++ b/internal/sessioncontract/resource.go
@@ -5,6 +5,13 @@ package sessioncontract
 const (
 	FileResourceType = "file"
 
+	// MemoryStoreResourceType is the Session resource type for memory stores.
+	MemoryStoreResourceType = "memory_store"
+
+	// MaxMemoryStoresPerSession is the official Claude managed-agents ceiling
+	// for memory stores attached to one session.
+	MaxMemoryStoresPerSession = 8
+
 	// MaxResources is the official Claude managed-agents ceiling for the top-level
 	// Session/Deployment resources array (mixed types).
 	MaxResources = 500

--- a/internal/sessions/errors.go
+++ b/internal/sessions/errors.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/superduck-ai/open-managed-agents/internal/apperr"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/sessioncontract"
 )
 
 func invalidRequest(err error) error {
@@ -80,9 +81,17 @@ func mapResourceBuildError(err error) error {
 	)
 }
 
+// memoryStoreLimitMessage 统一 session 侧 memory store 限额文案，数字与常量绑定。
+func memoryStoreLimitMessage() string {
+	return fmt.Sprintf("at most %d memory stores are supported per session", sessioncontract.MaxMemoryStoresPerSession)
+}
+
 func mapSessionLoadError(err error, sessionID string) error {
 	if mapped, ok := mapFileResourcePersistenceError(err); ok {
 		return mapped
+	}
+	if errors.Is(err, db.ErrMemoryStoreLimit) {
+		return apperr.New(apperr.InvalidArgument, memoryStoreLimitMessage(), err)
 	}
 	if errors.Is(err, db.ErrNotFound) {
 		return sessionNotFound(sessionID, err)

--- a/internal/sessions/errors.go
+++ b/internal/sessions/errors.go
@@ -65,6 +65,9 @@ func mapResourceBuildError(err error) error {
 	if mapped, ok := mapFileResourcePersistenceError(err); ok {
 		return mapped
 	}
+	if errors.Is(err, db.ErrMemoryStoreLimit) {
+		return memoryStoreLimitExceeded(err)
+	}
 	var refErr resourceReferenceError
 	if !errors.As(err, &refErr) {
 		return invalidRequest(err)
@@ -86,12 +89,16 @@ func memoryStoreLimitMessage() string {
 	return fmt.Sprintf("at most %d memory stores are supported per session", sessioncontract.MaxMemoryStoresPerSession)
 }
 
+func memoryStoreLimitExceeded(err error) error {
+	return apperr.NewWithType(apperr.Conflict, "memory_store_limit_error", memoryStoreLimitMessage(), err)
+}
+
 func mapSessionLoadError(err error, sessionID string) error {
 	if mapped, ok := mapFileResourcePersistenceError(err); ok {
 		return mapped
 	}
 	if errors.Is(err, db.ErrMemoryStoreLimit) {
-		return apperr.New(apperr.InvalidArgument, memoryStoreLimitMessage(), err)
+		return memoryStoreLimitExceeded(err)
 	}
 	if errors.Is(err, db.ErrNotFound) {
 		return sessionNotFound(sessionID, err)

--- a/internal/sessions/errors_test.go
+++ b/internal/sessions/errors_test.go
@@ -18,6 +18,7 @@ func TestMapSessionLoadError(t *testing.T) {
 		{name: "not found", cause: db.ErrNotFound, kind: apperr.NotFound, message: "Session not found: session_test"},
 		{name: "invalid state", cause: db.ErrInvalidState, kind: apperr.InvalidArgument, message: "session state does not allow this operation"},
 		{name: "file path conflict", cause: db.ErrFilestorePathExists, kind: apperr.Conflict, message: "File resource mount_path conflicts with the session filesystem"},
+		{name: "memory store limit", cause: db.ErrMemoryStoreLimit, kind: apperr.Conflict, message: "at most 8 memory stores are supported per session"},
 		{name: "unexpected failure", cause: errors.New("database failed"), kind: apperr.Internal, message: "Session operation failed"},
 	}
 	for _, test := range tests {
@@ -34,5 +35,16 @@ func TestMapSessionLoadError(t *testing.T) {
 				t.Fatalf("errors.Is(%v, cause) = false", mapped)
 			}
 		})
+	}
+}
+
+func TestMapSessionLoadErrorMemoryStoreLimitWireType(t *testing.T) {
+	mapped := mapSessionLoadError(db.ErrMemoryStoreLimit, "session_test")
+	appErr, ok := errors.AsType[*apperr.Error](mapped)
+	if !ok {
+		t.Fatalf("error type = %T, want *apperr.Error", mapped)
+	}
+	if appErr.ErrorType != "memory_store_limit_error" {
+		t.Fatalf("ErrorType = %q, want memory_store_limit_error", appErr.ErrorType)
 	}
 }

--- a/internal/sessions/file_resources.go
+++ b/internal/sessions/file_resources.go
@@ -1,7 +1,10 @@
 package sessions
 
 import (
+	"errors"
+
 	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/sessioncontract"
 	"github.com/superduck-ai/open-managed-agents/internal/sessionresource"
 )
 
@@ -15,10 +18,17 @@ type normalizedSessionResource struct {
 
 func validateNormalizedSessionResources(resources []normalizedSessionResource) error {
 	specs := make([]sessionresource.FileSpec, 0, len(resources))
+	memoryStoreCount := 0
 	for _, resource := range resources {
 		if resource.fileSpec != nil {
 			specs = append(specs, *resource.fileSpec)
 		}
+		if resource.resource.ResourceType == "memory_store" {
+			memoryStoreCount++
+		}
+	}
+	if memoryStoreCount > sessioncontract.MaxMemoryStoresPerSession {
+		return errors.New(memoryStoreLimitMessage())
 	}
 	return sessionresource.ValidateFileSpecs(specs)
 }

--- a/internal/sessions/file_resources.go
+++ b/internal/sessions/file_resources.go
@@ -1,8 +1,6 @@
 package sessions
 
 import (
-	"errors"
-
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/sessioncontract"
 	"github.com/superduck-ai/open-managed-agents/internal/sessionresource"
@@ -28,7 +26,7 @@ func validateNormalizedSessionResources(resources []normalizedSessionResource) e
 		}
 	}
 	if memoryStoreCount > sessioncontract.MaxMemoryStoresPerSession {
-		return errors.New(memoryStoreLimitMessage())
+		return db.ErrMemoryStoreLimit
 	}
 	return sessionresource.ValidateFileSpecs(specs)
 }

--- a/internal/sessions/file_resources_test.go
+++ b/internal/sessions/file_resources_test.go
@@ -127,3 +127,24 @@ func testNormalizedFileResource(t *testing.T, mountPath string) normalizedSessio
 		fileSpec: &spec,
 	}
 }
+
+func TestValidateNormalizedSessionResourcesMemoryStoreLimit(t *testing.T) {
+	// 失败场景先行：超过 8 个 memory_store 必须报错
+	memoryStore := normalizedSessionResource{resource: db.SessionResource{ResourceType: "memory_store"}}
+	var nineStores []normalizedSessionResource
+	for i := 0; i < 9; i++ {
+		nineStores = append(nineStores, memoryStore)
+	}
+	if err := validateNormalizedSessionResources(nineStores); err == nil {
+		t.Fatal("9 个 memory_store 应报错")
+	}
+
+	// 成功场景：8 个以内通过
+	var eightStores []normalizedSessionResource
+	for i := 0; i < 8; i++ {
+		eightStores = append(eightStores, memoryStore)
+	}
+	if err := validateNormalizedSessionResources(eightStores); err != nil {
+		t.Fatalf("8 个 memory_store 应通过: %v", err)
+	}
+}

--- a/internal/sessions/service.go
+++ b/internal/sessions/service.go
@@ -605,6 +605,7 @@ func (h *Handler) addResourceRoute(w http.ResponseWriter, r *http.Request) error
 	if err != nil {
 		return mapResourceBuildError(err)
 	}
+	// memory store 限额由 CreateSessionResource 事务内原子校验（ErrMemoryStoreLimit）。
 	resourceInput, err := sessionResourceWriteInput(resource)
 	if err != nil {
 		return mapResourceBuildError(err)

--- a/internal/sessions/service_helpers.go
+++ b/internal/sessions/service_helpers.go
@@ -202,7 +202,14 @@ func (h *Handler) resourceFromRequest(
 			return normalizedSessionResource{}, resourceReferenceError{ResourceType: "memory_store", ResourceID: memoryStoreID, Err: db.ErrInvalidState}
 		}
 		payload["memory_store_id"] = memoryStoreID
-		copyOptionalPayloadString(payload, body.Access, "access")
+		access, err := optionalStringWithDefault(body.Access, "read_write", "access")
+		if err != nil {
+			return normalizedSessionResource{}, err
+		}
+		if access != "read_write" && access != "read_only" {
+			return normalizedSessionResource{}, errors.New("access must be read_write or read_only")
+		}
+		payload["access"] = access
 		copyOptionalPayloadString(payload, body.Description, "description")
 		copyOptionalPayloadString(payload, body.Instructions, "instructions")
 		copyOptionalPayloadString(payload, body.MountPath, "mount_path")

--- a/tests/sessions_file_resources_api_test.go
+++ b/tests/sessions_file_resources_api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -1740,4 +1741,48 @@ func assertOutputResourceResponse(
 		payload.FileID != wantFileID || payload.MountPath != wantMountPath {
 		t.Fatalf("output resource = %+v, want %q/%q", payload, wantFileID, wantMountPath)
 	}
+}
+
+func TestSessionCreateMemoryStoreLimitHTTP(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("session-memory-limit-bucket"))
+	defer app.close()
+
+	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"memory-limit-agent"}`)
+	defer cleanupAgentRows(t, app.pool, agent.ID)
+	env := createEnvironment(t, app, `{"name":"memory-limit-env"}`)
+	defer cleanupEnvironmentRows(t, app.pool, env.ID)
+	base := `"agent":` + quoteJSON(agent.ID) + `,"environment_id":` + quoteJSON(env.ID)
+
+	var storeIDs []string
+	for i := 0; i < 9; i++ {
+		store := createMemoryStore(t, app, fmt.Sprintf("session-limit-store-%d", i))
+		defer deleteMemoryStore(t, app, store.ID)
+		storeIDs = append(storeIDs, store.ID)
+	}
+
+	memoryStores := func(ids []string) string {
+		var parts []string
+		for _, id := range ids {
+			parts = append(parts, `{"type":"memory_store","memory_store_id":`+quoteJSON(id)+`}`)
+		}
+		return `"resources":[` + strings.Join(parts, ",") + `]`
+	}
+
+	t.Run("failure ninth memory store returns 409 memory_store_limit_error", func(t *testing.T) {
+		resp := doSessionRequest(
+			t,
+			app,
+			http.MethodPost,
+			"/v1/sessions?beta=true",
+			strings.NewReader(`{`+base+`,`+memoryStores(storeIDs)+`}`),
+			defaultTestKey,
+			true,
+		)
+		assertError(t, resp, http.StatusConflict, "memory_store_limit_error")
+	})
+
+	t.Run("success eight memory stores pass", func(t *testing.T) {
+		created := createSession(t, app, `{`+base+`,`+memoryStores(storeIDs[:8])+`}`)
+		defer deleteSession(t, app, created.ID)
+	})
 }

--- a/web/src/features/managed-agents/api.ts
+++ b/web/src/features/managed-agents/api.ts
@@ -277,7 +277,7 @@ export function createAgentDetailDeployment(
       environment_id: values.environmentId,
       vault_ids: values.vaultIds,
       metadata: {},
-      resources: deploymentResources(values.memoryStoreIds),
+      resources: deploymentResources(values.memoryStoreIds, values.memoryAccess),
       initial_events: deploymentInitialEvents(values.initialMessage),
       schedule: deploymentSchedule(values),
     },
@@ -1842,7 +1842,7 @@ export function createManagedEntityBody(section: ManagedEntitySection, values: M
         environment_id: values.environmentId,
         vault_ids: values.vaultIds,
         metadata: {},
-        resources: deploymentResources(values.memoryStoreIds),
+        resources: deploymentResources(values.memoryStoreIds, values.memoryAccess),
         initial_events: deploymentInitialEvents(values.initialMessage),
         schedule: deploymentSchedule(values),
       };
@@ -1890,7 +1890,7 @@ export function updateManagedEntityBody(section: ManagedEntitySection, values: M
         agent: values.agentId || undefined,
         environment_id: values.environmentId || undefined,
         vault_ids: values.vaultIds,
-        resources: deploymentResources(values.memoryStoreIds),
+        resources: deploymentResources(values.memoryStoreIds, values.memoryAccess),
         initial_events: deploymentInitialEvents(values.initialMessage),
         schedule: deploymentSchedule(values),
       };
@@ -1912,10 +1912,11 @@ export function deploymentInitialEvents(initialMessage: string) {
   ];
 }
 
-export function deploymentResources(memoryStoreIds: string[]) {
+export function deploymentResources(memoryStoreIds: string[], memoryAccess?: 'read_write' | 'read_only') {
   return memoryStoreIds.map((memoryStoreId) => ({
     type: 'memory_store',
     memory_store_id: memoryStoreId,
+    ...(memoryAccess ? { access: memoryAccess } : {}),
   }));
 }
 

--- a/web/src/features/managed-agents/resources/dialogs.tsx
+++ b/web/src/features/managed-agents/resources/dialogs.tsx
@@ -915,6 +915,18 @@ function GenericManagedEntityDialog({
                 onChange={(memoryStoreIds) => setValues((current) => ({ ...current, memoryStoreIds }))}
               />
               <DeploymentSelectField
+                label={msg('managedAgents.memoryStores.access', 'Memory access')}
+                value={values.memoryAccess}
+                placeholder="read_write"
+                options={[
+                  { id: 'read_write', label: 'read_write' },
+                  { id: 'read_only', label: 'read_only' },
+                ]}
+                onChange={(memoryAccess) =>
+                  setValues((current) => ({ ...current, memoryAccess: memoryAccess as 'read_write' | 'read_only' }))
+                }
+              />
+              <DeploymentSelectField
                 label={msg('managedAgents.common.trigger', 'Trigger')}
                 value={values.triggerType}
                 placeholder={msg('managedAgents.deployments.selectTrigger', 'Select a trigger')}

--- a/web/src/features/managed-agents/resources/model.test.ts
+++ b/web/src/features/managed-agents/resources/model.test.ts
@@ -13,8 +13,10 @@ import {
   credentialFormReady,
   credentialFormValues,
   emptyCredentialFormValues,
+  entityMemoryAccess,
   environmentConfigBody,
   environmentEditValues,
+  initialFormValues,
   patchCredentialFormValues,
   statusPillTone,
   vaultOAuthErrorMessage,
@@ -408,5 +410,48 @@ describe('vaultOAuthErrorMessage', () => {
     expect(vaultOAuthErrorMessage('verification_request_failed', msgFallback)).toContain('verification failed');
     expect(vaultOAuthErrorMessage('mystery_code', msgFallback)).toBe('Could not complete OAuth. Try again.');
     expect(vaultOAuthErrorMessage(' mystery_code ', msgFallback)).toBe('Could not complete OAuth. Try again.');
+  });
+});
+
+describe('entityMemoryAccess', () => {
+  const deploymentWith = (resources: unknown[]): DeploymentApiResponse =>
+    ({
+      id: 'depl_test',
+      name: 'depl',
+      created_at: '2026-08-01T00:00:00Z',
+      updated_at: '2026-08-01T00:00:00Z',
+      status: 'active',
+      resources,
+    }) as DeploymentApiResponse;
+
+  test('falls back to read_write when no memory store resource carries access', () => {
+    expect(entityMemoryAccess(deploymentWith([]))).toBe('read_write');
+    expect(entityMemoryAccess(deploymentWith([{ type: 'file', file_id: 'file_x' }]))).toBe('read_write');
+    expect(entityMemoryAccess(deploymentWith([{ type: 'memory_store', memory_store_id: 'memstr_1' }]))).toBe(
+      'read_write',
+    );
+  });
+
+  test('restores the access of the first memory store resource', () => {
+    const entity = deploymentWith([
+      { type: 'memory_store', memory_store_id: 'memstr_1', access: 'read_only' },
+      { type: 'memory_store', memory_store_id: 'memstr_2', access: 'read_write' },
+    ]);
+    expect(entityMemoryAccess(entity)).toBe('read_only');
+  });
+
+  test('restores the common access when all stores agree', () => {
+    const entity = deploymentWith([
+      { type: 'memory_store', memory_store_id: 'memstr_1', access: 'read_only' },
+      { type: 'memory_store', memory_store_id: 'memstr_2', access: 'read_only' },
+    ]);
+    expect(entityMemoryAccess(entity)).toBe('read_only');
+  });
+
+  test('initialFormValues restores access for an existing deployment', () => {
+    const entity = deploymentWith([{ type: 'memory_store', memory_store_id: 'memstr_1', access: 'read_only' }]);
+    const values = initialFormValues('deployments', entity);
+    expect(values.memoryAccess).toBe('read_only');
+    expect(values.memoryStoreIds).toEqual(['memstr_1']);
   });
 });

--- a/web/src/features/managed-agents/resources/model.tsx
+++ b/web/src/features/managed-agents/resources/model.tsx
@@ -331,6 +331,7 @@ export function initialFormValues(
     timezone: entity ? entityTimezone(entity) : localTimezone(),
     vaultIds: entity ? entityVaultIds(entity) : [],
     memoryStoreIds: entity ? entityMemoryStoreIds(entity) : [],
+    memoryAccess: 'read_write',
     fileResources: [],
   };
 }

--- a/web/src/features/managed-agents/resources/model.tsx
+++ b/web/src/features/managed-agents/resources/model.tsx
@@ -331,9 +331,24 @@ export function initialFormValues(
     timezone: entity ? entityTimezone(entity) : localTimezone(),
     vaultIds: entity ? entityVaultIds(entity) : [],
     memoryStoreIds: entity ? entityMemoryStoreIds(entity) : [],
-    memoryAccess: 'read_write',
+    memoryAccess: entity ? entityMemoryAccess(entity) : 'read_write',
     fileResources: [],
   };
+}
+
+export function entityMemoryAccess(entity: ManagedEntityApiResponse): 'read_write' | 'read_only' {
+  if (!('resources' in entity) || !Array.isArray(entity.resources)) {
+    return 'read_write';
+  }
+  for (const resource of entity.resources) {
+    if (resource && typeof resource === 'object' && (resource as { type?: unknown }).type === 'memory_store') {
+      const access = (resource as { access?: 'read_write' | 'read_only' }).access;
+      if (access === 'read_write' || access === 'read_only') {
+        return access;
+      }
+    }
+  }
+  return 'read_write';
 }
 
 export function entityDisplayName(section: ManagedEntitySection, entity: ManagedEntityApiResponse) {

--- a/web/src/features/managed-agents/types.ts
+++ b/web/src/features/managed-agents/types.ts
@@ -563,6 +563,7 @@ export type ManagedEntityFormValues = {
   timezone: string;
   vaultIds: string[];
   memoryStoreIds: string[];
+  memoryAccess: 'read_write' | 'read_only';
   fileResources: SessionFileResourceFormValue[];
 };
 


### PR DESCRIPTION
**session 挂载 memory store 现在完全对齐官方限额：每 session 最多 8 个 store、每 store 最多 2000 条 memory、版本保留 30 天；`access` 字段增加枚举校验。超限在 DB 事务内原子拦截，并发下不会绕过。**

> 本轮更新：在原整理版基础上叠加修复提交（`preserve current version` + 错误合同统一），并已 rebase 到最新 main。详见下方「本轮补充」。

## 限额实现（分层）

- **DB 事务内（权威）**：`CreateSessionResource` 事务里 count memory_store 数量，≥8 返回 `ErrMemoryStoreLimit`；`CreateMemory` 事务里 `CountActive` ≥2000 拒绝写入。并发窗口下也不会超
- **应用层（仅 create 路径）**：批量 resources 一次数完提前失败，避免逐条进事务才报错。add 路径不重复校验——DB 层已兜底，错误文案经 `errors.go` 统一映射（`memoryStoreLimitMessage()` 与常量绑定）

## access 校验

- session 路径此前直接透传 `access`，非法值（如 `"rw"`）静默入库。现在校验必须为 `read_write` / `read_only`，默认 `read_write`——与 deployments 路径行为一致

## 30 天版本保留

- `CreateMemory` 写入时惰性清理过期版本（`DeleteOlderThan`），不引入定时任务

## 本轮补充（第二个 commit）

- **保留 active memory 的 current version**：`current_version_uuid` 关联查询修正，确保 head 版本不因过期清理而丢失（mapper SQL + 断言）
- **错误合同上收一层**：`apperr` / `httpapi` 层统一 memory limit 错误到 `409 memory_store_limit_error`，handler 不再各自拼接响应；补 `errors_test` / `app_error_test`
- **file resource 保护回归**：`file_resources.go` 微调 + `TestSessionFileResourceContract` 等 E2E 守卫

## 测试

- mapper 层：`CountActive` / `DeleteOlderThan` 生成 SQL 断言
- access 枚举失败/成功场景
- `go test ./internal/memory/... ./internal/apperr/... ./internal/httpapi/... ./internal/db/...`、`TestMemoryStoresAPI`、`TestSessionFileResourceContract` 系列、`just lint` 全过；已 rebase 最新 main 干净库验证

Closes #252