### PR TITLE
Add CCRv2 Git commit signing with Code Session keys

### DIFF
--- a/cmd/code-session-signing-public-key/main.go
+++ b/cmd/code-session-signing-public-key/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(arguments []string, output io.Writer) error {
+	if len(arguments) != 1 {
+		return errors.New("usage: code-session-signing-public-key <PKCS#8 Ed25519 private-key-file>")
+	}
+	credentials, err := codesessions.NewSessionCredentials(config.Config{
+		CodeSession: config.CodeSessionConfig{JWTSigningPrivateKeyFile: arguments[0]},
+	})
+	if err != nil {
+		return err
+	}
+	publicKey, err := credentials.GitSigningPublicKey()
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(output, publicKey)
+	return err
+}

--- a/cmd/code-session-signing-public-key/main_test.go
+++ b/cmd/code-session-signing-public-key/main_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunRejectsInvalidInput(t *testing.T) {
+	if err := run(nil, ioDiscardForTest{}); err == nil {
+		t.Fatal("run() accepted missing key path")
+	}
+	if err := run([]string{filepath.Join(t.TempDir(), "missing.pem")}, ioDiscardForTest{}); err == nil {
+		t.Fatal("run() accepted missing key file")
+	}
+}
+
+func TestRunPrintsOnlyOpenSSHEd25519PublicKey(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	encodedPrivateKey, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey() error = %v", err)
+	}
+	keyFile := filepath.Join(t.TempDir(), "signing-key.pem")
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: encodedPrivateKey})
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+
+	var output bytes.Buffer
+	if err := run([]string{keyFile}, &output); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	line := strings.TrimSuffix(output.String(), "\n")
+	parts := strings.Fields(line)
+	if len(parts) != 3 || parts[0] != "ssh-ed25519" || parts[2] != "oma-code-signing" {
+		t.Fatalf("unexpected output: %q", output.String())
+	}
+	blob, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode public key: %v", err)
+	}
+	if !bytes.HasSuffix(blob, publicKey) {
+		t.Fatal("printed key does not contain the generated public key")
+	}
+	if bytes.Contains(output.Bytes(), encodedPrivateKey) || strings.Contains(output.String(), "PRIVATE KEY") {
+		t.Fatal("output contains private key material")
+	}
+}
+
+type ioDiscardForTest struct{}
+
+func (ioDiscardForTest) Write(value []byte) (int, error) {
+	return len(value), nil
+}

--- a/docs/configuration-reference.yaml
+++ b/docs/configuration-reference.yaml
@@ -74,7 +74,7 @@ code_session:
   otlp_file_log_enabled: true
   otlp_log_root: logs
   otlp_log_body_preview_bytes: 262144
-  # Required in prod; dev creates an in-memory key when this is empty.
+  # Required in prod; also signs CCRv2 Git commits. Dev creates an in-memory key when empty.
   jwt_signing_private_key_file: ""
   upstream_proxy_mitm_enabled: false
   # Required only when upstream_proxy_mitm_enabled is true.

--- a/docs/design/be/ccrv2/git-commit-signing.md
+++ b/docs/design/be/ccrv2/git-commit-signing.md
@@ -1,0 +1,74 @@
+# CCRv2 Git 提交签名
+
+## 目标与边界
+
+CCR v2 sandbox 使用 environment-manager 的 `/tmp/code-sign` 作为 Git SSH 签名程序。私钥只保存在 oma-server；sandbox 只持有与当前 Code Session 和 worker epoch 绑定的 session-ingress JWT。当前版本只提供 `/v1/code/sessions/{code_session_id}/sign-commit`，不恢复旧版 `/v1/session_ingress/sources/sign-commit/*` 路由。
+
+Git 提交身份继续由环境内已有的 `user.name` 和 `user.email` 决定。OMA 只证明提交由部署方注册的 Ed25519 签名密钥签署，不改写作者或提交者字段。
+
+```mermaid
+sequenceDiagram
+    participant Git
+    participant EM as environment-manager
+    participant OMA as oma-server
+    participant GH as GitHub
+
+    Git->>EM: gpg.ssh.program /tmp/code-sign
+    EM->>OMA: POST /v1/code/sessions/{id}/sign-commit<br/>Bearer session-ingress JWT
+    OMA->>OMA: 校验 session、tenant、current worker epoch
+    OMA->>OMA: 使用稳定 Ed25519 私钥生成 SSHSIG
+    OMA-->>EM: {signature}
+    EM-->>Git: 写入 .sig
+    Git->>GH: push signed commit
+    GH->>GH: 使用账号 Signing Key 验证
+```
+
+## HTTP 合同
+
+请求体上限为 16 MiB：
+
+```json
+{
+  "contents": "<Git 传入的原始待签名文本>",
+  "source": {
+    "type": "git_repository",
+    "git_info": {
+      "type": "github",
+      "repo": "owner/repo",
+      "ref": "refs/heads/main"
+    }
+  },
+  "git_object_format": "sha1"
+}
+```
+
+- `contents` 必须非空，并按解码后的原始 UTF-8 字节签名；不得修剪空白。
+- `source` 可省略，仅作为已脱敏的仓库元数据，不进入签名或授权决策。提供时必须是带 provider 和 repo 的 `git_repository`。
+- `git_object_format` 可省略，默认 `sha1`；可选值为 `sha1`、`sha256`。该字段描述 Git 仓库对象格式，SSHSIG 自身始终使用 SHA-512 摘要。
+
+成功响应为 HTTP 200：
+
+```json
+{
+  "signature": "-----BEGIN SSH SIGNATURE-----\n...\n-----END SSH SIGNATURE-----\n"
+}
+```
+
+鉴权失败、路径 session 不匹配、旧式 epoch 0 Token 或失效 epoch 返回 401；无效请求返回 400；超限返回 413；签名器不可用返回 500。鉴权在读取请求体之前完成。
+
+## 签名与密钥生命周期
+
+OMA 复用 `SessionCredentials` 中由 `code_session.jwt_signing_private_key_file` 加载的 Ed25519 私钥。SSHSIG 使用 version 1、`git` namespace、空 reserved 字段、SHA-512 摘要和 `ssh-ed25519` 签名。Ed25519 对相同内容和密钥产生确定性签名，但不同提交内容必须分别签名，不能复用一段固定签名。
+
+生产环境必须挂载稳定的 PKCS#8 私钥。可通过以下命令只导出 OpenSSH 公钥：
+
+```bash
+just print-code-session-signing-public-key \
+  config/secrets/code-session-jwt-ed25519.pem
+```
+
+将输出添加到 GitHub 账号的 SSH Signing Key。轮换该私钥会同时失效现有 session-ingress JWT，并要求在 GitHub 更新 Signing Key。所有 Session 共用该部署签名身份，因此接口只接受数据库确认仍处于当前 worker epoch 的 CCRv2 Token；oma-server 运行日志只记录 session ID、内容长度和 Git object format，不记录正文、Token、source 或签名。
+
+## environment-manager 行为
+
+environment-manager 全局配置 `gpg.format=ssh`、`gpg.ssh.program=/tmp/code-sign`、`user.signingkey=~/.ssh/commit_signing_key.pub` 和 `commit.gpgsign=true`。Anthropic 模板仓库也保留本地 `commit.gpgsign=true`；仅模板初始提交显式使用 `--no-gpg-sign`，避免环境初始化与 codesign MCP 并行启动时发生竞态。此后的普通 `git commit` 必须获得远程签名，服务不可用时提交失败而不是降级为未签名提交。

--- a/docs/en/configuration.mdx
+++ b/docs/en/configuration.mdx
@@ -69,9 +69,15 @@ For production, mount stable private keys through read-only secrets. Never bake 
 just generate-code-session-jwt-key \
   config/secrets/code-session-jwt-ed25519.pem
 
+# Export only the public key to add to GitHub SSH Signing Keys
+just print-code-session-signing-public-key \
+  config/secrets/code-session-jwt-ed25519.pem
+
 just generate-vault-kek \
   config/secrets/vault-kek
 ```
+
+The Code Session JWT key also signs CCRv2 Git commits. For GitHub to display `Verified`, keep this private key stable, add the command output as a GitHub SSH Signing Key, and ensure the environment's existing Git commit email is verified by the same account. After rotating the private key, update the GitHub Signing Key as well.
 
 <Note>
   `docs/configuration-reference.yaml` contains every accepted field with safe example values. `config/config.example.yaml` is the smaller template for daily development.

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -69,9 +69,15 @@ LLM Provider 是工作区数据，不属于进程配置。服务启动后，在�
 just generate-code-session-jwt-key \
   config/secrets/code-session-jwt-ed25519.pem
 
+# 只导出需要添加到 GitHub SSH Signing Keys 的公钥
+just print-code-session-signing-public-key \
+  config/secrets/code-session-jwt-ed25519.pem
+
 just generate-vault-kek \
   config/secrets/vault-kek
 ```
+
+Code Session JWT 私钥同时用于 CCRv2 Git 提交签名。要让 GitHub 显示 `Verified`，请保持该私钥稳定，将上述命令输出添加为 GitHub SSH Signing Key，并确保环境现有的 Git 提交邮箱已在同一账号验证。私钥轮换后需要同步更新 GitHub Signing Key。
 
 <Note>
   仓库中的 `docs/configuration-reference.yaml` 记录全部已接受字段和安全示例值；`config/config.example.yaml` 是日常开发使用的最小示例。

--- a/internal/codesessions/code_signing.go
+++ b/internal/codesessions/code_signing.go
@@ -1,0 +1,90 @@
+package codesessions
+
+import (
+	"crypto/ed25519"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"strings"
+)
+
+const (
+	sshSignatureMagic     = "SSHSIG"
+	sshSignatureNamespace = "git"
+	sshSignatureHash      = "sha512"
+	sshEd25519Algorithm   = "ssh-ed25519"
+	sshArmorLineLength    = 70
+)
+
+// SignGitCommit signs the exact Git payload using the Code Session Ed25519 key
+// and returns an armored OpenSSH SSHSIG document.
+func (s *Service) SignGitCommit(contents []byte) (string, error) {
+	if s == nil || s.credentials == nil {
+		return "", errors.New("code-session commit signer is not configured")
+	}
+	return s.credentials.signGitCommit(contents)
+}
+
+// GitSigningPublicKey returns the OpenSSH public-key line that operators add
+// to a Git hosting account. The private key is never included.
+func (c *SessionCredentials) GitSigningPublicKey() (string, error) {
+	if c == nil || len(c.publicKey) != ed25519.PublicKeySize {
+		return "", errors.New("code-session signing public key is not configured")
+	}
+	encoded := base64.StdEncoding.EncodeToString(sshEd25519PublicKeyBlob(c.publicKey))
+	return sshEd25519Algorithm + " " + encoded + " oma-code-signing", nil
+}
+
+func (c *SessionCredentials) signGitCommit(contents []byte) (string, error) {
+	if c == nil || len(c.privateKey) != ed25519.PrivateKeySize || len(c.publicKey) != ed25519.PublicKeySize {
+		return "", errors.New("code-session commit signer is not configured")
+	}
+	digest := sha512.Sum512(contents)
+	signedData := append([]byte(nil), sshSignatureMagic...)
+	signedData = appendSSHString(signedData, []byte(sshSignatureNamespace))
+	signedData = appendSSHString(signedData, nil)
+	signedData = appendSSHString(signedData, []byte(sshSignatureHash))
+	signedData = appendSSHString(signedData, digest[:])
+
+	signature := ed25519.Sign(c.privateKey, signedData)
+	signatureBlob := appendSSHString(nil, []byte(sshEd25519Algorithm))
+	signatureBlob = appendSSHString(signatureBlob, signature)
+
+	blob := append([]byte(nil), sshSignatureMagic...)
+	version := make([]byte, 4)
+	binary.BigEndian.PutUint32(version, 1)
+	blob = append(blob, version...)
+	blob = appendSSHString(blob, sshEd25519PublicKeyBlob(c.publicKey))
+	blob = appendSSHString(blob, []byte(sshSignatureNamespace))
+	blob = appendSSHString(blob, nil)
+	blob = appendSSHString(blob, []byte(sshSignatureHash))
+	blob = appendSSHString(blob, signatureBlob)
+	return armorSSHSignature(blob), nil
+}
+
+func sshEd25519PublicKeyBlob(publicKey ed25519.PublicKey) []byte {
+	blob := appendSSHString(nil, []byte(sshEd25519Algorithm))
+	return appendSSHString(blob, publicKey)
+}
+
+func appendSSHString(destination, value []byte) []byte {
+	length := make([]byte, 4)
+	binary.BigEndian.PutUint32(length, uint32(len(value)))
+	destination = append(destination, length...)
+	return append(destination, value...)
+}
+
+func armorSSHSignature(blob []byte) string {
+	encoded := base64.StdEncoding.EncodeToString(blob)
+	var builder strings.Builder
+	builder.WriteString("-----BEGIN SSH SIGNATURE-----\n")
+	for len(encoded) > sshArmorLineLength {
+		builder.WriteString(encoded[:sshArmorLineLength])
+		builder.WriteByte('\n')
+		encoded = encoded[sshArmorLineLength:]
+	}
+	builder.WriteString(encoded)
+	builder.WriteString("\n-----END SSH SIGNATURE-----\n")
+	return builder.String()
+}

--- a/internal/codesessions/code_signing_http.go
+++ b/internal/codesessions/code_signing_http.go
@@ -1,0 +1,92 @@
+package codesessions
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type signCommitRequest struct {
+	Contents        string            `json:"contents"`
+	Source          *signCommitSource `json:"source,omitempty"`
+	GitObjectFormat string            `json:"git_object_format,omitempty"`
+}
+
+type signCommitSource struct {
+	Type    string             `json:"type"`
+	GitInfo *signCommitGitInfo `json:"git_info"`
+}
+
+type signCommitGitInfo struct {
+	Type string `json:"type"`
+	Repo string `json:"repo"`
+	Ref  string `json:"ref,omitempty"`
+}
+
+type signCommitResponse struct {
+	Signature string `json:"signature"`
+}
+
+func (h *Handler) handleSignCommit(w http.ResponseWriter, r *http.Request) error {
+	codeSessionID := chi.URLParam(r, "code_session_id")
+	claims, err := h.sessionIngressClaims(r, codeSessionID)
+	if err != nil {
+		return err
+	}
+	if claims.WorkerEpoch <= 0 {
+		return sessionIngressTokenInvalid(errors.New("commit signing requires a managed code-session credential"))
+	}
+
+	request, err := httpapi.DecodeObjectBodyAs[signCommitRequest](w, r, maxIngressBodySize)
+	if err != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			return signCommitRequestTooLarge(err)
+		}
+		return invalidSignCommitRequest("Invalid JSON body", err)
+	}
+	objectFormat, err := validateSignCommitRequest(request)
+	if err != nil {
+		return err
+	}
+	signature, err := h.service.SignGitCommit([]byte(request.Contents))
+	if err != nil {
+		return signCommitFailure(err)
+	}
+	h.logger.InfoContext(
+		r.Context(),
+		"git commit signed",
+		"session_id", claims.SessionID,
+		"content_length", len(request.Contents),
+		"git_object_format", objectFormat,
+	)
+	httpapi.WriteJSON(w, http.StatusOK, signCommitResponse{Signature: signature})
+	return nil
+}
+
+func validateSignCommitRequest(request *signCommitRequest) (string, error) {
+	if request.Contents == "" {
+		return "", invalidSignCommitRequest("contents must not be empty", nil)
+	}
+	objectFormat := strings.TrimSpace(request.GitObjectFormat)
+	if objectFormat == "" {
+		objectFormat = "sha1"
+	}
+	if objectFormat != "sha1" && objectFormat != "sha256" {
+		return "", invalidSignCommitRequest("git_object_format must be sha1 or sha256", nil)
+	}
+	if request.Source == nil {
+		return objectFormat, nil
+	}
+	if strings.TrimSpace(request.Source.Type) != "git_repository" {
+		return "", invalidSignCommitRequest("source.type must be git_repository", nil)
+	}
+	if request.Source.GitInfo == nil || strings.TrimSpace(request.Source.GitInfo.Type) == "" || strings.TrimSpace(request.Source.GitInfo.Repo) == "" {
+		return "", invalidSignCommitRequest("source.git_info must include type and repo", nil)
+	}
+	return objectFormat, nil
+}

--- a/internal/codesessions/code_signing_test.go
+++ b/internal/codesessions/code_signing_test.go
@@ -1,0 +1,309 @@
+package codesessions
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+)
+
+func TestGitCommitSigningRejectsUnconfiguredCredentials(t *testing.T) {
+	if _, err := (*SessionCredentials)(nil).signGitCommit([]byte("commit")); err == nil {
+		t.Fatal("signGitCommit() accepted nil credentials")
+	}
+	if _, err := (*SessionCredentials)(nil).GitSigningPublicKey(); err == nil {
+		t.Fatal("GitSigningPublicKey() accepted nil credentials")
+	}
+	if _, err := (*Service)(nil).SignGitCommit([]byte("commit")); err == nil {
+		t.Fatal("SignGitCommit() accepted nil service")
+	}
+}
+
+func TestGitCommitSigningProducesVerifiableSSHSIG(t *testing.T) {
+	now := time.Date(2026, time.August, 27, 12, 0, 0, 0, time.UTC)
+	credentials := newTestSessionCredentials(t, &now)
+	contents := []byte("tree 0123456789abcdef\nauthor Example <example@example.com> 0 +0000\n\nmessage\n")
+
+	signature, err := credentials.signGitCommit(contents)
+	if err != nil {
+		t.Fatalf("signGitCommit() error = %v", err)
+	}
+	second, err := credentials.signGitCommit(contents)
+	if err != nil {
+		t.Fatalf("second signGitCommit() error = %v", err)
+	}
+	if signature != second {
+		t.Fatal("Ed25519 signature is not deterministic for identical contents")
+	}
+	parsed := parseTestSSHSIG(t, signature)
+	if parsed.namespace != sshSignatureNamespace || parsed.hashAlgorithm != sshSignatureHash || len(parsed.reserved) != 0 {
+		t.Fatalf("unexpected SSHSIG metadata: namespace=%q reserved=%x hash=%q", parsed.namespace, parsed.reserved, parsed.hashAlgorithm)
+	}
+	if !bytes.Equal(parsed.publicKey, credentials.publicKey) {
+		t.Fatal("SSHSIG public key does not match SessionCredentials")
+	}
+	digest := sha512.Sum512(contents)
+	signedData := append([]byte(nil), sshSignatureMagic...)
+	signedData = appendSSHString(signedData, []byte(parsed.namespace))
+	signedData = appendSSHString(signedData, parsed.reserved)
+	signedData = appendSSHString(signedData, []byte(parsed.hashAlgorithm))
+	signedData = appendSSHString(signedData, digest[:])
+	if !ed25519.Verify(parsed.publicKey, signedData, parsed.signature) {
+		t.Fatal("SSHSIG Ed25519 signature did not verify")
+	}
+	changedDigest := sha512.Sum512(append(append([]byte(nil), contents...), '!'))
+	changedData := append([]byte(nil), sshSignatureMagic...)
+	changedData = appendSSHString(changedData, []byte(parsed.namespace))
+	changedData = appendSSHString(changedData, parsed.reserved)
+	changedData = appendSSHString(changedData, []byte(parsed.hashAlgorithm))
+	changedData = appendSSHString(changedData, changedDigest[:])
+	if ed25519.Verify(parsed.publicKey, changedData, parsed.signature) {
+		t.Fatal("SSHSIG verified different contents")
+	}
+
+	publicKey, err := credentials.GitSigningPublicKey()
+	if err != nil {
+		t.Fatalf("GitSigningPublicKey() error = %v", err)
+	}
+	parts := strings.Fields(publicKey)
+	if len(parts) != 3 || parts[0] != sshEd25519Algorithm || parts[2] != "oma-code-signing" {
+		t.Fatalf("unexpected OpenSSH public key line: %q", publicKey)
+	}
+	publicBlob, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode OpenSSH public key: %v", err)
+	}
+	if !bytes.Equal(publicBlob, parsed.publicKeyBlob) {
+		t.Fatal("exported public key does not match SSHSIG public key blob")
+	}
+}
+
+func TestGitCommitSigningInteroperatesWithOpenSSH(t *testing.T) {
+	sshKeygen, err := exec.LookPath("ssh-keygen")
+	if err != nil {
+		t.Skip("ssh-keygen is not installed")
+	}
+	now := time.Date(2026, time.August, 27, 12, 0, 0, 0, time.UTC)
+	credentials := newTestSessionCredentials(t, &now)
+	contents := []byte("commit payload for OpenSSH\n")
+	signature, err := credentials.signGitCommit(contents)
+	if err != nil {
+		t.Fatalf("signGitCommit() error = %v", err)
+	}
+	signatureFile := filepath.Join(t.TempDir(), "commit.sig")
+	if err := os.WriteFile(signatureFile, []byte(signature), 0o600); err != nil {
+		t.Fatalf("write signature file: %v", err)
+	}
+	command := exec.Command(sshKeygen, "-Y", "check-novalidate", "-n", sshSignatureNamespace, "-s", signatureFile)
+	command.Stdin = bytes.NewReader(contents)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("ssh-keygen rejected SSHSIG: %v: %s", err, output)
+	}
+	command = exec.Command(sshKeygen, "-Y", "check-novalidate", "-n", sshSignatureNamespace, "-s", signatureFile)
+	command.Stdin = strings.NewReader("different payload\n")
+	if err := command.Run(); err == nil {
+		t.Fatal("ssh-keygen accepted SSHSIG for different contents")
+	}
+}
+
+func TestSignCommitHTTPContract(t *testing.T) {
+	now := time.Date(2026, time.August, 27, 12, 0, 0, 0, time.UTC)
+	credentials := newTestSessionCredentials(t, &now)
+	service := NewServiceWithCredentials(nil, credentials, nil)
+	handler := NewHandler(configForCodeSigningTest(), service, nil, nil)
+	router := chi.NewRouter()
+	handler.RegisterV1Routes(router)
+
+	managedIdentity := testSessionCredentialIdentity()
+	managedIdentity.WorkerEpoch = 1
+	managedToken, err := credentials.Issue(managedIdentity)
+	if err != nil {
+		t.Fatalf("issue managed token: %v", err)
+	}
+	legacyIdentity := testSessionCredentialIdentity()
+	legacyToken, err := credentials.Issue(legacyIdentity)
+	if err != nil {
+		t.Fatalf("issue legacy token: %v", err)
+	}
+
+	failures := []struct {
+		name       string
+		sessionID  string
+		token      string
+		body       string
+		wantStatus int
+	}{
+		{name: "missing token", sessionID: "cse_test", body: `{"contents":"commit"}`, wantStatus: http.StatusUnauthorized},
+		{name: "legacy token", sessionID: "cse_test", token: legacyToken, body: `{"contents":"commit"}`, wantStatus: http.StatusUnauthorized},
+		{name: "mismatched session", sessionID: "cse_other", token: managedToken, body: `{"contents":"commit"}`, wantStatus: http.StatusUnauthorized},
+		{name: "malformed JSON", sessionID: "cse_test", token: managedToken, body: `{"contents":`, wantStatus: http.StatusBadRequest},
+		{name: "null body", sessionID: "cse_test", token: managedToken, body: `null`, wantStatus: http.StatusBadRequest},
+		{name: "empty contents", sessionID: "cse_test", token: managedToken, body: `{"contents":""}`, wantStatus: http.StatusBadRequest},
+		{name: "invalid object format", sessionID: "cse_test", token: managedToken, body: `{"contents":"commit","git_object_format":"md5"}`, wantStatus: http.StatusBadRequest},
+		{name: "invalid source", sessionID: "cse_test", token: managedToken, body: `{"contents":"commit","source":{"type":"url"}}`, wantStatus: http.StatusBadRequest},
+	}
+	for _, test := range failures {
+		t.Run("failure "+test.name, func(t *testing.T) {
+			response := performSignCommitRequest(t, router, test.sessionID, test.token, test.body)
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d: %s", response.Code, test.wantStatus, response.Body.String())
+			}
+		})
+	}
+
+	t.Run("failure oversized body", func(t *testing.T) {
+		body := `{"contents":"` + strings.Repeat("a", maxIngressBodySize) + `"}`
+		response := performSignCommitRequest(t, router, "cse_test", managedToken, body)
+		if response.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusRequestEntityTooLarge, response.Body.String())
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		contents := "  exact commit contents\n"
+		body, err := json.Marshal(signCommitRequest{
+			Contents: contents,
+			Source: &signCommitSource{
+				Type: "git_repository",
+				GitInfo: &signCommitGitInfo{
+					Type: "github",
+					Repo: "superduck-ai/open-managed-agents",
+					Ref:  "refs/heads/main",
+				},
+			},
+			GitObjectFormat: "sha256",
+		})
+		if err != nil {
+			t.Fatalf("marshal request: %v", err)
+		}
+		response := performSignCommitRequest(t, router, "cse_test", managedToken, string(body))
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d: %s", response.Code, http.StatusOK, response.Body.String())
+		}
+		var decoded signCommitResponse
+		if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		parsed := parseTestSSHSIG(t, decoded.Signature)
+		digest := sha512.Sum512([]byte(contents))
+		signedData := append([]byte(nil), sshSignatureMagic...)
+		signedData = appendSSHString(signedData, []byte(parsed.namespace))
+		signedData = appendSSHString(signedData, parsed.reserved)
+		signedData = appendSSHString(signedData, []byte(parsed.hashAlgorithm))
+		signedData = appendSSHString(signedData, digest[:])
+		if !ed25519.Verify(parsed.publicKey, signedData, parsed.signature) {
+			t.Fatal("HTTP response did not sign the exact contents")
+		}
+	})
+}
+
+func configForCodeSigningTest() config.Config {
+	return config.Config{}
+}
+
+func performSignCommitRequest(t *testing.T, handler http.Handler, sessionID, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/code/sessions/"+sessionID+"/sign-commit", strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}
+
+type testSSHSIG struct {
+	publicKeyBlob []byte
+	publicKey     ed25519.PublicKey
+	namespace     string
+	reserved      []byte
+	hashAlgorithm string
+	signature     []byte
+}
+
+func parseTestSSHSIG(t *testing.T, armored string) testSSHSIG {
+	t.Helper()
+	if !strings.HasSuffix(armored, "\n") {
+		t.Fatal("armored signature is missing trailing newline")
+	}
+	lines := strings.Split(strings.TrimSuffix(armored, "\n"), "\n")
+	if len(lines) < 3 || lines[0] != "-----BEGIN SSH SIGNATURE-----" || lines[len(lines)-1] != "-----END SSH SIGNATURE-----" {
+		t.Fatalf("invalid SSHSIG armor: %q", armored)
+	}
+	for _, line := range lines[1 : len(lines)-1] {
+		if len(line) > sshArmorLineLength {
+			t.Fatalf("armored line length = %d, want <= %d", len(line), sshArmorLineLength)
+		}
+	}
+	blob, err := base64.StdEncoding.DecodeString(strings.Join(lines[1:len(lines)-1], ""))
+	if err != nil {
+		t.Fatalf("decode SSHSIG armor: %v", err)
+	}
+	reader := bytes.NewReader(blob)
+	magic := make([]byte, len(sshSignatureMagic))
+	if _, err := io.ReadFull(reader, magic); err != nil || string(magic) != sshSignatureMagic {
+		t.Fatalf("read SSHSIG magic = %q, %v", magic, err)
+	}
+	var version uint32
+	if err := binary.Read(reader, binary.BigEndian, &version); err != nil || version != 1 {
+		t.Fatalf("read SSHSIG version = %d, %v", version, err)
+	}
+	publicKeyBlob := readTestSSHString(t, reader)
+	namespace := string(readTestSSHString(t, reader))
+	reserved := readTestSSHString(t, reader)
+	hashAlgorithm := string(readTestSSHString(t, reader))
+	signatureBlob := bytes.NewReader(readTestSSHString(t, reader))
+	if reader.Len() != 0 {
+		t.Fatalf("SSHSIG has %d trailing bytes", reader.Len())
+	}
+	algorithm := string(readTestSSHString(t, signatureBlob))
+	signature := readTestSSHString(t, signatureBlob)
+	if algorithm != sshEd25519Algorithm || signatureBlob.Len() != 0 {
+		t.Fatalf("unexpected signature blob algorithm=%q trailing=%d", algorithm, signatureBlob.Len())
+	}
+	publicReader := bytes.NewReader(publicKeyBlob)
+	publicAlgorithm := string(readTestSSHString(t, publicReader))
+	publicKey := readTestSSHString(t, publicReader)
+	if publicAlgorithm != sshEd25519Algorithm || len(publicKey) != ed25519.PublicKeySize || publicReader.Len() != 0 {
+		t.Fatalf("unexpected public key blob algorithm=%q key_bytes=%d trailing=%d", publicAlgorithm, len(publicKey), publicReader.Len())
+	}
+	return testSSHSIG{
+		publicKeyBlob: publicKeyBlob,
+		publicKey:     ed25519.PublicKey(publicKey),
+		namespace:     namespace,
+		reserved:      reserved,
+		hashAlgorithm: hashAlgorithm,
+		signature:     signature,
+	}
+}
+
+func readTestSSHString(t *testing.T, reader *bytes.Reader) []byte {
+	t.Helper()
+	var length uint32
+	if err := binary.Read(reader, binary.BigEndian, &length); err != nil {
+		t.Fatalf("read SSH string length: %v", err)
+	}
+	if uint64(length) > uint64(reader.Len()) {
+		t.Fatalf("SSH string length = %d, remaining = %d", length, reader.Len())
+	}
+	value := make([]byte, length)
+	if _, err := io.ReadFull(reader, value); err != nil {
+		t.Fatalf("read SSH string: %v", err)
+	}
+	return value
+}

--- a/internal/codesessions/errors.go
+++ b/internal/codesessions/errors.go
@@ -28,6 +28,18 @@ func sessionIngressTokenInvalid(cause error) error {
 	return apperr.New(apperr.Unauthenticated, "Invalid session ingress token", cause)
 }
 
+func invalidSignCommitRequest(message string, cause error) error {
+	return apperr.New(apperr.InvalidArgument, message, cause)
+}
+
+func signCommitRequestTooLarge(cause error) error {
+	return apperr.New(apperr.RequestTooLarge, "Request body exceeds maximum size", cause)
+}
+
+func signCommitFailure(cause error) error {
+	return internalError("Could not sign commit", cause)
+}
+
 func codeSessionEventsLoadError(err error, codeSessionID string) error {
 	return internalError(
 		"Could not list code session events",

--- a/internal/codesessions/routes.go
+++ b/internal/codesessions/routes.go
@@ -38,6 +38,7 @@ func (h *Handler) registerCodeSessionRoutes(router chi.Router) {
 		sessionRouter.Get("/", h.errorAdapter.Wrap(h.handleCodeSessionHTTPPoll))
 		sessionRouter.Post("/", h.handleSessionIngressPersistence)
 		sessionRouter.Put("/", h.handleSessionIngressPersistence)
+		sessionRouter.Post("/sign-commit", h.errorAdapter.Wrap(h.handleSignCommit))
 		sessionRouter.Route("/worker", func(workerRouter chi.Router) {
 			workerRouter.Get("/", h.handleGetCodeSessionWorker)
 			workerRouter.Put("/", h.handlePutCodeSessionWorker)

--- a/justfile
+++ b/justfile
@@ -66,6 +66,10 @@ generate-code-session-jwt-key output:
 test-generate-code-session-jwt-key:
   ./scripts/tests/generate-code-session-jwt-key_test.sh
 
+# Print the OpenSSH signing public key for GitHub without exposing the private key.
+print-code-session-signing-public-key private_key_file: generate
+  @go run ./cmd/code-session-signing-public-key "{{ private_key_file }}"
+
 # Generate the stable CCRv2 MITM CA key. Example: just generate-upstream-proxy-ca-key config/secrets/upstream-proxy-ca-key.pem
 generate-upstream-proxy-ca-key output:
   ./scripts/generate-upstream-proxy-ca-key.sh "{{ output }}"

--- a/tests/code_signing_api_test.go
+++ b/tests/code_signing_api_test.go
@@ -1,0 +1,71 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCodeSessionCommitSigningRequiresCurrentWorkerEpoch(t *testing.T) {
+	app := newTestAppWithStore(t, nil, newFakeStore("code-signing-api-bucket"))
+	defer app.close()
+
+	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"code-signing-agent"}`)
+	defer cleanupAgentRows(t, app.pool, agent.ID)
+	environment := createEnvironment(t, app, `{"name":"code-signing-environment"}`)
+	defer cleanupEnvironmentRows(t, app.pool, environment.ID)
+	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(environment.ID)+`}`)
+	codeSessionID := launchLocalCodeSession(t, app, session.ID)
+	if epoch := registerCodeSessionWorker(t, app, codeSessionID); epoch != "1" {
+		t.Fatalf("initial worker epoch = %q, want 1", epoch)
+	}
+	staleToken := codeSessionIngressToken(t, app, codeSessionID)
+	if _, err := app.pool.Exec(
+		context.Background(),
+		`update code_sessions set current_worker_epoch = current_worker_epoch + 1 where external_id = $1`,
+		codeSessionID,
+	); err != nil {
+		t.Fatalf("advance worker epoch: %v", err)
+	}
+
+	t.Run("failure stale epoch", func(t *testing.T) {
+		response := requestCommitSignature(t, app, codeSessionID, staleToken, `{"contents":"commit payload"}`)
+		assertError(t, response, http.StatusUnauthorized, "authentication_error")
+	})
+
+	t.Run("success current epoch", func(t *testing.T) {
+		body := `{"contents":"tree abcdef\n\nSigned through OMA\n","source":{"type":"git_repository","git_info":{"type":"github","repo":"superduck-ai/open-managed-agents"}},"git_object_format":"sha1"}`
+		response := requestCommitSignature(t, app, codeSessionID, codeSessionIngressToken(t, app, codeSessionID), body)
+		defer response.Body.Close()
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want %d: %s", response.StatusCode, http.StatusOK, readAll(t, response.Body))
+		}
+		var decoded struct {
+			Signature string `json:"signature"`
+		}
+		decodeJSON(t, response.Body, &decoded)
+		if !strings.HasPrefix(decoded.Signature, "-----BEGIN SSH SIGNATURE-----\n") || !strings.HasSuffix(decoded.Signature, "-----END SSH SIGNATURE-----\n") {
+			t.Fatalf("unexpected signature response: %q", decoded.Signature)
+		}
+	})
+}
+
+func requestCommitSignature(t *testing.T, app *testApp, codeSessionID, token, body string) *http.Response {
+	t.Helper()
+	request, err := http.NewRequest(
+		http.MethodPost,
+		app.baseURL+"/v1/code/sessions/"+codeSessionID+"/sign-commit",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("new commit signing request: %v", err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := app.client.Do(request)
+	if err != nil {
+		t.Fatalf("request commit signature: %v", err)
+	}
+	return response
+}


### PR DESCRIPTION
## Summary

- Add Ed25519 SSHSIG commit signing for CCRv2 Code Sessions.
- Expose a session-scoped `sign-commit` endpoint with validation, authorization, size limits, and safe structured logging.
- Add a CLI to export the OpenSSH public signing key.
- Document key lifecycle, GitHub Signing Key setup, and environment-manager integration.
- Add coverage for SSHSIG verification, OpenSSH interoperability, HTTP validation, and private-key protection.

## Testing

Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Git commit signing for Code Sessions using Ed25519 and SSH signatures.
  - Added an authenticated API endpoint for signing commits.
  - Added a command to export the Code Session signing public key in OpenSSH format.
  - Added a convenient task for printing the public key.

- **Documentation**
  - Documented signing-key configuration, GitHub setup, key rotation, and commit-signing behavior.

- **Bug Fixes**
  - Invalid, oversized, unauthenticated, or stale signing requests now receive appropriate errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->