### PR TITLE
fix(web): 将文档链接域名更新为 oma.mintlifysite.com

### DIFF
--- a/web/src/app/layout/ConsoleLayout.test.tsx
+++ b/web/src/app/layout/ConsoleLayout.test.tsx
@@ -35,7 +35,9 @@ describe('ConsoleShell', () => {
     expect(screen.getByText('Analytics')).toBeTruthy();
     expect(screen.getByText('Claude Code')).toBeTruthy();
     expect(screen.getByText('Manage')).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Documentation' }).getAttribute('href')).toBe('https://oma.mintlifysite.com/');
+    expect(screen.getByRole('link', { name: 'Documentation' }).getAttribute('href')).toBe(
+      'https://oma.mintlifysite.com/',
+    );
     expect(screen.getByText('Deployments')).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Files' }).getAttribute('href')).toBe('/workspaces/default/files');
     expect(screen.getByRole('link', { name: 'Skills' }).getAttribute('href')).toBe('/workspaces/default/skills');

--- a/web/src/app/layout/ConsoleLayout.test.tsx
+++ b/web/src/app/layout/ConsoleLayout.test.tsx
@@ -35,7 +35,7 @@ describe('ConsoleShell', () => {
     expect(screen.getByText('Analytics')).toBeTruthy();
     expect(screen.getByText('Claude Code')).toBeTruthy();
     expect(screen.getByText('Manage')).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Documentation' }).getAttribute('href')).toBe('https://oma.mintlify.site/');
+    expect(screen.getByRole('link', { name: 'Documentation' }).getAttribute('href')).toBe('https://oma.mintlifysite.com/');
     expect(screen.getByText('Deployments')).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Files' }).getAttribute('href')).toBe('/workspaces/default/files');
     expect(screen.getByRole('link', { name: 'Skills' }).getAttribute('href')).toBe('/workspaces/default/skills');

--- a/web/src/app/layout/ConsoleLayout.tsx
+++ b/web/src/app/layout/ConsoleLayout.tsx
@@ -632,7 +632,7 @@ function SidebarFooter({
       <SidebarMenu>
         <SidebarMenuItem>
           <SidebarMenuButton
-            render={<a href="https://oma.mintlify.site/" target="_blank" rel="noreferrer" />}
+            render={<a href="https://oma.mintlifysite.com/" target="_blank" rel="noreferrer" />}
             tooltip={msg('nav.documentation', 'Documentation')}
             className={interactiveMotionClass}
             aria-label={collapsed ? msg('nav.documentation', 'Documentation') : undefined}

--- a/web/src/features/auth/LoginPage.test.tsx
+++ b/web/src/features/auth/LoginPage.test.tsx
@@ -20,15 +20,15 @@ describe('LoginFlow', () => {
     expect(screen.getByText('Build with Open Managed Agents')).toBeTruthy();
     const developerDocs = screen.getByRole('link', { name: /Developer Docs/i });
     expect(developerDocs.getAttribute('data-slot')).toBe('button');
-    expect(developerDocs.getAttribute('href')).toBe('https://oma.mintlify.site/docs/en/overview');
+    expect(developerDocs.getAttribute('href')).toBe('https://oma.mintlifysite.com/docs/en/overview');
     expect(screen.getByRole('link', { name: /API Reference/i }).getAttribute('href')).toBe(
-      'https://oma.mintlify.site/docs/en/api/overview',
+      'https://oma.mintlifysite.com/docs/en/api/overview',
     );
     expect(screen.getByRole('link', { name: /Cookbooks/i }).getAttribute('href')).toBe(
-      'https://oma.mintlify.site/docs/en/quickstart',
+      'https://oma.mintlifysite.com/docs/en/quickstart',
     );
     expect(screen.getByRole('link', { name: /Quickstarts/i }).getAttribute('href')).toBe(
-      'https://oma.mintlify.site/docs/en/quickstart',
+      'https://oma.mintlifysite.com/docs/en/quickstart',
     );
     expect(document.querySelectorAll('[data-slot="card"]').length).toBe(1);
     expect(document.querySelector('.surface-card')).toBeNull();
@@ -112,16 +112,16 @@ describe('LoginFlow', () => {
     expect(document.documentElement.lang).toBe('zh-CN');
     expect(screen.getByText('使用 Open Managed Agents 构建')).toBeTruthy();
     expect(screen.getByRole('link', { name: '开发者文档' }).getAttribute('href')).toBe(
-      'https://oma.mintlify.site/docs/zh/overview',
+      'https://oma.mintlifysite.com/docs/zh/overview',
     );
     expect(screen.getByRole('link', { name: 'API 参考' }).getAttribute('href')).toBe(
-      'https://oma.mintlify.site/docs/zh/api/overview',
+      'https://oma.mintlifysite.com/docs/zh/api/overview',
     );
     expect(screen.getByRole('link', { name: 'Cookbooks' }).getAttribute('href')).toBe(
-      'https://oma.mintlify.site/docs/zh/quickstart',
+      'https://oma.mintlifysite.com/docs/zh/quickstart',
     );
     expect(screen.getByRole('link', { name: '快速开始' }).getAttribute('href')).toBe(
-      'https://oma.mintlify.site/docs/zh/quickstart',
+      'https://oma.mintlifysite.com/docs/zh/quickstart',
     );
     expect(screen.getByLabelText(/邮箱/i)).toBeTruthy();
     expect(screen.getByRole('button', { name: '使用邮箱继续' })).toBeTruthy();

--- a/web/src/features/auth/LoginPage.tsx
+++ b/web/src/features/auth/LoginPage.tsx
@@ -291,7 +291,7 @@ function LoginShell({ children }: { children: ReactNode }) {
             {topNavItems.map((item) => (
               <ButtonLink
                 key={item.id}
-                href={`https://oma.mintlify.site/docs/${docsLocale}/${item.path}`}
+                href={`https://oma.mintlifysite.com/docs/${docsLocale}/${item.path}`}
                 rel="noreferrer"
                 size="sm"
                 target="_blank"

--- a/web/src/features/dashboard/DashboardPage.test.tsx
+++ b/web/src/features/dashboard/DashboardPage.test.tsx
@@ -55,9 +55,9 @@ describe('Dashboard i18n', () => {
     expect(getApiKey.getAttribute('href')).toBe('/settings/workspaces/default/keys');
     expect(getApiKey.dataset.slot).toBe('button');
     const docsLink = screen.getByRole('link', { name: '查看文档' });
-    expect(docsLink.getAttribute('href')).toBe('https://oma.mintlify.site/docs/zh/overview');
+    expect(docsLink.getAttribute('href')).toBe('https://oma.mintlifysite.com/docs/zh/overview');
     expect(screen.getByRole('link', { name: '比较模型' }).getAttribute('href')).toBe(
-      'https://oma.mintlify.site/docs/zh/api/models/list-models',
+      'https://oma.mintlifysite.com/docs/zh/api/models/list-models',
     );
     expect(screen.getByRole('link', { name: '构建 Agent' }).dataset.slot).toBe('button');
     expect(screen.getByText('本月支出')).toBeTruthy();
@@ -85,10 +85,10 @@ describe('Dashboard i18n', () => {
     renderDashboardPage(<DashboardPage section="dashboard" />);
 
     expect(screen.getByRole('link', { name: 'Explore docs' }).getAttribute('href')).toBe(
-      'https://oma.mintlify.site/docs/en/overview',
+      'https://oma.mintlifysite.com/docs/en/overview',
     );
     expect(screen.getByRole('link', { name: 'Compare models' }).getAttribute('href')).toBe(
-      'https://oma.mintlify.site/docs/en/api/models/list-models',
+      'https://oma.mintlifysite.com/docs/en/api/models/list-models',
     );
   });
 

--- a/web/src/features/dashboard/home.tsx
+++ b/web/src/features/dashboard/home.tsx
@@ -20,13 +20,13 @@ import { PanelCard } from './frame';
 import { useDashboardWorkspaceScope, type IconComponent } from './model';
 
 const docsHrefByLocale = {
-  en: 'https://oma.mintlify.site/docs/en/overview',
-  'zh-CN': 'https://oma.mintlify.site/docs/zh/overview',
+  en: 'https://oma.mintlifysite.com/docs/en/overview',
+  'zh-CN': 'https://oma.mintlifysite.com/docs/zh/overview',
 } as const;
 
 const modelDocsHrefByLocale = {
-  en: 'https://oma.mintlify.site/docs/en/api/models/list-models',
-  'zh-CN': 'https://oma.mintlify.site/docs/zh/api/models/list-models',
+  en: 'https://oma.mintlifysite.com/docs/en/api/models/list-models',
+  'zh-CN': 'https://oma.mintlifysite.com/docs/zh/api/models/list-models',
 } as const;
 
 const modelCards = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
文档站点域名已从 `oma.mintlify.site` 变更为 `oma.mintlifysite.com`。本次将控制台中所有指向旧域名的文档入口替换为新域名，并同步更新对应测试断言。

## Changes
- 登录页顶部导航文档链接
- 控制台侧栏 Documentation 入口
- 仪表盘「查看文档 / Explore docs」和模型文档链接
- 上述页面的前端测试期望 URL

仓库内已无 `oma.mintlify.site` 残留引用。

## Design docs
设计文档无需更新：`docs/design/` 未记录文档站点域名，本次仅替换前端公开链接的 host，不改变路由、API 或权限行为。

## Verification
- `bun run format:check` 通过
- `LoginPage` 测试 7/7 通过
- `ConsoleLayout` 文档链接测试通过
- `DashboardPage` 中英文档链接测试通过（完整 `DashboardPage.test.tsx` 会因 Bun 段错误中断，与本次字符串替换无关）
- `bun run lint:complexity`、`bun run lint:duplicates`、`bun run build` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d59f5c51-fe89-4a9d-b561-cf80ea692155?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d59f5c51-fe89-4a9d-b561-cf80ea692155&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation links throughout the console, login, dashboard, and home pages to use the new documentation domain.
  - Preserved English and Simplified Chinese locale and path handling.

- **Tests**
  - Updated link verification to reflect the new documentation URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->