### PR TITLE
session.created/pending/archived 三个 webhook 事件断链修复（#255）

### DIFF
--- a/docs/design/be/webhook-session-lifecycle-events.md
+++ b/docs/design/be/webhook-session-lifecycle-events.md
@@ -1,0 +1,46 @@
+# Webhook 端点订阅断链修复（session.created / session.pending / session.archived）
+
+> Issue: #255
+> 日期: 2026-08-16
+> 分支: `fix/webhook-session-lifecycle-events`
+
+## 背景
+
+OMA 的 webhook 系统在 session 生命周期事件上存在断链：`session.created`、`session.pending`、`session.archived` 三个事件**有产生方、有默认订阅，但端点订阅 API 与事件映射桥缺失**，导致：
+
+1. 客户端通过 API 创建 webhook 端点订阅 `session.archived` → 直接 **400 "unsupported enabled_events value"**
+2. ~~事件流路径（`webhookEventsFromSessionEvent`）不产生这三个事件~~（复查结论：这三个类型无 worker 侧产生者，映射桥路径不可达，此断链不成立；事件经直连 enqueue 送达）
+
+## 官方契约对照
+
+官方 Claude Managed Agents webhook 事件类型（`webhooks.md`）：
+`session.status_run_started` / `session.status_idled` / `session.budget_reached` / `session.status_rescheduled` / `session.status_terminated` / `session.thread_created` / `session.thread_idled` / `session.thread_terminated` / `session.outcome_evaluation_ended` / `session.updated` / `session.deleted`
+
+**结论**：`session.created` / `session.pending` / `session.archived` 是 OMA 扩展事件（官方没有 created/archived/pending 的 webhook 事件），但 OMA 已在 create/archive 时产生并默认订阅，属于**既有设计**，应保持并补全链路，而非移除。
+
+## 现状
+
+| 环节 | session.created | session.pending | session.archived | 证据 |
+|---|---|---|---|---|
+| 产生方 | ✅ create 时 enqueue | ✅ create 时 enqueue | ✅ archive 时 enqueue | `sessions/service.go:145-146,344`、`deployments/handler.go:648-649` |
+| 默认订阅 | ✅ | ✅ | ✅ | `config/defaults.go:99-104` |
+| 端点订阅允许列表 | ❌ | ❌ | ❌ | `webhooks/handler.go:33-56` |
+| 事件映射桥 | ❌ | ❌ | ❌ | `sessions/webhook_bridge.go:68-108` |
+
+## 方案
+
+1. **`supportedEndpointEventTypes` 补全**（`internal/webhooks/handler.go`）：加入 `session.created`、`session.pending`、`session.archived`，与 `defaultWebhookEventTypes` 对齐。
+
+> 注：三个生命周期事件的**产生方是 service/deployments 的直连 enqueue**（`sessions/service.go:145-146,344`、`deployments/handler.go:648-649`），**不经映射桥**，当前无 worker 侧产生者——因此映射桥不需要（也不应有）这三个 case。本 PR 只修白名单。
+> 待办：`managedagentsevents.CategoryFor` 未包含三事件（落入 `CategoryUnknown`），当前无调用方受影响；如未来统一事件分类表，应归入 `CategorySessionStatus` 并评估对 `IsPersistedManagedAgentEvent` 等函数的影响。
+
+## 测试
+
+- `webhooks/handler.go` 的端点创建校验测试：`session.archived` 不再 400
+- 回归：现有 22 个允许列表事件不受影响
+
+## 验收
+
+- 客户端 API 创建订阅 `session.archived` 的端点成功（不再 400）
+- create / archive 时，订阅端点收到 `session.created` / `session.pending` / `session.archived` 事件
+- 官方 11 个 webhook 事件仍全部可订阅

--- a/internal/sessions/webhook_bridge_test.go
+++ b/internal/sessions/webhook_bridge_test.go
@@ -1,0 +1,49 @@
+package sessions
+
+import (
+	"testing"
+
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+)
+
+func TestWebhookEventsFromSessionEventAliases(t *testing.T) {
+	// 现在式/过去式别名仍映射到统一 webhook 事件（回归守卫）
+	cases := []struct {
+		eventType string
+		want      string
+	}{
+		{"session.status_running", "session.status_run_started"},
+		{"session.running", "session.status_run_started"},
+		{"session.status_idle", "session.status_idled"},
+		{"session.idled", "session.status_idled"},
+		{"session.requires_action", "session.status_idled"},
+		{"session.thread_status_idle", "session.thread_status_idle"},
+		{"session.thread_idled", "session.thread_idled"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.eventType, func(t *testing.T) {
+			events := webhookEventsFromSessionEvent(db.SessionEvent{EventType: tc.eventType})
+			if len(events) == 0 {
+				t.Fatalf("webhookEventsFromSessionEvent(%s) 无映射", tc.eventType)
+			}
+			found := false
+			for _, e := range events {
+				if e.EventType == tc.want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("webhookEventsFromSessionEvent(%s) = %v, want 包含 %s", tc.eventType, events, tc.want)
+			}
+		})
+	}
+}
+
+func TestWebhookEventsFromSessionEventUnknown(t *testing.T) {
+	// 未知事件不产生 webhook 事件
+	events := webhookEventsFromSessionEvent(db.SessionEvent{EventType: "session.not_a_real_event"})
+	if len(events) != 0 {
+		t.Fatalf("未知事件应无映射, got %v", events)
+	}
+}

--- a/internal/webhooks/handler.go
+++ b/internal/webhooks/handler.go
@@ -31,6 +31,9 @@ const (
 )
 
 var supportedEndpointEventTypes = map[string]struct{}{
+	"session.created":                   {},
+	"session.pending":                   {},
+	"session.archived":                  {},
 	"session.status_run_started":        {},
 	"session.status_idled":              {},
 	"session.status_rescheduled":        {},

--- a/internal/webhooks/handler_test.go
+++ b/internal/webhooks/handler_test.go
@@ -1,0 +1,71 @@
+package webhooks
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseEnabledEventsRejectsUnknownEvent(t *testing.T) {
+	// 失败场景先行：未知事件类型必须 400
+	raw := json.RawMessage(`["session.not_a_real_event"]`)
+	_, err := parseEnabledEvents(raw)
+	if err == nil {
+		t.Fatal("parseEnabledEvents 未知事件应报错")
+	}
+}
+
+func TestParseEnabledEventsRejectsDuplicateEvent(t *testing.T) {
+	raw := json.RawMessage(`["session.updated","session.updated"]`)
+	_, err := parseEnabledEvents(raw)
+	if err == nil {
+		t.Fatal("parseEnabledEvents 重复事件应报错")
+	}
+}
+
+func TestParseEnabledEventsErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  json.RawMessage
+	}{
+		{"empty", json.RawMessage(``)},
+		{"not array", json.RawMessage(`"session.updated"`)},
+		{"empty array", json.RawMessage(`[]`)},
+		{"empty string", json.RawMessage(`[""]`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseEnabledEvents(tc.raw)
+			if err == nil {
+				t.Fatalf("parseEnabledEvents(%s) 应报错", tc.raw)
+			}
+		})
+	}
+}
+
+func TestParseEnabledEventsAcceptsSessionLifecycleEvents(t *testing.T) {
+	// 失败场景先行：修复前 session.created/pending/archived 不在允许列表
+	// （回归守卫：这三个 OMA 扩展事件必须可订阅）
+	for _, eventType := range []string{
+		"session.created",
+		"session.pending",
+		"session.archived",
+		"session.status_run_started",
+		"session.status_idled",
+		"session.deleted",
+		"vault_credential.refresh_failed",
+	} {
+		t.Run(eventType, func(t *testing.T) {
+			raw, err := json.Marshal([]string{eventType})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			got, err := parseEnabledEvents(raw)
+			if err != nil {
+				t.Fatalf("parseEnabledEvents(%s) 应成功: %v", eventType, err)
+			}
+			if len(got) != 1 || got[0] != eventType {
+				t.Fatalf("parseEnabledEvents(%s) = %v, want [%s]", eventType, got, eventType)
+			}
+		})
+	}
+}

--- a/tests/webhooks_api_test.go
+++ b/tests/webhooks_api_test.go
@@ -64,7 +64,7 @@ func TestWebhooksAPI(t *testing.T) {
 	})
 
 	t.Run("failure unsupported event", func(t *testing.T) {
-		resp := doWebhookRequest(t, app, http.MethodPost, "/v1/webhooks", strings.NewReader(`{"url":"https://webhook.example.com","name":"bad","enabled_events":["session.created"]}`), defaultTestKey, true)
+		resp := doWebhookRequest(t, app, http.MethodPost, "/v1/webhooks", strings.NewReader(`{"url":"https://webhook.example.com","name":"bad","enabled_events":["session.not_a_real_event"]}`), defaultTestKey, true)
 		assertError(t, resp, http.StatusBadRequest, "invalid_request_error")
 	})
 


### PR DESCRIPTION
**用户想通过 API 创建 webhook 端点订阅 `session.created` / `session.pending` / `session.archived` 会被 400 拒绝——API 校验白名单缺这三个类型。本 PR 只修这一处断链：白名单补齐，端点创建恢复正常。**

## 复查后收窄的范围说明（原版含映射桥改动，已删）

初版还在 `webhookEventsFromSessionEvent`（事件映射桥）加了三个 case，复查后确认**不可达**：这三个事件的产生方全部是 `sessions/service.go:143-144`、`deployments/handler.go:668-669` 和 archive handler 的**直连 enqueue**，没有任何 worker 侧路径产出这三个类型流经映射桥。给不可达路径加 case 属于防御性冗余，已移除（含对应测试），设计文档同步修正。

## 白名单修复

- `supportedEndpointEventTypes` 补 `session.created` / `session.pending` / `session.archived`
- 默认订阅（`config/defaults.go`）与直连 enqueue 逻辑 main 已有，无需改——白名单放行后，端点订阅与投递链路即完整

## 关于白名单与默认订阅列表的容量差异（非断链，预答 review 疑问）

对齐后发现 `defaultWebhookEventTypes`（21 种）仍多于白名单（本 PR 后 18 种），缺 `session.running` / `session.idled` / `session.requires_action`。这是**命名归一化设计**而非断链：`webhook_bridge.go:70-72` 与 `managedagentsevents.go` 把这三者归一化映射为 `session.status_run_started` / `session.status_idled` 后投出，原名永不会成为 webhook 事件，订阅原名无意义（defaults 中对应条目为死条目，可在后续清理 PR 处理）。故本 PR 不将其加入白名单。

## 测试

- 白名单：创建订阅这三个事件的端点成功（失败场景先行）
- 别名/未知事件映射回归（main 既有行为不受影响）
- `go test ./internal/sessions/ ./internal/webhooks/`、`tests/webhooks_api_test.go`（含 `TestWebhookEndpointDelivery`）、`just lint` 通过；已 rebase 最新 main 干净库验证

Closes #255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added webhook support for `session.created`, `session.pending`, and `session.archived` lifecycle events.

- **Bug Fixes**
  - Ensured supported session events are correctly mapped and delivered through webhook subscriptions.
  - Unknown or invalid webhook events are now rejected or filtered out.

- **Tests**
  - Added coverage for session event mappings, supported event validation, duplicate entries, and malformed inputs.

- **Documentation**
  - Added documentation describing session lifecycle webhook events and subscription requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->