### PR TITLE
fix(web): 防止 Agents 列表名称与模型列表头重叠

### DIFF
--- a/web/src/features/managed-agents/agents/AgentsResourcePage.tsx
+++ b/web/src/features/managed-agents/agents/AgentsResourcePage.tsx
@@ -618,16 +618,16 @@ export function AgentsResourcePage({
             onAction={retryAgentsLoad}
           />
         ) : isAgentsPage ? (
-          <Table className={dataTableClassName}>
+          <Table className={cn(dataTableClassName, 'min-w-[1063px]')}>
             <TableHeader>
               <TableRow className={dataTableHeaderRowClassName}>
                 <TableHead className={cn(dataTableHeaderCellClassName, 'w-[185px]')}>
                   {managedColumnLabel('ID', msg)}
                 </TableHead>
-                <TableHead className={cn(dataTableHeaderCellClassName, 'min-w-[140px] w-[22%] overflow-hidden')}>
+                <TableHead className={cn(dataTableHeaderCellClassName, 'w-[200px]')}>
                   {managedColumnLabel('Name', msg)}
                 </TableHead>
-                <TableHead className={cn(dataTableHeaderCellClassName, 'w-[210px] overflow-hidden')}>
+                <TableHead className={cn(dataTableHeaderCellClassName, 'w-[210px]')}>
                   {managedColumnLabel('Model', msg)}
                 </TableHead>
                 <TableHead className={cn(dataTableHeaderCellClassName, 'w-[120px]')}>

--- a/web/src/features/managed-agents/agents/AgentsResourcePage.tsx
+++ b/web/src/features/managed-agents/agents/AgentsResourcePage.tsx
@@ -624,10 +624,10 @@ export function AgentsResourcePage({
                 <TableHead className={cn(dataTableHeaderCellClassName, 'w-[185px]')}>
                   {managedColumnLabel('ID', msg)}
                 </TableHead>
-                <TableHead className={cn(dataTableHeaderCellClassName, 'w-auto')}>
+                <TableHead className={cn(dataTableHeaderCellClassName, 'min-w-[140px] w-[22%] overflow-hidden')}>
                   {managedColumnLabel('Name', msg)}
                 </TableHead>
-                <TableHead className={cn(dataTableHeaderCellClassName, 'w-[210px]')}>
+                <TableHead className={cn(dataTableHeaderCellClassName, 'w-[210px] overflow-hidden')}>
                   {managedColumnLabel('Model', msg)}
                 </TableHead>
                 <TableHead className={cn(dataTableHeaderCellClassName, 'w-[120px]')}>


### PR DESCRIPTION
## Summary
- Agents 列表使用 `table-fixed` 时，名称列 `w-auto` 在窄视口（侧栏 + DevTools）剩余宽度趋近 0
- 表头 `whitespace-nowrap` 使「名称」「模型」文字溢出叠在一起
- 为名称列设置 `min-w-[140px] w-[22%]`，并为名称/模型表头加 `overflow-hidden`
## 问题
<img width="3584" height="1164" alt="image" src="https://github.com/user-attachments/assets/547b501a-c5db-40e5-905f-7c7c5baaa52f" />
<img width="2686" height="830" alt="image" src="https://github.com/user-attachments/assets/b26d03a3-918f-4191-b1fc-8d683b19c03b" />

## 修复后效果 （不重叠）
<img width="2114" height="768" alt="image" src="https://github.com/user-attachments/assets/eb8298b6-f469-4e0e-a2f3-2887ba16a92c" />

## Test plan
- [ ] 打开 `/workspaces/default/agents`，确认「名称」「模型」表头不重叠
- [ ] 缩窄窗口或打开 DevTools，确认优先横向滚动而非表头叠字
- [ ] 有名称/无名称（或很短名称）的行展示正常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the agents table layout with a minimum width for better readability.
  * Standardized the Name column width to provide more consistent display across screen sizes.
  * Updated Model column behavior to better accommodate longer model details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->