### PR TITLE
fix(sessions): keep event stream open during tool calls

### DIFF
--- a/docs/design/fe/sessions/session-conversation-workspace.md
+++ b/docs/design/fe/sessions/session-conversation-workspace.md
@@ -41,6 +41,7 @@ Session 详情页同时承担两个职责：继续与运行中的智能体对话
 - 发送普通消息使用既有 `user.message` 事件合同，停止使用 `user.interrupt`；当最新 `session.status_idle.stop_reason` 为 `requires_action` 时，按 `event_ids` 在右侧详情区域渲染可滚动的 Action Card。普通工具 Allow/Deny 发送 `user.tool_confirmation`，AskUserQuestion 问卷答案发送 `user.custom_tool_result`；等待期间保留并禁用左侧普通消息输入框。
 - 成功发送后清空草稿，将响应中的已创建事件合并进现有缓存并恢复 SSE；响应未返回事件时才回退到刷新事件历史。失败保留草稿并使用详情页现有错误提示。
 - Session 状态最终以 SSE/后端响应为准；发送后的临时 running 状态只用于恢复实时订阅，前端禁用状态只用于交互反馈，不替代后端权限检查。
+- 未归档且未进入 terminated/deleted 终态的 Session（包括 idle 工具等待）保持 primary SSE；归档或进入终态后停止订阅。回归验收必须覆盖 idle 建流后的事件到达与实时渲染，以及终态不建流。
 - 流式预览继承 SSE envelope 的事件时间；Session 或 thread 进入 idle/terminated 时清理未完成预览，避免临时消息残留。
 - 转录视图不重复展示与上一条 Agent 消息文本完全相同的 `session.status_idle.result`；Debug 视图仍保留两条原始事件。
 

--- a/docs/design/fe/sessions/session-conversation-workspace.md
+++ b/docs/design/fe/sessions/session-conversation-workspace.md
@@ -41,6 +41,8 @@ Session 详情页同时承担两个职责：继续与运行中的智能体对话
 - 发送普通消息使用既有 `user.message` 事件合同，停止使用 `user.interrupt`；当最新 `session.status_idle.stop_reason` 为 `requires_action` 时，按 `event_ids` 在右侧详情区域渲染可滚动的 Action Card。普通工具 Allow/Deny 发送 `user.tool_confirmation`，AskUserQuestion 问卷答案发送 `user.custom_tool_result`；等待期间保留并禁用左侧普通消息输入框。
 - 成功发送后清空草稿，将响应中的已创建事件合并进现有缓存并恢复 SSE；响应未返回事件时才回退到刷新事件历史。失败保留草稿并使用详情页现有错误提示。
 - Session 状态最终以 SSE/后端响应为准；发送后的临时 running 状态只用于恢复实时订阅，前端禁用状态只用于交互反馈，不替代后端权限检查。
+- 流式预览继承 SSE envelope 的事件时间；Session 或 thread 进入 idle/terminated 时清理未完成预览，避免临时消息残留。
+- 转录视图不重复展示与上一条 Agent 消息文本完全相同的 `session.status_idle.result`；Debug 视图仍保留两条原始事件。
 
 ## 非目标
 

--- a/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
@@ -677,43 +677,21 @@ export function registerManagedAgentsResourceTests() {
     }));
     const fetchSessionEvents = globalThis.fetch;
     let staleReadAfterPost = false;
-    let messagePosted = false;
-    let outputAdded = false;
     globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = requestUrl(input);
       const method = requestMethod(input, init);
       if (url === '/v1/sessions/sesn_one123456/events?beta=true' && method === 'POST') {
         const response = await fetchSessionEvents(input, init);
         staleReadAfterPost = true;
-        messagePosted = true;
-        return response;
-      }
-      if (messagePosted && url.startsWith('/v1/sessions/sesn_one123456/events/stream?') && method === 'GET') {
         const now = new Date().toISOString();
-        if (!outputAdded) {
-          api.resources.sessions[0].resources.push({
-            id: 'sesrsc_report123456',
-            type: 'file',
-            created_at: now,
-            file_id: 'file_report123456',
-            mount_path: '/outputs/report.csv',
-          });
-          outputAdded = true;
-        }
-        const frames = [
-          { id: 'evt_running_after_send', type: 'session.status_running', created_at: now },
-          {
-            id: 'evt_agent_reply_after_send',
-            type: 'agent.message',
-            created_at: now,
-            processed_at: now,
-            content: [{ type: 'text', text: 'Agent reply arrived live.' }],
-          },
-          { id: 'evt_idle_after_send', type: 'session.status_idle', created_at: now },
-        ]
-          .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
-          .join('');
-        return new Response(frames, { headers: { 'Content-Type': 'text/event-stream' } });
+        api.resources.sessions[0].resources.push({
+          id: 'sesrsc_report123456',
+          type: 'file',
+          created_at: now,
+          file_id: 'file_report123456',
+          mount_path: '/outputs/report.csv',
+        });
+        return response;
       }
       if (staleReadAfterPost && url.startsWith('/v1/sessions/sesn_one123456/events?') && method === 'GET') {
         staleReadAfterPost = false;
@@ -740,7 +718,6 @@ export function registerManagedAgentsResourceTests() {
 
       await waitFor(() => expect((composer as HTMLTextAreaElement).value).toBe(''));
       expect(await screen.findByText('Render this message immediately.')).toBeTruthy();
-      expect(await screen.findByText('Agent reply arrived live.')).toBeTruthy();
       expect(api.requests.filter((request) => request.url === sessionURL)).toHaveLength(initialSessionRequestCount);
       const workspaceTabs = screen.getByRole('tablist', { name: 'Session workspace' });
       fireEvent.click(within(workspaceTabs).getByRole('tab', { name: /Resources/ }));
@@ -1462,7 +1439,7 @@ export function registerManagedAgentsResourceTests() {
     expect(api.requests.some((request) => request.url.includes('/threads/sthr_reporter123456/stream?'))).toBe(false);
   });
 
-  test('does not subscribe to session streams when running metadata has completed history', async () => {
+  test('keeps the primary session stream open when running metadata has completed history', async () => {
     resetTestDom('https://oma.duck.ai/workspaces/default/sessions/sesn_one123456');
     const api = mockManagedResourceApi();
     api.resources.sessions[0].status = 'running';
@@ -1481,10 +1458,14 @@ export function registerManagedAgentsResourceTests() {
         ),
       ).toBe(true),
     );
-    expect(api.requests.some((request) => request.url.includes('/stream?'))).toBe(false);
+    await waitFor(() =>
+      expect(api.requests.some((request) => request.url.startsWith('/v1/sessions/sesn_one123456/events/stream?'))).toBe(
+        true,
+      ),
+    );
   });
 
-  test('does not subscribe to session streams after an idle session detail loads', async () => {
+  test('keeps the primary session stream open after an idle session detail loads', async () => {
     resetTestDom('https://oma.duck.ai/workspaces/default/sessions/sesn_one123456');
     const api = mockManagedResourceApi();
     api.resources.sessions[0].status = 'idle';
@@ -1503,7 +1484,11 @@ export function registerManagedAgentsResourceTests() {
         ),
       ).toBe(true),
     );
-    expect(api.requests.some((request) => request.url.includes('/stream?'))).toBe(false);
+    await waitFor(() =>
+      expect(api.requests.some((request) => request.url.startsWith('/v1/sessions/sesn_one123456/events/stream?'))).toBe(
+        true,
+      ),
+    );
   });
 
   test('does not subscribe to session streams after a terminated session detail loads', async () => {

--- a/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
+++ b/web/src/features/managed-agents/ManagedAgentsPage.resources.suite.tsx
@@ -19,6 +19,8 @@ import {
   serverAgent,
   sessionStatusValuesFromUrl,
   setAgentConfigEditorValue,
+  sseFrame,
+  streamResponse,
   waitFor,
   within,
   workspaceContextValue,
@@ -1470,6 +1472,36 @@ export function registerManagedAgentsResourceTests() {
     const api = mockManagedResourceApi();
     api.resources.sessions[0].status = 'idle';
     api.resources.sessions[0].updated_at = new Date(Date.now() - 40_000).toISOString();
+    const fetchSessionEvents = globalThis.fetch;
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = requestUrl(input);
+      const response = await fetchSessionEvents(input, init);
+      if (url.startsWith('/v1/sessions/sesn_one123456/events/stream?') && requestMethod(input, init) === 'GET') {
+        const createdAt = new Date().toISOString();
+        return streamResponse(
+          [
+            sseFrame('session.status_running', {
+              id: 'evt_idle_live_running',
+              type: 'session.status_running',
+              created_at: createdAt,
+            }),
+            sseFrame('agent.message', {
+              id: 'evt_idle_live_agent',
+              type: 'agent.message',
+              created_at: createdAt,
+              processed_at: createdAt,
+              content: [{ type: 'text', text: 'Agent reply arrived live.' }],
+            }),
+            sseFrame('session.status_idle', {
+              id: 'evt_idle_live_idle',
+              type: 'session.status_idle',
+              created_at: createdAt,
+            }),
+          ].join(''),
+        );
+      }
+      return response;
+    });
 
     renderManagedAgentsPage('sessions');
 
@@ -1489,6 +1521,7 @@ export function registerManagedAgentsResourceTests() {
         true,
       ),
     );
+    expect(await screen.findByText('Agent reply arrived live.')).toBeTruthy();
   });
 
   test('does not subscribe to session streams after a terminated session detail loads', async () => {
@@ -1511,6 +1544,39 @@ export function registerManagedAgentsResourceTests() {
       ).toBe(true),
     );
     expect(api.requests.some((request) => request.url.includes('/stream?'))).toBe(false);
+  });
+
+  test('keeps deleted session metadata terminal when cached history is stale', async () => {
+    resetTestDom('https://oma.duck.ai/workspaces/default/sessions/sesn_one123456');
+    const api = mockManagedResourceApi();
+    api.resources.sessions[0].status = 'deleted';
+    api.resources.sessions[0].archived_at = null;
+
+    renderManagedAgentsPage('sessions');
+
+    expect(await screen.findByTestId('session-detail-page')).toBeTruthy();
+    await waitFor(() =>
+      expect(api.requests.some((request) => request.url.startsWith('/v1/sessions/sesn_one123456/events?'))).toBe(true),
+    );
+    expect(api.requests.some((request) => request.url.includes('/stream?'))).toBe(false);
+    expect((screen.getByRole('textbox', { name: 'Message' }) as HTMLTextAreaElement).disabled).toBe(true);
+  });
+
+  test('allows a cached deleted event to archive terminated session metadata', async () => {
+    resetTestDom('https://oma.duck.ai/workspaces/default/sessions/sesn_one123456');
+    const api = mockManagedResourceApi();
+    api.resources.sessions[0].status = 'terminated';
+    api.resources.sessions[0].archived_at = null;
+    api.resources.sessionEvents.push({
+      id: 'evt_session_deleted',
+      type: 'session.deleted',
+      created_at: new Date(Date.now() + 1000).toISOString(),
+    });
+
+    renderManagedAgentsPage('sessions');
+
+    expect(await screen.findByTestId('session-detail-page')).toBeTruthy();
+    expect(await screen.findByText('Archived')).toBeTruthy();
   });
 
   test('renders session detail controls in Chinese', async () => {

--- a/web/src/features/managed-agents/api.test.ts
+++ b/web/src/features/managed-agents/api.test.ts
@@ -53,23 +53,23 @@ describe('managed agents API', () => {
     ]);
   });
 
-  test('omits an idle result that duplicates the preceding agent message from the transcript', () => {
+  test('omits an idle result that duplicates an agent message with the same timestamp', () => {
     const createdAt = '2026-08-26T13:13:00Z';
     const entries = buildSessionEventEntries(
       [
-        {
-          id: 'sevt_agent',
-          type: 'agent.message',
-          created_at: createdAt,
-          processed_at: createdAt,
-          content: [{ type: 'text', text: 'Final answer' }],
-        },
         {
           id: 'sevt_idle',
           type: 'session.status_idle',
           created_at: createdAt,
           processed_at: createdAt,
           result: 'Final answer',
+        },
+        {
+          id: 'sevt_agent',
+          type: 'agent.message',
+          created_at: createdAt,
+          processed_at: createdAt,
+          content: [{ type: 'text', text: 'Final answer' }],
         },
       ],
       'transcript',
@@ -80,6 +80,79 @@ describe('managed agents API', () => {
 
     expect(entries.map((entry) => ('traceEntry' in entry ? entry.traceEntry.rawEventId : entry.id))).toEqual([
       'sevt_agent',
+    ]);
+  });
+
+  test('keeps a generic result that matches the preceding agent message', () => {
+    const createdAt = '2026-08-26T13:13:00Z';
+    const entries = buildSessionEventEntries(
+      [
+        {
+          id: 'sevt_agent',
+          type: 'agent.message',
+          created_at: createdAt,
+          content: [{ type: 'text', text: 'Final answer' }],
+        },
+        { id: 'sevt_result', type: 'result', created_at: '2026-08-26T13:13:01Z', result: 'Final answer' },
+      ],
+      'transcript',
+      Date.parse(createdAt),
+      undefined,
+      { platformTranscriptFiltering: true },
+    );
+
+    expect(entries.map((entry) => ('traceEntry' in entry ? entry.traceEntry.rawEventId : entry.id))).toEqual([
+      'sevt_agent',
+      'sevt_result',
+    ]);
+  });
+
+  test('uses canonical agent and user families as duplicate-result boundaries', () => {
+    const createdAt = '2026-08-26T13:13:00Z';
+    const agentEntries = buildSessionEventEntries(
+      [
+        { id: 'sevt_agent', type: 'agent', created_at: createdAt, content: [{ type: 'text', text: 'Final answer' }] },
+        {
+          id: 'sevt_idle',
+          type: 'session.status_idle',
+          created_at: '2026-08-26T13:13:01Z',
+          result: 'Final answer',
+        },
+      ],
+      'transcript',
+      Date.parse(createdAt),
+      undefined,
+      { platformTranscriptFiltering: true },
+    );
+    const userEntries = buildSessionEventEntries(
+      [
+        {
+          id: 'sevt_agent_message',
+          type: 'agent.message',
+          created_at: createdAt,
+          content: [{ type: 'text', text: 'Earlier answer' }],
+        },
+        { id: 'sevt_user', type: 'user', created_at: '2026-08-26T13:13:01Z', content: 'Follow-up' },
+        {
+          id: 'sevt_idle_after_user',
+          type: 'session.status_idle',
+          created_at: '2026-08-26T13:13:02Z',
+          result: 'Earlier answer',
+        },
+      ],
+      'transcript',
+      Date.parse(createdAt),
+      undefined,
+      { platformTranscriptFiltering: true },
+    );
+
+    expect(agentEntries.map((entry) => ('traceEntry' in entry ? entry.traceEntry.rawEventId : entry.id))).toEqual([
+      'sevt_agent',
+    ]);
+    expect(userEntries.map((entry) => ('traceEntry' in entry ? entry.traceEntry.rawEventId : entry.id))).toEqual([
+      'sevt_agent_message',
+      'sevt_user',
+      'sevt_idle_after_user',
     ]);
   });
 

--- a/web/src/features/managed-agents/api.test.ts
+++ b/web/src/features/managed-agents/api.test.ts
@@ -83,6 +83,35 @@ describe('managed agents API', () => {
     ]);
   });
 
+  test('orders a non-duplicate idle result after an agent message with the same timestamp', () => {
+    const createdAt = '2026-08-26T13:13:00Z';
+    const entries = buildSessionEventEntries(
+      [
+        {
+          id: 'sevt_idle',
+          type: 'session.status_idle',
+          created_at: createdAt,
+          result: 'Run completed',
+        },
+        {
+          id: 'sevt_agent',
+          type: 'agent.message',
+          created_at: createdAt,
+          content: [{ type: 'text', text: 'Final answer' }],
+        },
+      ],
+      'transcript',
+      Date.parse(createdAt),
+      undefined,
+      { platformTranscriptFiltering: true },
+    );
+
+    expect(entries.map((entry) => ('traceEntry' in entry ? entry.traceEntry.rawEventId : entry.id))).toEqual([
+      'sevt_agent',
+      'sevt_idle',
+    ]);
+  });
+
   test('keeps a generic result that matches the preceding agent message', () => {
     const createdAt = '2026-08-26T13:13:00Z';
     const entries = buildSessionEventEntries(

--- a/web/src/features/managed-agents/api.test.ts
+++ b/web/src/features/managed-agents/api.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test } from 'bun:test';
+import { QueryClient } from '@tanstack/react-query';
 import { setAnthropicClientForTest } from '@/shared/api/anthropic';
-import { listSessionFileOptions } from './api';
+import { listSessionFileOptions, mergeSessionStreamFrame, sessionDetailScopeEvents } from './api';
+import { buildSessionEventEntries } from './sessions/sessionTraceModel';
 
 const originalFetch = globalThis.fetch;
 
@@ -10,6 +12,77 @@ afterEach(() => {
 });
 
 describe('managed agents API', () => {
+  test('preserves preview time and removes an orphaned preview when the session idles', () => {
+    const queryClient = new QueryClient();
+    const workspaceId = 'workspace_123';
+    const sessionId = 'sesn_123';
+    const createdAt = '2026-08-26T13:13:00Z';
+
+    mergeSessionStreamFrame(queryClient, workspaceId, sessionId, '', {
+      type: 'event_start',
+      created_at: createdAt,
+      processed_at: createdAt,
+      event: { id: 'sevt_preview', type: 'agent.message' },
+    });
+
+    expect(sessionDetailScopeEvents(queryClient, workspaceId, sessionId, [''])[0]).toMatchObject({
+      id: 'sevt_preview',
+      created_at: createdAt,
+      processed_at: null,
+      is_streaming: true,
+    });
+
+    mergeSessionStreamFrame(queryClient, workspaceId, sessionId, '', {
+      id: 'sevt_final',
+      type: 'agent.message',
+      created_at: createdAt,
+      processed_at: createdAt,
+      content: [{ type: 'text', text: 'Final answer' }],
+    });
+    mergeSessionStreamFrame(queryClient, workspaceId, sessionId, '', {
+      id: 'sevt_idle',
+      type: 'session.status_idle',
+      created_at: createdAt,
+      processed_at: createdAt,
+      result: 'Final answer',
+    });
+
+    expect(sessionDetailScopeEvents(queryClient, workspaceId, sessionId, ['']).map((event) => event.id)).toEqual([
+      'sevt_final',
+      'sevt_idle',
+    ]);
+  });
+
+  test('omits an idle result that duplicates the preceding agent message from the transcript', () => {
+    const createdAt = '2026-08-26T13:13:00Z';
+    const entries = buildSessionEventEntries(
+      [
+        {
+          id: 'sevt_agent',
+          type: 'agent.message',
+          created_at: createdAt,
+          processed_at: createdAt,
+          content: [{ type: 'text', text: 'Final answer' }],
+        },
+        {
+          id: 'sevt_idle',
+          type: 'session.status_idle',
+          created_at: createdAt,
+          processed_at: createdAt,
+          result: 'Final answer',
+        },
+      ],
+      'transcript',
+      Date.parse(createdAt),
+      undefined,
+      { platformTranscriptFiltering: true },
+    );
+
+    expect(entries.map((entry) => ('traceEntry' in entry ? entry.traceEntry.rawEventId : entry.id))).toEqual([
+      'sevt_agent',
+    ]);
+  });
+
   test('loads every workspace file page for session resource options', async () => {
     const firstPage = Array.from({ length: 1000 }, (_, index) => fileMetadata(index));
     const finalFile = fileMetadata(1000);

--- a/web/src/features/managed-agents/api.ts
+++ b/web/src/features/managed-agents/api.ts
@@ -1217,7 +1217,7 @@ export function sessionEventHistoryShouldSkipStream(events: QuickstartSessionEve
     if (type === 'user.message') {
       return false;
     }
-    if (type === 'session.status_idle' || type === 'session.status_terminated' || type === 'session.deleted') {
+    if (type === 'session.status_terminated' || type === 'session.deleted') {
       return true;
     }
     if (type === 'session.status_running' || type === 'session.status_rescheduled') {

--- a/web/src/features/managed-agents/api.ts
+++ b/web/src/features/managed-agents/api.ts
@@ -1199,6 +1199,9 @@ export function mergeSessionStreamFrame(
   }
   const cacheKey = sessionDetailEventCacheKey(workspaceId, sessionId, threadId);
   queryClient.setQueryData<SessionDetailEventCache>(cacheKey, (cache) => mergeSessionEventCache(cache, [event]));
+  if (eventType.endsWith('status_idle') || eventType.endsWith('status_terminated')) {
+    cleanupIncompleteSessionStreamEvents(queryClient, workspaceId, sessionId, threadId);
+  }
 }
 
 export function sessionEventHistoryShouldSkipStream(events: QuickstartSessionEvent[], threadId: string) {
@@ -1294,6 +1297,8 @@ export function sessionStreamingMessageFromStart(
       ...started,
       type: type === 'agent.thinking' ? 'agent.thinking' : 'agent.message',
       content,
+      created_at: started.created_at ?? event.created_at,
+      processed_at: started.processed_at ?? event.processed_at,
     },
     threadId || undefined,
   );

--- a/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
+++ b/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
@@ -297,7 +297,12 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
       return;
     }
     setSession((currentSession) => {
-      if (!currentSession || currentSession.id !== session.id || currentSession.status.toLowerCase() === 'terminated') {
+      const currentStatus = currentSession?.status.toLowerCase();
+      if (
+        !currentSession ||
+        currentSession.id !== session.id ||
+        ((currentStatus === 'terminated' || currentStatus === 'deleted') && next.status !== 'deleted')
+      ) {
         return currentSession;
       }
       // Mirror the live-frame path: a cached session.deleted must also archive,

--- a/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
+++ b/web/src/features/managed-agents/sessions/SessionDetailPage.tsx
@@ -297,7 +297,7 @@ export function SessionDetailPage({ config, sessionId }: { config: ResourceConfi
       return;
     }
     setSession((currentSession) => {
-      if (!currentSession || currentSession.id !== session.id) {
+      if (!currentSession || currentSession.id !== session.id || currentSession.status.toLowerCase() === 'terminated') {
         return currentSession;
       }
       // Mirror the live-frame path: a cached session.deleted must also archive,

--- a/web/src/features/managed-agents/sessions/sessionDetailModel.ts
+++ b/web/src/features/managed-agents/sessions/sessionDetailModel.ts
@@ -702,7 +702,8 @@ export function sessionShouldStreamEvents(session: Pick<SessionApiResponse, 'arc
   if (!session || session.archived_at) {
     return false;
   }
-  return session.status.toLowerCase() !== 'terminated';
+  const status = session.status.toLowerCase();
+  return status !== 'terminated' && status !== 'deleted';
 }
 
 export function sessionElapsedMs(session: SessionApiResponse, events: QuickstartSessionEvent[]) {

--- a/web/src/features/managed-agents/sessions/sessionDetailModel.ts
+++ b/web/src/features/managed-agents/sessions/sessionDetailModel.ts
@@ -702,7 +702,7 @@ export function sessionShouldStreamEvents(session: Pick<SessionApiResponse, 'arc
   if (!session || session.archived_at) {
     return false;
   }
-  return sessionStatusIsLive(session.status);
+  return session.status.toLowerCase() !== 'terminated';
 }
 
 export function sessionElapsedMs(session: SessionApiResponse, events: QuickstartSessionEvent[]) {

--- a/web/src/features/managed-agents/sessions/sessionTraceModel.ts
+++ b/web/src/features/managed-agents/sessions/sessionTraceModel.ts
@@ -50,6 +50,7 @@ export function buildSessionTraceEntries(
   const displayEvents = events.map(sessionCanonicalDisplayEvent);
   const requiresActionEventIDs = latestRequiresActionEventIDs(displayEvents);
   const threadHints = buildSessionThreadHints(displayEvents);
+  let latestAgentMessageText = '';
   // Transcript 使用只读回放模型：result / confirmation 先按 tool use id 建索引，
   // 之后折回对应 tool_call；Debug 仍保留原始事件用于审计。
   displayEvents.forEach((event) => {
@@ -69,6 +70,17 @@ export function buildSessionTraceEntries(
   });
 
   return displayEvents.flatMap((event, index) => {
+    const type = sessionEventType(event);
+    const agentMessageText =
+      type === 'agent.message' || type === 'assistant.message' ? sessionEventTranscriptText(event).trim() : '';
+    if (view === 'transcript' && sessionIsResultEvent(event) && sessionResultText(event) === latestAgentMessageText) {
+      return [];
+    }
+    if (agentMessageText) {
+      latestAgentMessageText = agentMessageText;
+    } else if (type === 'user.message') {
+      latestAgentMessageText = '';
+    }
     let enrichedEvent = sessionEventWithThreadHint(event, threadHints.byThreadId);
     if (requiresActionEventIDs.has(sessionEventKey(enrichedEvent))) {
       enrichedEvent = { ...enrichedEvent, requires_action: true };

--- a/web/src/features/managed-agents/sessions/sessionTraceModel.ts
+++ b/web/src/features/managed-agents/sessions/sessionTraceModel.ts
@@ -283,7 +283,7 @@ export function buildSessionEventEntries(
   const entries: SessionEventListEntry[] = [];
   let lastIdleAt = 0;
   let queuedBoundaryInserted = false;
-  const sortedRawEvents = [...events.map(sessionCanonicalDisplayEvent)].sort(compareSessionEvents);
+  const sortedRawEvents = [...events.map(sessionCanonicalDisplayEvent)].sort(compareSessionTranscriptEvents);
   const rawCursorByKey = new Map<string, number>();
   sortedRawEvents.forEach((event, index) => {
     rawCursorByKey.set(sessionEventKey(event), index);

--- a/web/src/features/managed-agents/sessions/sessionTraceModel.ts
+++ b/web/src/features/managed-agents/sessions/sessionTraceModel.ts
@@ -48,6 +48,9 @@ export function buildSessionTraceEntries(
   const toolResults = new Map<string, QuickstartSessionEvent[]>();
   const toolConfirmations = new Map<string, QuickstartSessionEvent[]>();
   const displayEvents = events.map(sessionCanonicalDisplayEvent);
+  if (view === 'transcript') {
+    displayEvents.sort(compareSessionTranscriptEvents);
+  }
   const requiresActionEventIDs = latestRequiresActionEventIDs(displayEvents);
   const threadHints = buildSessionThreadHints(displayEvents);
   let latestAgentMessageText = '';
@@ -71,14 +74,20 @@ export function buildSessionTraceEntries(
 
   return displayEvents.flatMap((event, index) => {
     const type = sessionEventType(event);
+    const eventFamily = sessionEventFamily(event);
     const agentMessageText =
-      type === 'agent.message' || type === 'assistant.message' ? sessionEventTranscriptText(event).trim() : '';
-    if (view === 'transcript' && sessionIsResultEvent(event) && sessionResultText(event) === latestAgentMessageText) {
+      eventFamily === 'agent' && !sessionEventIsThinking(event) ? sessionEventTranscriptText(event).trim() : '';
+    if (
+      view === 'transcript' &&
+      type === 'session.status_idle' &&
+      sessionIsResultEvent(event) &&
+      sessionResultText(event) === latestAgentMessageText
+    ) {
       return [];
     }
     if (agentMessageText) {
       latestAgentMessageText = agentMessageText;
-    } else if (type === 'user.message') {
+    } else if (eventFamily === 'user') {
       latestAgentMessageText = '';
     }
     let enrichedEvent = sessionEventWithThreadHint(event, threadHints.byThreadId);
@@ -103,7 +112,7 @@ export function buildSessionTraceEntries(
       return contentEntries;
     }
 
-    const family = sessionEventFamily(enrichedEvent);
+    const family = eventFamily;
     const toolUseId = sessionToolUseId(enrichedEvent);
     const matchedByPublicEventId = typeof enrichedEvent.id === 'string' && toolUseId === enrichedEvent.id;
     const resultEvent =
@@ -128,6 +137,21 @@ export function buildSessionTraceEntries(
       sessionTraceEntryFromEvent(enrichedEvent, index, family, resultEvent, confirmationEvent, traceStartMs, msg),
     ];
   });
+}
+
+function compareSessionTranscriptEvents(left: QuickstartSessionEvent, right: QuickstartSessionEvent) {
+  const chronologicalOrder = compareSessionEvents(left, right);
+  if (chronologicalOrder !== 0) {
+    return chronologicalOrder;
+  }
+  return sessionTranscriptTieRank(left) - sessionTranscriptTieRank(right);
+}
+
+function sessionTranscriptTieRank(event: QuickstartSessionEvent) {
+  if (sessionEventFamily(event) === 'agent' && !sessionEventIsThinking(event)) {
+    return 0;
+  }
+  return sessionEventType(event) === 'session.status_idle' && sessionIsResultEvent(event) ? 2 : 1;
 }
 
 export function latestRequiresActionEventIDs(events: QuickstartSessionEvent[]) {


### PR DESCRIPTION
## 问题

Session 进入 `idle` / 工具等待阶段后，前端会关闭或跳过 primary SSE。Write、Bash 等工具调用的后续事件无法实时到达页面，只能刷新后从历史记录中看到。

## 修复

- 未归档的 idle Session 继续订阅事件流，仅 terminated Session 停止订阅
- 历史尾部为 idle 时不再跳过建流，terminated/deleted 仍按终态处理
- 防止旧 idle 历史覆盖已经 terminated 的状态
- 更新现有集成测试，覆盖 idle Session 保持 primary SSE

## 验证

- `bun test`：481 pass，0 fail
- `bun run format:check`
- `bun run build`
- `bun run lint:complexity`
- `bun run lint:duplicates`

本次只修复现有 SSE 生命周期判断，没有引入新的 Channel、Adapter、cursor replay 或连接管理层。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed-agent session updates so active and idle sessions continue receiving event information.
  - Session history remains connected while a session is idle, preventing missed updates.
  - Resources added after sending a message are now reflected correctly.
  - Terminated or deleted sessions no longer receive unnecessary updates.
  - Deleted session events now correctly preserve archived session state.
  - Removed duplicate idle results from conversation transcripts.
  - Streaming previews now transition cleanly to final messages with consistent timestamps.
  - Improved conversation event ordering for clearer transcripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->