### PR TITLE
移除 ConsoleHandler 输出中的 ANSI 控制字符

### DIFF
--- a/docs/design/be/runtime-configuration.md
+++ b/docs/design/be/runtime-configuration.md
@@ -55,7 +55,7 @@ flowchart LR
     componentLoggers --> workers
 ```
 
-该边界让配置比较、序列化和测试保持确定性，也让日志级别、输出 handler 与公共字段由进程入口统一控制。领域代码不能通过把 logger 塞进 `Config` 来绕过依赖声明，也不能自行创建另一套全局 handler。
+该边界让配置比较、序列化和测试保持确定性，也让日志级别、输出 handler 与公共字段由进程入口统一控制。进程入口使用的 console handler 始终输出不含 ANSI 控制字符的纯文本，终端、文件、管道和日志采集器采用相同格式。领域代码不能通过把 logger 塞进 `Config` 来绕过依赖声明，也不能自行创建另一套全局 handler。
 
 Docker Compose 同样只挂载一份完整 YAML，不再通过 `.env` 插值业务字段，也不做 YAML merge。本地 Compose 从受跟踪的无密钥模板 `deploy/docker-compose/oma-server.yaml` 初始化 gitignored 的 `deploy/docker-compose/oma-server.local.yaml`，并只读挂载后者；密码、API key 和私钥路径只能写入本地文件。生产环境应由容器平台或 Secret Manager 将受权限保护的完整 YAML 只读挂载到同一目标路径。
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,5 +1,5 @@
 // Package logging provides logging helpers, including a console slog
-// handler that renders human-friendly, ANSI-colored output for local/dev use.
+// handler that renders human-friendly output for local/dev use.
 package logging
 
 import (
@@ -9,15 +9,6 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
-)
-
-const (
-	ansiReset  = "\033[0m"
-	ansiRed    = "\033[31m"
-	ansiGreen  = "\033[32m"
-	ansiYellow = "\033[33m"
-	ansiCyan   = "\033[36m"
-	ansiGray   = "\033[90m"
 )
 
 // LoggerOrDefault normalizes optional logger dependencies at component
@@ -30,7 +21,7 @@ func LoggerOrDefault(logger *slog.Logger) *slog.Logger {
 	return slog.Default()
 }
 
-// ConsoleHandler writes colored, single-line logs. HTTP access logs
+// ConsoleHandler writes plain-text, single-line logs. HTTP access logs
 // (component=http) are rendered as "[clientKind] METHOD STATUS durationMs URL".
 type ConsoleHandler struct {
 	mu     *sync.Mutex
@@ -118,16 +109,8 @@ func (h *ConsoleHandler) Handle(_ context.Context, r slog.Record) error {
 }
 
 func formatHTTPLine(r slog.Record, values map[string]string, order []string) string {
-	base := ""
-	if r.Level >= slog.LevelError || statusIsError(values["status"]) {
-		base = ansiRed
-	}
-
 	var b strings.Builder
-	b.WriteString(base)
-	b.WriteString(ansiGray)
 	b.WriteString(r.Time.Format("15:04:05.000"))
-	b.WriteString(resetTo(base))
 	b.WriteString(" [")
 	b.WriteString(values["clientKind"])
 	b.WriteString("] ")
@@ -149,26 +132,14 @@ func formatHTTPLine(r slog.Record, values map[string]string, order []string) str
 		"method": true, "status": true, "durationMs": true, "url": true,
 	}
 	appendRest(&b, values, order, skip)
-
-	b.WriteString(ansiReset)
 	return b.String()
 }
 
 func formatGenericLine(r slog.Record, values map[string]string, order []string) string {
-	base := ""
-	if r.Level >= slog.LevelError {
-		base = ansiRed
-	}
-
 	var b strings.Builder
-	b.WriteString(base)
-	b.WriteString(ansiGray)
 	b.WriteString(r.Time.Format("15:04:05.000"))
-	b.WriteString(resetTo(base))
 	b.WriteString(" ")
-	b.WriteString(levelColor(r.Level))
 	b.WriteString(levelLabel(r.Level))
-	b.WriteString(resetTo(base))
 	if component := values["component"]; component != "" {
 		b.WriteString(" [")
 		b.WriteString(component)
@@ -179,16 +150,7 @@ func formatGenericLine(r slog.Record, values map[string]string, order []string) 
 
 	skip := map[string]bool{"component": true}
 	appendRest(&b, values, order, skip)
-
-	b.WriteString(ansiReset)
 	return b.String()
-}
-
-func resetTo(base string) string {
-	if base == "" {
-		return ansiReset
-	}
-	return ansiReset + base
 }
 
 func appendRest(b *strings.Builder, values map[string]string, order []string, skip map[string]bool) {
@@ -218,23 +180,6 @@ func levelLabel(level slog.Level) string {
 	default:
 		return "DEBUG"
 	}
-}
-
-func levelColor(level slog.Level) string {
-	switch {
-	case level >= slog.LevelError:
-		return ansiRed
-	case level >= slog.LevelWarn:
-		return ansiYellow
-	case level >= slog.LevelInfo:
-		return ansiGreen
-	default:
-		return ansiCyan
-	}
-}
-
-func statusIsError(status string) bool {
-	return len(status) > 0 && (status[0] == '4' || status[0] == '5')
 }
 
 func attrValueString(v slog.Value) string {

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -2,10 +2,12 @@ package logging
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestConsoleHandlerFormatsHTTPLine(t *testing.T) {
@@ -25,7 +27,10 @@ func TestConsoleHandlerFormatsHTTPLine(t *testing.T) {
 		"clientKind", "api",
 	)
 
-	line := stripANSI(strings.TrimSpace(buf.String()))
+	line := strings.TrimSpace(buf.String())
+	if strings.Contains(line, "\x1b[") {
+		t.Fatalf("non-terminal http log contains ANSI escape codes: %q", line)
+	}
 	if !strings.Contains(line, " [api] GET 200 12.3ms /v1/files ") {
 		t.Fatalf("unexpected http log line: %q", line)
 	}
@@ -33,6 +38,25 @@ func TestConsoleHandlerFormatsHTTPLine(t *testing.T) {
 		if !strings.Contains(line, want) {
 			t.Fatalf("http log line missing %q: %q", want, line)
 		}
+	}
+}
+
+func TestConsoleHandlerFormatsGenericLineWithoutANSI(t *testing.T) {
+	var buf bytes.Buffer
+	handler := NewConsoleHandler(&buf, slog.LevelInfo)
+	record := slog.NewRecord(
+		time.Date(2026, time.August, 28, 10, 55, 41, 447000000, time.UTC),
+		slog.LevelError,
+		"request failed",
+		0,
+	)
+
+	if err := handler.Handle(context.Background(), record); err != nil {
+		t.Fatalf("Handle() error = %v", err)
+	}
+
+	if got, want := strings.TrimSpace(buf.String()), "10:55:41.447 ERROR request failed"; got != want {
+		t.Fatalf("log line = %q, want %q", got, want)
 	}
 }
 
@@ -49,16 +73,4 @@ func TestLoggerOrDefault(t *testing.T) {
 			t.Fatal("LoggerOrDefault(nil) did not return slog.Default()")
 		}
 	})
-}
-
-func stripANSI(s string) string {
-	replacer := strings.NewReplacer(
-		ansiReset, "",
-		ansiRed, "",
-		ansiGreen, "",
-		ansiYellow, "",
-		ansiCyan, "",
-		ansiGray, "",
-	)
-	return replacer.Replace(s)
 }


### PR DESCRIPTION
## Summary

- 将 ConsoleHandler 改为始终输出纯文本日志
- 删除日志级别和 HTTP 状态码的 ANSI 着色逻辑
- 更新运行时配置文档，明确纯文本输出约定
- 增加 HTTP 与通用日志无 ANSI 字符的单元测试

## Testing

- 已增加并更新 logging 包单元测试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Console logs are now consistently emitted as plain text without ANSI color codes across terminals, files, pipes, and log collectors.
  * HTTP and generic log messages retain their existing structure and routing while avoiding terminal-specific formatting.

* **Documentation**
  * Updated runtime configuration documentation to clarify plain-text console logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->