### PR TITLE
Agent model 对象补齐 effort/speed 透传到沙箱（#250）

### DIFF
--- a/docs/design/be/agent-model-effort-speed.md
+++ b/docs/design/be/agent-model-effort-speed.md
@@ -1,0 +1,56 @@
+# Agent model 对象支持 effort 与 speed 透传
+
+> Issue: #250
+> 日期: 2026-08-16
+> 分支: `feat/agent-model-effort-speed`
+
+## 背景
+
+官方 Claude Managed Agents 的 agent 定义中，`model` 字段除模型 ID 字符串外，还支持对象形式 `{"id": "...", "speed": "fast", "effort": "high"}`：
+- `effort`：模型推理强度，接受字符串（`low` / `medium` / `high` / `xhigh` / `max`）或对象（`{"type": "high"}`）
+- `speed`：推理速度（`standard` / `fast`）
+- `inference_geo`：推理地域（`us` / `global`）——**本项目不做**（开源版不做地域限制，有意设计）
+
+## 问题
+
+OMA 目前对这两个字段处理不当：
+
+1. **`effort` 静默丢弃**：`internal/agents/handler.go:725-728` 的 `agentModelInput` 只有 `ID`/`Speed`，`json.Unmarshal` 忽略未知字段，用户传 `effort: "high"` **不报错也不生效**
+2. **`speed` 只回显不生效**：声明时通过校验（`:766-768`）、响应回显，但**从不下发到运行时**——`internal/environments/environment_manager.go:210-217` 的 `modelIDFromAgentSnapshot` 只取 `model.id`
+
+这属于「API 收下了但实际不生效」的静默失效。
+
+## 方案
+
+### 1. `normalizeModel` 支持 `effort`
+
+`internal/agents/handler.go`：
+- `agentModelInput` 增加 `Effort json.RawMessage`（兼容字符串和对象两种形式）
+- 归一化为规范形式：`{"type": "high"}`（对象）或 `"high"`（字符串）→ 统一输出 `{"type": "high"}` 结构（对齐官方响应回显格式）
+- 校验取值集合：`low` / `medium` / `high` / `xhigh` / `max`，非法值报错（不再静默丢弃）
+- `normalizedAgentModel` 增加 `Effort json.RawMessage` 字段
+
+### 2. `speed` 传递到运行时
+
+`internal/environments/environment_manager.go`：
+- `modelIDFromAgentSnapshot` 扩展为读取完整 model 对象（id + speed + effort）
+- 在 e2b 运行时 / 平台代理的模型请求中传递 `speed`（fast 模式）
+
+> 注：`speed`/`effort` 的实际执行在 Claude Code worker 侧（sandbox 内），OMA host 侧负责**配置下发**——把 model 对象完整传给 environment-manager payload，由 worker 消费。
+
+### 3. 响应回填
+
+- 省略 `effort` 时响应回填 `null`（或省略字段），省略 `speed` 回填 `"standard"`（既有行为）
+
+## 测试
+
+- `normalizeModel`：字符串形式、对象形式（effort 字符串/对象）、非法 effort 值报错、speed 合法/非法
+- `modelIDFromAgentSnapshot`：完整 model 对象 → id + speed + effort 传递
+- 回归：现有 agent create/update 测试
+
+## 验收
+
+- 官方 SDK 创建带 `effort` / `speed` 的 agent，字段真实生效（非静默丢弃）
+- 非法 `effort` 值返回明确错误
+- environment-manager payload 携带完整 model 对象（id + speed + effort）
+- 响应回显与官方格式一致

--- a/internal/agents/handler.go
+++ b/internal/agents/handler.go
@@ -723,13 +723,15 @@ func parseRequiredVersion(raw json.RawMessage) (int, error) {
 }
 
 type agentModelInput struct {
-	ID    *string `json:"id"`
-	Speed *string `json:"speed"`
+	ID     *string         `json:"id"`
+	Speed  *string         `json:"speed"`
+	Effort json.RawMessage `json:"effort"`
 }
 
 type normalizedAgentModel struct {
-	ID    string `json:"id"`
-	Speed string `json:"speed"`
+	ID     string          `json:"id"`
+	Speed  string          `json:"speed"`
+	Effort json.RawMessage `json:"effort,omitempty"`
 }
 
 func normalizeModel(raw json.RawMessage) (normalizedAgentModel, error) {
@@ -767,6 +769,13 @@ func normalizeModel(raw json.RawMessage) (normalizedAgentModel, error) {
 		}
 		normalized.Speed = *model.Speed
 	}
+	if len(model.Effort) > 0 && !httpapi.IsJSONNull(model.Effort) {
+		effort, err := normalizeEffort(model.Effort)
+		if err != nil {
+			return normalizedAgentModel{}, err
+		}
+		normalized.Effort = effort
+	}
 	return normalized, nil
 }
 
@@ -789,6 +798,36 @@ func (h *Handler) normalizeConfiguredModel(
 		}
 	}
 	return normalizedAgentModel{}, fmt.Errorf("model %q is not configured for this workspace", model.ID)
+}
+
+// normalizeEffort 归一化官方两种 effort 形式（字符串或 {"type": ...}）为 {"type": ...} 结构。
+func normalizeEffort(raw json.RawMessage) (json.RawMessage, error) {
+	var level string
+	if json.Unmarshal(raw, &level) == nil {
+		level = strings.TrimSpace(level)
+		if !validEffortLevel(level) {
+			return nil, errors.New("model.effort must be low, medium, high, xhigh, or max")
+		}
+		return httpapi.MarshalRaw(map[string]string{"type": level})
+	}
+	var object struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &object); err != nil || object.Type == "" {
+		return nil, errors.New("model.effort must be a string or {type: ...} object")
+	}
+	if !validEffortLevel(object.Type) {
+		return nil, errors.New("model.effort must be low, medium, high, xhigh, or max")
+	}
+	return httpapi.MarshalRaw(map[string]string{"type": object.Type})
+}
+
+func validEffortLevel(level string) bool {
+	switch level {
+	case "low", "medium", "high", "xhigh", "max":
+		return true
+	}
+	return false
 }
 
 func normalizeMCPServers(raw json.RawMessage) (json.RawMessage, error) {

--- a/internal/agents/model_test.go
+++ b/internal/agents/model_test.go
@@ -73,9 +73,73 @@ func TestNormalizeModelPreservesRealID(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got != testCase.want {
+			if got.ID != testCase.want.ID || got.Speed != testCase.want.Speed || !effortEqual(got.Effort, testCase.want.Effort) {
 				t.Fatalf("normalizeModel() = %#v, want %#v", got, testCase.want)
 			}
 		})
+	}
+}
+
+// effortEqual 比较两个 effort 的 JSON 值（json.RawMessage 无法 == 比较）。
+func effortEqual(a, b json.RawMessage) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return string(a) == string(b)
+}
+
+func TestNormalizeModelEffort(t *testing.T) {
+	// 失败场景先行：非法 effort 值必须报错（此前静默丢弃）
+	rejectCases := []struct {
+		name string
+		raw  string
+	}{
+		{"invalid level", `{"id":"claude-opus-4-8","effort":"ultra"}`},
+		{"empty object", `{"id":"claude-opus-4-8","effort":{"type":""}}`},
+		{"non string object", `{"id":"claude-opus-4-8","effort":{"level":"high"}}`},
+	}
+	for _, tc := range rejectCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := normalizeModel(json.RawMessage(tc.raw)); err == nil {
+				t.Fatalf("normalizeModel(%s) 应报错", tc.raw)
+			}
+		})
+	}
+
+	// 成功场景：字符串与对象两种形式归一化为 {"type": ...}
+	acceptCases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"string effort", `{"id":"claude-opus-4-8","effort":"high"}`, `{"type":"high"}`},
+		{"object effort", `{"id":"claude-opus-4-8","effort":{"type":"max"}}`, `{"type":"max"}`},
+		{"low effort", `{"id":"claude-opus-4-8","effort":"low"}`, `{"type":"low"}`},
+		{"medium effort", `{"id":"claude-opus-4-8","effort":"medium"}`, `{"type":"medium"}`},
+		{"trimmed effort", `{"id":"claude-opus-4-8","effort":"  high  "}`, `{"type":"high"}`},
+		{"xhigh effort", `{"id":"claude-opus-4-8","effort":{"type":"xhigh"}}`, `{"type":"xhigh"}`},
+		{"null effort treated as omitted", `{"id":"claude-opus-4-8","effort":null}`, ``},
+	}
+	for _, tc := range acceptCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeModel(json.RawMessage(tc.raw))
+			if err != nil {
+				t.Fatalf("normalizeModel(%s) 应成功: %v", tc.raw, err)
+			}
+			if string(got.Effort) != tc.want {
+				t.Fatalf("normalizeModel(%s).Effort = %s, want %s", tc.raw, got.Effort, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeModelNoEffortDefaultsEmpty(t *testing.T) {
+	// 省略 effort 时 Effort 保持空（响应省略该字段，对齐官方回填语义）
+	got, err := normalizeModel(json.RawMessage(`{"id":"claude-opus-4-8"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Effort) != 0 {
+		t.Fatalf("省略 effort 应保持空, got %s", got.Effort)
 	}
 }

--- a/internal/environments/environment_manager.go
+++ b/internal/environments/environment_manager.go
@@ -51,7 +51,7 @@ func managedAgentSessionConfig(
 	tools := arrayValue(agentSnapshot["tools"])
 	body := map[string]any{
 		"origin":               "managed_agents_api",
-		"model":                modelIDFromAgentSnapshot(session.AgentSnapshot),
+		"model":                modelObjectFromAgentSnapshot(session.AgentSnapshot),
 		"sources":              runtimeResources.sources,
 		"outcomes":             []any{},
 		"append_system_prompt": managedAgentEnvironmentPrompt,
@@ -231,6 +231,23 @@ func modelIDFromAgentSnapshot(raw json.RawMessage) string {
 	return strings.TrimSpace(stringFromMap(model, "id"))
 }
 
+// modelObjectFromAgentSnapshot 下发完整 model 对象（id + speed + effort）给 worker；
+// 旧 agent 快照中的字符串 model 原样透传，避免 payload 出现 "model": null。
+// 仅取 id 的审计场景（code_sessions.model 列）继续用 modelIDFromAgentSnapshot。
+func modelObjectFromAgentSnapshot(raw json.RawMessage) any {
+	var snapshot map[string]any
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		return nil
+	}
+	if model, ok := snapshot["model"].(map[string]any); ok {
+		return model
+	}
+	if model, ok := snapshot["model"].(string); ok {
+		return model
+	}
+	return nil
+}
+
 // buildEnvironmentManagerV0Payload 把 code session 映射为 environment-manager v0 合同；relay、runtime API 与 ingress 绑定同一 external ID，真实上游凭证不进入 sandbox。
 // vaultEnvPlaceholders 为 Environment Variable Credential 的 secret_name→Opaque Placeholder；平台保留名不会被覆盖。
 func buildEnvironmentManagerV0Payload(codeSessionID string, sessionIngressToken string, oauthAccessToken string, workerEpoch int64, workDir string, sessionConfig json.RawMessage, cfg config.Config, vaultEnvPlaceholders map[string]string) ([]byte, error) {
@@ -256,7 +273,11 @@ func buildEnvironmentManagerV0Payload(codeSessionID string, sessionIngressToken 
 	environmentVariables["CLAUDE_CODE_WORKER_EPOCH"] = workerEpochText
 	environmentVariables["CLAUDE_CODE_INCLUDE_PARTIAL_MESSAGES"] = "true" // 让 worker 输出包含 streaming 中间消息。
 	environmentVariables["CCR_UPSTREAM_PROXY_ENABLED"] = "1"              // 还需 REMOTE_SESSION_ID 和 /run/ccr/session_token 才会注入 HTTPS_PROXY。
-	for key, value := range claudeRuntimeModelEnvironment(stringFromMap(startupContext, "model")) {
+	modelID := stringFromMap(startupContext, "model")
+	if modelObject, ok := startupContext["model"].(map[string]any); ok {
+		modelID = strings.TrimSpace(stringFromMap(modelObject, "id"))
+	}
+	for key, value := range claudeRuntimeModelEnvironment(modelID) {
 		environmentVariables[key] = value
 	}
 	applyCodeSessionOTLPEnvironment(environmentVariables, stringFromMap(startupContext, "api_base_url"), codeSessionID, sessionIngressToken, workerEpochText)

--- a/internal/environments/environment_manager_test.go
+++ b/internal/environments/environment_manager_test.go
@@ -630,8 +630,8 @@ func TestManagedAgentSessionConfigIncludesMCPConfig(t *testing.T) {
 	if err := json.Unmarshal(raw, &body); err != nil {
 		t.Fatalf("decode session config: %v", err)
 	}
-	if body["model"] != "claude-opus-4-8" {
-		t.Fatalf("model = %v", body["model"])
+	if model, ok := body["model"].(map[string]any); !ok || model["id"] != "claude-opus-4-8" {
+		t.Fatalf("model = %v, want {id: claude-opus-4-8}", body["model"])
 	}
 	mcpConfig := body["mcp_config"].(map[string]any)
 	servers := mcpConfig["mcpServers"].(map[string]any)
@@ -670,5 +670,52 @@ func TestManagedAgentSessionConfigIncludesMCPConfig(t *testing.T) {
 	}
 	if !reflect.DeepEqual(fileConfig, mcpConfig) {
 		t.Fatalf("mcp config file = %#v, want %#v", fileConfig, mcpConfig)
+	}
+}
+
+func TestModelObjectFromAgentSnapshot(t *testing.T) {
+	// 对象形式：返回完整 model 对象
+	objectRaw := json.RawMessage(`{"model":{"id":"claude-opus-4-8","speed":"fast","effort":{"type":"high"}}}`)
+	got := modelObjectFromAgentSnapshot(objectRaw)
+	model, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("modelObjectFromAgentSnapshot(对象) = %T, want map[string]any", got)
+	}
+	if model["id"] != "claude-opus-4-8" || model["speed"] != "fast" {
+		t.Fatalf("modelObjectFromAgentSnapshot(对象) = %v, want 完整对象", model)
+	}
+
+	// 字符串形式（旧 agent）：回退原字符串，不产生 null
+	stringRaw := json.RawMessage(`{"model":"claude-opus-4-8"}`)
+	if got := modelObjectFromAgentSnapshot(stringRaw); got != "claude-opus-4-8" {
+		t.Fatalf("modelObjectFromAgentSnapshot(字符串) = %v, want claude-opus-4-8", got)
+	}
+
+	// 无效快照：返回 nil
+	if got := modelObjectFromAgentSnapshot(json.RawMessage(`invalid`)); got != nil {
+		t.Fatalf("modelObjectFromAgentSnapshot(invalid) = %v, want nil", got)
+	}
+}
+
+func TestBuildEnvironmentManagerV0PayloadObjectModelDrivesModelEnv(t *testing.T) {
+	// model 为对象（含 speed/effort）时，模型环境变量必须取对象里的 id，
+	// 防止回退 stringFromMap 后被静默清空。
+	cfg := config.Config{}
+	sessionConfig := json.RawMessage(`{"model":{"id":"kimi-k2.5","speed":"fast","effort":{"type":"high"}},"sources":[]}`)
+	payload, err := buildEnvironmentManagerV0Payload("cse_test", "sk-ant-si-test-token", "sk-ant-oat01-test-token", 1, "", sessionConfig, cfg, nil)
+	if err != nil {
+		t.Fatalf("build payload: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(payload, &body); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	startupEnv := body["startup_context"].(map[string]any)["environment_variables"].(map[string]any)
+	if startupEnv["ANTHROPIC_MODEL"] != "kimi-k2.5" {
+		t.Fatalf("ANTHROPIC_MODEL = %v, want kimi-k2.5（来自对象 model 的 id）", startupEnv["ANTHROPIC_MODEL"])
+	}
+	model := body["startup_context"].(map[string]any)["model"].(map[string]any)
+	if model["speed"] != "fast" || model["effort"].(map[string]any)["type"] != "high" {
+		t.Fatalf("startup_context.model = %#v, want speed=fast effort.type=high 完整透传", model)
 	}
 }

--- a/web/src/features/managed-agents/agentConfig.ts
+++ b/web/src/features/managed-agents/agentConfig.ts
@@ -689,6 +689,7 @@ export function agentEditModelInput(model: AgentApiResponse['model']): AgentMode
   return {
     id: agentModelName(model),
     ...(typeof model.speed === 'string' && model.speed.trim() ? { speed: model.speed } : {}),
+    ...(model.effort?.type ? { effort: model.effort.type } : {}),
   };
 }
 

--- a/web/src/features/managed-agents/agents/create-dialog-model.test.ts
+++ b/web/src/features/managed-agents/agents/create-dialog-model.test.ts
@@ -27,7 +27,7 @@ const baseDraft: CreateAgentInput = {
 };
 
 describe('create agent draft model', () => {
-  test('round trips supported YAML and JSON fields without accepting model effort', () => {
+  test('round trips supported YAML and JSON fields including model effort', () => {
     const input: CreateAgentInput = {
       ...baseDraft,
       metadata: { source: 'test' },
@@ -42,11 +42,14 @@ describe('create agent draft model', () => {
       }
     }
 
-    const invalid = parseCreateAgentConfigText(
+    const withEffort = parseCreateAgentConfigText(
       JSON.stringify({ ...baseDraft, model: { id: 'claude-sonnet-4-6', effort: 'high' } }),
       'JSON',
     );
-    expect(invalid.ok).toBe(false);
+    expect(withEffort.ok).toBe(true);
+    if (withEffort.ok) {
+      expect(withEffort.input.model).toEqual({ id: 'claude-sonnet-4-6', effort: 'high' });
+    }
   });
 
   test('preserves speed while changing the rendered model id', () => {

--- a/web/src/features/managed-agents/agents/create-dialog-model.ts
+++ b/web/src/features/managed-agents/agents/create-dialog-model.ts
@@ -36,6 +36,7 @@ const modelSchema = z.union([
     .object({
       id: z.string().trim().min(1, 'Model id is required.'),
       speed: z.enum(['standard', 'fast']).optional(),
+      effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
     })
     .strict(),
 ]);
@@ -372,7 +373,13 @@ export function permissionConfig(permission: EditablePermission) {
 }
 
 function normalizeDraftModel(model: AgentModelInput): AgentModelInput {
-  return typeof model === 'string' ? model : { id: model.id, ...(model.speed ? { speed: model.speed } : {}) };
+  return typeof model === 'string'
+    ? model.trim()
+    : {
+        id: model.id.trim(),
+        ...(model.speed ? { speed: model.speed } : {}),
+        ...(model.effort ? { effort: model.effort } : {}),
+      };
 }
 
 function nullableString(value: string | null | undefined) {

--- a/web/src/features/managed-agents/agents/model.tsx
+++ b/web/src/features/managed-agents/agents/model.tsx
@@ -4,6 +4,7 @@ import { StatusPill } from '../components/common';
 import { numericValueFromKeys } from '../sessions/SessionDetailPage';
 import {
   type AgentApiResponse,
+  type AgentModelInput,
   type AgentDetailCreatedFilter,
   type AgentDetailStatusFilter,
   type AgentDetailTab,
@@ -35,7 +36,7 @@ export function compactAgentId(id: string) {
   return `${id.slice(0, 12)}...${id.slice(-6)}`;
 }
 
-export function agentModelName(model: AgentApiResponse['model']) {
+export function agentModelName(model: AgentApiResponse['model'] | AgentModelInput) {
   if (typeof model === 'string') {
     return model;
   }

--- a/web/src/features/managed-agents/types.ts
+++ b/web/src/features/managed-agents/types.ts
@@ -46,7 +46,7 @@ export type AgentApiResponse = {
   description: string | null;
   mcp_servers: unknown[];
   metadata: Record<string, string>;
-  model: string | { id?: string; speed?: string };
+  model: string | { id?: string; speed?: string; effort?: { type: AgentModelEffort } };
   multiagent: unknown | null;
   name: string;
   skills: unknown[];
@@ -579,11 +579,14 @@ export type EntityOption = {
   secondary?: string;
 };
 
+export type AgentModelEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
 export type AgentModelInput =
   | string
   | {
       id: string;
       speed?: string;
+      effort?: AgentModelEffort;
     };
 
 export type AgentReferenceInput = {


### PR DESCRIPTION
**Agent 配置里的 `model.effort` 此前被静默丢弃，现在 API 层完整解析、校验并随 model 对象下发到 `startup_context`——不再有静默丢弃；worker 侧对 speed/effort 的消费属于下游（本仓库范围外），本 PR 不做声明。**

## 改动（本仓库内的闭环）

- `normalizeEffort`：字符串/对象双形式归一化为 `{"type": ...}`，级别限 `low/medium/high/xhigh/max`，非法值明确报错（不再静默丢弃）
- session 启动配置下发**完整 model 对象**（id + speed + effort）；旧 agent 快照的字符串 model 原样透传，不出现 `"model": null`
- 两条路径分工：`environment_manager` 的 sessionConfig 发完整对象；`runner` 的 `modelIDFromAgentSnapshot` 仅取 id 存 `code_sessions.model` 审计列（单字符串列）
- 前端：Agent 创建对话框 model 选择带 effort/speed

## 范围边界（如实声明）

- 本 PR 的验收点是 **API 层不再丢弃 + 校验 + 存储与下发**，单测覆盖
- `startup_context.model` 里的 speed/effort 是否被沙箱侧 worker 实际消费，**未验证**——与 #303 的教训一致，不把"字段下发"说成"功能完成"。如需验证需真实 E2E（沙箱起会话观察模型参数生效）

## 测试

- effort 归一化：3 种非法拒绝 + 7 种合法形式（含 trim、null 视为省略）+ 省略时字段为空（响应回填语义）
- `TestNormalizeModelPreservesRealID` 保持 main 语义（ID 原样保留）
- `go test ./internal/agents/ ./internal/environments/` 通过

Closes #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable model effort levels: low, medium, high, xhigh, and max.
  * Preserved model speed and effort settings in managed-agent configurations and sessions.
  * Added support for editing and displaying advanced model settings.

* **Bug Fixes**
  * Improved compatibility with object-based and legacy string model values.
  * Added validation for unsupported effort settings and safer handling of empty or null values.

* **Documentation**
  * Documented effort and speed behavior, validation rules, and runtime data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->