### PR TITLE
fix(scripts): generate-go.sh 只删孤儿产物，修复并发调用静默残缺

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,7 @@
 ## 测试要求
 
 - 测试组织顺序应先写失败场景，再写成功场景。
-- `*.gen.go` 不纳入版本控制；干净 checkout 在直接运行 Go 编译、测试或静态分析前先执行 `./scripts/generate-go.sh`（先清空 `internal/db/**/*.sqlmap.gen.go`，再 `go generate ./internal/db`，避免已删除 Mapper 的残留生成文件参与编译）。仓库标准 `just` 命令会自动完成生成。
+- `*.gen.go` 不纳入版本控制；干净 checkout 在直接运行 Go 编译、测试或静态分析前先执行 `./scripts/generate-go.sh`（只删除 `internal/db` 下已不再被 `go:generate` 声明的孤儿 `*.sqlmap.gen.go`，再 `go generate ./internal/db` 重写其余产物，避免已删除 Mapper 的残留生成文件参与编译）。仓库标准 `just` 命令会自动完成生成。
 - 修改 `web/` 下的文件后，运行 `just web-format-check`，确保 Prettier 格式门禁通过。
 - 修改 Go 代码后，运行 `just lint`；该命令使用仓库根目录的 `.golangci.yml` 执行与 CI 相同的静态分析和格式检查。
 - 修改 schema 或 handler 后，运行 `just test`（等价于先生成 Go 源码，再运行 `go test ./... -count=1`）。

--- a/docs/design/development-quality-gates.md
+++ b/docs/design/development-quality-gates.md
@@ -15,7 +15,7 @@
 
 ## 配置与执行
 
-- yourbatis 根据 `internal/db/*.xml` 生成的 `*.sqlmap.gen.go` 不提交；`scripts/generate-go.sh` 是统一生成入口。该脚本会先删除 `internal/db` 下已有的 `*.sqlmap.gen.go`，再执行 `go generate ./internal/db`，避免已删除 Mapper 留下的 ignored 生成文件继续参与编译。Go lint、死代码、复杂度、测试、开发启动和 Docker 构建在类型检查或编译前调用该入口，避免本地残留的 ignored 文件掩盖干净 checkout 中的缺失生成代码。
+- yourbatis 根据 `internal/db/*.xml` 生成的 `*.sqlmap.gen.go` 不提交；`scripts/generate-go.sh` 是统一生成入口。该脚本从 `internal/db/*_mapper.go` 的 `go:generate` 指令解析全部 `-out` 目标，只删除不在该集合中的孤儿 `*.sqlmap.gen.go`，再执行 `go generate ./internal/db` 重写其余产物，避免已删除 Mapper 留下的 ignored 生成文件继续参与编译。Go lint、死代码、复杂度、测试、开发启动和 Docker 构建在类型检查或编译前调用该入口，避免本地残留的 ignored 文件掩盖干净 checkout 中的缺失生成代码。这些入口可能并发调用该脚本，因此它不删除仍被声明的产物：无条件清空会让 `internal/db` 在整个生成期间残缺，并发调用时后启动的删除会抹掉前一个进程已生成的文件，而 `go generate` 不会回头补，导致退出码为 0 但产物不完整。
 - `.golangci.yml` 是常规 Go lint 规则来源；复杂度和死代码等需要不同扫描范围的专项门禁使用独立的固定配置。
 - `just lint` 在本地对所有 Go package（包括测试）运行相同配置。
 - `.golangci-dead-code.yml` 单独启用 golangci-lint 的 `unused` 分析器并覆盖测试代码；`just dead-code` 通过 `scripts/go-dead-code.sh` 枚举当前 Go module 的仓库 package，避免本地前端依赖中的第三方 Go 示例污染结果。

--- a/justfile
+++ b/justfile
@@ -10,6 +10,9 @@ help:
 generate:
   ./scripts/generate-go.sh
 
+test-generate-go:
+  ./scripts/tests/generate-go_test.sh
+
 # Create the gitignored Docker Compose runtime config without overwriting an existing secret-bearing file.
 init-compose-config:
   @compose_template="deploy/docker-compose/oma-server.yaml"; compose_local="deploy/docker-compose/oma-server.local.yaml"; \

--- a/scripts/generate-go.sh
+++ b/scripts/generate-go.sh
@@ -4,6 +4,34 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-find ./internal/db -type f -name '*.sqlmap.gen.go' -delete
+mapper_directory="internal/db"
 
-go generate ./internal/db
+expected_outputs="$(mktemp)"
+actual_outputs="$(mktemp)"
+cleanup() {
+  rm -f -- "$expected_outputs" "$actual_outputs"
+}
+trap cleanup EXIT
+
+grep -h 'go:generate' "$mapper_directory"/*_mapper.go |
+  grep -oE '\-out [^ ]+' |
+  sed 's|^-out ||; s|^\./||' |
+  sort -u >"$expected_outputs"
+
+# 空集合会让下面把全部产物判定为孤儿。
+if [[ ! -s "$expected_outputs" ]]; then
+  echo "generate-go: no sqlmapgen -out targets found in $mapper_directory/*_mapper.go" >&2
+  exit 1
+fi
+
+find "$mapper_directory" -type f -name '*.sqlmap.gen.go' |
+  sed "s|^$mapper_directory/||" |
+  sort -u >"$actual_outputs"
+
+# 只删孤儿：删除仍被声明的产物会让 internal/db 在生成期间残缺，并发调用时互相抹除。
+while IFS= read -r orphan; do
+  [[ -n "$orphan" ]] || continue
+  rm -f -- "$mapper_directory/$orphan"
+done < <(comm -13 "$expected_outputs" "$actual_outputs")
+
+go generate ./"$mapper_directory"

--- a/scripts/tests/generate-go_test.sh
+++ b/scripts/tests/generate-go_test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GENERATOR="$REPO_ROOT/scripts/generate-go.sh"
+MAPPER_DIRECTORY="$REPO_ROOT/internal/db"
+ORPHAN="$MAPPER_DIRECTORY/deleted_mapper_orphan.sqlmap.gen.go"
+
+cleanup() {
+  rm -f -- "$ORPHAN"
+}
+trap cleanup EXIT
+
+generated_files() {
+  find "$MAPPER_DIRECTORY" -type f -name '*.sqlmap.gen.go' | wc -l | tr -d ' '
+}
+
+generated_digest() {
+  find "$MAPPER_DIRECTORY" -type f -name '*.sqlmap.gen.go' |
+    sort |
+    xargs shasum -a 256 |
+    shasum -a 256 |
+    awk '{print $1}'
+}
+
+expected_count() {
+  grep -h 'go:generate' "$MAPPER_DIRECTORY"/*_mapper.go |
+    grep -oE '\-out [^ ]+' |
+    sed 's|^-out ||; s|^\./||' |
+    sort -u |
+    wc -l |
+    tr -d ' '
+}
+
+"$GENERATOR" >/dev/null
+expected="$(expected_count)"
+expected_digest="$(generated_digest)"
+
+# 失败场景优先：产物齐备时重跑，生成期间工作区不得残缺。删除仍被 go:generate
+# 声明的产物会让 internal/db 在整个生成期间少文件，并发调用时后启动的删除就会
+# 抹掉前一个进程已生成的文件，使调用方在退出码为 0 的情况下拿到残缺的目录。
+# 这里全程采样文件数，不靠固定延时错峰两次调用，因此与机器快慢无关。
+minimum_seen="$expected"
+"$GENERATOR" >/dev/null &
+generator_pid=$!
+while kill -0 "$generator_pid" 2>/dev/null; do
+  current="$(generated_files)"
+  if [[ "$current" -lt "$minimum_seen" ]]; then
+    minimum_seen="$current"
+  fi
+  sleep 0.05
+done
+wait "$generator_pid"
+
+if [[ "$minimum_seen" != "$expected" ]]; then
+  echo "generate dropped to $minimum_seen generated files mid-run, want $expected throughout" >&2
+  exit 1
+fi
+
+# 成功场景：不再被 go:generate 声明的孤儿产物仍必须被清理。
+printf '%s\n' 'package db' >"$ORPHAN"
+"$GENERATOR" >/dev/null
+
+if [[ -e "$ORPHAN" ]]; then
+  echo "generator kept orphan generated file $ORPHAN" >&2
+  exit 1
+fi
+
+if [[ "$(generated_files)" != "$expected" ]]; then
+  echo "generator left $(generated_files) generated files, want $expected" >&2
+  exit 1
+fi
+
+# 幂等：重复生成不得改动任何产物内容。
+if [[ "$(generated_digest)" != "$expected_digest" ]]; then
+  echo "regenerated artifacts differ from the first run" >&2
+  exit 1
+fi
+
+echo "generate-go tests passed"


### PR DESCRIPTION
## 问题

`scripts/generate-go.sh` 在 `go generate` 前无条件删除 `internal/db` 下全部 `*.sqlmap.gen.go`，使该目录在整个生成期间（本机约 9 秒）残缺。该脚本有多个无互斥的调用入口，并发调用时后启动的删除会抹掉前一个进程已生成的文件，而 `go generate` 不会回头补，导致**退出码为 0 但产物不完整**，随后编译报 `undefined: NewXxxMapper`。

调用入口：`.pre-commit-config.yaml:24` 的 `go-generate` hook、`scripts/pre-commit-go-lint.sh:12`、`scripts/go-dead-code.sh:12`、`scripts/go-complexity.sh:12`，以及 `justfile` 的 `generate`/`lint`/`dead-code`/`go-complexity`/`test` 等 target。

## 根因

`scripts/generate-go.sh:7` 由 #282（`9dca1a5`）引入，目的是清理「Mapper 源码已删除、生成文件仍残留」的**孤儿**产物，但实现是无条件全删，顺带删掉 61 个马上会被重新生成的有效产物。

`sqlmapgen` 经 `os.WriteFile` 覆盖写（yourbatis `internal/generator/generator.go:121`），`go generate` 每次都会重写仍被声明的产物 —— 删除有效产物对结果没有贡献，只制造了一个 9 秒的残缺窗口。

## 改动

只删孤儿：从 `internal/db/*_mapper.go` 的 `go:generate` 指令解析全部 `-out` 目标，删除不在该集合中的 `*.sqlmap.gen.go`，其余交给 `go generate` 覆盖。

这样残缺窗口从 9 秒的全树消失压缩到单文件覆盖写的瞬间，**无需文件锁** —— `flock` 在 macOS 上不存在，`lockf`/`mkdir` 锁会引入平台分支与陈旧锁清理，而 CI 是 `ubuntu-latest`、本地是 macOS。

需要说明边界：`sqlmapgen` 用 `os.WriteFile` 覆盖写而非「临时文件 + rename」，两个进程同时写同一产物时理论上仍可能交错，窗口是单文件写入的微秒级。这是既有行为，完全的写入原子性取决于 yourbatis 侧，不在本 PR 范围。本 PR 消除的是「一个进程删掉另一个进程已完成产物」这一实际发生的故障。

保留 #282 的孤儿清理目的，并加一道闸：解析不到任何 `-out` 目标时报错退出，避免期望集合为空导致全部产物被误判为孤儿。

同步更新 `AGENTS.md:172`、`docs/design/development-quality-gates.md:18` 的行为描述，新增 `scripts/tests/generate-go_test.sh` 与 `just test-generate-go`。

## 验证

**A/B 对照** —— 取样「先启动的进程返回那一瞬间工作树的状态」，这是真实故障点（pre-commit 的 `go-generate` hook 返回后调用方立刻编译）。起点产物完整，A 前台跑，B 在 8 秒后并发跑：

| | round 1 | round 2 | round 3 |
|---|---|---|---|
| 原版（main） | 10/61 | 9/61 | **0/61** |
| 本 PR | 61/61 | 61/61 | 61/61 |

原版三轮全部残缺、其中一轮工作树为空，A 的退出码均为 0。

**孤儿清理仍生效** —— 注入两个无 `go:generate` 声明的 gen 文件后运行脚本，精确回到 61 个、孤儿被删除；删除 `admin_api_keys_mapper.go` 与其 `.xml` 后运行脚本，对应 gen 文件被清理（60/60），恢复源码后回到 61/61。

**产物字节一致** —— 修复前后 61 个 gen 文件的聚合 SHA-256 相同（`7e49d3cc...`）。

**测试有效性** —— `scripts/tests/generate-go_test.sh` 直接验证不变量「生成期间工作区一刻都不残缺」：产物齐备后重跑，全程采样产物数取最小值，另比对两次生成的聚合 SHA-256 断言幂等。不依赖固定延时错峰两次调用，与机器快慢无关。在原版脚本下连续失败（`generate dropped to 0 generated files mid-run, want 61 throughout`），修复版下连续通过；篡改单个产物内容后幂等断言也能检出（文件数不变）。

**门禁** —— `just lint`、`just dead-code`、`just go-complexity` 均 0 issues；`pre-commit run --files` 对本次改动文件全部 Passed。`just test` 与 main 基线同为 28 个失败、集合完全一致（`comm` 差集为空），失败源于本机 minio `SlowDownWrite` 与 PG 状态，非本改动引入。`just duplicates` 和 `web-complexity` 因本机缺 `web/node_modules`（jscpd/eslint 未安装）无法运行，本 PR 未触碰 `web/` 下任何文件。

## 附：一处此前的误判

早先曾判断该现象源于 yourbatis 的 `loadTypePackage`，并提了 superduck-ai/yourbatis#4 与 issue #3，现已关闭。给 yourbatis v0.1.5 打 trace 确认 `loadTypePackage` 在本仓库**调用次数为 0**（`lookupStructField` 中 `if !info.HasEmbedded` 提前返回，`internal/db` 下无任何匿名内嵌 struct）；`lstat: no such file` 由 `go list` 抛出而非 yourbatis（源码 grep `lstat` 零命中）。

Closes #311


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Go code generation now preserves declared generated files during regeneration, supporting concurrent runs without incomplete outputs.
  * Orphaned generated files are automatically removed.
  * Generation validates declared targets and cleans up temporary files.

* **Tests**
  * Added automated coverage for complete generation, orphan cleanup, concurrent generation, and repeatability.
  * Added a convenient target for running generation tests.

* **Documentation**
  * Updated development quality-gate and generation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
