### PR TITLE
Implement worker event delivery for managed code sessions

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -14,9 +14,6 @@ database:
 redis:
   url: redis://localhost:6379
 
-nats:
-  url: nats://localhost:4222,nats://localhost:4223,nats://localhost:4224
-
 # Optional SMTP email verification. When omitted, any non-empty verification
 # code is accepted. Configure all three fields together for real email delivery.
 # auth:

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -14,6 +14,11 @@ database:
 redis:
   url: redis://localhost:6379
 
+nats:
+  url: nats://localhost:4222,nats://localhost:4223,nats://localhost:4224
+  connect_timeout: 5s
+  drain_timeout: 10s
+
 # Optional SMTP email verification. When omitted, any non-empty verification
 # code is accepted. Configure all three fields together for real email delivery.
 # auth:

--- a/docs/design/be/ccrv2/ccr-v2-worker-events-delivery-backend-design.md
+++ b/docs/design/be/ccrv2/ccr-v2-worker-events-delivery-backend-design.md
@@ -345,8 +345,9 @@ data: {
 4. 解析 `from_sequence_num` 或 `Last-Event-ID`。
 5. cursor 非法时直接返回 `400`，不会把 worker 标记为 connected。
 6. 如果显式参数或 JWT claim 解析出当前 epoch，调用 `MarkCodeSessionWorkerConnectedForEpoch`。
-7. 写 SSE headers，进入 polling loop。
-8. stream 退出时用 epoch 条件调用 `MarkCodeSessionWorkerDisconnectedForEpoch`。
+7. 在写 response headers 前创建按 code session subject 过滤的临时 JetStream pull consumer；使用 `DeliverNew` 和显式 ACK。
+8. 写 SSE headers，先从 PostgreSQL 发送 backlog，再阻塞消费 JetStream 实时消息。
+9. stream 退出时删除临时 consumer，并用 epoch 条件调用 `MarkCodeSessionWorkerDisconnectedForEpoch`。
 
 只有旧版 JWT 本身也没有 `worker_epoch` 时，stream 才保持 legacy 兼容：只读 queued events，不刷新连接状态。managed-agent 实际建立 SSE 时可以不在 URL 重复传 epoch；其 JWT claim 会让该连接进入 epoch-scoped delivery/replay 路径。
 
@@ -375,7 +376,7 @@ from_sequence_num=<lastSequenceNum>
 Last-Event-ID: <lastSequenceNum>
 ```
 
-epoch-scoped stream 使用本地 `lastSentSequence` 从 cursor 开始推进，每个 polling loop 只查询并写出 `sequence_num > lastSentSequence` 的事件，避免同一条健康连接反复发送同一事件。
+epoch-scoped stream 使用本地 `lastSentSequence` 从 cursor 开始推进。连接建立时从 PostgreSQL 查询并写出 `sequence_num > lastSentSequence` 的 backlog；随后不再执行 500ms 数据库轮询，而是消费 JetStream 的实时完整事件信封。重复或已发送 sequence 会被 ACK 并跳过；若收到的 sequence 大于 `lastSentSequence + 1`，stream 会先按当前 cursor 从 PostgreSQL 补洞，再处理当前消息。
 
 查询约束：
 
@@ -399,9 +400,20 @@ where e.code_session_external_id = $1
 order by e.sequence_num asc;
 ```
 
-如果查询返回 0 行，DB 层仍会再次校验当前 epoch；新 register bump 后，旧 stream 会停止。
+初始查询返回 0 行时，DB 层仍会再次校验当前 epoch。健康连接保留 15 秒 keepalive epoch 校验；新 register 成功后，旧 stream 最迟在下一次 keepalive 时发现 epoch 已变化并停止。JetStream 不承载 epoch 或其他流控制消息。
 
-### 8.5 新 epoch 接管
+### 8.5 PostgreSQL / JetStream 双写边界
+
+所有 inbound 来源（public session event、control response、initialize、activation history 和 code-session API）先写 PostgreSQL，事务提交后再发布版本 1 的 JetStream 完整信封。数据库 event ID 作为 `Nats-Msg-Id`，一小时窗口内的幂等重试不会产生第二条持久消息。
+
+JetStream 只是实时传输副本，PostgreSQL 继续承载 sequence、delivery 状态和 ACK 权威数据。publish ACK 失败、连接中断或默认 NATS `max_payload` 拒绝消息时：
+
+- 原请求与 PostgreSQL 提交保持成功；
+- 只记录 code session、event ID、sequence 和 error，不记录 payload；
+- 不使用事务 outbox、后台补偿、运行期周期性数据库扫描或 DLQ；
+- 有后续 sequence 时由 gap fill 恢复，否则由 worker 下次重连的 PostgreSQL backlog 恢复。
+
+### 8.6 新 epoch 接管
 
 新 worker register 后，`current_worker_epoch` 增加。新 epoch 的 SSE stream 会重放未 `processed` 且满足查询条件的事件：
 

--- a/docs/design/be/nats-messaging-foundation.md
+++ b/docs/design/be/nats-messaging-foundation.md
@@ -2,7 +2,7 @@
 
 ## 当前边界
 
-应用在组装层创建一条全局 NATS 连接，确认目标账号已启用 JetStream，并在进程退出时 drain。Session SSE 的实时 fanout 固定使用这条连接上的 Core NATS Pub/Sub，不再提供 Redis fanout。River job、最终事件的 PostgreSQL 持久化和 Redis 平台登录会话保持不变。后续 producer 和 consumer 应复用这条连接，不得在 handler 或每次请求内重新连接。
+应用在组装层创建一条全局 NATS 连接，确认目标账号已启用 JetStream，并在进程退出时 drain。Session SSE 的实时 fanout 固定使用这条连接上的 Core NATS Pub/Sub；code-session worker 入站事件使用同一连接上的 JetStream。River job、最终事件和 worker delivery 状态的 PostgreSQL 持久化，以及 Redis 平台登录会话保持不变。后续 producer 和 consumer 应复用这条连接，不得在 handler 或每次请求内重新连接。
 
 ```mermaid
 flowchart LR
@@ -13,6 +13,8 @@ flowchart LR
     client --> js["JetStream readiness check"]
     core --> fanout["Core NATS session fanout"]
     fanout --> hub["instance Hub → SSE"]
+    js --> workerStream["OMA_WORKER_INBOUND stream"]
+    workerStream --> workerSSE["temporary pull consumer → worker SSE"]
     main --> drain["graceful drain on shutdown"]
 ```
 
@@ -20,7 +22,7 @@ flowchart LR
 
 升级部署前应为所有 API 实例提供可用的 NATS URL，并让已有 SSE 客户端在切换后重新连接、通过历史 API 同步最终事件。Redis 仍是其他运行时能力的依赖，但不再承载 Session SSE 事件传输。
 
-NATS 连接关闭 reconnect publish buffer，避免断线期间累积的过期 preview 在重连后发送。Core 发布失败由已有 fanout 边界记录；未来可靠 producer 必须自行使用 JetStream ACK、稳定幂等键与重试，不能依赖连接缓冲实现可靠投递。fanout 只维护按 subject 的共享 subscription state 和本地 SSE 引用计数；消息排队、异步回调串行化和断线后的 subscription 恢复都由 nats.go 负责。确认首次订阅的 NATS round trip 在 registry 锁外执行，同 subject 的并发订阅共享一次确认。fanout 在连接 drain 前关闭自己的订阅，不关闭其他组件共享的连接。具体事件与故障合同见 [Worker SSE fanout](ccrv2/ccr-v2-worker-sse-fanout.md)。
+NATS 连接关闭 reconnect publish buffer，避免断线期间累积的过期 preview 在重连后发送。Core 发布失败由已有 fanout 边界记录；JetStream producer 等待服务端 publish ACK，并以 PostgreSQL inbound event ID 作为 `Nats-Msg-Id`。fanout 只维护按 subject 的共享 subscription state 和本地 SSE 引用计数；消息排队、异步回调串行化和断线后的 subscription 恢复都由 nats.go 负责。确认首次订阅的 NATS round trip 在 registry 锁外执行，同 subject 的并发订阅共享一次确认。fanout 在连接 drain 前关闭自己的订阅，不关闭其他组件共享的连接。具体事件与故障合同见 [Worker SSE fanout](ccrv2/ccr-v2-worker-sse-fanout.md) 和 [Worker delivery ACK](ccrv2/ccr-v2-worker-events-delivery-backend-design.md)。
 
 ## 本地拓扑
 
@@ -31,9 +33,19 @@ Docker Compose 使用 `docker.io/library/nats:2.14.6-alpine` 启动三个 JetStr
 
 当前本地拓扑不启用认证或 TLS，因此不得把上述端口发布到非受信网络。三节点只提供本地故障切换拓扑，不等于生产安全配置。生产部署必须使用独立账号与凭证、TLS、网络策略和资源配额；凭证可由 NATS URL 或后续独立凭证字段承载，但不得写入日志或受跟踪示例。后续创建 JetStream stream 时还必须显式选择合适的 replica 数；集群不会自动把单副本 stream 变成三副本。
 
+## Worker 入站事件 stream
+
+应用启动时创建或校验固定 stream `OMA_WORKER_INBOUND`：subject 为 `oma.worker.inbound.v1.>`，file storage，3 replicas，`LimitsPolicy + DiscardOld`，`MaxAge=1h`，`MaxBytes=1GiB`，duplicate window 为 1 小时。该 subject 不与 Core NATS 的 `oma.s.>` 重叠。无法满足 3 副本时应用 fail closed，单节点和双节点 JetStream 不属于受支持部署。
+
+每条 `event` 消息使用版本 1 的完整 JSON 信封，包含 code session ID、数据库 event ID、payload event ID、sequence、event type/subtype 和完整 payload。信封可能包含用户内容，只允许存留在上述短期 stream 中，不得写入运行日志。NATS Server 的默认 `max_payload` 保持不变；合法 HTTP payload 超过该限制时，PostgreSQL 写入仍成功，JetStream 发布只记录不含 payload 的 Warn。
+
+PostgreSQL 是权威账本。写路径先提交 PostgreSQL，再发布 JetStream；publish 失败不回滚请求，不使用 outbox、后台 republish、DLQ 或周期性数据库扫描。worker 重连时从 PostgreSQL 补历史；健康连接若从后续 JetStream 消息发现 sequence 缺口，也会按 cursor 从 PostgreSQL 顺序补齐。若失败消息之后没有新消息，则等下一次 worker 重连恢复。
+
+每条 worker SSE 连接先创建 `DeliverNew + AckExplicit`、按 code session subject 过滤的临时 pull consumer，再查询 PostgreSQL backlog。这保证补历史期间的新消息被 consumer 缓存。SSE 写出并沿用数据库 `MarkSent*` 后才 ACK JetStream；重复 sequence 直接 ACK。请求结束时删除 consumer，并用一分钟 inactive threshold 兜底清理异常断开的 consumer。JetStream 只承载数据库入站事件；旧 worker stream 通过 15 秒 keepalive 对 PostgreSQL epoch 的校验退出。
+
 ## 后续接入约束
 
-可靠业务队列接入前必须先定义 subject 命名、消息 schema/version、幂等键、投递与 ack 策略、重试/backoff、dead-letter 流和租户隔离。Core NATS 的 at-most-once 语义不能被误当成持久队列；需要持久化、重试的路径必须使用 JetStream，并为失败和重复投递补充测试。当前没有创建 stream 或 consumer，SSE preview 不落 JetStream；不要创建捕获 `oma.s.>` 的 stream 而意外持久化预览内容。
+其他可靠业务队列接入前必须先定义 subject 命名、消息 schema/version、幂等键、投递与 ack 策略、重试/backoff、dead-letter 流和租户隔离。Core NATS 的 at-most-once 语义不能被误当成持久队列；需要持久化、重试的路径必须使用 JetStream，并为失败和重复投递补充测试。Session SSE preview 仍不落 JetStream；不要创建捕获 `oma.s.>` 的 stream 而意外持久化预览内容。
 
 ## 验收
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -39,6 +39,7 @@ import (
 	vaultsapi "github.com/superduck-ai/open-managed-agents/internal/vaults"
 	webhooksapi "github.com/superduck-ai/open-managed-agents/internal/webhooks"
 	workbenchapi "github.com/superduck-ai/open-managed-agents/internal/workbench"
+	"github.com/superduck-ai/open-managed-agents/internal/workerevents"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/redis/go-redis/v9"
@@ -89,6 +90,7 @@ type ServerDeps struct {
 	VaultSecrets           *secrets.Service
 	Redis                  *redis.Client
 	SessionEventBus        sessionfanout.EventBus
+	WorkerEventBroker      workerevents.Broker
 }
 
 // NewServer 用显式依赖组装 HTTP API Server。
@@ -104,6 +106,7 @@ func NewServer(deps ServerDeps) *Server {
 	}
 	codeSessionLogger := componentLogger("codesessions")
 	codeSessionService := codesessions.NewServiceWithCredentials(deps.DB, deps.CodeSessionCredentials, codeSessionLogger).
+		WithWorkerEventBroker(deps.WorkerEventBroker).
 		WithSandboxTimeoutExtender(deps.SandboxTimeoutExtender, deps.Config.E2B.SandboxTimeout)
 	webhookLogger := componentLogger("webhooks")
 	webhookEnqueuer := webhooksapi.NewEnqueuer(deps.DB, deps.Config.Webhook, webhookLogger)

--- a/internal/codesessions/errors.go
+++ b/internal/codesessions/errors.go
@@ -47,6 +47,10 @@ func codeSessionEventsLoadError(err error, codeSessionID string) error {
 	)
 }
 
+func workerEventStreamUnavailable(cause error) error {
+	return internalError("Could not connect code session worker stream", cause)
+}
+
 func mapCodeSessionLoadError(err error, codeSessionID string) error {
 	if errors.Is(err, db.ErrNotFound) {
 		return codeSessionNotFound(err)

--- a/internal/codesessions/ingress.go
+++ b/internal/codesessions/ingress.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/db"
 	"github.com/superduck-ai/open-managed-agents/internal/httpapi"
 	"github.com/superduck-ai/open-managed-agents/internal/ids"
+	"github.com/superduck-ai/open-managed-agents/internal/workerevents"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -232,6 +233,16 @@ func (h *Handler) handleCodeSessionWorkerEventsStream(w http.ResponseWriter, r *
 		httpapi.WriteError(w, r, httpapi.NewError(http.StatusInternalServerError, "api_error", "Streaming is not supported"))
 		return
 	}
+	subscription, err := h.service.workerEvents.Subscribe(r.Context(), codeSessionID)
+	if err != nil {
+		h.errorAdapter.Write(w, r, workerEventStreamUnavailable(err))
+		return
+	}
+	defer func() {
+		if err := subscription.Close(); err != nil {
+			h.logger.WarnContext(r.Context(), "close code session worker event subscription", "code_session_id", codeSessionID, "error", err)
+		}
+	}()
 	if hasEpoch {
 		if err := h.db.MarkCodeSessionWorkerConnectedForEpoch(r.Context(), codeSessionID, epoch); err != nil {
 			h.writeWorkerEpochDBError(w, r, codeSessionID, err, "Could not connect code session worker stream")
@@ -251,7 +262,7 @@ func (h *Handler) handleCodeSessionWorkerEventsStream(w http.ResponseWriter, r *
 	header.Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
-	h.streamCodeSessionWorkerEvents(r.Context(), w, flusher, codeSessionID, epoch, hasEpoch, fromSequence)
+	h.streamCodeSessionWorkerEvents(r.Context(), w, flusher, subscription, codeSessionID, epoch, hasEpoch, fromSequence)
 }
 
 func (h *Handler) handleCodeSessionWorkerRegister(w http.ResponseWriter, r *http.Request) {
@@ -288,62 +299,122 @@ func (h *Handler) handleCodeSessionWorkerRegister(w http.ResponseWriter, r *http
 	httpapi.WriteJSON(w, http.StatusOK, map[string]string{"worker_epoch": strconv.FormatInt(epoch, 10)})
 }
 
-func (h *Handler) streamCodeSessionWorkerEvents(ctx context.Context, w io.Writer, flusher http.Flusher, codeSessionID string, epoch int64, epochScoped bool, fromSequence int64) {
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
+func (h *Handler) streamCodeSessionWorkerEvents(ctx context.Context, w io.Writer, flusher http.Flusher,
+	subscription workerevents.Subscription, codeSessionID string, epoch int64, epochScoped bool, fromSequence int64) {
+
 	keepAlive := time.NewTicker(15 * time.Second)
 	defer keepAlive.Stop()
 	lastSentSequence := fromSequence
+	var ok bool
+	lastSentSequence, ok = h.sendCodeSessionWorkerBacklog(ctx, w, flusher, codeSessionID, epoch, epochScoped, lastSentSequence)
+	if !ok {
+		return
+	}
 	for {
-		var events []db.CodeSessionEvent
-		var err error
-		if epochScoped {
-			events, err = h.db.ListCodeSessionInboundEventsForWorkerStream(ctx, codeSessionID, epoch, lastSentSequence)
-		} else {
-			events, err = h.db.ListQueuedCodeSessionInboundEvents(ctx, codeSessionID)
-		}
-		if err != nil {
-			if errors.Is(err, db.ErrWorkerEpochMismatch) || errors.Is(err, db.ErrNotFound) {
-				return
-			}
-			if !errors.Is(err, context.Canceled) {
-				h.logger.ErrorContext(ctx, "list queued code session worker stream events", "code_session_id", codeSessionID, "error", err)
-			}
-			return
-		}
-		for _, event := range events {
-			if err := writeCodeSessionWorkerSSEEvent(w, flusher, event); err != nil {
-				h.logger.ErrorContext(ctx, "write code session worker stream event", "code_session_id", codeSessionID, "event_id", event.ExternalID, "error", err)
-				return
-			}
-			if event.SequenceNum > lastSentSequence {
-				lastSentSequence = event.SequenceNum
-			}
-			markCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			if epochScoped {
-				err = h.db.MarkCodeSessionInboundEventSentForEpoch(markCtx, codeSessionID, event.ExternalID, epoch)
-			} else {
-				err = h.db.MarkCodeSessionInboundEventSent(markCtx, event.ExternalID)
-			}
-			cancel()
-			if errors.Is(err, db.ErrWorkerEpochMismatch) {
-				return
-			}
-			if err != nil && !errors.Is(err, db.ErrNotFound) {
-				h.logger.ErrorContext(ctx, "mark code session worker stream event sent", "code_session_id", codeSessionID, "event_id", event.ExternalID, "error", err)
-			}
-		}
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case err, open := <-subscription.Errors():
+			if open && err != nil && !errors.Is(err, context.Canceled) {
+				h.logger.WarnContext(ctx, "consume code session worker event", "code_session_id", codeSessionID, "error", err)
+			}
+			return
+		case delivery, open := <-subscription.Messages():
+			if !open {
+				return
+			}
+			envelope := delivery.Envelope
+			if envelope.Version != 1 || envelope.CodeSessionID != codeSessionID {
+				h.logger.WarnContext(ctx, "reject code session worker event envelope", "code_session_id", codeSessionID, "event_id", envelope.EventID)
+				return
+			}
+			if envelope.SequenceNum <= lastSentSequence {
+				_ = delivery.Ack()
+				continue
+			}
+			if envelope.SequenceNum > lastSentSequence+1 {
+				lastSentSequence, ok = h.sendCodeSessionWorkerBacklog(ctx, w, flusher, codeSessionID, epoch, epochScoped, lastSentSequence)
+				if !ok {
+					return
+				}
+			}
+			if envelope.SequenceNum > lastSentSequence {
+				event := codeSessionEventFromWorkerEnvelope(envelope)
+				lastSentSequence, ok = h.sendCodeSessionWorkerEvents(ctx, w, flusher, codeSessionID, epoch, epochScoped, lastSentSequence, []db.CodeSessionEvent{event})
+				if !ok {
+					return
+				}
+			}
+			if err := delivery.Ack(); err != nil {
+				h.logger.WarnContext(ctx, "ack code session worker event", "code_session_id", codeSessionID, "event_id", envelope.EventID, "error", err)
+				return
+			}
 		case <-keepAlive.C:
+			if epochScoped {
+				if err := h.db.ValidateCodeSessionWorkerEpoch(ctx, codeSessionID, epoch); err != nil {
+					return
+				}
+			}
 			if _, err := io.WriteString(w, ": keepalive\n\n"); err != nil {
 				return
 			}
 			flusher.Flush()
 		}
 	}
+}
+
+func (h *Handler) sendCodeSessionWorkerBacklog(ctx context.Context, w io.Writer, flusher http.Flusher, codeSessionID string, epoch int64, epochScoped bool, afterSequence int64) (int64, bool) {
+	var events []db.CodeSessionEvent
+	var err error
+	if epochScoped {
+		events, err = h.db.ListCodeSessionInboundEventsForWorkerStream(ctx, codeSessionID, epoch, afterSequence)
+	} else {
+		events, err = h.db.ListQueuedCodeSessionInboundEvents(ctx, codeSessionID)
+	}
+	if err != nil {
+		if !errors.Is(err, db.ErrWorkerEpochMismatch) && !errors.Is(err, db.ErrNotFound) && !errors.Is(err, context.Canceled) {
+			h.logger.ErrorContext(ctx, "list queued code session worker stream events", "code_session_id", codeSessionID, "error", err)
+		}
+		return afterSequence, false
+	}
+	return h.sendCodeSessionWorkerEvents(ctx, w, flusher, codeSessionID, epoch, epochScoped, afterSequence, events)
+}
+
+func (h *Handler) sendCodeSessionWorkerEvents(ctx context.Context, w io.Writer, flusher http.Flusher, codeSessionID string, epoch int64, epochScoped bool, lastSequence int64, events []db.CodeSessionEvent) (int64, bool) {
+	for _, event := range events {
+		if event.SequenceNum <= lastSequence {
+			continue
+		}
+		if err := writeCodeSessionWorkerSSEEvent(w, flusher, event); err != nil {
+			h.logger.ErrorContext(ctx, "write code session worker stream event", "code_session_id", codeSessionID, "event_id", event.ExternalID, "error", err)
+			return lastSequence, false
+		}
+		lastSequence = event.SequenceNum
+		markCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		var err error
+		if epochScoped {
+			err = h.db.MarkCodeSessionInboundEventSentForEpoch(markCtx, codeSessionID, event.ExternalID, epoch)
+		} else {
+			err = h.db.MarkCodeSessionInboundEventSent(markCtx, event.ExternalID)
+		}
+		cancel()
+		if errors.Is(err, db.ErrWorkerEpochMismatch) {
+			return lastSequence, false
+		}
+		if err != nil && !errors.Is(err, db.ErrNotFound) {
+			h.logger.ErrorContext(ctx, "mark code session worker stream event sent", "code_session_id", codeSessionID, "event_id", event.ExternalID, "error", err)
+		}
+	}
+	return lastSequence, true
+}
+
+func codeSessionEventFromWorkerEnvelope(envelope workerevents.EnvelopeV1) db.CodeSessionEvent {
+	var payloadUUID *string
+	if envelope.PayloadEventID != "" {
+		value := envelope.PayloadEventID
+		payloadUUID = &value
+	}
+	return db.CodeSessionEvent{ExternalID: envelope.EventID, CodeSessionExternalID: envelope.CodeSessionID, SequenceNum: envelope.SequenceNum, EventType: envelope.EventType, EventSubtype: envelope.EventSubtype, PayloadUUID: payloadUUID, Payload: envelope.Payload}
 }
 
 func (h *Handler) handleCodeSessionWorkerEvents(w http.ResponseWriter, r *http.Request) {

--- a/internal/codesessions/managed_agent_code_session.go
+++ b/internal/codesessions/managed_agent_code_session.go
@@ -192,7 +192,7 @@ func (s *Service) ActivateManagedAgentCodeSession(
 	if s == nil || s.db == nil {
 		return db.ErrNotFound
 	}
-	return s.db.WithManagedAgentActivationTx(ctx, func(tx db.ManagedAgentActivationTx) error {
+	err := s.db.WithManagedAgentActivationTx(ctx, func(tx db.ManagedAgentActivationTx) error {
 		// lock session by session external id
 		lockedSession, err := tx.LockSessionForEvents(
 			ctx,
@@ -238,6 +238,21 @@ func (s *Service) ActivateManagedAgentCodeSession(
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+	// The activation transaction remains authoritative. Publish its committed
+	// history afterward; duplicate message IDs make republishing existing queued
+	// events harmless in JetStream.
+	events, err := s.db.ListQueuedCodeSessionInboundEvents(ctx, codeSession.ExternalID)
+	if err != nil {
+		s.logger.WarnContext(ctx, "load activated code session inbound events for publish", "code_session_id", codeSession.ExternalID, "error", err)
+		return nil
+	}
+	for _, event := range events {
+		s.publishInboundEvent(ctx, event)
+	}
+	return nil
 }
 
 // convertSessionEventToInbound maps one public session event payload into a

--- a/internal/codesessions/service.go
+++ b/internal/codesessions/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/superduck-ai/open-managed-agents/internal/logging"
 	maevents "github.com/superduck-ai/open-managed-agents/internal/managedagentsevents"
 	"github.com/superduck-ai/open-managed-agents/internal/runtime/sandboxruntime"
+	"github.com/superduck-ai/open-managed-agents/internal/workerevents"
 )
 
 // Service 封装会被 sessions、environment runner 与 code-session HTTP handler 共同复用的业务能力。
@@ -28,6 +29,7 @@ type Service struct {
 	sink                   PublicEventSink
 	sandboxTimeoutExtender SandboxTimeoutExtender
 	sandboxTimeout         time.Duration
+	workerEvents           workerevents.Broker
 }
 
 func NewServiceWithCredentials(database *db.DB, credentials *SessionCredentials, logger *slog.Logger) *Service {
@@ -36,7 +38,15 @@ func NewServiceWithCredentials(database *db.DB, credentials *SessionCredentials,
 		panic("codesessions: session credentials are required")
 	}
 	logger = logging.LoggerOrDefault(logger)
-	return &Service{db: database, credentials: credentials, logger: logger}
+	return &Service{db: database, credentials: credentials, logger: logger, workerEvents: workerevents.NewMemory()}
+}
+
+// WithWorkerEventBroker wires the live transport copy of durable inbound events.
+func (s *Service) WithWorkerEventBroker(broker workerevents.Broker) *Service {
+	if s != nil && broker != nil {
+		s.workerEvents = broker
+	}
+	return s
 }
 
 // WithSandboxTimeoutExtender wires the provider lifecycle operation used to
@@ -162,28 +172,6 @@ func (s *Service) QueueRawPublicSessionEvents(ctx context.Context, codeSession d
 	// 持久化入站队列消费事件。
 	for _, payload := range payloads {
 		_, duplicate, err := s.appendInboundPayload(ctx, codeSession.ExternalID, payload, "public-session")
-		if err != nil {
-			return err
-		}
-		if duplicate {
-			continue
-		}
-	}
-	return nil
-}
-
-func (s *Service) QueueRawCodeSessionEvents(ctx context.Context, codeSession db.CodeSession, payloads []json.RawMessage, source string) error {
-	if s == nil || len(payloads) == 0 {
-		return nil
-	}
-	source = strings.TrimSpace(source)
-	if source == "" {
-		source = "code-session-api"
-	}
-	// 不得通过进程内 push 绕过持久化队列。CCR v2 投递必须校验 epoch，
-	// 并且在 worker 被替换后仍可重放。
-	for _, payload := range payloads {
-		_, duplicate, err := s.appendInboundPayload(ctx, codeSession.ExternalID, payload, source)
 		if err != nil {
 			return err
 		}
@@ -433,7 +421,34 @@ func (s *Service) appendInboundPayload(ctx context.Context, codeSessionID string
 	if err != nil {
 		return db.CodeSessionEvent{}, false, err
 	}
-	return s.db.AppendCodeSessionInboundEvent(ctx, codeSessionID, input)
+	event, duplicate, err := s.db.AppendCodeSessionInboundEvent(ctx, codeSessionID, input)
+	if err != nil {
+		return db.CodeSessionEvent{}, false, err
+	}
+	s.publishInboundEvent(ctx, event)
+	return event, duplicate, nil
+}
+
+func (s *Service) publishInboundEvent(ctx context.Context, event db.CodeSessionEvent) {
+	if s.workerEvents == nil {
+		return
+	}
+	payloadEventID := ""
+	if event.PayloadUUID != nil {
+		payloadEventID = *event.PayloadUUID
+	}
+	envelope := workerevents.EventEnvelope(
+		event.CodeSessionExternalID,
+		event.ExternalID,
+		payloadEventID,
+		event.SequenceNum,
+		event.EventType,
+		event.EventSubtype,
+		event.Payload,
+	)
+	if err := s.workerEvents.Publish(ctx, envelope); err != nil {
+		s.logger.WarnContext(ctx, "publish code session inbound event", "code_session_id", event.CodeSessionExternalID, "event_id", event.ExternalID, "sequence_num", event.SequenceNum, "error", err)
+	}
 }
 
 func newInboundEventInput(codeSessionID string, payload json.RawMessage, source string) (db.AppendCodeSessionEventInput, error) {

--- a/internal/codesessions/worker_events_test.go
+++ b/internal/codesessions/worker_events_test.go
@@ -1,0 +1,58 @@
+package codesessions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/superduck-ai/open-managed-agents/internal/db"
+	"github.com/superduck-ai/open-managed-agents/internal/workerevents"
+)
+
+func TestPublishInboundEvent(t *testing.T) {
+	t.Run("publish failure does not escape the PostgreSQL write boundary", func(t *testing.T) {
+		broker := &recordingWorkerEventBroker{publishErr: errors.New("unavailable")}
+		service := newTestService(t, nil).WithWorkerEventBroker(broker)
+		service.publishInboundEvent(t.Context(), workerEventFixture())
+		if len(broker.envelopes) != 1 {
+			t.Fatalf("publish calls = %d, want 1", len(broker.envelopes))
+		}
+	})
+
+	t.Run("publishes the full versioned envelope", func(t *testing.T) {
+		broker := &recordingWorkerEventBroker{}
+		service := newTestService(t, nil).WithWorkerEventBroker(broker)
+		service.publishInboundEvent(t.Context(), workerEventFixture())
+		if len(broker.envelopes) != 1 {
+			t.Fatalf("publish calls = %d, want 1", len(broker.envelopes))
+		}
+		envelope := broker.envelopes[0]
+		if envelope.Version != 1 || envelope.CodeSessionID != "cse_test" || envelope.EventID != "csev_test" || envelope.PayloadEventID != "payload-test" || envelope.SequenceNum != 9 || envelope.EventType != "user" || envelope.EventSubtype != "message" || string(envelope.Payload) != `{"text":"hello"}` {
+			t.Fatalf("envelope = %#v", envelope)
+		}
+	})
+}
+
+func workerEventFixture() db.CodeSessionEvent {
+	payloadID := "payload-test"
+	return db.CodeSessionEvent{
+		ExternalID: "csev_test", CodeSessionExternalID: "cse_test", SequenceNum: 9,
+		EventType: "user", EventSubtype: "message", PayloadUUID: &payloadID,
+		Payload: json.RawMessage(`{"text":"hello"}`),
+	}
+}
+
+type recordingWorkerEventBroker struct {
+	envelopes  []workerevents.EnvelopeV1
+	publishErr error
+}
+
+func (b *recordingWorkerEventBroker) Publish(_ context.Context, envelope workerevents.EnvelopeV1) error {
+	b.envelopes = append(b.envelopes, envelope)
+	return b.publishErr
+}
+
+func (b *recordingWorkerEventBroker) Subscribe(context.Context, string) (workerevents.Subscription, error) {
+	return nil, errors.New("not implemented")
+}

--- a/internal/workerevents/broker.go
+++ b/internal/workerevents/broker.go
@@ -1,0 +1,248 @@
+package workerevents
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const (
+	StreamName    = "OMA_WORKER_INBOUND"
+	subjectPrefix = "oma.worker.inbound.v1."
+	streamSubject = subjectPrefix + ">"
+)
+
+// EnvelopeV1 is the durable, versioned transport copy of a PostgreSQL inbound event.
+type EnvelopeV1 struct {
+	Version        int             `json:"version"`
+	CodeSessionID  string          `json:"code_session_id"`
+	EventID        string          `json:"event_id"`
+	PayloadEventID string          `json:"payload_event_id,omitempty"`
+	SequenceNum    int64           `json:"sequence_num"`
+	EventType      string          `json:"event_type"`
+	EventSubtype   string          `json:"event_subtype,omitempty"`
+	Payload        json.RawMessage `json:"payload"`
+}
+
+type Delivery struct {
+	Envelope EnvelopeV1
+	ack      func() error
+}
+
+func (d Delivery) Ack() error {
+	if d.ack == nil {
+		return nil
+	}
+	return d.ack()
+}
+
+type Subscription interface {
+	Messages() <-chan Delivery
+	Errors() <-chan error
+	Close() error
+}
+
+type Broker interface {
+	Publish(context.Context, EnvelopeV1) error
+	Subscribe(context.Context, string) (Subscription, error)
+}
+
+func EventEnvelope(codeSessionID, eventID, payloadEventID string, sequenceNum int64, eventType, eventSubtype string, payload json.RawMessage) EnvelopeV1 {
+	return EnvelopeV1{Version: 1, CodeSessionID: codeSessionID, EventID: eventID, PayloadEventID: payloadEventID, SequenceNum: sequenceNum, EventType: eventType, EventSubtype: eventSubtype, Payload: payload}
+}
+
+func subject(codeSessionID string) (string, error) {
+	if codeSessionID == "" || strings.ContainsAny(codeSessionID, ".*> \t\r\n") {
+		return "", errors.New("invalid code session ID for worker event subject")
+	}
+	return subjectPrefix + codeSessionID, nil
+}
+
+type JetStreamBroker struct{ js jetstream.JetStream }
+
+func NewJetStream(ctx context.Context, connection *nats.Conn) (*JetStreamBroker, error) {
+	if connection == nil || !connection.IsConnected() {
+		return nil, nats.ErrDisconnected
+	}
+	js, err := jetstream.New(connection)
+	if err != nil {
+		return nil, fmt.Errorf("create worker event JetStream client: %w", err)
+	}
+	_, err = js.CreateOrUpdateStream(ctx, jetstream.StreamConfig{
+		Name: StreamName, Subjects: []string{streamSubject}, Retention: jetstream.LimitsPolicy,
+		Discard: jetstream.DiscardOld, MaxAge: time.Hour, MaxBytes: 1 << 30,
+		Storage: jetstream.FileStorage, Replicas: 3, Duplicates: time.Hour,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ensure worker event stream: %w", err)
+	}
+	return &JetStreamBroker{js: js}, nil
+}
+
+func (b *JetStreamBroker) Publish(ctx context.Context, envelope EnvelopeV1) error {
+	subjectName, err := subject(envelope.CodeSessionID)
+	if err != nil {
+		return err
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("marshal worker event envelope: %w", err)
+	}
+	message := nats.NewMsg(subjectName)
+	message.Data = body
+	if envelope.EventID != "" {
+		message.Header.Set(nats.MsgIdHdr, envelope.EventID)
+	}
+	if _, err := b.js.PublishMsg(ctx, message); err != nil {
+		return fmt.Errorf("publish worker event: %w", err)
+	}
+	return nil
+}
+
+func (b *JetStreamBroker) Subscribe(ctx context.Context, codeSessionID string) (Subscription, error) {
+	filter, err := subject(codeSessionID)
+	if err != nil {
+		return nil, err
+	}
+	consumer, err := b.js.CreateConsumer(ctx, StreamName, jetstream.ConsumerConfig{
+		DeliverPolicy: jetstream.DeliverNewPolicy, AckPolicy: jetstream.AckExplicitPolicy,
+		FilterSubject: filter, AckWait: time.Minute, InactiveThreshold: time.Minute,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create worker event consumer: %w", err)
+	}
+	subCtx, cancel := context.WithCancel(ctx)
+	s := &jetStreamSubscription{js: b.js, consumer: consumer, name: consumer.CachedInfo().Name, ctx: subCtx, cancel: cancel, messages: make(chan Delivery), errors: make(chan error, 1)}
+	go s.receive()
+	return s, nil
+}
+
+type jetStreamSubscription struct {
+	js        jetstream.JetStream
+	consumer  jetstream.Consumer
+	name      string
+	ctx       context.Context
+	cancel    context.CancelFunc
+	messages  chan Delivery
+	errors    chan error
+	closeOnce sync.Once
+}
+
+func (s *jetStreamSubscription) Messages() <-chan Delivery { return s.messages }
+func (s *jetStreamSubscription) Errors() <-chan error      { return s.errors }
+
+func (s *jetStreamSubscription) receive() {
+	defer close(s.messages)
+	defer close(s.errors)
+	for s.ctx.Err() == nil {
+		batch, err := s.consumer.Fetch(32, jetstream.FetchContext(s.ctx))
+		if err != nil {
+			if s.ctx.Err() == nil {
+				s.report(err)
+			}
+			return
+		}
+		for message := range batch.Messages() {
+			var envelope EnvelopeV1
+			if err := json.Unmarshal(message.Data(), &envelope); err != nil {
+				s.report(fmt.Errorf("decode worker event envelope: %w", err))
+				return
+			}
+			delivery := Delivery{Envelope: envelope, ack: message.Ack}
+			select {
+			case s.messages <- delivery:
+			case <-s.ctx.Done():
+				return
+			}
+		}
+		if err := batch.Error(); err != nil && !errors.Is(err, context.Canceled) {
+			s.report(err)
+			return
+		}
+	}
+}
+
+func (s *jetStreamSubscription) report(err error) {
+	select {
+	case s.errors <- err:
+	default:
+	}
+}
+
+func (s *jetStreamSubscription) Close() error {
+	var deleteErr error
+	s.closeOnce.Do(func() {
+		s.cancel()
+		deleteCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		deleteErr = s.js.DeleteConsumer(deleteCtx, StreamName, s.name)
+	})
+	return deleteErr
+}
+
+// MemoryBroker mirrors live-only broker behavior for unit and API tests.
+type MemoryBroker struct {
+	mu     sync.Mutex
+	nextID uint64
+	subs   map[uint64]*memorySubscription
+}
+
+func NewMemory() *MemoryBroker { return &MemoryBroker{subs: make(map[uint64]*memorySubscription)} }
+
+func (b *MemoryBroker) Publish(ctx context.Context, envelope EnvelopeV1) error {
+	b.mu.Lock()
+	targets := make([]*memorySubscription, 0, len(b.subs))
+	for _, sub := range b.subs {
+		if sub.codeSessionID == envelope.CodeSessionID {
+			targets = append(targets, sub)
+		}
+	}
+	b.mu.Unlock()
+	for _, sub := range targets {
+		select {
+		case sub.messages <- Delivery{Envelope: envelope}:
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-sub.done:
+		}
+	}
+	return nil
+}
+
+func (b *MemoryBroker) Subscribe(ctx context.Context, codeSessionID string) (Subscription, error) {
+	if _, err := subject(codeSessionID); err != nil {
+		return nil, err
+	}
+	b.mu.Lock()
+	b.nextID++
+	id := b.nextID
+	s := &memorySubscription{broker: b, id: id, codeSessionID: codeSessionID, messages: make(chan Delivery, 256), errors: make(chan error), done: make(chan struct{})}
+	b.subs[id] = s
+	b.mu.Unlock()
+	go func() { <-ctx.Done(); _ = s.Close() }()
+	return s, nil
+}
+
+type memorySubscription struct {
+	broker        *MemoryBroker
+	id            uint64
+	codeSessionID string
+	messages      chan Delivery
+	errors        chan error
+	done          chan struct{}
+	closeOnce     sync.Once
+}
+
+func (s *memorySubscription) Messages() <-chan Delivery { return s.messages }
+func (s *memorySubscription) Errors() <-chan error      { return s.errors }
+func (s *memorySubscription) Close() error {
+	s.closeOnce.Do(func() { s.broker.mu.Lock(); delete(s.broker.subs, s.id); close(s.done); s.broker.mu.Unlock() })
+	return nil
+}

--- a/internal/workerevents/broker_test.go
+++ b/internal/workerevents/broker_test.go
@@ -1,0 +1,178 @@
+package workerevents
+
+import (
+	"net"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	server "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestJetStreamBrokerRejectsInsufficientReplicas(t *testing.T) {
+	srv := runNATSServer(t, server.Options{Host: "127.0.0.1", Port: -1, JetStream: true, StoreDir: t.TempDir()})
+	connection := connectNATS(t, srv.ClientURL())
+	if _, err := NewJetStream(t.Context(), connection); err == nil {
+		t.Fatal("NewJetStream() error = nil, want three-replica stream failure")
+	}
+}
+
+func TestJetStreamBrokerDeliversFullEnvelopeAndCleansConsumer(t *testing.T) {
+	servers := runNATSCluster(t)
+	publisherConnection := connectNATS(t, servers[0].ClientURL())
+	subscriberConnection := connectNATS(t, servers[1].ClientURL())
+	publisher, err := NewJetStream(t.Context(), publisherConnection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subscriber, err := NewJetStream(t.Context(), subscriberConnection)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessionID := "csess_test"
+	subscription, err := subscriber.Subscribe(t.Context(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope := EventEnvelope(sessionID, "csev_test", "payload-test", 7, "user.message", "", []byte(`{"text":"hello"}`))
+	if err := publisher.Publish(t.Context(), envelope); err != nil {
+		t.Fatal(err)
+	}
+	if err := publisher.Publish(t.Context(), envelope); err != nil {
+		t.Fatal(err)
+	}
+	if err := publisher.Publish(t.Context(), EventEnvelope("csess_other", "csev_other", "", 1, "user.message", "", []byte(`{}`))); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case delivery := <-subscription.Messages():
+		if delivery.Envelope.EventID != envelope.EventID || string(delivery.Envelope.Payload) != string(envelope.Payload) || delivery.Envelope.SequenceNum != 7 {
+			t.Fatalf("delivery = %#v, want full envelope %#v", delivery.Envelope, envelope)
+		}
+		if err := delivery.Ack(); err != nil {
+			t.Fatal(err)
+		}
+	case err := <-subscription.Errors():
+		t.Fatalf("subscription error: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for worker event")
+	}
+	select {
+	case duplicate := <-subscription.Messages():
+		t.Fatalf("received duplicate or cross-session event: %#v", duplicate.Envelope)
+	case <-time.After(250 * time.Millisecond):
+	}
+	if err := subscription.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	js, err := jetstream.New(subscriberConnection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream, err := js.Stream(t.Context(), StreamName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := stream.Info(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Config.Replicas != 3 || info.Config.MaxAge != time.Hour || info.Config.MaxBytes != 1<<30 || info.Config.Storage != jetstream.FileStorage {
+		t.Fatalf("stream config = %#v", info.Config)
+	}
+	if info.State.Consumers != 0 {
+		t.Fatalf("consumer count = %d, want 0", info.State.Consumers)
+	}
+}
+
+func runNATSCluster(t *testing.T) []*server.Server {
+	t.Helper()
+	const count = 3
+	ports := make([]int, count)
+	for i := range ports {
+		ports[i] = freePort(t)
+	}
+	servers := make([]*server.Server, 0, count)
+	for i := 0; i < count; i++ {
+		routes := make([]*url.URL, 0, count-1)
+		for j, port := range ports {
+			if i == j {
+				continue
+			}
+			route, err := url.Parse("nats-route://127.0.0.1:" + fmtInt(port))
+			if err != nil {
+				t.Fatal(err)
+			}
+			routes = append(routes, route)
+		}
+		srv := runNATSServer(t, server.Options{
+			ServerName: "worker-events-" + fmtInt(i+1), Host: "127.0.0.1", Port: -1, JetStream: true,
+			StoreDir: filepath.Join(t.TempDir(), fmtInt(i)),
+			Cluster:  server.ClusterOpts{Name: "worker-events-test", Host: "127.0.0.1", Port: ports[i]},
+			Routes:   routes,
+		})
+		servers = append(servers, srv)
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		ready := false
+		for _, srv := range servers {
+			ready = ready || (srv.JetStreamIsLeader() && len(srv.JetStreamClusterPeers()) == count)
+		}
+		if ready {
+			return servers
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	for _, srv := range servers {
+		t.Logf("server=%s routes=%d clustered=%t leader=%t peers=%v", srv.Name(), srv.NumRoutes(), srv.JetStreamIsClustered(), srv.JetStreamIsLeader(), srv.JetStreamClusterPeers())
+	}
+	t.Fatal("NATS cluster routes did not converge")
+	return nil
+}
+
+func runNATSServer(t *testing.T, options server.Options) *server.Server {
+	t.Helper()
+	srv, err := server.NewServer(&options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.Start()
+	t.Cleanup(srv.Shutdown)
+	if !srv.ReadyForConnections(5 * time.Second) {
+		t.Fatal("NATS server not ready")
+	}
+	return srv
+}
+
+func connectNATS(t *testing.T, serverURL string) *nats.Conn {
+	t.Helper()
+	connection, err := nats.Connect(serverURL, nats.ReconnectBufSize(-1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(connection.Close)
+	return connection
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func fmtInt(value int) string { return strconv.Itoa(value) }

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	skillsapi "github.com/superduck-ai/open-managed-agents/internal/skills"
 	"github.com/superduck-ai/open-managed-agents/internal/storage"
 	"github.com/superduck-ai/open-managed-agents/internal/webhooks"
+	"github.com/superduck-ai/open-managed-agents/internal/workerevents"
 )
 
 func main() {
@@ -95,6 +96,10 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("open session event fanout: %w", err)
 	}
 	defer sessionEventBus.Close()
+	workerEventBroker, err := workerevents.NewJetStream(ctx, natsConnection)
+	if err != nil {
+		return fmt.Errorf("open worker event broker: %w", err)
+	}
 	logger.Info("nats messaging ready", "jetstream", true)
 
 	storageClient, err := storage.New(cfg.Storage)
@@ -140,7 +145,7 @@ func run(logger *slog.Logger) error {
 		DB:              database,
 		Provider:        sandboxProvider,
 		Config:          cfg,
-		CodeSessions:    codesessions.NewServiceWithCredentials(database, codeSessionCredentials, environmentLogger),
+		CodeSessions:    codesessions.NewServiceWithCredentials(database, codeSessionCredentials, environmentLogger).WithWorkerEventBroker(workerEventBroker),
 		Skills:          skillsapi.NewRuntimeResolver(database),
 		FilestoreTokens: filestoreCredentials,
 		Logger:          environmentLogger,
@@ -191,6 +196,7 @@ func run(logger *slog.Logger) error {
 			VaultSecrets:           vaultSecrets,
 			Redis:                  redisClient,
 			SessionEventBus:        sessionEventBus,
+			WorkerEventBroker:      workerEventBroker,
 		}),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       10 * time.Minute,


### PR DESCRIPTION
## Summary

- Add worker event broker and delivery flow for managed code sessions
- Integrate worker event handling into API and service wiring
- Define related errors, configuration, and NATS messaging documentation
- Add coverage for broker and worker event behavior

## Testing

- Added and updated unit tests for worker event delivery and broker behavior
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Worker events are now delivered in real time through a reliable event stream.
  - Code-session event delivery supports acknowledgments, duplicate filtering, sequence-gap recovery, and backlog replay.
  - Worker events are published after successful persistence and restored when sessions become active.

- **Bug Fixes**
  - Improved resilience when event publishing or streaming connections fail without interrupting database persistence.

- **Documentation**
  - Updated messaging and event-delivery documentation to describe stream-based delivery, recovery, acknowledgments, and replay.

- **Configuration**
  - Added local NATS connection settings, including connection and drain timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->