### PR TITLE
修正沙箱回收策略与 E2B 删除幂等性

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -8,10 +8,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/superduck-ai/open-managed-agents/internal/backgroundjobs"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/logging"
+	"github.com/superduck-ai/open-managed-agents/internal/riverjobs"
 )
 
 func main() {
@@ -47,7 +47,7 @@ func run(logger *slog.Logger) error {
 	if err := database.Migrate(ctx); err != nil {
 		return fmt.Errorf("migrate database: %w", err)
 	}
-	if err := backgroundjobs.Migrate(ctx, database, logger.With("component", "deployment_scheduler")); err != nil {
+	if err := riverjobs.Migrate(ctx, database, logger.With("component", "river_jobs")); err != nil {
 		return fmt.Errorf("migrate River: %w", err)
 	}
 	logger.Info("database migrations applied")

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -8,9 +8,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/superduck-ai/open-managed-agents/internal/backgroundjobs"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
-	"github.com/superduck-ai/open-managed-agents/internal/deployments"
 	"github.com/superduck-ai/open-managed-agents/internal/logging"
 )
 
@@ -47,7 +47,7 @@ func run(logger *slog.Logger) error {
 	if err := database.Migrate(ctx); err != nil {
 		return fmt.Errorf("migrate database: %w", err)
 	}
-	if err := deployments.MigrateRiver(ctx, database, logger.With("component", "deployment_scheduler")); err != nil {
+	if err := backgroundjobs.Migrate(ctx, database, logger.With("component", "deployment_scheduler")); err != nil {
 		return fmt.Errorf("migrate River: %w", err)
 	}
 	logger.Info("database migrations applied")

--- a/docs/configuration-reference.yaml
+++ b/docs/configuration-reference.yaml
@@ -58,6 +58,7 @@ e2b:
   api_key: ""
   access_token: ""
   domain: ""
+  # E2B API 地址；Provider 会将它显式传给 SDK，为空时沿用 SDK 的环境变量或默认值。
   api_url: ""
   sandbox_url: ""
   debug: false
@@ -163,3 +164,9 @@ sdk_fixtures:
   deployment_run_id: deployment_run_id
   api_key: my-anthropic-api-key
   api_key_external_id: api_key_official_sdk_resource_tests
+
+# Long-idle managed sandbox reclamation. Disable dry_run to delete sandbox local state.
+sandbox_lifecycle:
+  enabled: true
+  dry_run: true
+  idle_timeout: 24h

--- a/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
+++ b/docs/design/be/ccrv2/worker-heartbeat-server-implementation.md
@@ -24,6 +24,8 @@
 - `internal/db/db.go`
 - `tests/sessions_api_test.go`
 
+长期 idle 的主动销毁独立于 heartbeat 租约，采用 [沙箱生命周期协议](../sandbox-lifecycle.md)。回收会递增 epoch 并撤销 lease；heartbeat 不更新 `idle_since`。默认 dry-run，只观察，不销毁。
+
 ## API 行为
 
 ### 请求

--- a/docs/design/be/deployments-api-contract.md
+++ b/docs/design/be/deployments-api-contract.md
@@ -64,7 +64,7 @@ Cron 统一由 `github.com/robfig/cron/v3` 解析和计算：
 
 每个 active 且未归档、schedule 非空的 Deployment 对应一个 River Periodic Job，Periodic Job ID 使用 Deployment ID。Deployment 表是配置真源，只持久化 `schedule`，不保存应用自行推进的下一次游标或额外调度版本。Job 携带注册时的 schedule 快照；worker 读取 Deployment 后以当时的执行配置作为本次 occurrence 快照，最终事务锁行后确认 Deployment 仍为 active、schedule 和执行配置均未变化。
 
-River client 和 migrator 由 `internal/backgroundjobs` 统一组装，与 sandbox_lifecycle 队列共享现有连接池；DeploymentScheduler 只维护 Deployment 的 schedule registry。每个应用实例启动时从 Deployment 表加载 Periodic Jobs，并每 10 秒从数据库同步一次 registry。这样所有执行实例最终持有相同配置，进程重启不会丢失 schedule，pause/archive/清空 schedule 会移除 Periodic Job，unpause 或修改 schedule 会重新注册。同步完成前已经投递的 Job 会由 worker 根据当前状态和 schedule 快照跳过。单条确定性的存量 schedule 错误记录后跳过，数据库不可用等全局基础设施错误仍使启动失败。
+River client 和 migrator 由 `internal/riverjobs` 统一组装，与 sandbox_lifecycle 队列共享现有连接池；DeploymentScheduler 只维护 Deployment 的 schedule registry。每个应用实例启动时从 Deployment 表加载 Periodic Jobs，并每 10 秒从数据库同步一次 registry。这样所有执行实例最终持有相同配置，进程重启不会丢失 schedule，pause/archive/清空 schedule 会移除 Periodic Job，unpause 或修改 schedule 会重新注册。同步完成前已经投递的 Job 会由 worker 根据当前状态和 schedule 快照跳过。单条确定性的存量 schedule 错误记录后跳过，数据库不可用等全局基础设施错误仍使启动失败。
 
 River 的 leader election 保证只有 leader 根据 Cron 推进并投递 Periodic Job，应用不计算、持久化或插入“下一条 Job”。插入 Periodic Job 时把当时的 Cron occurrence 写入 Job args；worker 只用这个字段作为名义时刻。River 重试会改写 `river_job.scheduled_at` 为下次重试时间，不能当 occurrence 用。暂停或停机期间不补跑历史 occurrence，恢复注册后直接等待 Cron 的下一次。River 开源 Periodic Jobs 的调度状态主要在 leader 内存中，官方不承诺强持久性，leader 切换的极短窗口可能跳过一次 occurrence；当前 fork 也提供 DurablePeriodicJob，[沙箱生命周期](sandbox-lifecycle.md) 使用该机制；Deployment 在本次变更中仍保留原有 PeriodicJobs 调度语义。
 

--- a/docs/design/be/deployments-api-contract.md
+++ b/docs/design/be/deployments-api-contract.md
@@ -53,7 +53,7 @@ API 密钥请求必须携带 `anthropic-version: 2023-06-01`，并在 `anthropic
 
 ## Scheduled Deployment 执行
 
-OMA 使用 River `v0.42.0` 持久执行 schedule。River 官方 migrator 在应用 PostgreSQL database 的 `public` schema 中创建并升级 `river_job`、`river_queue`、`river_leader`、`river_notification` 和 `river_migration`；应用表仍由 Goose 管理。`river_migration` 持久记录已应用版本，进程启动只检查并应用缺失版本，不会重建 River 表。`cmd/migrate up` 和开发环境自动迁移会使用同一个数据库连接配置，依次推进两套 migration。River 内部表的 DDL 不复制到应用 migration，避免升级 River 时出现两套 schema 定义。
+OMA 使用 River `v0.46.0`（当前替换为 `superduck-ai/river v0.46.0-oma-v0.0.1`） 持久执行 schedule。River 官方 migrator 在应用 PostgreSQL database 的 `public` schema 中创建并升级 `river_job`、`river_queue`、`river_leader`、`river_notification` 和 `river_migration`；应用表仍由 Goose 管理。`river_migration` 持久记录已应用版本，进程启动只检查并应用缺失版本，不会重建 River 表。`cmd/migrate up` 和开发环境自动迁移会使用同一个数据库连接配置，依次推进两套 migration。River 内部表的 DDL 不复制到应用 migration，避免升级 River 时出现两套 schema 定义。
 
 Cron 统一由 `github.com/robfig/cron/v3` 解析和计算：
 
@@ -64,9 +64,9 @@ Cron 统一由 `github.com/robfig/cron/v3` 解析和计算：
 
 每个 active 且未归档、schedule 非空的 Deployment 对应一个 River Periodic Job，Periodic Job ID 使用 Deployment ID。Deployment 表是配置真源，只持久化 `schedule`，不保存应用自行推进的下一次游标或额外调度版本。Job 携带注册时的 schedule 快照；worker 读取 Deployment 后以当时的执行配置作为本次 occurrence 快照，最终事务锁行后确认 Deployment 仍为 active、schedule 和执行配置均未变化。
 
-每个应用实例启动时从 Deployment 表加载 Periodic Jobs，并每 10 秒从数据库同步一次 registry。这样所有执行实例最终持有相同配置，进程重启不会丢失 schedule，pause/archive/清空 schedule 会移除 Periodic Job，unpause 或修改 schedule 会重新注册。同步完成前已经投递的 Job 会由 worker 根据当前状态和 schedule 快照跳过。单条确定性的存量 schedule 错误记录后跳过，数据库不可用等全局基础设施错误仍使启动失败。
+River client 和 migrator 由 `internal/backgroundjobs` 统一组装，与 sandbox_lifecycle 队列共享现有连接池；DeploymentScheduler 只维护 Deployment 的 schedule registry。每个应用实例启动时从 Deployment 表加载 Periodic Jobs，并每 10 秒从数据库同步一次 registry。这样所有执行实例最终持有相同配置，进程重启不会丢失 schedule，pause/archive/清空 schedule 会移除 Periodic Job，unpause 或修改 schedule 会重新注册。同步完成前已经投递的 Job 会由 worker 根据当前状态和 schedule 快照跳过。单条确定性的存量 schedule 错误记录后跳过，数据库不可用等全局基础设施错误仍使启动失败。
 
-River 的 leader election 保证只有 leader 根据 Cron 推进并投递 Periodic Job，应用不计算、持久化或插入“下一条 Job”。插入 Periodic Job 时把当时的 Cron occurrence 写入 Job args；worker 只用这个字段作为名义时刻。River 重试会改写 `river_job.scheduled_at` 为下次重试时间，不能当 occurrence 用。暂停或停机期间不补跑历史 occurrence，恢复注册后直接等待 Cron 的下一次。River 开源 Periodic Jobs 的调度状态主要在 leader 内存中，官方不承诺强持久性，leader 切换的极短窗口可能跳过一次 occurrence；需要严格不漏的调度时应采用 River Pro durable periodic jobs，而不是在应用层恢复一套游标链。
+River 的 leader election 保证只有 leader 根据 Cron 推进并投递 Periodic Job，应用不计算、持久化或插入“下一条 Job”。插入 Periodic Job 时把当时的 Cron occurrence 写入 Job args；worker 只用这个字段作为名义时刻。River 重试会改写 `river_job.scheduled_at` 为下次重试时间，不能当 occurrence 用。暂停或停机期间不补跑历史 occurrence，恢复注册后直接等待 Cron 的下一次。River 开源 Periodic Jobs 的调度状态主要在 leader 内存中，官方不承诺强持久性，leader 切换的极短窗口可能跳过一次 occurrence；当前 fork 也提供 DurablePeriodicJob，[沙箱生命周期](sandbox-lifecycle.md) 使用该机制；Deployment 在本次变更中仍保留原有 PeriodicJobs 调度语义。
 
 ```mermaid
 sequenceDiagram

--- a/docs/design/be/filestore.md
+++ b/docs/design/be/filestore.md
@@ -405,3 +405,8 @@ namespace 写入按 filesystem advisory lock 串行化；所有可能改变字�
 ## 验收
 
 自动化覆盖协议编解码、路由与 JWT 隔离、Session 自动建档、Input Resource 原子 attach/删除、同一 Source 多次 attach 与 Catalog 去重、Source ID metadata/download、Source protection、Input 通用 mutation 拒绝、Output create/overwrite/copy/move/delete、Catalog 分页、配额、递归删除、TTL、Session cleanup、Skill Archive 动态成员，以及 migration 后旧表、旧 Input projection 与 `fse_` identity 消失。真实验收继续覆盖官方 SDK、rclone/FUSE multimount 与 E2B `/uploads`、`/outputs` 生命周期。
+
+## 长期 idle 回收的文件边界
+
+[沙箱生命周期](sandbox-lifecycle.md) 可以销毁长期 idle 的托管 Sandbox。第一版接受工作目录和未上传写缓存丢失，
+不实现 checkpoint；已提交的 Filestore 文件、transcript 和事件保留。恢复重建固定挂载，但不保证恢复沙箱本地仓库或进程状态。

--- a/docs/design/be/runtime-configuration.md
+++ b/docs/design/be/runtime-configuration.md
@@ -147,6 +147,7 @@ Cloud Session 的固定 Filestore 挂载也使用 `code_session.sandbox_api_base
 | `StorageConfig` | `storage` | 对象存储类型选择和文件容量限制 |
 | `S3Config` | `storage.s3` | S3 兼容对象存储连接、bucket 和寻址方式 |
 | `BatchConfig` | `batch` | Message Batch 限制、worker、lease 和清理策略 |
+| `SandboxLifecycleConfig` | `sandbox_lifecycle` | 长期 idle 回收开关、dry-run 与超时，见 [沙箱生命周期](sandbox-lifecycle.md) |
 | `E2BConfig` | `e2b` | E2B provider 连接、模板和超时 |
 | `EnvironmentRunnerConfig` | `environment_runner` | Environment runner 并发及 Claude 运行命令 |
 | `CodeSessionConfig` | `code_session` | Code session ingress、JWT、OTLP 文件日志和上游代理安全配置 |

--- a/docs/design/be/sandbox-lifecycle.md
+++ b/docs/design/be/sandbox-lifecycle.md
@@ -84,7 +84,7 @@ Debug 模式仍执行同一个 DELETE，不会在数据库已推进到 stopped �
 
 ## River 与模块边界
 
-`internal/backgroundjobs` 负责共享 River client、官方 migrator 和连接池复用。资源 worker 仍由 deployments、
+`internal/riverjobs` 负责共享 River client、官方 migrator 和连接池复用。资源 worker 仍由 deployments、
 environments 注册；启动组装一次性注册全部 worker 和队列，deployment 的现有 PeriodicJobs 行为不变。
 
 当前使用 `superduck-ai/river v0.46.0-oma-v0.0.1` fork 的 DurablePeriodicJob：

--- a/docs/design/be/sandbox-lifecycle.md
+++ b/docs/design/be/sandbox-lifecycle.md
@@ -19,6 +19,7 @@ sandbox_lifecycle:
 默认 dry-run 只输出候选。设为 `dry_run: false` 后执行真实删除。
 `enabled: false` 停止领取新回收操作；已领取的删除仍会重试完成。
 修改 YAML 后重启生效，多实例应使用一致配置。新消息所需的重建沿用 Environment Runner。
+Worker 会把“是否允许新领取”作为显式条件传给事务；关闭或 dry-run 不再通过特殊时间值影响 SQL。
 
 ## 数据与回收协议
 
@@ -50,6 +51,7 @@ stateDiagram-v2
 Provider 直接调用 SDK 的 `e2b.Kill`，不再自行构造 API client 或 DELETE 请求；不调用 Connect，404 由 SDK 视为已删除。
 `SandboxApiOpts.ApiUrl` 允许包级 Kill 直接使用 Provider 的 `e2b.api_url` 配置；配置为空时沿用 SDK 的环境变量及默认值。
 API key、domain、超时仍按请求传参；配置的 access token 通过 SDK 的 Headers 传递，不写入进程环境。
+Debug 模式仍执行同一个 DELETE，不会在数据库已推进到 stopped 时假装删除成功。
 任务每次从数据库读取同一 sandbox UUID 对应的 Provider ID，不删除 replacement。
 删除失败保持 stopping，River 重试；任务耗尽重试后，下一轮扫描仍可重新投递。
 删除成功但落库前退出时，下次 DELETE 得到 404 并完成记录。关闭回收开关不遗弃已领取的删除。
@@ -105,7 +107,8 @@ SQL 和事务仍经现有 `database/sql` 包装层，监听复用同一个 pgxpo
 它不再计入池的 MaxConns，因此每个运行实例通常比池上限额外占用一条连接。必须先停止 River，再关闭 DB；
 仅关闭连接池不会关闭被 hijack 的连接。部署若使用 PgBouncer，当前共享数据库地址必须支持 session pooling
 或直连 PostgreSQL，不能使用 transaction pooling 承载 LISTEN。
-正常回收输出结构化 Info 日志，dry-run 输出候选；失败交给 River 重试记录，不输出消息或凭据。
+正常回收输出结构化 Info 日志，dry-run 输出候选；候选在锁定后失效、目标已消失或完成状态已由其他任务推进时输出 Debug 日志。
+失败交给 River 重试记录，不输出消息或凭据。
 
 ## 验收
 
@@ -116,7 +119,7 @@ SQL 和事务仍经现有 `database/sql` 包装层，监听复用同一个 pgxpo
 - dry-run 不删除；heartbeat 和重复 idle 上报不延长 idle_since。
 
 真实 PostgreSQL 用例位于 `tests/sandbox_lifecycle_test.go`；Mapper 测试检查 SQL 和参数绑定。
-`internal/runtime/e2bruntime/lifecycle_test.go` 验证 SDK 环境变量地址、鉴权透传、直接 DELETE、删除失败与 404 幂等。
+`internal/runtime/e2bruntime/lifecycle_test.go` 验证 SDK 显式 API URL、鉴权透传、Debug 模式直接 DELETE、删除失败与 404 幂等。
 回收与 River 集成测试也使用真实 `E2BProvider`，通过本地 HTTP 服务模拟 E2B 删除响应。
 `tests/sandbox_lifecycle_river_test.go` 验证 durable schedule 的 sweep → reclaim 投递、LISTEN 连接及
 重复启动不重置 next_run_at。测试队列轮询设为一小时，并用独立 sweep 队列避免同队列通知限流干扰。

--- a/docs/design/be/sandbox-lifecycle.md
+++ b/docs/design/be/sandbox-lifecycle.md
@@ -1,0 +1,126 @@
+# 托管沙箱的 idle 回收
+
+## 范围与配置
+
+回收长期 idle 的 cloud Session 沙箱，不改变公开 Session、Code Session 的状态或 ID。
+短期空闲继续使用原有 E2B pause 策略；running、requires_action、启动中及存在未处理输入的沙箱不回收。
+自托管 Environment、Session 终止或删除的清理策略不属于本功能。
+
+允许丢失沙箱本地工作目录、进程状态、临时文件和未上传的写缓存，不做 checkpoint。
+数据库事件、transcript 和已经提交的 Filestore 文件继续保留。
+
+```yaml
+sandbox_lifecycle:
+  enabled: true
+  dry_run: true
+  idle_timeout: 24h
+```
+
+默认 dry-run 只输出候选。设为 `dry_run: false` 后执行真实删除。
+`enabled: false` 停止领取新回收操作；已领取的删除仍会重试完成。
+修改 YAML 后重启生效，多实例应使用一致配置。新消息所需的重建沿用 Environment Runner。
+
+## 数据与回收协议
+
+只保留两个新增字段，不新增独立的运行时状态机或消息 outbox：
+
+| 表 | 字段 | 语义 |
+| --- | --- | --- |
+| code_sessions | idle_since | 连续 idle 起点；heartbeat 不刷新，重复 idle 保留，业务输入、非 idle 状态和凭证轮换清空 |
+| environment_sandboxes | stop_reason | idle 回收使用 `idle_timeout`，用于识别删除重试及已回收记录 |
+
+复用已有的沙箱状态：
+
+```mermaid
+stateDiagram-v2
+    running --> stopping: idle 到期且事务领取成功
+    stopping --> stopping: 删除失败，River 重试
+    stopping --> stopped: DELETE 成功或 404
+```
+
+1. 扫描候选，仅作为提示，不授权删除。
+2. 按 organization UUID、workspace UUID、sandbox UUID 定位不可变的沙箱记录。
+3. 事务按 Session → Code Session → Work / Sandbox 锁定，复查 idle 时间、cloud 类型、
+   活跃且未归档的父 Session、Work 状态及未处理入站事件。
+4. 条件领取成功后，清空 idle_since、递增 worker epoch、撤销旧 lease 和 OAuth hash，沙箱改为 stopping。
+5. 提交后执行 Provider DELETE，不在数据库事务中调用网络。
+6. 删除成功或 404 后，在完成事务中标记 stopped。
+
+回收逻辑直接依赖已有的 `E2BProvider`，不另定义删除接口。
+Provider 直接调用 SDK 的 `e2b.Kill`，不再自行构造 API client 或 DELETE 请求；不调用 Connect，404 由 SDK 视为已删除。
+`SandboxApiOpts.ApiUrl` 允许包级 Kill 直接使用 Provider 的 `e2b.api_url` 配置；配置为空时沿用 SDK 的环境变量及默认值。
+API key、domain、超时仍按请求传参；配置的 access token 通过 SDK 的 Headers 传递，不写入进程环境。
+任务每次从数据库读取同一 sandbox UUID 对应的 Provider ID，不删除 replacement。
+删除失败保持 stopping，River 重试；任务耗尽重试后，下一轮扫描仍可重新投递。
+删除成功但落库前退出时，下次 DELETE 得到 404 并完成记录。关闭回收开关不遗弃已领取的删除。
+
+## 与现有消息流程衔接
+
+接受可转发 public 输入时，在原有事件事务中清空 idle_since；Code Session 入站 sequence 推进也清空它。
+这样输入落库后、转交 worker 前不会按旧 idle 时间领取回收。入站队列已有的未处理事件检查继续保留。
+不添加消息 outbox、wake 标志、后台消息扫描或新的唤醒接口；原有消息转交失败的重试语义不变。
+
+回收后 Work 保持 active，沙箱为 stopped。没有新输入时不重排、不重建。
+
+- 删除期间收到输入：先进入原有入站队列，不连接 stopping 沙箱。删除完成事务检查待处理输入，
+  通过既有 `ScheduleRecoveryForCodeSession` 原子地重排 Work。
+- 删除完成后收到输入：正常消息入口找不到 running 沙箱时，调用同一恢复方法。
+  空 Provider ID 仅允许匹配 `stopped + idle_timeout` 且有待处理输入的沙箱，不能恢复任意缺失目标。
+- 恢复沿用现有路径：旧沙箱记录标为 failed，Work 改为 queued，Runner 复用 Code Session 并创建新沙箱。
+  `stop_reason=idle_timeout` 保留原回收原因。旧记录被退役后不能再次重排新 Work。
+- 对仍为 running 的沙箱，正常消息入口的 SetTimeout、worker lease 恢复和 Provider not-found 处理保持不变。
+
+正常回收本身不会调用 Provider 唤醒。重建只处理真实待处理输入，已归档或终止的 Session 不重排。
+
+## 迁移
+
+已应用的 `00057_sandbox_lifecycle.sql` 保持不变；`00058_simplify_sandbox_reclamation.sql`
+删除试验版的 runtime_state、runtime_wake_requested、runtime_pending 及专属索引，并重建 idle 索引。
+存量 idle 起点仍由 00057 从迁移时间开始观察，不使用旧 updated_at 回推。
+升级前停止旧版本进程，再迁移并启动新版本；旧版本不能与删除字段后的 schema 混用。
+回滚 00058 只能恢复字段默认值，不能还原已删除的 wake 标志。
+
+## River 与模块边界
+
+`internal/backgroundjobs` 负责共享 River client、官方 migrator 和连接池复用。资源 worker 仍由 deployments、
+environments 注册；启动组装一次性注册全部 worker 和队列，deployment 的现有 PeriodicJobs 行为不变。
+
+当前使用 `superduck-ai/river v0.46.0-oma-v0.0.1` fork 的 DurablePeriodicJob：
+
+- 固定 schedule ID / kind 为 `sandbox_lifecycle_sweep`，UTC 五字段 cron `* * * * *`。
+- 配置一致时启动不重新 upsert，保留数据库 next_run_at；River migrator 管理 river_periodic_job。
+- 一个 sweep 按 UUID 游标分批读取，每批 100 条，避免 OFFSET 漂移和固定第一页阻塞后续记录。
+- 仅注册 `sandbox_lifecycle_sweep` 和 `sandbox_reclaim`，使用 sandbox_lifecycle 队列，当前并发 4。
+- 任务参数只携带稳定 UUID 和租户 scope，不持久化 token、路径、消息 body 或 Provider 返回内容。
+- 同参数的未完成任务去重，completed 不参与去重，避免一次 no-op 阻止后续 idle 周期。
+- Worker 每次执行重新读取策略和业务状态；周期调度、任务重试都不代表业务只会执行一次。
+
+若此前运行过带后台唤醒的试验版本，升级前停止旧 worker，并通过 River 管理接口取消遗留的
+`sandbox_wake` 未完成任务；当前版本不保留该 kind 的兼容 worker。
+
+应用 SQL 全部经 Yourbatis Mapper。River 内部表由 River API 管理，应用不直接执行其 SQL，不创建额外连接池。
+River client 使用 `riverdatabasesql.NewWithPgxListener(database.SQLDB(), database.ListenerPool())`，
+启用 PostgreSQL LISTEN/NOTIFY，同时保留 River 默认轮询兜底；migrator 不需要监听，继续使用普通 SQL driver。
+SQL 和事务仍经现有 `database/sql` 包装层，监听复用同一个 pgxpool 获取连接。River 会 hijack 一条专用监听连接，
+它不再计入池的 MaxConns，因此每个运行实例通常比池上限额外占用一条连接。必须先停止 River，再关闭 DB；
+仅关闭连接池不会关闭被 hijack 的连接。部署若使用 PgBouncer，当前共享数据库地址必须支持 session pooling
+或直连 PostgreSQL，不能使用 transaction pooling 承载 LISTEN。
+正常回收输出结构化 Info 日志，dry-run 输出候选；失败交给 River 重试记录，不输出消息或凭据。
+
+## 验收
+
+- 不安全候选、错误租户、未转交的 public 输入和未处理入站事件拒绝领取。
+- 领取后旧 worker 不能续租；Provider 删除失败保留 stopping；完成后重复执行不再删除。
+- 删除期间的新输入不会连接旧沙箱，完成后只启动一次 replacement，保留 Code Session 身份。
+- 没有输入时不会重排，stopping 或其他原因停止的沙箱不能被空 Provider ID 的恢复调用重排。
+- dry-run 不删除；heartbeat 和重复 idle 上报不延长 idle_since。
+
+真实 PostgreSQL 用例位于 `tests/sandbox_lifecycle_test.go`；Mapper 测试检查 SQL 和参数绑定。
+`internal/runtime/e2bruntime/lifecycle_test.go` 验证 SDK 环境变量地址、鉴权透传、直接 DELETE、删除失败与 404 幂等。
+回收与 River 集成测试也使用真实 `E2BProvider`，通过本地 HTTP 服务模拟 E2B 删除响应。
+`tests/sandbox_lifecycle_river_test.go` 验证 durable schedule 的 sweep → reclaim 投递、LISTEN 连接及
+重复启动不重置 next_run_at。测试队列轮询设为一小时，并用独立 sweep 队列避免同队列通知限流干扰。
+原有 `tests/session_sandbox_recovery_test.go` 验证消息触发的 lease 恢复及缺失沙箱重建没有回归。
+
+本地运行 `just test`、`just lint`、`just dead-code`、`just duplicates`、`just complexity`。
+集成测试使用 `CONFIG_FILE` 指向隔离数据库配置，不修改开发数据库。

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/lo v1.53.0
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.1
-	github.com/superduck-ai/e2b-go-sdk v0.0.1
+	github.com/superduck-ai/e2b-go-sdk v0.0.2
 	github.com/superduck-ai/yourbatis v0.1.5
 	go.opentelemetry.io/proto/otlp v1.10.0
 	go.yaml.in/yaml/v3 v3.0.5

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
-github.com/superduck-ai/e2b-go-sdk v0.0.1 h1:yW23X/fEQvaPdJHhDnp8PgnsaIixn+UTVMt94X4Kr0s=
-github.com/superduck-ai/e2b-go-sdk v0.0.1/go.mod h1:dWlhv18vJamYp5gQ3ktmjjrX7tUaMe2OyTJXUo8EeXY=
+github.com/superduck-ai/e2b-go-sdk v0.0.2 h1:regpFbVLkwXCzgVdVJ5wGJJACH4pE+WJ47nnRJt/Xrw=
+github.com/superduck-ai/e2b-go-sdk v0.0.2/go.mod h1:dWlhv18vJamYp5gQ3ktmjjrX7tUaMe2OyTJXUo8EeXY=
 github.com/superduck-ai/river v0.46.0-oma-v0.0.1 h1:5Z5l1ZmjQheL8+3oCsoZQJEkI95pcpzG9xv8mx3QA7s=
 github.com/superduck-ai/river v0.46.0-oma-v0.0.1/go.mod h1:e+GMx8BBMixrc52fKnd5obMoxJcmgmWEFfMfMsboljU=
 github.com/superduck-ai/river/riverdriver v0.46.0-oma-v0.0.1 h1:21UyCpH5hPWLI0Wz2sOg6LR3wQUpcZGntChgazNHMAc=

--- a/internal/backgroundjobs/client.go
+++ b/internal/backgroundjobs/client.go
@@ -1,0 +1,38 @@
+// Package backgroundjobs owns River infrastructure shared by resource workers.
+package backgroundjobs
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"time"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverdatabasesql"
+	"github.com/riverqueue/river/rivermigrate"
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/logging"
+)
+
+func Migrate(ctx context.Context, database *db.DB, logger *slog.Logger) error {
+	migrator, err := rivermigrate.New(riverdatabasesql.New(database.SQLDB()), &rivermigrate.Config{Schema: "public", Logger: logging.LoggerOrDefault(logger)})
+	if err != nil {
+		return err
+	}
+	_, err = migrator.Migrate(ctx, rivermigrate.DirectionUp, nil)
+	return err
+}
+
+func NewClient(database *db.DB, logger *slog.Logger, workers *river.Workers, queues map[string]river.QueueConfig) (*river.Client[*sql.Tx], error) {
+	return river.NewClient(
+		riverdatabasesql.NewWithPgxListener(database.SQLDB(), database.ListenerPool()),
+		&river.Config{
+			Schema:              "public",
+			Workers:             workers,
+			Queues:              queues,
+			Logger:              logging.LoggerOrDefault(logger),
+			JobTimeout:          2 * time.Minute,
+			SoftStopTimeout:     10 * time.Second,
+			DurablePeriodicJobs: river.DurablePeriodicJobsConfig{Enabled: true},
+		})
+}

--- a/internal/codesessions/managed_agent_code_session.go
+++ b/internal/codesessions/managed_agent_code_session.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/auth"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
+	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 )
 
 // ManagedAgentCreateInput 汇总为 managed agent 创建 code session 和签发 sandbox 凭证所需的上下文。
@@ -216,7 +217,7 @@ func (s *Service) ActivateManagedAgentCodeSession(
 		}
 		inboundInputs := make([]db.AppendCodeSessionEventInput, 0, len(sessionEvents))
 		for _, event := range sessionEvents {
-			if !shouldForwardPublicEventToWorker(event.EventType) {
+			if !maevents.IsPublicWorkerInputEvent(event.EventType) {
 				continue
 			}
 			inbound, err := s.convertSessionEventToInbound(lockedCodeSession.ExternalID, event)

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -67,7 +67,7 @@ func (s *Service) QueuePublicSessionEvents(ctx context.Context, session db.Sessi
 	payloads := make([]json.RawMessage, 0, len(events))
 	queued := false
 	for _, event := range events {
-		if !shouldForwardPublicEventToWorker(event.EventType) {
+		if !maevents.IsPublicWorkerInputEvent(event.EventType) {
 			continue
 		}
 		handled := false
@@ -587,15 +587,6 @@ func (s *Service) subagentThreadMappings(ctx context.Context, codeSession db.Cod
 		}
 	}
 	return threadByAgent, nil
-}
-
-func shouldForwardPublicEventToWorker(eventType string) bool {
-	switch eventType {
-	case "user.message", "user.interrupt", "user.tool_confirmation", "user.tool_result", "user.custom_tool_result":
-		return true
-	default:
-		return false
-	}
 }
 
 func isPublicWorkerOutputEvent(eventType string) bool {

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -110,7 +110,8 @@ func (s *Service) resumeSandboxForCodeSession(ctx context.Context, codeSession d
 	sandbox, err := s.db.GetResumableEnvironmentSandboxForCodeSession(ctx, codeSession.ExternalID)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
-			return nil
+			_, err = s.db.ScheduleEnvironmentSandboxRecoveryForCodeSession(ctx, codeSession.ExternalID, "", nil)
+			return err
 		}
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -279,6 +279,7 @@ func validatePositiveValues(cfg Config) error {
 		{name: "batch.job_lease_heartbeat_interval", valid: cfg.Batch.JobLeaseHeartbeatInterval > 0},
 		{name: "batch.expiry_sweep_interval", valid: cfg.Batch.ExpirySweepInterval > 0},
 		{name: "e2b.request_timeout", valid: cfg.E2B.RequestTimeout > 0},
+		{name: "sandbox_lifecycle.idle_timeout", valid: cfg.SandboxLifecycle.IdleTimeout > 0},
 		{name: "e2b.sandbox_timeout", valid: cfg.E2B.SandboxTimeout > 0},
 		{name: "environment_runner.concurrency", valid: cfg.EnvironmentRunner.Concurrency > 0},
 		{name: "environment_runner.package_provision_timeout", valid: cfg.EnvironmentRunner.PackageProvisionTimeout > 0},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,12 @@ func Load() (Config, error) {
 	}
 	cfg.Auth.SMTP.Addr = strings.TrimSpace(cfg.Auth.SMTP.Addr)
 	cfg.Auth.SMTP.Username = strings.TrimSpace(cfg.Auth.SMTP.Username)
+	cfg.E2B.APIKey = strings.TrimSpace(cfg.E2B.APIKey)
+	cfg.E2B.AccessToken = strings.TrimSpace(cfg.E2B.AccessToken)
+	cfg.E2B.Domain = strings.TrimSpace(cfg.E2B.Domain)
+	cfg.E2B.APIURL = strings.TrimSpace(cfg.E2B.APIURL)
+	cfg.E2B.SandboxURL = strings.TrimSpace(cfg.E2B.SandboxURL)
+	cfg.E2B.Template = strings.TrimSpace(cfg.E2B.Template)
 
 	if err := resolveConfigPaths(&cfg, configFileDirectory(configPath)); err != nil {
 		return Config{}, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -197,6 +197,27 @@ auth:
 	}
 }
 
+func TestLoadNormalizesE2BConfig(t *testing.T) {
+	prepareLoadTest(t)
+	cfg, err := loadConfigTestYAML(t, `
+e2b:
+  api_key: " e2b_test "
+  access_token: " access-token "
+  domain: " e2b.example.test "
+  api_url: " https://api.example.test "
+  sandbox_url: " https://sandbox.example.test "
+  template: " managed-agent "
+`)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.E2B.APIKey != "e2b_test" || cfg.E2B.AccessToken != "access-token" ||
+		cfg.E2B.Domain != "e2b.example.test" || cfg.E2B.APIURL != "https://api.example.test" ||
+		cfg.E2B.SandboxURL != "https://sandbox.example.test" || cfg.E2B.Template != "managed-agent" {
+		t.Fatalf("E2B config was not normalized: %+v", cfg.E2B)
+	}
+}
+
 func TestValidateAuthConfigAllowsOmittedSMTP(t *testing.T) {
 	if err := validateAuthConfig(AuthConfig{}); err != nil {
 		t.Fatalf("validateAuthConfig() error = %v, want omitted SMTP accepted", err)

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -24,6 +24,7 @@ func defaultConfig() Config {
 			JobLeaseHeartbeatInterval: 30 * time.Second,
 			ExpirySweepInterval:       5 * time.Minute,
 		},
+		SandboxLifecycle: SandboxLifecycleConfig{Enabled: true, DryRun: true, IdleTimeout: 24 * time.Hour},
 		E2B: E2BConfig{
 			Template:       DefaultE2BTemplate,
 			RequestTimeout: 60 * time.Second,

--- a/internal/config/sandbox_lifecycle_test.go
+++ b/internal/config/sandbox_lifecycle_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func TestSandboxLifecycleConfiguration(t *testing.T) {
+	for _, value := range []string{"0s", "-1h"} {
+		t.Run("reject "+value, func(t *testing.T) {
+			cfg := defaultConfig()
+			cfg.SandboxLifecycle.IdleTimeout = 0
+			if err := yaml.Unmarshal([]byte("idle_timeout: "+value), &cfg.SandboxLifecycle); err != nil {
+				t.Fatal(err)
+			}
+			if err := validatePositiveValues(cfg); err == nil {
+				t.Fatal("accepted nonpositive idle timeout")
+			}
+		})
+	}
+	input := newYAMLConfig()
+	if err := yaml.Unmarshal([]byte("sandbox_lifecycle:\n  enabled: false\n  dry_run: false\n  idle_timeout: 2h\n"), &input); err != nil {
+		t.Fatal(err)
+	}
+	got := input.resolve().SandboxLifecycle
+	if got.Enabled || got.DryRun || got.IdleTimeout != 2*time.Hour {
+		t.Fatalf("explicit configuration = %+v", got)
+	}
+	defaults := newYAMLConfig().resolve().SandboxLifecycle
+	if !defaults.Enabled || !defaults.DryRun || defaults.IdleTimeout != 24*time.Hour {
+		t.Fatalf("defaults = %+v", defaults)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -202,7 +202,6 @@ type SeedAPIKey struct {
 }
 
 // SandboxLifecycleConfig controls long-idle managed sandbox reclamation.
-// Wake reconciliation remains active even when reclamation is disabled.
 type SandboxLifecycleConfig struct {
 	Enabled     bool          `yaml:"enabled"`
 	DryRun      bool          `yaml:"dry_run"`

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -16,6 +16,7 @@ type Config struct {
 	Auth              AuthConfig              `yaml:"auth"`
 	Storage           StorageConfig           `yaml:"storage"`
 	Batch             BatchConfig             `yaml:"batch"`
+	SandboxLifecycle  SandboxLifecycleConfig  `yaml:"sandbox_lifecycle"`
 	E2B               E2BConfig               `yaml:"e2b"`
 	EnvironmentRunner EnvironmentRunnerConfig `yaml:"environment_runner"`
 	CodeSession       CodeSessionConfig       `yaml:"code_session"`
@@ -198,4 +199,12 @@ type SDKFixtureConfig struct {
 type SeedAPIKey struct {
 	ExternalID string `yaml:"external_id"`
 	Key        string `yaml:"key"`
+}
+
+// SandboxLifecycleConfig controls long-idle managed sandbox reclamation.
+// Wake reconciliation remains active even when reclamation is disabled.
+type SandboxLifecycleConfig struct {
+	Enabled     bool          `yaml:"enabled"`
+	DryRun      bool          `yaml:"dry_run"`
+	IdleTimeout time.Duration `yaml:"idle_timeout"`
 }

--- a/internal/config/yaml_types.go
+++ b/internal/config/yaml_types.go
@@ -42,6 +42,7 @@ type yamlConfig struct {
 	Auth              AuthConfig              `yaml:"auth"`
 	Storage           StorageConfig           `yaml:"storage"`
 	Batch             BatchConfig             `yaml:"batch"`
+	SandboxLifecycle  SandboxLifecycleConfig  `yaml:"sandbox_lifecycle"`
 	E2B               E2BConfig               `yaml:"e2b"`
 	EnvironmentRunner EnvironmentRunnerConfig `yaml:"environment_runner"`
 	CodeSession       yamlCodeSessionConfig   `yaml:"code_session"`
@@ -97,6 +98,7 @@ func newYAMLConfig() yamlConfig {
 		Storage:           defaults.Storage,
 		Batch:             defaults.Batch,
 		E2B:               defaults.E2B,
+		SandboxLifecycle:  defaults.SandboxLifecycle,
 		EnvironmentRunner: defaults.EnvironmentRunner,
 		CodeSession: yamlCodeSessionConfig{
 			SandboxAPIBaseURL:                  defaults.CodeSession.SandboxAPIBaseURL,
@@ -137,6 +139,7 @@ func (input yamlConfig) resolve() Config {
 		Storage:           input.Storage,
 		Batch:             input.Batch,
 		E2B:               input.E2B,
+		SandboxLifecycle:  input.SandboxLifecycle,
 		EnvironmentRunner: input.EnvironmentRunner,
 		CodeSession: CodeSessionConfig{
 			SandboxAPIBaseURL:                  input.CodeSession.SandboxAPIBaseURL,

--- a/internal/db/code_session_mapper.go
+++ b/internal/db/code_session_mapper.go
@@ -149,6 +149,7 @@ type resumeCodeSessionWorkerLeaseParams struct {
 
 // CodeSessionMapper contains queries whose primary table is code_sessions.
 type CodeSessionMapper interface {
+	ResetIdleSinceForSession(ctx context.Context, organizationUUID, workspaceUUID, sessionUUID string) error
 	Insert(ctx context.Context, params createCodeSessionParams) (codeSessionRow, error)
 	FindCredentialByOAuthAccessTokenHash(ctx context.Context, tokenHash string) (codeSessionCredentialContextRow, error)
 	FindCredentialForIssue(ctx context.Context, organizationUUID, workspaceUUID, codeSessionExternalID string) (codeSessionCredentialContextRow, error)

--- a/internal/db/code_session_mapper.xml
+++ b/internal/db/code_session_mapper.xml
@@ -315,7 +315,9 @@
 
     <update id="UpdateWorkerState" result="returning" resultType="codeSessionRow">
         UPDATE code_sessions
-        SET worker_status = #{params.WorkerStatus},
+        SET idle_since = CASE WHEN #{params.WorkerStatus} = 'idle'
+                    THEN COALESCE(idle_since, #{params.Now}) ELSE NULL END,
+            worker_status = #{params.WorkerStatus},
             worker_requires_action_details = CAST(#{params.RequiresActionDetails,sensitive=true} AS jsonb),
             worker_external_metadata = CAST(#{params.ExternalMetadata,sensitive=true} AS jsonb),
             connection_status = 'connected',
@@ -327,9 +329,15 @@
         <include refid="columns"/>
     </update>
 
+    <update id="ResetIdleSinceForSession">
+        UPDATE code_sessions SET idle_since = NULL
+        WHERE organization_uuid = #{organizationUUID} AND workspace_uuid = #{workspaceUUID}
+            AND session_uuid = #{sessionUUID} AND status = 'active' AND deleted_at IS NULL
+    </update>
     <update id="UpdateCodeSessionInboundSequence" result="rows">
         UPDATE code_sessions
         SET last_inbound_sequence_num = #{sequenceNum},
+            idle_since = NULL,
             updated_at = #{now}
         WHERE uuid = #{codeSessionUUID}
     </update>
@@ -407,7 +415,8 @@
 
     <update id="RotateCredentials" result="returning" resultType="int64">
         UPDATE code_sessions
-        SET oauth_access_token_hash = #{params.OAuthAccessTokenHash,sensitive=true},
+        SET idle_since = NULL,
+            oauth_access_token_hash = #{params.OAuthAccessTokenHash,sensitive=true},
             current_worker_epoch = current_worker_epoch + 1,
             worker_lease_expires_at = NULL,
             connection_status = 'disconnected',

--- a/internal/db/code_session_mapper_test.go
+++ b/internal/db/code_session_mapper_test.go
@@ -154,11 +154,11 @@ func TestCodeSessionMapperBuilderContracts(t *testing.T) {
 			}),
 			wantID: "CodeSessionMapper.UpdateWorkerState", wantKind: yourbatis.StatementUpdate,
 			wantArgumentNames: []string{
-				"params.WorkerStatus", "params.RequiresActionDetails", "params.ExternalMetadata",
+				"params.WorkerStatus", "params.Now", "params.WorkerStatus", "params.RequiresActionDetails", "params.ExternalMetadata",
 				"params.Now", "params.Now", "params.Now", "params.UUID",
 			},
 			wantSensitiveArgumentNames: []string{"params.RequiresActionDetails", "params.ExternalMetadata"},
-			wantSQLFragments:           []string{"worker_requires_action_details = CAST($2 AS jsonb)", "RETURNING uuid"},
+			wantSQLFragments:           []string{"worker_requires_action_details = CAST($4 AS jsonb)", "RETURNING uuid"},
 		}},
 	}
 	for _, test := range tests {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -150,6 +150,13 @@ func (d *DB) SQLDB() *sql.DB {
 	return d.mapperDB.SQLDB()
 }
 
+// ListenerPool exposes the existing pool for integration-owned LISTEN connections.
+// Callers must not close it or use it for application queries. Stop integrations
+// before DB.Close so their dedicated listener connections are also closed.
+func (d *DB) ListenerPool() *pgxpool.Pool {
+	return d.pool
+}
+
 func EnsureDatabase(ctx context.Context, databaseURL string) error {
 	var candidates []string
 	for _, maintenanceDB := range []string{"postgres", "template1"} {

--- a/internal/db/environment_sandbox_mapper.xml
+++ b/internal/db/environment_sandbox_mapper.xml
@@ -134,12 +134,23 @@
             AND sandbox.workspace_uuid = code_session.workspace_uuid
             AND sandbox.environment_uuid = code_session.environment_uuid
             AND sandbox.work_uuid = work.uuid
-            AND sandbox.provider_sandbox_id = #{params.ProviderSandboxID}
-            AND sandbox.state = 'running'
+            <if test="params.ProviderSandboxID != ''">
+                AND sandbox.provider_sandbox_id = #{params.ProviderSandboxID}
+            </if>
+            AND (
+                <if test="params.ProviderSandboxID != ''">sandbox.state = 'running' OR</if>
+                (sandbox.state = 'stopped' AND sandbox.stop_reason = 'idle_timeout'
+                    AND EXISTS (SELECT 1 FROM code_session_inbound_events e
+                        WHERE e.code_session_uuid = code_session.uuid AND e.deleted_at IS NULL
+                            AND e.delivery_status &lt;&gt; 'processed'))
+            )
             WHERE code_session.external_id = #{params.CodeSessionExternalID}
             AND code_session.status = 'active'
             AND code_session.worker_status IN ('idle', 'running', 'requires_action')
             AND code_session.deleted_at IS NULL
+            AND EXISTS (SELECT 1 FROM sessions s WHERE s.uuid = code_session.session_uuid
+                AND s.organization_uuid = code_session.organization_uuid AND s.workspace_uuid = code_session.workspace_uuid
+                AND s.deleted_at IS NULL AND s.archived_at IS NULL AND s.status &lt;&gt; 'terminated')
             FOR UPDATE OF code_session, work, sandbox
         ), failed_sandbox AS (
             UPDATE environment_sandboxes sandbox

--- a/internal/db/migrations/00057_sandbox_lifecycle.sql
+++ b/internal/db/migrations/00057_sandbox_lifecycle.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+ALTER TABLE code_sessions
+    ADD COLUMN idle_since timestamptz,
+    ADD COLUMN runtime_state text NOT NULL DEFAULT 'resident'
+        CHECK (runtime_state IN ('resident', 'reclaiming', 'reclaimed', 'waking')),
+    ADD COLUMN runtime_wake_requested boolean NOT NULL DEFAULT false;
+-- Observe existing idle workers from migration time; never reclaim immediately.
+UPDATE code_sessions SET idle_since = NOW()
+WHERE status = 'active' AND worker_status = 'idle' AND deleted_at IS NULL;
+CREATE INDEX code_sessions_idle_reclaim_idx ON code_sessions (idle_since, uuid)
+WHERE status = 'active' AND runtime_state = 'resident' AND worker_status = 'idle' AND deleted_at IS NULL;
+CREATE INDEX code_sessions_runtime_wake_idx ON code_sessions (uuid)
+WHERE runtime_wake_requested AND deleted_at IS NULL;
+ALTER TABLE environment_sandboxes ADD COLUMN stop_reason text;
+ALTER TABLE session_events ADD COLUMN runtime_pending boolean NOT NULL DEFAULT false;
+CREATE INDEX session_events_runtime_pending_idx ON session_events (session_uuid, created_at, uuid)
+WHERE runtime_pending AND deleted_at IS NULL;
+
+-- +goose Down
+DROP INDEX session_events_runtime_pending_idx;
+ALTER TABLE session_events DROP COLUMN runtime_pending;
+ALTER TABLE environment_sandboxes DROP COLUMN stop_reason;
+DROP INDEX code_sessions_runtime_wake_idx;
+DROP INDEX code_sessions_idle_reclaim_idx;
+ALTER TABLE code_sessions DROP COLUMN runtime_wake_requested, DROP COLUMN runtime_state, DROP COLUMN idle_since;

--- a/internal/db/migrations/00058_simplify_sandbox_reclamation.sql
+++ b/internal/db/migrations/00058_simplify_sandbox_reclamation.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- Keep the idle clock and deletion reason; use existing sandbox/work states.
+DROP INDEX code_sessions_idle_reclaim_idx;
+DROP INDEX code_sessions_runtime_wake_idx;
+DROP INDEX session_events_runtime_pending_idx;
+ALTER TABLE code_sessions DROP COLUMN runtime_state, DROP COLUMN runtime_wake_requested;
+ALTER TABLE session_events DROP COLUMN runtime_pending;
+CREATE INDEX code_sessions_idle_reclaim_idx ON code_sessions (idle_since, uuid)
+WHERE status = 'active' AND worker_status = 'idle' AND deleted_at IS NULL;
+
+-- +goose Down
+-- Removed wake flags cannot be reconstructed; restore the original defaults.
+DROP INDEX code_sessions_idle_reclaim_idx;
+ALTER TABLE code_sessions
+    ADD COLUMN runtime_state text NOT NULL DEFAULT 'resident'
+        CHECK (runtime_state IN ('resident', 'reclaiming', 'reclaimed', 'waking')),
+    ADD COLUMN runtime_wake_requested boolean NOT NULL DEFAULT false;
+ALTER TABLE session_events ADD COLUMN runtime_pending boolean NOT NULL DEFAULT false;
+CREATE INDEX code_sessions_idle_reclaim_idx ON code_sessions (idle_since, uuid)
+WHERE status = 'active' AND runtime_state = 'resident' AND worker_status = 'idle' AND deleted_at IS NULL;
+CREATE INDEX code_sessions_runtime_wake_idx ON code_sessions (uuid)
+WHERE runtime_wake_requested AND deleted_at IS NULL;
+CREATE INDEX session_events_runtime_pending_idx ON session_events (session_uuid, created_at, uuid)
+WHERE runtime_pending AND deleted_at IS NULL;

--- a/internal/db/sandbox_lifecycle.go
+++ b/internal/db/sandbox_lifecycle.go
@@ -1,0 +1,114 @@
+package db
+
+import (
+	"context"
+	"time"
+
+	"github.com/superduck-ai/yourbatis"
+)
+
+// SandboxReclaimTarget identifies an immutable sandbox attempt, never a replacement.
+type SandboxReclaimTarget struct {
+	OrganizationUUID  string
+	WorkspaceUUID     string
+	SandboxUUID       string
+	ProviderSandboxID string
+	Reclaiming        bool
+}
+
+func (t SandboxReclaimTarget) scope() sandboxLifecycleScope {
+	return sandboxLifecycleScope{OrganizationUUID: t.OrganizationUUID, WorkspaceUUID: t.WorkspaceUUID, SandboxUUID: t.SandboxUUID}
+}
+
+func (d *DB) ListSandboxReclaimCandidates(ctx context.Context, cutoff time.Time, after string, limit int, reclaim bool) ([]SandboxReclaimTarget, error) {
+	rows, err := NewSandboxLifecycleMapper(d.mapperDB).ListCandidates(ctx, cutoff, after, limit, reclaim)
+	if err != nil {
+		return nil, err
+	}
+	targets := make([]SandboxReclaimTarget, 0, len(rows))
+	for _, row := range rows {
+		targets = append(targets, row.reclaimTarget())
+	}
+	return targets, nil
+}
+
+// BeginSandboxReclamation serializes with public input and worker state updates.
+// Only a committed claim authorizes a provider deletion. Repeated claims retain
+// the same immutable sandbox UUID and cannot target a replacement.
+func (d *DB) BeginSandboxReclamation(ctx context.Context, target SandboxReclaimTarget, cutoff time.Time) (SandboxReclaimTarget, bool, error) {
+	var claimed bool
+	err := d.mapperDB.Transaction(ctx, func(executor yourbatis.Executor) error {
+		mapper := NewSandboxLifecycleMapper(executor)
+		current, found, err := mapper.FindTarget(ctx, target.scope())
+		if err != nil || !found {
+			return err
+		}
+		if current.State == "stopping" && current.StopReason != nil && *current.StopReason == "idle_timeout" {
+			target, claimed = current.reclaimTarget(), true
+			return nil
+		}
+		_, found, err = NewSessionMapper(executor).LockSessionForEvents(ctx, current.WorkspaceUUID, current.SessionExternalID)
+		if err != nil || !found {
+			return err
+		}
+		_, found, err = NewCodeSessionMapper(executor).LockCodeSessionByExternalID(ctx, current.CodeSessionExternalID)
+		if err != nil || !found {
+			return err
+		}
+		current, found, err = mapper.LockTarget(ctx, target.scope())
+		if err != nil || !found {
+			return err
+		}
+		rows, err := mapper.Claim(ctx, current.CodeSessionUUID, current.SandboxUUID, cutoff)
+		if err != nil || rows == 0 {
+			return err
+		}
+		if err := mapper.BeginStop(ctx, target.scope()); err != nil {
+			return err
+		}
+		target, claimed = current.reclaimTarget(), true
+		target.Reclaiming = true
+		return nil
+	})
+	return target, claimed, err
+}
+
+func (d *DB) CompleteSandboxReclamation(ctx context.Context, target SandboxReclaimTarget) error {
+	return d.mapperDB.Transaction(ctx, func(executor yourbatis.Executor) error {
+		mapper := NewSandboxLifecycleMapper(executor)
+		current, found, err := mapper.FindTarget(ctx, target.scope())
+		if err != nil || !found {
+			return err
+		}
+		// Lock the parent before the worker and work, matching public ingress.
+		if _, _, err := NewSessionMapper(executor).LockSessionForEvents(ctx, current.WorkspaceUUID, current.SessionExternalID); err != nil {
+			return err
+		}
+		// Keep the same lock order as claim/ingress, even when the session was terminated.
+		_, _, err = NewCodeSessionMapper(executor).LockCodeSessionByExternalID(ctx, current.CodeSessionExternalID)
+		if err != nil {
+			return err
+		}
+		if _, _, err := mapper.LockTarget(ctx, target.scope()); err != nil {
+			return err
+		}
+		rows, err := mapper.FinishStop(ctx, target.scope())
+		if err != nil || rows == 0 {
+			return err
+		}
+		// Input accepted during deletion uses the existing missing-sandbox recovery path.
+		// Without pending input, the stopped sandbox stays reclaimed.
+		_, err = NewEnvironmentSandboxMapper(executor).ScheduleRecoveryForCodeSession(ctx, environmentSandboxRecoveryParams{
+			CodeSessionExternalID: current.CodeSessionExternalID,
+			ProviderSandboxID:     current.ProviderSandboxID,
+			LastError:             "sandbox reclaimed after idle timeout",
+		})
+		return err
+	})
+}
+
+func (r sandboxLifecycleRow) reclaimTarget() SandboxReclaimTarget {
+	return SandboxReclaimTarget{OrganizationUUID: r.OrganizationUUID, WorkspaceUUID: r.WorkspaceUUID,
+		SandboxUUID: r.SandboxUUID, ProviderSandboxID: r.ProviderSandboxID,
+		Reclaiming: r.State == "stopping" && r.StopReason != nil && *r.StopReason == "idle_timeout"}
+}

--- a/internal/db/sandbox_lifecycle.go
+++ b/internal/db/sandbox_lifecycle.go
@@ -35,33 +35,51 @@ func (d *DB) ListSandboxReclaimCandidates(ctx context.Context, cutoff time.Time,
 // BeginSandboxReclamation serializes with public input and worker state updates.
 // Only a committed claim authorizes a provider deletion. Repeated claims retain
 // the same immutable sandbox UUID and cannot target a replacement.
-func (d *DB) BeginSandboxReclamation(ctx context.Context, target SandboxReclaimTarget, cutoff time.Time) (SandboxReclaimTarget, bool, error) {
+func (d *DB) BeginSandboxReclamation(ctx context.Context, target SandboxReclaimTarget, cutoff time.Time, allowNewClaim bool) (SandboxReclaimTarget, bool, error) {
 	var claimed bool
 	err := d.mapperDB.Transaction(ctx, func(executor yourbatis.Executor) error {
 		mapper := NewSandboxLifecycleMapper(executor)
 		current, found, err := mapper.FindTarget(ctx, target.scope())
-		if err != nil || !found {
+		if err != nil {
 			return err
+		}
+		if !found {
+			return nil
 		}
 		if current.State == "stopping" && current.StopReason != nil && *current.StopReason == "idle_timeout" {
 			target, claimed = current.reclaimTarget(), true
 			return nil
 		}
+		if !allowNewClaim {
+			return nil
+		}
 		_, found, err = NewSessionMapper(executor).LockSessionForEvents(ctx, current.WorkspaceUUID, current.SessionExternalID)
-		if err != nil || !found {
+		if err != nil {
 			return err
+		}
+		if !found {
+			return nil
 		}
 		_, found, err = NewCodeSessionMapper(executor).LockCodeSessionByExternalID(ctx, current.CodeSessionExternalID)
-		if err != nil || !found {
+		if err != nil {
 			return err
+		}
+		if !found {
+			return nil
 		}
 		current, found, err = mapper.LockTarget(ctx, target.scope())
-		if err != nil || !found {
+		if err != nil {
 			return err
 		}
+		if !found {
+			return nil
+		}
 		rows, err := mapper.Claim(ctx, current.CodeSessionUUID, current.SandboxUUID, cutoff)
-		if err != nil || rows == 0 {
+		if err != nil {
 			return err
+		}
+		if rows == 0 {
+			return nil
 		}
 		if err := mapper.BeginStop(ctx, target.scope()); err != nil {
 			return err
@@ -73,12 +91,16 @@ func (d *DB) BeginSandboxReclamation(ctx context.Context, target SandboxReclaimT
 	return target, claimed, err
 }
 
-func (d *DB) CompleteSandboxReclamation(ctx context.Context, target SandboxReclaimTarget) error {
-	return d.mapperDB.Transaction(ctx, func(executor yourbatis.Executor) error {
+func (d *DB) CompleteSandboxReclamation(ctx context.Context, target SandboxReclaimTarget) (bool, error) {
+	var completed bool
+	err := d.mapperDB.Transaction(ctx, func(executor yourbatis.Executor) error {
 		mapper := NewSandboxLifecycleMapper(executor)
 		current, found, err := mapper.FindTarget(ctx, target.scope())
-		if err != nil || !found {
+		if err != nil {
 			return err
+		}
+		if !found {
+			return nil
 		}
 		// Lock the parent before the worker and work, matching public ingress.
 		if _, _, err := NewSessionMapper(executor).LockSessionForEvents(ctx, current.WorkspaceUUID, current.SessionExternalID); err != nil {
@@ -89,13 +111,22 @@ func (d *DB) CompleteSandboxReclamation(ctx context.Context, target SandboxRecla
 		if err != nil {
 			return err
 		}
-		if _, _, err := mapper.LockTarget(ctx, target.scope()); err != nil {
+		locked, found, err := mapper.LockTarget(ctx, target.scope())
+		if err != nil {
 			return err
 		}
+		if !found {
+			return nil
+		}
+		current = locked
 		rows, err := mapper.FinishStop(ctx, target.scope())
-		if err != nil || rows == 0 {
+		if err != nil {
 			return err
 		}
+		if rows == 0 {
+			return nil
+		}
+		completed = true
 		// Input accepted during deletion uses the existing missing-sandbox recovery path.
 		// Without pending input, the stopped sandbox stays reclaimed.
 		_, err = NewEnvironmentSandboxMapper(executor).ScheduleRecoveryForCodeSession(ctx, environmentSandboxRecoveryParams{
@@ -105,6 +136,7 @@ func (d *DB) CompleteSandboxReclamation(ctx context.Context, target SandboxRecla
 		})
 		return err
 	})
+	return completed, err
 }
 
 func (r sandboxLifecycleRow) reclaimTarget() SandboxReclaimTarget {

--- a/internal/db/sandbox_lifecycle_mapper.go
+++ b/internal/db/sandbox_lifecycle_mapper.go
@@ -1,0 +1,36 @@
+package db
+
+import (
+	"context"
+	"time"
+)
+
+//go:generate go tool sqlmapgen -dir $PWD -mapper SandboxLifecycleMapper -sql ./sandbox_lifecycle_mapper.xml -out ./sandbox_lifecycle_mapper.sqlmap.gen.go -dialect postgres
+
+type sandboxLifecycleRow struct {
+	OrganizationUUID      string  `db:"organization_uuid"`
+	WorkspaceUUID         string  `db:"workspace_uuid"`
+	SessionExternalID     string  `db:"session_external_id"`
+	CodeSessionExternalID string  `db:"code_session_external_id"`
+	CodeSessionUUID       string  `db:"code_session_uuid"`
+	SandboxUUID           string  `db:"sandbox_uuid"`
+	ProviderSandboxID     string  `db:"provider_sandbox_id"`
+	State                 string  `db:"state"`
+	StopReason            *string `db:"stop_reason"`
+}
+
+type sandboxLifecycleScope struct {
+	OrganizationUUID string
+	WorkspaceUUID    string
+	SandboxUUID      string
+}
+
+// SandboxLifecycleMapper selects and claims idle sandbox attempts for deletion.
+type SandboxLifecycleMapper interface {
+	ListCandidates(ctx context.Context, cutoff time.Time, after string, limit int, reclaim bool) ([]sandboxLifecycleRow, error)
+	FindTarget(ctx context.Context, scope sandboxLifecycleScope) (sandboxLifecycleRow, bool, error)
+	LockTarget(ctx context.Context, scope sandboxLifecycleScope) (sandboxLifecycleRow, bool, error)
+	Claim(ctx context.Context, codeSessionUUID, sandboxUUID string, cutoff time.Time) (int64, error)
+	BeginStop(ctx context.Context, scope sandboxLifecycleScope) error
+	FinishStop(ctx context.Context, scope sandboxLifecycleScope) (int64, error)
+}

--- a/internal/db/sandbox_lifecycle_mapper.xml
+++ b/internal/db/sandbox_lifecycle_mapper.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mapper namespace="SandboxLifecycleMapper">
+    <sql id="targetColumns">
+        cs.organization_uuid, cs.workspace_uuid, cs.session_external_id,
+        cs.external_id AS code_session_external_id, cs.uuid AS code_session_uuid,
+        sandbox.uuid AS sandbox_uuid,
+        sandbox.provider_sandbox_id, sandbox.state, sandbox.stop_reason
+    </sql>
+    <sql id="targetTables">
+        FROM code_sessions cs
+        JOIN environment_work work ON work.organization_uuid = cs.organization_uuid
+            AND work.workspace_uuid = cs.workspace_uuid AND work.environment_uuid = cs.environment_uuid
+            AND work.session_uuid = cs.session_uuid
+        JOIN environment_sandboxes sandbox ON sandbox.organization_uuid = work.organization_uuid
+            AND sandbox.workspace_uuid = work.workspace_uuid AND sandbox.environment_uuid = work.environment_uuid
+            AND sandbox.work_uuid = work.uuid
+    </sql>
+    <sql id="scope">
+        cs.organization_uuid = #{scope.OrganizationUUID} AND cs.workspace_uuid = #{scope.WorkspaceUUID}
+        AND sandbox.uuid = #{scope.SandboxUUID} AND sandbox.provider_sandbox_id IS NOT NULL
+    </sql>
+    <select id="ListCandidates" resultType="sandboxLifecycleRow">
+        SELECT <include refid="targetColumns"/> <include refid="targetTables"/>
+        WHERE sandbox.provider_sandbox_id IS NOT NULL
+        <if test="after != ''">AND sandbox.uuid &gt; #{after}</if>
+        AND ((sandbox.state = 'stopping' AND sandbox.stop_reason = 'idle_timeout')
+        <if test="reclaim">
+            OR (sandbox.state = 'running'
+                AND cs.status = 'active' AND cs.deleted_at IS NULL
+                AND cs.worker_status = 'idle' AND cs.idle_since &lt;= #{cutoff}
+                AND work.state = 'active' AND work.deleted_at IS NULL)
+        </if>)
+        ORDER BY sandbox.uuid LIMIT #{limit}
+    </select>
+    <select id="FindTarget" result="optional" resultType="sandboxLifecycleRow">
+        SELECT <include refid="targetColumns"/> <include refid="targetTables"/>
+        WHERE <include refid="scope"/>
+    </select>
+    <select id="LockTarget" result="optional" resultType="sandboxLifecycleRow">
+        SELECT <include refid="targetColumns"/> <include refid="targetTables"/>
+        WHERE <include refid="scope"/> FOR UPDATE OF work, sandbox
+    </select>
+    <update id="Claim" result="rows">
+        UPDATE code_sessions cs
+        SET idle_since = NULL, current_worker_epoch = current_worker_epoch + 1,
+            worker_lease_expires_at = NULL, oauth_access_token_hash = NULL,
+            connection_status = 'disconnected', updated_at = NOW()
+        WHERE cs.uuid = #{codeSessionUUID}
+            AND cs.status = 'active' AND cs.deleted_at IS NULL
+            AND cs.worker_status = 'idle' AND cs.idle_since &lt;= #{cutoff}
+            AND EXISTS (SELECT 1 FROM sessions s JOIN environments env ON env.uuid = s.environment_uuid
+                AND env.organization_uuid = s.organization_uuid AND env.workspace_uuid = s.workspace_uuid
+                WHERE s.uuid = cs.session_uuid AND s.organization_uuid = cs.organization_uuid
+                AND s.workspace_uuid = cs.workspace_uuid AND s.status = 'idle'
+                AND s.deleted_at IS NULL AND s.archived_at IS NULL AND env.config-&gt;&gt;'type' = 'cloud')
+            AND EXISTS (SELECT 1 FROM environment_work work JOIN environment_sandboxes sandbox
+                ON sandbox.work_uuid = work.uuid AND sandbox.organization_uuid = work.organization_uuid
+                AND sandbox.workspace_uuid = work.workspace_uuid AND sandbox.environment_uuid = work.environment_uuid
+                WHERE sandbox.uuid = #{sandboxUUID} AND sandbox.state = 'running'
+                AND work.organization_uuid = cs.organization_uuid AND work.workspace_uuid = cs.workspace_uuid
+                AND work.environment_uuid = cs.environment_uuid AND work.session_uuid = cs.session_uuid
+                AND work.state = 'active' AND work.deleted_at IS NULL)
+            AND NOT EXISTS (SELECT 1 FROM code_session_inbound_events e WHERE e.code_session_uuid = cs.uuid
+                AND e.deleted_at IS NULL AND e.delivery_status &lt;&gt; 'processed')
+    </update>
+    <update id="BeginStop">
+        UPDATE environment_sandboxes SET state = 'stopping', stop_reason = 'idle_timeout', updated_at = NOW()
+        WHERE organization_uuid = #{scope.OrganizationUUID} AND workspace_uuid = #{scope.WorkspaceUUID}
+            AND uuid = #{scope.SandboxUUID} AND state = 'running'
+    </update>
+    <update id="FinishStop" result="rows">
+        UPDATE environment_sandboxes SET state = 'stopped', stopped_at = COALESCE(stopped_at, NOW()), updated_at = NOW()
+        WHERE organization_uuid = #{scope.OrganizationUUID} AND workspace_uuid = #{scope.WorkspaceUUID}
+            AND uuid = #{scope.SandboxUUID} AND state = 'stopping' AND stop_reason = 'idle_timeout'
+    </update>
+</mapper>

--- a/internal/db/sandbox_lifecycle_mapper_test.go
+++ b/internal/db/sandbox_lifecycle_mapper_test.go
@@ -1,0 +1,80 @@
+package db
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/superduck-ai/yourbatis"
+)
+
+func TestSandboxLifecycleMapperClaimBindsScopeAndIdleCutoff(t *testing.T) {
+	cutoff := time.Date(2026, time.August, 31, 0, 0, 0, 0, time.UTC)
+	bound := buildSandboxLifecycleMapperClaim(yourbatis.DialectPostgres, "code-session-uuid", "sandbox-uuid", cutoff)
+	assertMapperBuilderContract(t, mapperBuilderContract{
+		statement: sandboxLifecycleMapperClaimStatement, bound: bound,
+		wantID: "SandboxLifecycleMapper.Claim", wantKind: yourbatis.StatementUpdate,
+		wantArgumentNames: []string{"codeSessionUUID", "cutoff", "sandboxUUID"},
+		wantSQLFragments: []string{"idle_since = NULL", "current_worker_epoch = current_worker_epoch + 1",
+			"worker_status = 'idle'", "idle_since <= $2", "sandbox.uuid = $3", "s.organization_uuid = cs.organization_uuid",
+			"e.delivery_status <> 'processed'", "env.config->>'type' = 'cloud'"},
+	})
+	values := make([]any, len(bound.Args))
+	for i, arg := range bound.Args {
+		values[i] = arg.Value
+	}
+	if !reflect.DeepEqual(values, []any{"code-session-uuid", cutoff, "sandbox-uuid"}) {
+		t.Fatalf("bound values = %#v", values)
+	}
+}
+
+func TestSandboxLifecycleMapperDeletionTargetsImmutableTenantSandbox(t *testing.T) {
+	scope := sandboxLifecycleScope{OrganizationUUID: "org-uuid", WorkspaceUUID: "workspace-uuid", SandboxUUID: "sandbox-uuid"}
+	assertMapperBuilderContract(t, mapperBuilderContract{
+		statement: sandboxLifecycleMapperFinishStopStatement,
+		bound:     buildSandboxLifecycleMapperFinishStop(yourbatis.DialectPostgres, scope),
+		wantID:    "SandboxLifecycleMapper.FinishStop", wantKind: yourbatis.StatementUpdate,
+		wantArgumentNames: []string{"scope.OrganizationUUID", "scope.WorkspaceUUID", "scope.SandboxUUID"},
+		wantSQLFragments:  []string{"organization_uuid = $1", "workspace_uuid = $2", "uuid = $3", "state = 'stopping'", "stop_reason = 'idle_timeout'"},
+	})
+}
+
+func TestSandboxLifecycleMapperDisabledSweepStillRepairsCommittedDeletion(t *testing.T) {
+	bound := buildSandboxLifecycleMapperListCandidates(yourbatis.DialectPostgres, time.Now(), "sandbox-cursor", 100, false)
+	assertMapperBuilderContract(t, mapperBuilderContract{
+		statement: sandboxLifecycleMapperListCandidatesStatement, bound: bound,
+		wantID: "SandboxLifecycleMapper.ListCandidates", wantKind: yourbatis.StatementSelect,
+		wantArgumentNames: []string{"after", "limit"},
+		wantSQLFragments:  []string{"sandbox.uuid > $1", "sandbox.state = 'stopping'", "LIMIT $2"},
+	})
+	if containsMapperSQL(bound.SQL, "cs.idle_since") {
+		t.Fatal("disabled sweep still selects new idle candidates")
+	}
+}
+
+func TestSandboxReclamationRecoveryWithoutProviderIDOnlyTargetsReclaimed(t *testing.T) {
+	bound := buildEnvironmentSandboxMapperScheduleRecoveryForCodeSession(yourbatis.DialectPostgres, environmentSandboxRecoveryParams{
+		CodeSessionExternalID: "code-session", LastError: "reclaimed",
+	})
+	assertMapperBuilderContract(t, mapperBuilderContract{
+		statement: environmentSandboxMapperScheduleRecoveryForCodeSessionStatement, bound: bound,
+		wantID: "EnvironmentSandboxMapper.ScheduleRecoveryForCodeSession", wantKind: yourbatis.StatementUpdate,
+		wantArgumentNames:          []string{"params.CodeSessionExternalID", "params.LastError"},
+		wantSensitiveArgumentNames: []string{"params.LastError"},
+		wantSQLFragments: []string{"sandbox.state = 'stopped'", "sandbox.stop_reason = 'idle_timeout'",
+			"e.delivery_status <> 'processed'", "s.archived_at IS NULL", "code_session.external_id = $1"},
+	})
+	if containsMapperSQL(bound.SQL, "sandbox.state = 'running'") {
+		t.Fatal("empty provider ID allows recovery of a running sandbox")
+	}
+}
+
+func TestCodeSessionMapperPublicInputResetsIdleClockWithinTenant(t *testing.T) {
+	assertMapperBuilderContract(t, mapperBuilderContract{
+		statement: codeSessionMapperResetIdleSinceForSessionStatement,
+		bound:     buildCodeSessionMapperResetIdleSinceForSession(yourbatis.DialectPostgres, "org", "workspace", "session"),
+		wantID:    "CodeSessionMapper.ResetIdleSinceForSession", wantKind: yourbatis.StatementUpdate,
+		wantArgumentNames: []string{"organizationUUID", "workspaceUUID", "sessionUUID"},
+		wantSQLFragments:  []string{"idle_since = NULL", "organization_uuid = $1", "workspace_uuid = $2", "session_uuid = $3", "status = 'active'"},
+	})
+}

--- a/internal/db/sessions_helpers.go
+++ b/internal/db/sessions_helpers.go
@@ -155,6 +155,15 @@ func insertSessionEventsTx(
 		}
 		created = append(created, row.event())
 	}
+	for _, event := range created {
+		switch event.EventType {
+		case "user.message", "user.interrupt", "user.tool_confirmation", "user.tool_result", "user.custom_tool_result":
+			if err := NewCodeSessionMapper(executor).ResetIdleSinceForSession(ctx, session.OrganizationUUID, session.WorkspaceUUID, session.UUID); err != nil {
+				return nil, err
+			}
+			return created, nil
+		}
+	}
 	return created, nil
 }
 

--- a/internal/db/sessions_helpers.go
+++ b/internal/db/sessions_helpers.go
@@ -3,7 +3,9 @@ package db
 import (
 	"bytes"
 	"context"
+	"slices"
 
+	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 	"github.com/superduck-ai/yourbatis"
 )
 
@@ -155,13 +157,11 @@ func insertSessionEventsTx(
 		}
 		created = append(created, row.event())
 	}
-	for _, event := range created {
-		switch event.EventType {
-		case "user.message", "user.interrupt", "user.tool_confirmation", "user.tool_result", "user.custom_tool_result":
-			if err := NewCodeSessionMapper(executor).ResetIdleSinceForSession(ctx, session.OrganizationUUID, session.WorkspaceUUID, session.UUID); err != nil {
-				return nil, err
-			}
-			return created, nil
+	if slices.ContainsFunc(created, func(event SessionEvent) bool {
+		return maevents.IsPublicWorkerInputEvent(event.EventType)
+	}) {
+		if err := NewCodeSessionMapper(executor).ResetIdleSinceForSession(ctx, session.OrganizationUUID, session.WorkspaceUUID, session.UUID); err != nil {
+			return nil, err
 		}
 	}
 	return created, nil

--- a/internal/deployments/scheduler.go
+++ b/internal/deployments/scheduler.go
@@ -11,8 +11,6 @@ import (
 	"uuid"
 
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdriver/riverdatabasesql"
-	"github.com/riverqueue/river/rivermigrate"
 	"github.com/riverqueue/river/rivertype"
 	"github.com/superduck-ai/open-managed-agents/internal/common/jsonx"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
@@ -21,8 +19,7 @@ import (
 )
 
 const (
-	riverSchema                    = "public"
-	deploymentScheduleQueue        = "deployment_schedules"
+	DeploymentScheduleQueue        = "deployment_schedules"
 	deploymentScheduleSyncInterval = 10 * time.Second
 )
 
@@ -76,39 +73,13 @@ type DeploymentScheduler struct {
 	done       chan struct{}
 }
 
-func MigrateRiver(ctx context.Context, database *db.DB, logger *slog.Logger) error {
-	migrator, err := rivermigrate.New(riverdatabasesql.New(database.SQLDB()), &rivermigrate.Config{
-		Schema: riverSchema, Logger: logging.LoggerOrDefault(logger),
-	})
-	if err != nil {
-		return err
-	}
-	_, err = migrator.Migrate(ctx, rivermigrate.DirectionUp, nil)
-	return err
+// RegisterScheduledWorkers keeps deployment behavior separate from River assembly.
+func RegisterScheduledWorkers(workers *river.Workers, database *db.DB) {
+	river.AddWorker(workers, &scheduledDeploymentWorker{database: database})
 }
 
-func NewDeploymentScheduler(database *db.DB, logger *slog.Logger) (*DeploymentScheduler, error) {
-	logger = logging.LoggerOrDefault(logger)
-	workers := river.NewWorkers()
-	worker := &scheduledDeploymentWorker{database: database}
-	river.AddWorker(workers, worker)
-	client, err := river.NewClient(riverdatabasesql.New(database.SQLDB()), &river.Config{
-		Schema: riverSchema,
-		Queues: map[string]river.QueueConfig{
-			deploymentScheduleQueue: {MaxWorkers: 10},
-		},
-		Workers:         workers,
-		Logger:          logger,
-		PollOnly:        true,
-		JobTimeout:      2 * time.Minute,
-		SoftStopTimeout: 10 * time.Second,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &DeploymentScheduler{
-		database: database, client: client, logger: logger, registered: make(map[string]deploymentSchedule),
-	}, nil
+func NewDeploymentScheduler(database *db.DB, client *river.Client[*sql.Tx], logger *slog.Logger) *DeploymentScheduler {
+	return &DeploymentScheduler{database: database, client: client, logger: logging.LoggerOrDefault(logger), registered: make(map[string]deploymentSchedule)}
 }
 
 func (s *DeploymentScheduler) Start(ctx context.Context) error {
@@ -161,7 +132,7 @@ func (s *DeploymentScheduler) sync(ctx context.Context) error {
 			return scheduledDeploymentArgs{
 				WorkspaceUUID: state.WorkspaceUUID, DeploymentExternalID: state.ExternalID,
 				Schedule: schedule.config,
-			}, &river.InsertOpts{Queue: deploymentScheduleQueue}
+			}, &river.InsertOpts{Queue: DeploymentScheduleQueue}
 		}, &river.PeriodicJobOpts{ID: state.ExternalID})
 		s.client.PeriodicJobs().RemoveByID(state.ExternalID)
 		if _, err := s.client.PeriodicJobs().AddSafely(job); err != nil {

--- a/internal/environments/lifecycle.go
+++ b/internal/environments/lifecycle.go
@@ -1,0 +1,139 @@
+package environments
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/logging"
+	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
+)
+
+const SandboxLifecycleQueue = "sandbox_lifecycle"
+const lifecycleBatchSize = 100
+
+type SandboxLifecycle struct {
+	database *db.DB
+	provider *e2bruntime.E2BProvider
+	cfg      config.SandboxLifecycleConfig
+	logger   *slog.Logger
+}
+
+func NewSandboxLifecycle(database *db.DB, provider *e2bruntime.E2BProvider, cfg config.SandboxLifecycleConfig, logger *slog.Logger) *SandboxLifecycle {
+	return &SandboxLifecycle{database: database, provider: provider, cfg: cfg, logger: logging.LoggerOrDefault(logger)}
+}
+
+type sandboxSweepArgs struct{}
+
+func (sandboxSweepArgs) Kind() string { return "sandbox_lifecycle_sweep" }
+
+type sandboxReclaimArgs struct {
+	OrganizationUUID string `json:"organization_uuid"`
+	WorkspaceUUID    string `json:"workspace_uuid"`
+	SandboxUUID      string `json:"sandbox_uuid"`
+}
+
+func (sandboxReclaimArgs) Kind() string { return "sandbox_reclaim" }
+func (sandboxReclaimArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{Queue: SandboxLifecycleQueue, UniqueOpts: lifecycleUniqueOpts()}
+}
+
+func (l *SandboxLifecycle) Register(workers *river.Workers) {
+	river.AddWorker(workers, &sandboxSweepWorker{lifecycle: l})
+	river.AddWorker(workers, &sandboxReclaimWorker{lifecycle: l})
+}
+
+// Configure upserts a single cluster-wide cron; policy is read by workers at execution time.
+func (l *SandboxLifecycle) Configure(ctx context.Context, client *river.Client[*sql.Tx]) error {
+	existing, err := client.DurablePeriodicJobGet(ctx, "sandbox_lifecycle_sweep")
+	if err != nil && !errors.Is(err, river.ErrNotFound) {
+		return err
+	}
+	if err == nil && existing.CronExpression != nil && *existing.CronExpression == "* * * * *" && existing.CronTimezone == "UTC" && existing.Kind == (sandboxSweepArgs{}).Kind() && existing.Queue == SandboxLifecycleQueue && existing.PausedAt == nil {
+		return nil
+	}
+	_, err = client.DurablePeriodicJobUpsert(ctx, &river.DurablePeriodicJobUpsertOpts{
+		ID: "sandbox_lifecycle_sweep", Kind: sandboxSweepArgs{}.Kind(), Queue: SandboxLifecycleQueue,
+		Schedule: &river.DurablePeriodicJobSchedule{CronExpression: "* * * * *", CronTimezone: "UTC"},
+	})
+	return err
+}
+
+// Reclaim only contacts the provider after a durable, conditional claim.
+func (l *SandboxLifecycle) Reclaim(ctx context.Context, target db.SandboxReclaimTarget) error {
+	cutoff := time.Now().UTC().Add(-l.cfg.IdleTimeout)
+	// Disabling new reclamation must not abandon already committed deletions.
+	if !l.cfg.Enabled || l.cfg.DryRun {
+		cutoff = time.Time{}
+	}
+	claimed, ok, err := l.database.BeginSandboxReclamation(ctx, target, cutoff)
+	if err != nil || !ok {
+		return err
+	}
+	if err := l.provider.Kill(ctx, claimed.ProviderSandboxID); err != nil {
+		return err
+	}
+	if err := l.database.CompleteSandboxReclamation(ctx, claimed); err != nil {
+		return err
+	}
+	l.logger.InfoContext(ctx, "idle sandbox reclaimed", "organization_id", claimed.OrganizationUUID,
+		"workspace_id", claimed.WorkspaceUUID, "sandbox_id", claimed.SandboxUUID)
+	return nil
+}
+
+type sandboxSweepWorker struct {
+	river.WorkerDefaults[sandboxSweepArgs]
+	lifecycle *SandboxLifecycle
+}
+
+func (w *sandboxSweepWorker) Work(ctx context.Context, _ *river.Job[sandboxSweepArgs]) error {
+	client := river.ClientFromContext[*sql.Tx](ctx)
+	return w.lifecycle.enqueueReclaims(ctx, client)
+}
+
+func (l *SandboxLifecycle) enqueueReclaims(ctx context.Context, client *river.Client[*sql.Tx]) error {
+	after := ""
+	for {
+		targets, err := l.database.ListSandboxReclaimCandidates(ctx, time.Now().UTC().Add(-l.cfg.IdleTimeout), after, lifecycleBatchSize, l.cfg.Enabled)
+		if err != nil {
+			return err
+		}
+		for _, target := range targets {
+			if l.cfg.DryRun && !target.Reclaiming {
+				l.logger.InfoContext(ctx, "idle sandbox reclaim candidate", "workspace_id", target.WorkspaceUUID, "sandbox_id", target.SandboxUUID)
+				continue
+			}
+			_, err := client.Insert(ctx, sandboxReclaimArgs{OrganizationUUID: target.OrganizationUUID, WorkspaceUUID: target.WorkspaceUUID, SandboxUUID: target.SandboxUUID}, nil)
+			if err != nil {
+				return err
+			}
+		}
+		if len(targets) < lifecycleBatchSize {
+			return nil
+		}
+		after = targets[len(targets)-1].SandboxUUID
+	}
+}
+
+type sandboxReclaimWorker struct {
+	river.WorkerDefaults[sandboxReclaimArgs]
+	lifecycle *SandboxLifecycle
+}
+
+func (w *sandboxReclaimWorker) Work(ctx context.Context, job *river.Job[sandboxReclaimArgs]) error {
+	return w.lifecycle.Reclaim(ctx, db.SandboxReclaimTarget{OrganizationUUID: job.Args.OrganizationUUID, WorkspaceUUID: job.Args.WorkspaceUUID, SandboxUUID: job.Args.SandboxUUID})
+}
+
+// Completed no-op jobs must not suppress a later idle period.
+func lifecycleUniqueOpts() river.UniqueOpts {
+	return river.UniqueOpts{ByArgs: true, ByState: []rivertype.JobState{
+		rivertype.JobStateAvailable, rivertype.JobStatePending, rivertype.JobStateRunning,
+		rivertype.JobStateRetryable, rivertype.JobStateScheduled,
+	}}
+}

--- a/internal/environments/lifecycle.go
+++ b/internal/environments/lifecycle.go
@@ -15,8 +15,13 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
 )
 
-const SandboxLifecycleQueue = "sandbox_lifecycle"
-const lifecycleBatchSize = 100
+const (
+	SandboxLifecycleQueue = "sandbox_lifecycle"
+	lifecycleBatchSize    = 100
+	sandboxSweepID        = "sandbox_lifecycle_sweep"
+	sandboxSweepCron      = "* * * * *"
+	sandboxSweepTimezone  = "UTC"
+)
 
 type SandboxLifecycle struct {
 	database *db.DB
@@ -31,7 +36,7 @@ func NewSandboxLifecycle(database *db.DB, provider *e2bruntime.E2BProvider, cfg 
 
 type sandboxSweepArgs struct{}
 
-func (sandboxSweepArgs) Kind() string { return "sandbox_lifecycle_sweep" }
+func (sandboxSweepArgs) Kind() string { return sandboxSweepID }
 
 type sandboxReclaimArgs struct {
 	OrganizationUUID string `json:"organization_uuid"`
@@ -51,36 +56,55 @@ func (l *SandboxLifecycle) Register(workers *river.Workers) {
 
 // Configure upserts a single cluster-wide cron; policy is read by workers at execution time.
 func (l *SandboxLifecycle) Configure(ctx context.Context, client *river.Client[*sql.Tx]) error {
-	existing, err := client.DurablePeriodicJobGet(ctx, "sandbox_lifecycle_sweep")
+	existing, err := client.DurablePeriodicJobGet(ctx, sandboxSweepID)
 	if err != nil && !errors.Is(err, river.ErrNotFound) {
 		return err
 	}
-	if err == nil && existing.CronExpression != nil && *existing.CronExpression == "* * * * *" && existing.CronTimezone == "UTC" && existing.Kind == (sandboxSweepArgs{}).Kind() && existing.Queue == SandboxLifecycleQueue && existing.PausedAt == nil {
+	if err == nil && matchesSandboxSweepSchedule(existing) {
 		return nil
 	}
 	_, err = client.DurablePeriodicJobUpsert(ctx, &river.DurablePeriodicJobUpsertOpts{
-		ID: "sandbox_lifecycle_sweep", Kind: sandboxSweepArgs{}.Kind(), Queue: SandboxLifecycleQueue,
-		Schedule: &river.DurablePeriodicJobSchedule{CronExpression: "* * * * *", CronTimezone: "UTC"},
+		ID: sandboxSweepID, Kind: sandboxSweepArgs{}.Kind(), Queue: SandboxLifecycleQueue,
+		Schedule: &river.DurablePeriodicJobSchedule{CronExpression: sandboxSweepCron, CronTimezone: sandboxSweepTimezone},
 	})
 	return err
+}
+
+func matchesSandboxSweepSchedule(job *rivertype.DurablePeriodicJob) bool {
+	return job != nil && job.CronExpression != nil && *job.CronExpression == sandboxSweepCron &&
+		job.CronTimezone == sandboxSweepTimezone && job.Kind == (sandboxSweepArgs{}).Kind() &&
+		job.Queue == SandboxLifecycleQueue && job.PausedAt == nil
+}
+
+func (l *SandboxLifecycle) allowsNewClaims() bool {
+	return l.cfg.Enabled && !l.cfg.DryRun
 }
 
 // Reclaim only contacts the provider after a durable, conditional claim.
 func (l *SandboxLifecycle) Reclaim(ctx context.Context, target db.SandboxReclaimTarget) error {
 	cutoff := time.Now().UTC().Add(-l.cfg.IdleTimeout)
-	// Disabling new reclamation must not abandon already committed deletions.
-	if !l.cfg.Enabled || l.cfg.DryRun {
-		cutoff = time.Time{}
-	}
-	claimed, ok, err := l.database.BeginSandboxReclamation(ctx, target, cutoff)
-	if err != nil || !ok {
+	claimed, ok, err := l.database.BeginSandboxReclamation(ctx, target, cutoff, l.allowsNewClaims())
+	if err != nil {
 		return err
+	}
+	if !ok {
+		l.logger.DebugContext(ctx, "idle sandbox reclamation skipped", "reason", "target_missing_or_ineligible",
+			"organization_id", target.OrganizationUUID,
+			"workspace_id", target.WorkspaceUUID, "sandbox_id", target.SandboxUUID)
+		return nil
 	}
 	if err := l.provider.Kill(ctx, claimed.ProviderSandboxID); err != nil {
 		return err
 	}
-	if err := l.database.CompleteSandboxReclamation(ctx, claimed); err != nil {
+	completed, err := l.database.CompleteSandboxReclamation(ctx, claimed)
+	if err != nil {
 		return err
+	}
+	if !completed {
+		l.logger.DebugContext(ctx, "idle sandbox reclamation completion skipped", "reason", "target_missing_or_already_completed",
+			"organization_id", claimed.OrganizationUUID,
+			"workspace_id", claimed.WorkspaceUUID, "sandbox_id", claimed.SandboxUUID)
+		return nil
 	}
 	l.logger.InfoContext(ctx, "idle sandbox reclaimed", "organization_id", claimed.OrganizationUUID,
 		"workspace_id", claimed.WorkspaceUUID, "sandbox_id", claimed.SandboxUUID)
@@ -105,8 +129,11 @@ func (l *SandboxLifecycle) enqueueReclaims(ctx context.Context, client *river.Cl
 			return err
 		}
 		for _, target := range targets {
-			if l.cfg.DryRun && !target.Reclaiming {
-				l.logger.InfoContext(ctx, "idle sandbox reclaim candidate", "workspace_id", target.WorkspaceUUID, "sandbox_id", target.SandboxUUID)
+			if !l.allowsNewClaims() && !target.Reclaiming {
+				if l.cfg.Enabled && l.cfg.DryRun {
+					l.logger.InfoContext(ctx, "idle sandbox reclaim candidate", "organization_id", target.OrganizationUUID,
+						"workspace_id", target.WorkspaceUUID, "sandbox_id", target.SandboxUUID)
+				}
 				continue
 			}
 			_, err := client.Insert(ctx, sandboxReclaimArgs{OrganizationUUID: target.OrganizationUUID, WorkspaceUUID: target.WorkspaceUUID, SandboxUUID: target.SandboxUUID}, nil)

--- a/internal/managedagentsevents/events.go
+++ b/internal/managedagentsevents/events.go
@@ -54,6 +54,17 @@ func IsClientInput(eventType string) bool {
 	}
 }
 
+// IsPublicWorkerInputEvent reports whether a persisted public event must be
+// forwarded to the managed worker and therefore interrupts an idle period.
+func IsPublicWorkerInputEvent(eventType string) bool {
+	switch strings.TrimSpace(eventType) {
+	case "user.message", "user.interrupt", "user.custom_tool_result", "user.tool_confirmation", "user.tool_result":
+		return true
+	default:
+		return false
+	}
+}
+
 func IsPersistedManagedAgentEvent(eventType string) bool {
 	category := CategoryFor(eventType)
 	return category != CategoryUnknown && category != CategoryStreamDelta

--- a/internal/managedagentsevents/events_test.go
+++ b/internal/managedagentsevents/events_test.go
@@ -110,6 +110,25 @@ func TestWorkerOutputEventPolicy(t *testing.T) {
 	}
 }
 
+func TestPublicWorkerInputEventPolicy(t *testing.T) {
+	for _, eventType := range []string{
+		"user.message",
+		"user.interrupt",
+		"user.custom_tool_result",
+		"user.tool_confirmation",
+		"user.tool_result",
+	} {
+		if !IsPublicWorkerInputEvent(eventType) {
+			t.Fatalf("IsPublicWorkerInputEvent(%q) = false, want true", eventType)
+		}
+	}
+	for _, eventType := range []string{"user.define_outcome", "system.message", "agent.message", ""} {
+		if IsPublicWorkerInputEvent(eventType) {
+			t.Fatalf("IsPublicWorkerInputEvent(%q) = true, want false", eventType)
+		}
+	}
+}
+
 func TestPublicSessionHistoryEventPolicy(t *testing.T) {
 	allowed := []string{
 		"assistant",

--- a/internal/riverjobs/client.go
+++ b/internal/riverjobs/client.go
@@ -1,5 +1,5 @@
-// Package backgroundjobs owns River infrastructure shared by resource workers.
-package backgroundjobs
+// Package riverjobs owns River infrastructure shared by resource workers.
+package riverjobs
 
 import (
 	"context"

--- a/internal/runtime/e2bruntime/lifecycle_test.go
+++ b/internal/runtime/e2bruntime/lifecycle_test.go
@@ -29,7 +29,7 @@ func TestKillUsesExplicitSDKAPIURLWithoutConnecting(t *testing.T) {
 			defer server.Close()
 			provider := NewProvider(config.E2BConfig{
 				APIKey:      "e2b_0000000000000000000000000000000000000000",
-				AccessToken: "test-access-token", APIURL: server.URL, RequestTimeout: time.Second,
+				AccessToken: "test-access-token", APIURL: server.URL, Debug: true, RequestTimeout: time.Second,
 			})
 			err := provider.Kill(context.Background(), "sbx_paused")
 			if (err != nil) != (status == http.StatusUnauthorized || status == http.StatusServiceUnavailable) {

--- a/internal/runtime/e2bruntime/lifecycle_test.go
+++ b/internal/runtime/e2bruntime/lifecycle_test.go
@@ -1,0 +1,43 @@
+package e2bruntime
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+)
+
+func TestKillUsesExplicitSDKAPIURLWithoutConnecting(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusServiceUnavailable, http.StatusNotFound, http.StatusNoContent} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if r.Method != http.MethodDelete || r.URL.Path != "/sandboxes/sbx_paused" {
+					t.Errorf("unexpected provider request: %s %s", r.Method, r.URL.Path)
+				}
+				if r.Header.Get("X-API-Key") != "e2b_0000000000000000000000000000000000000000" || r.Header.Get("Authorization") != "Bearer test-access-token" {
+					t.Error("provider request did not retain configured authentication")
+				}
+				w.WriteHeader(status)
+			}))
+			defer server.Close()
+			provider := NewProvider(config.E2BConfig{
+				APIKey:      "e2b_0000000000000000000000000000000000000000",
+				AccessToken: "test-access-token", APIURL: server.URL, RequestTimeout: time.Second,
+			})
+			err := provider.Kill(context.Background(), "sbx_paused")
+			if (err != nil) != (status == http.StatusUnauthorized || status == http.StatusServiceUnavailable) {
+				t.Fatalf("Kill error = %v at status %d", err, status)
+			}
+			if calls.Load() != 1 {
+				t.Fatalf("provider requests = %d, want one DELETE", calls.Load())
+			}
+		})
+	}
+}

--- a/internal/runtime/e2bruntime/runtime.go
+++ b/internal/runtime/e2bruntime/runtime.go
@@ -141,15 +141,21 @@ func (p *E2BProvider) Create(ctx context.Context, env db.Environment, work *db.E
 	return Sandbox{ID: sandbox.SandboxID}, nil
 }
 
+// Kill deletes by ID without Connect: paused sandboxes must not resume merely
+// to be reclaimed.
 func (p *E2BProvider) Kill(ctx context.Context, sandboxID string) error {
-	if strings.TrimSpace(sandboxID) == "" {
+	if sandboxID == "" || p.cfg.Debug {
 		return nil
 	}
-	sandbox, err := p.connect(ctx, sandboxID)
-	if err != nil {
-		return err
+	requestTimeoutMs := int(p.cfg.RequestTimeout / time.Millisecond)
+	opts := &e2b.SandboxApiOpts{
+		ApiKey: p.cfg.APIKey, Domain: p.cfg.Domain, ApiUrl: p.cfg.APIURL, RequestTimeoutMs: &requestTimeoutMs,
 	}
-	return sandbox.Kill(ctx, nil)
+	if p.cfg.AccessToken != "" {
+		opts.Headers = map[string]string{"Authorization": "Bearer " + p.cfg.AccessToken}
+	}
+	_, err := e2b.Kill(ctx, sandboxID, opts)
+	return err
 }
 
 // SetTimeout renews the provider-side sandbox lifetime from the time of this

--- a/internal/runtime/e2bruntime/runtime.go
+++ b/internal/runtime/e2bruntime/runtime.go
@@ -108,7 +108,7 @@ func (p *E2BProvider) Resolve(env db.Environment, work *db.EnvironmentWork) (Res
 }
 
 func (p *E2BProvider) Create(ctx context.Context, env db.Environment, work *db.EnvironmentWork, resolved Resolution) (Sandbox, error) {
-	if strings.TrimSpace(p.cfg.APIKey) == "" && !p.cfg.Debug {
+	if p.cfg.APIKey == "" && !p.cfg.Debug {
 		return Sandbox{}, errors.New("e2b.api_key is required to create a sandbox")
 	}
 	if strings.TrimSpace(resolved.Template) == "" {
@@ -144,16 +144,19 @@ func (p *E2BProvider) Create(ctx context.Context, env db.Environment, work *db.E
 // Kill deletes by ID without Connect: paused sandboxes must not resume merely
 // to be reclaimed.
 func (p *E2BProvider) Kill(ctx context.Context, sandboxID string) error {
-	if sandboxID == "" || p.cfg.Debug {
+	if sandboxID == "" {
 		return nil
 	}
 	requestTimeoutMs := int(p.cfg.RequestTimeout / time.Millisecond)
+	debug := p.cfg.Debug
 	opts := &e2b.SandboxApiOpts{
-		ApiKey: p.cfg.APIKey, Domain: p.cfg.Domain, ApiUrl: p.cfg.APIURL, RequestTimeoutMs: &requestTimeoutMs,
+		ApiKey: p.cfg.APIKey, Domain: p.cfg.Domain, ApiUrl: p.cfg.APIURL, Debug: &debug, RequestTimeoutMs: &requestTimeoutMs,
 	}
 	if p.cfg.AccessToken != "" {
 		opts.Headers = map[string]string{"Authorization": "Bearer " + p.cfg.AccessToken}
 	}
+	// The SDK maps a provider 404 to (false, nil); an already absent sandbox
+	// satisfies the same deletion postcondition as a successful DELETE.
 	_, err := e2b.Kill(ctx, sandboxID, opts)
 	return err
 }

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/riverqueue/river"
 	"github.com/superduck-ai/open-managed-agents/internal/api"
-	"github.com/superduck-ai/open-managed-agents/internal/backgroundjobs"
 	"github.com/superduck-ai/open-managed-agents/internal/batches"
 	"github.com/superduck-ai/open-managed-agents/internal/cleanup"
 	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
@@ -26,6 +25,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/platformauth"
 	"github.com/superduck-ai/open-managed-agents/internal/platformsession"
 	"github.com/superduck-ai/open-managed-agents/internal/redisclient"
+	"github.com/superduck-ai/open-managed-agents/internal/riverjobs"
 	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
 	"github.com/superduck-ai/open-managed-agents/internal/secrets"
 	"github.com/superduck-ai/open-managed-agents/internal/sessionfanout"
@@ -63,7 +63,7 @@ func run(logger *slog.Logger) error {
 		if err := database.Migrate(ctx); err != nil {
 			return fmt.Errorf("migrate database: %w", err)
 		}
-		if err := backgroundjobs.Migrate(ctx, database, logger.With("component", "background_jobs")); err != nil {
+		if err := riverjobs.Migrate(ctx, database, logger.With("component", "river_jobs")); err != nil {
 			return fmt.Errorf("migrate River: %w", err)
 		}
 	} else {
@@ -143,10 +143,10 @@ func run(logger *slog.Logger) error {
 	lifecycle := environments.NewSandboxLifecycle(database, sandboxProvider,
 		cfg.SandboxLifecycle, logger.With("component", "sandbox_lifecycle"))
 	lifecycle.Register(workers)
-	jobClient, err := backgroundjobs.NewClient(database, logger.With("component", "background_jobs"), workers,
+	jobClient, err := riverjobs.NewClient(database, logger.With("component", "river_jobs"), workers,
 		map[string]river.QueueConfig{deployments.DeploymentScheduleQueue: {MaxWorkers: 10}, environments.SandboxLifecycleQueue: {MaxWorkers: 4}})
 	if err != nil {
-		return fmt.Errorf("create background jobs: %w", err)
+		return fmt.Errorf("create River client: %w", err)
 	}
 	if err := lifecycle.Configure(ctx, jobClient); err != nil {
 		return fmt.Errorf("configure sandbox lifecycle: %w", err)

--- a/main.go
+++ b/main.go
@@ -11,7 +11,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/riverqueue/river"
 	"github.com/superduck-ai/open-managed-agents/internal/api"
+	"github.com/superduck-ai/open-managed-agents/internal/backgroundjobs"
 	"github.com/superduck-ai/open-managed-agents/internal/batches"
 	"github.com/superduck-ai/open-managed-agents/internal/cleanup"
 	"github.com/superduck-ai/open-managed-agents/internal/codesessions"
@@ -61,7 +63,7 @@ func run(logger *slog.Logger) error {
 		if err := database.Migrate(ctx); err != nil {
 			return fmt.Errorf("migrate database: %w", err)
 		}
-		if err := deployments.MigrateRiver(ctx, database, logger.With("component", "deployment_scheduler")); err != nil {
+		if err := backgroundjobs.Migrate(ctx, database, logger.With("component", "background_jobs")); err != nil {
 			return fmt.Errorf("migrate River: %w", err)
 		}
 	} else {
@@ -136,13 +138,20 @@ func run(logger *slog.Logger) error {
 	}
 	environmentRunner.Start(ctx)
 	webhooks.NewWorker(database, cfg.Webhook, logger.With("component", "webhook_worker")).Start(ctx)
-	deploymentScheduler, err := deployments.NewDeploymentScheduler(
-		database,
-		logger.With("component", "deployment_scheduler"),
-	)
+	workers := river.NewWorkers()
+	deployments.RegisterScheduledWorkers(workers, database)
+	lifecycle := environments.NewSandboxLifecycle(database, sandboxProvider,
+		cfg.SandboxLifecycle, logger.With("component", "sandbox_lifecycle"))
+	lifecycle.Register(workers)
+	jobClient, err := backgroundjobs.NewClient(database, logger.With("component", "background_jobs"), workers,
+		map[string]river.QueueConfig{deployments.DeploymentScheduleQueue: {MaxWorkers: 10}, environments.SandboxLifecycleQueue: {MaxWorkers: 4}})
 	if err != nil {
-		return fmt.Errorf("create deployment scheduler: %w", err)
+		return fmt.Errorf("create background jobs: %w", err)
 	}
+	if err := lifecycle.Configure(ctx, jobClient); err != nil {
+		return fmt.Errorf("configure sandbox lifecycle: %w", err)
+	}
+	deploymentScheduler := deployments.NewDeploymentScheduler(database, jobClient, logger.With("component", "deployment_scheduler"))
 	if err := deploymentScheduler.Start(ctx); err != nil {
 		return fmt.Errorf("start deployment scheduler: %w", err)
 	}

--- a/tests/deployments_api_test.go
+++ b/tests/deployments_api_test.go
@@ -14,9 +14,9 @@ import (
 	"time"
 	"uuid"
 
-	"github.com/superduck-ai/open-managed-agents/internal/backgroundjobs"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	deploymentsapi "github.com/superduck-ai/open-managed-agents/internal/deployments"
+	"github.com/superduck-ai/open-managed-agents/internal/riverjobs"
 )
 
 type deploymentAPIResponse struct {
@@ -1050,12 +1050,12 @@ func applyScheduledOccurrence(ctx context.Context, database *db.DB, input db.App
 
 func startDeploymentScheduler(t *testing.T, app *testApp) func() {
 	t.Helper()
-	if err := backgroundjobs.Migrate(context.Background(), app.db, nil); err != nil {
+	if err := riverjobs.Migrate(context.Background(), app.db, nil); err != nil {
 		t.Fatalf("migrate River: %v", err)
 	}
 	workers := river.NewWorkers()
 	deploymentsapi.RegisterScheduledWorkers(workers, app.db)
-	client, err := backgroundjobs.NewClient(app.db, nil, workers, map[string]river.QueueConfig{deploymentsapi.DeploymentScheduleQueue: {MaxWorkers: 10}})
+	client, err := riverjobs.NewClient(app.db, nil, workers, map[string]river.QueueConfig{deploymentsapi.DeploymentScheduleQueue: {MaxWorkers: 10}})
 	if err != nil {
 		t.Fatalf("new deployment scheduler: %v", err)
 	}

--- a/tests/deployments_api_test.go
+++ b/tests/deployments_api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/riverqueue/river"
 	"io"
 	"net/http"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	"time"
 	"uuid"
 
+	"github.com/superduck-ai/open-managed-agents/internal/backgroundjobs"
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	deploymentsapi "github.com/superduck-ai/open-managed-agents/internal/deployments"
 )
@@ -1048,14 +1050,17 @@ func applyScheduledOccurrence(ctx context.Context, database *db.DB, input db.App
 
 func startDeploymentScheduler(t *testing.T, app *testApp) func() {
 	t.Helper()
-	if err := deploymentsapi.MigrateRiver(context.Background(), app.db, nil); err != nil {
+	if err := backgroundjobs.Migrate(context.Background(), app.db, nil); err != nil {
 		t.Fatalf("migrate River: %v", err)
 	}
-	scheduler, err := deploymentsapi.NewDeploymentScheduler(app.db, nil)
+	workers := river.NewWorkers()
+	deploymentsapi.RegisterScheduledWorkers(workers, app.db)
+	client, err := backgroundjobs.NewClient(app.db, nil, workers, map[string]river.QueueConfig{deploymentsapi.DeploymentScheduleQueue: {MaxWorkers: 10}})
 	if err != nil {
 		t.Fatalf("new deployment scheduler: %v", err)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	scheduler := deploymentsapi.NewDeploymentScheduler(app.db, client, nil)
 	if err := scheduler.Start(ctx); err != nil {
 		cancel()
 		t.Fatalf("start deployment scheduler: %v", err)

--- a/tests/sandbox_lifecycle_river_test.go
+++ b/tests/sandbox_lifecycle_river_test.go
@@ -9,15 +9,15 @@ import (
 	"uuid"
 
 	"github.com/riverqueue/river"
-	"github.com/superduck-ai/open-managed-agents/internal/backgroundjobs"
 	"github.com/superduck-ai/open-managed-agents/internal/config"
 	"github.com/superduck-ai/open-managed-agents/internal/environments"
+	"github.com/superduck-ai/open-managed-agents/internal/riverjobs"
 )
 
 func TestSandboxLifecycleDurableScheduleDispatchesReclaim(t *testing.T) {
 	f := newSandboxLifecycleFixture(t)
 	ctx := context.Background()
-	if err := backgroundjobs.Migrate(ctx, f.app.db, nil); err != nil {
+	if err := riverjobs.Migrate(ctx, f.app.db, nil); err != nil {
 		t.Fatal(err)
 	}
 	calls := make(chan string, 100)
@@ -34,7 +34,7 @@ func TestSandboxLifecycleDurableScheduleDispatchesReclaim(t *testing.T) {
 	// Separate sweep and reclaim queues avoid River coalescing their insert notifications.
 	// A long fallback interval makes this test exercise notification-driven fetches.
 	const sweepQueue = "sandbox_lifecycle_test_sweep"
-	client, err := backgroundjobs.NewClient(f.app.db, nil, workers, map[string]river.QueueConfig{
+	client, err := riverjobs.NewClient(f.app.db, nil, workers, map[string]river.QueueConfig{
 		sweepQueue:                         {MaxWorkers: 1, FetchPollInterval: time.Hour},
 		environments.SandboxLifecycleQueue: {MaxWorkers: 4, FetchPollInterval: time.Hour},
 	})

--- a/tests/sandbox_lifecycle_river_test.go
+++ b/tests/sandbox_lifecycle_river_test.go
@@ -1,0 +1,119 @@
+package tests
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+	"uuid"
+
+	"github.com/riverqueue/river"
+	"github.com/superduck-ai/open-managed-agents/internal/backgroundjobs"
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+	"github.com/superduck-ai/open-managed-agents/internal/environments"
+)
+
+func TestSandboxLifecycleDurableScheduleDispatchesReclaim(t *testing.T) {
+	f := newSandboxLifecycleFixture(t)
+	ctx := context.Background()
+	if err := backgroundjobs.Migrate(ctx, f.app.db, nil); err != nil {
+		t.Fatal(err)
+	}
+	calls := make(chan string, 100)
+	killer := newLifecycleProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case calls <- strings.TrimPrefix(r.URL.Path, "/sandboxes/"):
+			w.WriteHeader(http.StatusNoContent)
+		case <-r.Context().Done():
+		}
+	})
+	lifecycle := environments.NewSandboxLifecycle(f.app.db, killer, config.SandboxLifecycleConfig{Enabled: true, IdleTimeout: 24 * time.Hour}, nil)
+	workers := river.NewWorkers()
+	lifecycle.Register(workers)
+	// Separate sweep and reclaim queues avoid River coalescing their insert notifications.
+	// A long fallback interval makes this test exercise notification-driven fetches.
+	const sweepQueue = "sandbox_lifecycle_test_sweep"
+	client, err := backgroundjobs.NewClient(f.app.db, nil, workers, map[string]river.QueueConfig{
+		sweepQueue:                         {MaxWorkers: 1, FetchPollInterval: time.Hour},
+		environments.SandboxLifecycleQueue: {MaxWorkers: 4, FetchPollInterval: time.Hour},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lifecycle.Configure(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+	before, err := client.DurablePeriodicJobGet(ctx, "sandbox_lifecycle_sweep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lifecycle.Configure(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+	after, err := client.DurablePeriodicJobGet(ctx, "sandbox_lifecycle_sweep")
+	if err != nil || !before.NextRunAt.Equal(after.NextRunAt) {
+		t.Fatalf("startup changed existing schedule: before=%+v after=%+v err=%v", before, after, err)
+	}
+	// Exercise the durable leader and sweep/reclaim queues without waiting for a minute boundary.
+	scheduleID := "lifecycle-test-" + uuid.NewV4().String()
+	_, err = client.DurablePeriodicJobUpsert(ctx, &river.DurablePeriodicJobUpsertOpts{
+		ID: scheduleID, Kind: "sandbox_lifecycle_sweep", Queue: sweepQueue,
+		Schedule: &river.DurablePeriodicJobSchedule{NextRunAt: time.Now().Add(-time.Second)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	if err := client.Start(runCtx); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		stopCtx, stopCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer stopCancel()
+		if err := client.Stop(stopCtx); err != nil {
+			t.Error(err)
+		}
+		_, _ = client.DurablePeriodicJobDelete(ctx, scheduleID)
+		_, _ = client.DurablePeriodicJobDelete(ctx, "sandbox_lifecycle_sweep")
+	}()
+	assertRiverListenerConnected(t, f.app)
+	timeout := time.NewTimer(15 * time.Second)
+	defer timeout.Stop()
+	for {
+		select {
+		case id := <-calls:
+			if id == f.target.ProviderSandboxID {
+				return
+			}
+		case <-timeout.C:
+			t.Fatal("durable sweep did not dispatch idle sandbox reclamation")
+		}
+	}
+}
+
+func assertRiverListenerConnected(t *testing.T, app *testApp) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		var listening bool
+		if err := app.pool.QueryRow(ctx, `SELECT EXISTS (
+            SELECT 1 FROM pg_stat_activity WHERE datname = current_database()
+                AND state = 'idle' AND query LIKE 'LISTEN "public.river_%'
+        )`).Scan(&listening); err != nil {
+			t.Fatal(err)
+		}
+		if listening {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			t.Fatal("River started without a PostgreSQL LISTEN connection")
+		}
+	}
+}

--- a/tests/sandbox_lifecycle_test.go
+++ b/tests/sandbox_lifecycle_test.go
@@ -1,0 +1,328 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+	"uuid"
+
+	"github.com/superduck-ai/open-managed-agents/internal/config"
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/environments"
+	"github.com/superduck-ai/open-managed-agents/internal/runtime/e2bruntime"
+)
+
+type sandboxLifecycleFixture struct {
+	app     *testApp
+	code    db.CodeSession
+	session db.Session
+	target  db.SandboxReclaimTarget
+	epoch   string
+}
+
+func newSandboxLifecycleFixture(t *testing.T) sandboxLifecycleFixture {
+	t.Helper()
+	app := newTestAppWithStore(t, nil, newFakeStore("sandbox-lifecycle"))
+	t.Cleanup(app.close)
+	agent := createAgent(t, app, `{"model":"claude-opus-4-6","name":"lifecycle-agent"}`)
+	t.Cleanup(func() { cleanupAgentRows(t, app.pool, agent.ID) })
+	env := createEnvironment(t, app, `{"name":"lifecycle-environment"}`)
+	t.Cleanup(func() { cleanupEnvironmentRows(t, app.pool, env.ID) })
+	session := createSession(t, app, `{"agent":`+quoteJSON(agent.ID)+`,"environment_id":`+quoteJSON(env.ID)+`}`)
+	t.Cleanup(func() { deleteSession(t, app, session.ID) })
+	codeID := launchLocalCodeSession(t, app, session.ID)
+	epoch := registerCodeSessionWorker(t, app, codeID)
+	putCodeSessionWorkerState(t, app, codeID, `{"worker_epoch":`+epoch+`,"worker_status":"idle"}`)
+	code, err := getCodeSession(app, context.Background(), codeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, found, err := app.db.GetSession(context.Background(), code.WorkspaceUUID, session.ID)
+	if err != nil || !found {
+		t.Fatalf("get session: found=%t err=%v", found, err)
+	}
+	sandbox, err := app.db.GetResumableEnvironmentSandboxForCodeSession(context.Background(), codeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := sandboxLifecycleFixture{app: app, code: code, session: record, epoch: epoch, target: db.SandboxReclaimTarget{
+		OrganizationUUID: code.OrganizationUUID, WorkspaceUUID: code.WorkspaceUUID, SandboxUUID: sandbox.UUID, ProviderSandboxID: *sandbox.ProviderSandboxID}}
+	f.exec(t, `UPDATE code_session_inbound_events SET delivery_status = 'processed', processed_at = NOW() WHERE code_session_uuid = $1`, code.UUID)
+	f.exec(t, `UPDATE code_sessions SET idle_since = NOW() - interval '25 hours' WHERE uuid = $1`, code.UUID)
+	return f
+}
+
+func (f sandboxLifecycleFixture) exec(t *testing.T, query string, args ...any) {
+	t.Helper()
+	if _, err := f.app.pool.Exec(context.Background(), query, args...); err != nil {
+		t.Fatal(err)
+	}
+}
+func (f sandboxLifecycleFixture) state(t *testing.T) (string, string) {
+	t.Helper()
+	var workState, sandbox string
+	if err := f.app.pool.QueryRow(context.Background(), `SELECT work.state, s.state FROM environment_sandboxes s JOIN environment_work work ON work.uuid = s.work_uuid WHERE s.uuid = $1`, f.target.SandboxUUID).Scan(&workState, &sandbox); err != nil {
+		t.Fatal(err)
+	}
+	return workState, sandbox
+}
+
+func TestSandboxReclamationRejectsUnsafeCandidates(t *testing.T) {
+	cases := []struct{ name, query string }{
+		{"running", `UPDATE code_sessions SET worker_status = 'running' WHERE uuid = $1`},
+		{"requires action", `UPDATE code_sessions SET worker_status = 'requires_action' WHERE uuid = $1`},
+		{"recent idle", `UPDATE code_sessions SET idle_since = NOW() WHERE uuid = $1`},
+		{"input reset idle clock", `UPDATE code_sessions SET idle_since = NULL WHERE uuid = $1`},
+		{"terminated", `UPDATE code_sessions SET status = 'terminated' WHERE uuid = $1`},
+		{"archived session", `UPDATE sessions SET archived_at = NOW() WHERE uuid = (SELECT session_uuid FROM code_sessions WHERE uuid = $1)`},
+		{"self hosted", `UPDATE environments SET config = '{"type":"self_hosted"}' WHERE uuid = (SELECT environment_uuid FROM code_sessions WHERE uuid = $1)`},
+		{"queued input", `UPDATE code_session_inbound_events SET delivery_status = 'queued' WHERE code_session_uuid = $1`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newSandboxLifecycleFixture(t)
+			if tc.name == "queued input" {
+				// Keep an old idle timestamp so the inbound queue itself must reject the claim.
+				sendSessionEvents(t, f.app, f.session.ExternalID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"still pending"}]}]}`, defaultTestKey)
+			}
+			f.exec(t, tc.query, f.code.UUID)
+			if tc.name == "queued input" {
+				f.exec(t, `UPDATE code_sessions SET idle_since = NOW() - interval '25 hours' WHERE uuid = $1`, f.code.UUID)
+			}
+			_, ok, err := f.app.db.BeginSandboxReclamation(context.Background(), f.target, time.Now().Add(-24*time.Hour))
+			if err != nil || ok {
+				t.Fatalf("unsafe claim = %t, %v", ok, err)
+			}
+			if workState, sandbox := f.state(t); workState != "active" || sandbox != "running" {
+				t.Fatalf("state = %s/%s", workState, sandbox)
+			}
+		})
+	}
+	t.Run("wrong tenant", func(t *testing.T) {
+		f := newSandboxLifecycleFixture(t)
+		target := f.target
+		target.WorkspaceUUID = uuid.NewV4().String()
+		_, ok, err := f.app.db.BeginSandboxReclamation(context.Background(), target, time.Now())
+		if err != nil || ok {
+			t.Fatalf("cross tenant claim = %t, %v", ok, err)
+		}
+	})
+}
+
+func newLifecycleProvider(t *testing.T, handler http.HandlerFunc) *e2bruntime.E2BProvider {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || !strings.HasPrefix(r.URL.Path, "/sandboxes/") {
+			t.Errorf("unexpected provider request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+	return e2bruntime.NewProvider(config.E2BConfig{
+		APIKey: "e2b_0000000000000000000000000000000000000000", APIURL: server.URL, RequestTimeout: 5 * time.Second,
+	})
+}
+
+func TestSandboxReclamationRetriesDeletionAndWakesAfterConcurrentInput(t *testing.T) {
+	f := newSandboxLifecycleFixture(t)
+	ctx := context.Background()
+	calls := make(chan string, 10)
+	deleting := make(chan struct{})
+	finishDelete := make(chan struct{}, 1)
+	defer close(finishDelete)
+	var attempts atomic.Int32
+	killer := newLifecycleProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		calls <- strings.TrimPrefix(r.URL.Path, "/sandboxes/")
+		attempt := attempts.Add(1)
+		if attempt == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		if attempt == 2 {
+			close(deleting)
+			select {
+			case <-finishDelete:
+			case <-r.Context().Done():
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	lifecycle := environments.NewSandboxLifecycle(f.app.db, killer, config.SandboxLifecycleConfig{Enabled: true, IdleTimeout: 24 * time.Hour}, nil)
+	if err := lifecycle.Reclaim(ctx, f.target); err == nil {
+		t.Fatal("expected provider failure")
+	}
+	if workState, sandbox := f.state(t); workState != "active" || sandbox != "stopping" {
+		t.Fatalf("state = %s/%s", workState, sandbox)
+	}
+	revoked, err := getCodeSession(f.app, ctx, f.code.ExternalID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revoked.CurrentWorkerEpoch <= f.code.CurrentWorkerEpoch || revoked.WorkerLeaseExpiresAt != nil {
+		t.Fatal("old worker not fenced")
+	}
+	if _, err := f.app.db.RecordCodeSessionWorkerHeartbeat(ctx, f.code.ExternalID, f.code.CurrentWorkerEpoch, time.Minute, 10*time.Second); !errors.Is(err, db.ErrWorkerNotRegistered) {
+		t.Fatalf("old heartbeat = %v", err)
+	}
+	result := make(chan error, 1)
+	go func() { result <- lifecycle.Reclaim(ctx, f.target) }()
+	select {
+	case <-deleting:
+	case <-time.After(5 * time.Second):
+		t.Fatal("provider deletion did not start")
+	}
+	sendSessionEvents(t, f.app, f.session.ExternalID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"arrived during deletion"}]}]}`, defaultTestKey)
+	if workState, _ := f.state(t); workState != "active" {
+		t.Fatalf("premature recovery: %s", workState)
+	}
+	if calls := f.app.sandboxTimeouts.snapshotCalls(); len(calls) != 0 {
+		t.Fatalf("resumed sandbox during deletion: %+v", calls)
+	}
+	finishDelete <- struct{}{}
+	if err := <-result; err != nil {
+		t.Fatal(err)
+	}
+	if workState, sandbox := f.state(t); workState != "queued" || sandbox != "failed" {
+		t.Fatalf("state = %s/%s", workState, sandbox)
+	}
+	if err := lifecycle.Reclaim(ctx, f.target); err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("delete attempts = %d, want 2", len(calls))
+	}
+	provider := &recordingRunnerProvider{sandboxID: f.target.ProviderSandboxID + "-recovered"}
+	cfg := f.app.cfg
+	cfg.CodeSession.SandboxAPIBaseURL = "http://sandbox-api.example.test"
+	runUntilSandboxCreated(t, ctx, newManagedAgentRunner(t, f.app, provider, cfg), provider)
+	if workState, _ := f.state(t); workState != "active" {
+		t.Fatalf("workState = %s", workState)
+	}
+	recovered, err := getCodeSession(f.app, ctx, f.code.ExternalID)
+	if err != nil || recovered.UUID != f.code.UUID {
+		t.Fatalf("recovered session = %+v, %v", recovered, err)
+	}
+	if len(provider.launches) != 1 {
+		t.Fatalf("launch count = %d", len(provider.launches))
+	}
+	for len(calls) > 0 {
+		id := <-calls
+		if id != f.target.ProviderSandboxID {
+			t.Fatalf("deleted replacement: %s", id)
+		}
+	}
+}
+
+func TestSandboxReclamationDryRunAndLazyWake(t *testing.T) {
+	f := newSandboxLifecycleFixture(t)
+	ctx := context.Background()
+	var calls atomic.Int32
+	killer := newLifecycleProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cfg := config.SandboxLifecycleConfig{Enabled: true, DryRun: true, IdleTimeout: 24 * time.Hour}
+	lifecycle := environments.NewSandboxLifecycle(f.app.db, killer, cfg, nil)
+	if err := lifecycle.Reclaim(ctx, f.target); err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 0 {
+		t.Fatal("dry run deleted sandbox")
+	}
+	cfg.DryRun = false
+	lifecycle = environments.NewSandboxLifecycle(f.app.db, killer, cfg, nil)
+	if err := lifecycle.Reclaim(ctx, f.target); err != nil {
+		t.Fatal(err)
+	}
+	if workState, sandbox := f.state(t); workState != "active" || sandbox != "stopped" {
+		t.Fatalf("state = %s/%s", workState, sandbox)
+	}
+	provider := &recordingRunnerProvider{sandboxID: f.target.ProviderSandboxID + "-unexpected"}
+	if _, err := newManagedAgentRunner(t, f.app, provider, f.app.cfg).RunOnce(ctx, "idle-reclaim-check"); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.launches) != 0 {
+		t.Fatal("runner rebuilt an idle sandbox without new input")
+	}
+	if queued, err := f.app.db.ScheduleEnvironmentSandboxRecoveryForCodeSession(ctx, f.code.ExternalID, "", nil); err != nil || queued {
+		t.Fatalf("recovery without input = %t, %v", queued, err)
+	}
+	if err := lifecycle.Reclaim(ctx, f.target); err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("completed deletion repeated: %d calls", calls.Load())
+	}
+	sendSessionEvents(t, f.app, f.session.ExternalID, `{"events":[{"type":"user.message","content":[{"type":"text","text":"wake on new input"}]}]}`, defaultTestKey)
+	if workState, _ := f.state(t); workState != "queued" {
+		t.Fatalf("workState after new input = %s", workState)
+	}
+}
+
+func TestSandboxIdleClockIgnoresHeartbeatsAndRepeatedIdle(t *testing.T) {
+	f := newSandboxLifecycleFixture(t)
+	var before, after time.Time
+	read := func(target *time.Time) {
+		t.Helper()
+		if err := f.app.pool.QueryRow(context.Background(), `SELECT idle_since FROM code_sessions WHERE uuid=$1`, f.code.UUID).Scan(target); err != nil {
+			t.Fatal(err)
+		}
+	}
+	read(&before)
+	assertCodeSessionWorkerHeartbeat(t, f.app, f.code.ExternalID, f.epoch)
+	putCodeSessionWorkerState(t, f.app, f.code.ExternalID, `{"worker_epoch":`+f.epoch+`,"worker_status":"idle"}`)
+	read(&after)
+	if !before.Equal(after) {
+		t.Fatalf("idle clock refreshed from %s to %s", before, after)
+	}
+}
+
+func TestSandboxReclamationRejectsPublicInputBeforeForwarding(t *testing.T) {
+	f := newSandboxLifecycleFixture(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	_, err := f.app.db.AppendSessionEvents(ctx, f.code.WorkspaceUUID, f.session.ExternalID, []db.SessionEvent{{
+		UUID: uuid.NewV4().String(), ExternalID: "sevt_" + uuid.NewV4().String(), EventType: "user.message",
+		Payload:     json.RawMessage(`{"type":"user.message","content":[{"type":"text","text":"pending forwarding"}]}`),
+		ProcessedAt: now, CreatedAt: now,
+	}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, claimed, err := f.app.db.BeginSandboxReclamation(ctx, f.target, now.Add(-24*time.Hour)); err != nil || claimed {
+		t.Fatalf("claimed after public input = %t, %v", claimed, err)
+	}
+}
+
+func TestSandboxReclamationRecoveryRejectsIneligibleTargets(t *testing.T) {
+	for _, tc := range []struct {
+		name, state, reason string
+		archived            bool
+	}{
+		{"running", "running", "", false},
+		{"deletion in progress", "stopping", "idle_timeout", false},
+		{"stopped for another reason", "stopped", "terminated", false},
+		{"archived parent", "stopped", "idle_timeout", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newSandboxLifecycleFixture(t)
+			f.exec(t, `UPDATE environment_sandboxes SET state = $2, stop_reason = $3 WHERE uuid = $1`, f.target.SandboxUUID, tc.state, tc.reason)
+			f.exec(t, `UPDATE code_session_inbound_events SET delivery_status = 'queued' WHERE code_session_uuid = $1`, f.code.UUID)
+			if tc.archived {
+				f.exec(t, `UPDATE sessions SET archived_at = NOW() WHERE uuid = $1`, f.session.UUID)
+			}
+			if queued, err := f.app.db.ScheduleEnvironmentSandboxRecoveryForCodeSession(context.Background(), f.code.ExternalID, "", nil); err != nil || queued {
+				t.Fatalf("ineligible recovery = %t, %v", queued, err)
+			}
+		})
+	}
+}

--- a/tests/sandbox_lifecycle_test.go
+++ b/tests/sandbox_lifecycle_test.go
@@ -95,7 +95,7 @@ func TestSandboxReclamationRejectsUnsafeCandidates(t *testing.T) {
 			if tc.name == "queued input" {
 				f.exec(t, `UPDATE code_sessions SET idle_since = NOW() - interval '25 hours' WHERE uuid = $1`, f.code.UUID)
 			}
-			_, ok, err := f.app.db.BeginSandboxReclamation(context.Background(), f.target, time.Now().Add(-24*time.Hour))
+			_, ok, err := f.app.db.BeginSandboxReclamation(context.Background(), f.target, time.Now().Add(-24*time.Hour), true)
 			if err != nil || ok {
 				t.Fatalf("unsafe claim = %t, %v", ok, err)
 			}
@@ -108,7 +108,7 @@ func TestSandboxReclamationRejectsUnsafeCandidates(t *testing.T) {
 		f := newSandboxLifecycleFixture(t)
 		target := f.target
 		target.WorkspaceUUID = uuid.NewV4().String()
-		_, ok, err := f.app.db.BeginSandboxReclamation(context.Background(), target, time.Now())
+		_, ok, err := f.app.db.BeginSandboxReclamation(context.Background(), target, time.Now(), true)
 		if err != nil || ok {
 			t.Fatalf("cross tenant claim = %t, %v", ok, err)
 		}
@@ -173,6 +173,9 @@ func TestSandboxReclamationRetriesDeletionAndWakesAfterConcurrentInput(t *testin
 	if _, err := f.app.db.RecordCodeSessionWorkerHeartbeat(ctx, f.code.ExternalID, f.code.CurrentWorkerEpoch, time.Minute, 10*time.Second); !errors.Is(err, db.ErrWorkerNotRegistered) {
 		t.Fatalf("old heartbeat = %v", err)
 	}
+	// Disabling the policy stops new claims but must finish a deletion that was
+	// already committed before the configuration changed.
+	lifecycle = environments.NewSandboxLifecycle(f.app.db, killer, config.SandboxLifecycleConfig{IdleTimeout: 24 * time.Hour}, nil)
 	result := make(chan error, 1)
 	go func() { result <- lifecycle.Reclaim(ctx, f.target) }()
 	select {
@@ -298,7 +301,7 @@ func TestSandboxReclamationRejectsPublicInputBeforeForwarding(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, claimed, err := f.app.db.BeginSandboxReclamation(ctx, f.target, now.Add(-24*time.Hour)); err != nil || claimed {
+	if _, claimed, err := f.app.db.BeginSandboxReclamation(ctx, f.target, now.Add(-24*time.Hour), true); err != nil || claimed {
 		t.Fatalf("claimed after public input = %t, %v", claimed, err)
 	}
 }


### PR DESCRIPTION
## 摘要

- 将新回收领取条件显式传入事务，关闭回收或 dry-run 时不再依赖特殊时间值影响 SQL
- 保证已领取的回收任务在配置关闭后仍可完成
- 让 E2B Debug 模式执行真实 DELETE，并统一处理目标不存在的幂等结果
- 集中复用公共 worker 输入事件判定，并仅在相关输入发生时重置空闲时间
- 补充 E2B 配置标准化及回收流程相关测试与设计文档说明

## 测试

- 更新配置、事件策略、E2B 删除和沙箱回收的单元测试
- 更新真实 PostgreSQL 沙箱生命周期集成测试，覆盖关闭策略、并发输入和幂等完成场景