### PR TITLE
Upgrade default Claude Code version to 2.1.251

### DIFF
--- a/docs/configuration-reference.yaml
+++ b/docs/configuration-reference.yaml
@@ -70,7 +70,7 @@ environment_runner:
   concurrency: 2
   package_provision_timeout: 2m
   manager_path: /usr/local/bin/environment-manager
-  claude_agent_version: 2.1.120
+  claude_agent_version: 2.1.251
   claude_path: /opt/claude-code/bin/claude
   # Extra hosts rewritten from SSH remotes to HTTPS (in addition to built-in github.com).
   # Bare DNS hostnames only (labels [a-z0-9-], no leading/trailing hyphen); each adds git@host: and ssh://git@host/ → https://host/.

--- a/docs/design/be/ccrv2/otlp-metrics-api.md
+++ b/docs/design/be/ccrv2/otlp-metrics-api.md
@@ -258,7 +258,7 @@ OTEL_EXPORTER_OTLP_METRICS_ENDPOINT={api_base_url}/v1/code/sessions/{code_sessio
 OTEL_EXPORTER_OTLP_METRICS_HEADERS=Authorization=Bearer {session_ingress_token}
 ```
 
-Console Agent 可观测不再从 PostgreSQL 读取 Active Time / Token 看板。写入端仍把 OTLP 转发到 OpenObserve（凭据键为 `observability.openobserve.ingestion.*`）；查询走 `observability.openobserve.query.*` 与 `POST /api/organizations/{org}/observability/panels/query`。默认 Claude Code 版本保持 `2.1.120`。
+Console Agent 可观测不再从 PostgreSQL 读取 Active Time / Token 看板。写入端仍把 OTLP 转发到 OpenObserve（凭据键为 `observability.openobserve.ingestion.*`）；查询走 `observability.openobserve.query.*` 与 `POST /api/organizations/{org}/observability/panels/query`。默认 Claude Code 版本为 `2.1.251`。
 
 Console 查询 API 只在 `observability.enabled=true` 时注册，统一使用平台 session 中的 organization/workspace scope；浏览器不能覆盖租户字段，也不会获得 OpenObserve SQL 或凭据。接口为：
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -34,7 +34,7 @@ func defaultConfig() Config {
 			Concurrency:             2,
 			PackageProvisionTimeout: 2 * time.Minute,
 			ManagerPath:             "/usr/local/bin/environment-manager",
-			ClaudeAgentVersion:      "2.1.120",
+			ClaudeAgentVersion:      "2.1.251",
 			ClaudePath:              "/opt/claude-code/bin/claude",
 		},
 		Observability: ObservabilityConfig{

--- a/internal/environments/environment_manager.go
+++ b/internal/environments/environment_manager.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultEnvironmentManagerPath = "/usr/local/bin/environment-manager"
-	defaultClaudeAgentVersion     = "2.1.120"
+	defaultClaudeAgentVersion     = "2.1.251"
 	defaultClaudePath             = "/opt/claude-code/bin/claude"
 	defaultEnvironmentWorkDir     = "/home/user"
 	launcherSettingsPath          = "/root/.claude/launcher-settings.json"

--- a/internal/environments/environment_manager_test.go
+++ b/internal/environments/environment_manager_test.go
@@ -236,7 +236,7 @@ func TestBuildEnvironmentManagerPayloadAndCommand(t *testing.T) {
 		},
 		EnvironmentRunner: config.EnvironmentRunnerConfig{
 			ManagerPath:        "/opt/env manager/bin/environment-manager",
-			ClaudeAgentVersion: "2.1.120",
+			ClaudeAgentVersion: "2.1.251",
 			ClaudePath:         "/opt/claude path/bin/claude",
 			GitSSHtoHTTPSHosts: []string{"gitlab.xxxx.cn"},
 		},
@@ -354,7 +354,7 @@ func TestBuildEnvironmentManagerPayloadAndCommand(t *testing.T) {
 		"export GIT_EDITOR=true",
 		"export GIT_SSL_CAINFO=/root/.ccr/ca-bundle.crt",
 		"export GIT_TERMINAL_PROMPT=0",
-		"Claude binary version mismatch: expected 2.1.120",
+		"Claude binary version mismatch: expected 2.1.251",
 		"> '/tmp/claude-code-sessions/cse_session_with_'\"'\"'quote'\"'\"'_and_slash/environment-manager.log' 2>&1",
 	} {
 		if !strings.Contains(allCommands, want) {


### PR DESCRIPTION
Updates the default Claude Code version from `2.1.120` to `2.1.251` and synchronizes the existing configuration documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Updated the default Claude Agent version to 2.1.251 across environment settings.
  - New environments will use Claude Agent 2.1.251 by default.
- **Documentation**
  - Updated configuration and API documentation to reflect Claude Agent version 2.1.251.
- **Compatibility**
  - Updated environment validation to recognize the new default version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->